### PR TITLE
Fix avatar upload and chat message deletion

### DIFF
--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1054,17 +1054,7 @@ const Chat = () => {
         ),
       );
 
-      // Use your service if you have it
-      // await messageService.deleteMessage(messageId);
-
-      // Or your fetch (as you wrote)
-      await fetch(`${import.meta.env.VITE_API_URL}/messages/${messageId}`, {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-      });
+      await messageService.deleteMessage(messageId);
     } catch (err) {
       console.error("Failed to delete message:", err);
       setError("Failed to delete message. Please try again.");

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -90,6 +90,17 @@ export const messageService = {
       throw error;
     }
   },
+
+  // Soft-delete a message
+  deleteMessage: async (messageId) => {
+    try {
+      const response = await api.delete(`/api/messages/${messageId}`);
+      return response.data;
+    } catch (error) {
+      console.error(`Error deleting message ${messageId}:`, error);
+      throw error;
+    }
+  },
 };
 
 export default messageService;


### PR DESCRIPTION
# Fix avatar upload and chat message deletion

## Summary

Two fixes: ensured the ImageKit fileId is sent to the backend when uploading avatars (enabling direct file deletion), and fixed chat message deletion which was silently failing due to a wrong API URL.

## Changes

### Send ImageKit fileId on avatar uploads
- **`src/pages/Profile.jsx`** — After a successful `uploadToImageKit` call, now includes `avatar_file_id: uploadResult.fileId` in the data sent to the backend. Also updated a stale "Cloudinary" comment to say "ImageKit".
- **`src/components/auth/RegisterForm.jsx`** — Includes `avatar_file_id` in registration payload when an avatar is uploaded.
- **`src/components/teams/TeamDetailsModal.jsx`** — Includes `teamavatar_file_id` in team update payload when a team avatar is uploaded.

### Fix chat message deletion
- **`src/services/messageService.js`** — Added `deleteMessage(messageId)` method that sends `DELETE /api/messages/:id` through the shared api client.
- **`src/pages/Chat.jsx`** — `handleDeleteMessage` now calls `messageService.deleteMessage()` instead of a raw `fetch` with the wrong URL. The previous code used `${VITE_API_URL}/messages/:id` which resolved to `/messages/:id` (missing `/api`), so delete requests were silently 404ing. The optimistic UI update made it look like deletion worked, but a page refresh brought deleted messages back.

## Notes

- The `uploadToImageKit` function in `src/config/imagekit.js` already returned `fileId` — it was just being discarded. No changes needed to the upload utility itself.
- No changes to optimistic UI update logic or socket event handling for message deletion.