### PR TITLE
Fix profile country updates and country-only location display

### DIFF
--- a/src/components/common/LocationDisplay.jsx
+++ b/src/components/common/LocationDisplay.jsx
@@ -44,7 +44,7 @@ const LocationDisplay = ({
   });
 
   // Return null if no location data
-  if (!locationData.city && !locationData.postalCode) {
+  if (!locationData.hasLocation) {
     return null;
   }
 

--- a/src/components/common/LocationSection.jsx
+++ b/src/components/common/LocationSection.jsx
@@ -140,7 +140,7 @@ const LocationSection = ({
               (No physical location)
             </span>
           </div>
-        ) : location.city || location.postalCode ? (
+        ) : location.hasLocation ? (
           <div className="flex items-start text-sm text-base-content/70">
             {!shouldShowTitle && (
               <MapPin size={16} className="mr-2 flex-shrink-0 mt-0.5" />

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -623,6 +623,11 @@ const Profile = () => {
           bio: formData.bio,
           postal_code: formData.postalCode,
           city: formData.city,
+          country: formData.country,
+          // Pick up geocoded state & coordinates from the API response
+          state: response.data?.state ?? user.state,
+          latitude: response.data?.latitude ?? user.latitude,
+          longitude: response.data?.longitude ?? user.longitude,
           // Use the avatar URL from Cloudinary if we uploaded a new image,
           // otherwise use the response data or keep the existing avatar
           avatar_url: avatarUrl || response.data?.avatar_url || user.avatar_url,
@@ -703,6 +708,19 @@ const Profile = () => {
       </PageContainer>
     );
   }
+
+  const profileLocation = {
+    postalCode: displayUser.postalCode || displayUser.postal_code || "",
+    city: displayUser.city || "",
+    state: displayUser.state || "",
+    country: displayUser.country || "",
+  };
+  const hasProfileLocation = Boolean(
+    profileLocation.postalCode ||
+      profileLocation.city ||
+      profileLocation.state ||
+      profileLocation.country,
+  );
 
   return (
     <div className="space-y-6">
@@ -1047,12 +1065,12 @@ const Profile = () => {
                           />
                           <h3 className="font-medium">Location</h3>
                         </div>
-                        {user.postalCode || user.postal_code || user.city ? (
+                        {hasProfileLocation ? (
                           <LocationDisplay
-                            postalCode={user.postal_code || user.postalCode}
-                            city={user.city}
-                            state={user.state}
-                            country={user.country}
+                            postalCode={profileLocation.postalCode}
+                            city={profileLocation.city}
+                            state={profileLocation.state}
+                            country={profileLocation.country}
                             className="text-sm text-base-content/60"
                             showIcon={false}
                             showPostalCode={true}
@@ -1117,12 +1135,12 @@ const Profile = () => {
                             />
                             <h3 className="font-medium">Location</h3>
                           </div>
-                          {user.postalCode || user.postal_code || user.city ? (
+                          {hasProfileLocation ? (
                             <LocationDisplay
-                              postalCode={user.postal_code || user.postalCode}
-                              city={user.city}
-                              state={user.state}
-                              country={user.country}
+                              postalCode={profileLocation.postalCode}
+                              city={profileLocation.city}
+                              state={profileLocation.state}
+                              country={profileLocation.country}
                               className="text-sm text-base-content/60"
                               showIcon={false}
                               showPostalCode={true}

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -246,7 +246,7 @@ export const formatLocation = (locationData, options = {}) => {
 
   const { postalCode, city, state, countryName } = locationData;
 
-  if (!city && !postalCode) {
+  if (!city && !postalCode && !state && !countryName) {
     return "";
   }
 


### PR DESCRIPTION
This fixes two related profile location issues:

- updating the country in the profile form now reflects immediately after save
- profiles with only a country set now display that location instead of showing "No location added yet"

## Problem

The profile page was keeping stale location data in memory after a successful save, so a changed country did not appear until an additional refresh.

Separately, the shared location display logic treated country-only data as if no location existed, which meant valid profile locations were hidden.

## Changes

- completed the updated profile object in `Profile.jsx` so it keeps fresh location fields after save
- rendered the profile location from the freshest local profile data instead of older stale values
- updated shared location display checks so country-only and state/country locations are treated as valid location data
- adjusted shared location formatting so it no longer returns empty output when only country/state is present

## Verification

- `npm run build`

## Notes

- `npm run lint` still reports existing unrelated repo-wide lint issues; this change does not address those
