### PR TITLE
Send ImageKit file IDs to backend

### DIFF
--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -242,6 +242,7 @@ const RegisterForm = () => {
 
         if (uploadResult.success) {
           userData.avatar_url = uploadResult.url;
+          userData.avatar_file_id = uploadResult.fileId;
         } else {
           console.error("Avatar upload failed:", uploadResult.error);
         }

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -1010,6 +1010,7 @@ const TeamDetailsModal = ({
 
         if (uploadResult.success) {
           submissionData.teamavatar_url = uploadResult.url;
+          submissionData.teamavatar_file_id = uploadResult.fileId;
         } else {
           console.error("Error uploading team avatar:", uploadResult.error);
           // Continue with the update even if image upload fails

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -556,11 +556,12 @@ const Profile = () => {
         if (uploadResult.success) {
           avatarUrl = uploadResult.url;
           userData.avatar_url = avatarUrl;
+          userData.avatar_file_id = uploadResult.fileId;
           setImagePreview(avatarUrl);
         } else {
           console.error("Avatar upload failed:", uploadResult.error);
           setError(
-            "Failed to upload image. Please try again.",
+            "Failed to upload image. Please try a different image or try again later.",
           );
           setLoading(false);
           return;
@@ -607,7 +608,7 @@ const Profile = () => {
           state: response.data?.state ?? user.state,
           latitude: response.data?.latitude ?? user.latitude,
           longitude: response.data?.longitude ?? user.longitude,
-          // Use the uploaded avatar URL if we uploaded a new image,
+          // Use the avatar URL from ImageKit if we uploaded a new image,
           // otherwise use the response data or keep the existing avatar
           avatar_url: avatarUrl || response.data?.avatar_url || user.avatar_url,
           avatarUrl: avatarUrl || response.data?.avatar_url || user.avatarUrl,


### PR DESCRIPTION
This PR updates the frontend to send ImageKit `fileId`s to the backend when avatar uploads succeed.

Previously, we only sent the uploaded image URL. That meant the backend could not store the ImageKit file identifier needed for direct asset deletion later. With this change, the backend now receives both the public URL and the ImageKit file ID.

## Changes

- `src/pages/Profile.jsx`
  - Added `avatar_file_id` to the profile update payload after a successful avatar upload

- `src/components/auth/RegisterForm.jsx`
  - Added `avatar_file_id` to the registration payload after a successful avatar upload

- `src/components/teams/TeamDetailsModal.jsx`
  - Added `teamavatar_file_id` to the team update payload after a successful team avatar upload

## Why

The backend needs the ImageKit file ID to support direct deletion of uploaded images. Sending only the URL is not enough for reliable cleanup.