### PR TITLE
Temporarily suspend dark mode

### DIFF
--- a/docs/DARK_MODE_SUSPENSION.md
+++ b/docs/DARK_MODE_SUSPENSION.md
@@ -1,0 +1,267 @@
+# Lomir - Temporary Dark Mode Suspension
+
+## Purpose
+
+This document explains why dark mode is currently suspended in Lomir, how the temporary suspension is implemented, and how proper dark mode can be reintroduced later.
+
+The goal of the current setup is very specific:
+
+- Users who prefer dark mode in their browser or operating system must still see Lomir in the exact same colors as the current light mode.
+- The app must not fall back to browser-default or DaisyUI-default dark styling.
+- The current behavior is a temporary accessibility and UX safeguard, not the final dark mode solution.
+
+---
+
+## Why Dark Mode Was Suspended
+
+At the time of this change, Lomir did not yet have a complete, tested, accessible dark theme.
+
+In practice this caused problems such as:
+
+- low contrast and legibility issues
+- white or very light text on very light backgrounds
+- browser- or framework-driven dark styling that did not match the Lomir design system
+- inconsistent results across browsers
+
+Because of that, the safest interim decision was:
+
+- keep the app visually identical to light mode everywhere
+- suppress automatic dark mode behavior until a real dark theme is ready
+
+This is a frontend-only concern for now. No backend changes are required unless theme preference should later be stored per user.
+
+---
+
+## Current Implementation
+
+The suspension is implemented in several layers so that browser, framework, and app-level theme behavior all point to light mode.
+
+### 1. Document-level light mode lock
+
+The HTML document is explicitly marked as light theme:
+
+- `index.html`
+  - `<html lang="en" data-theme="light">`
+  - `<meta name="color-scheme" content="only light" />`
+
+Why this matters:
+
+- `data-theme="light"` ensures DaisyUI components use the light theme.
+- `meta name="color-scheme"` tells the browser that the document should be treated as light-only.
+
+### 2. CSS-level browser UI lock
+
+In `src/index.css`, the root element declares:
+
+```css
+:root {
+  color-scheme: only light;
+}
+```
+
+Why this matters:
+
+- This keeps browser-painted UI such as form controls, scrollbars, and similar native surfaces in light mode.
+- It adds a CSS-level fallback in addition to the HTML meta tag.
+
+### 3. App-level theme lock
+
+Several app entry points explicitly keep the app on the light theme:
+
+- `src/main.jsx`
+- `src/App.jsx`
+- `src/hooks/useTheme.js`
+
+Current behavior:
+
+- the app sets `data-theme` to `light`
+- the theme hook initializes to `light`
+- `toggleTheme()` is intentionally locked to `light`
+
+Why this matters:
+
+- Even if a future component accidentally calls the current theme hook, it cannot switch the app into an unfinished dark mode.
+
+### 4. DaisyUI is configured to ship only the light theme
+
+In `tailwind.config.js`, DaisyUI is configured like this:
+
+```js
+daisyui({
+  themes: ["light --default"],
+})
+```
+
+Why this matters:
+
+- This prevents DaisyUI from generating its built-in `dark --prefersdark` media-query behavior.
+- Without this, Firefox and other browsers could still apply DaisyUI's automatic dark theme when the OS or browser prefers dark mode.
+
+### 5. The DaisyUI light theme is overridden with Lomir's actual light palette
+
+Also in `tailwind.config.js`, the built-in DaisyUI `light` theme is overridden using `daisyui/theme/index.js`.
+
+This is important because we do not want generic DaisyUI light colors. We want Lomir's existing light colors.
+
+The override restores Lomir-specific values for:
+
+- `base-100`
+- `base-200`
+- `base-300`
+- `base-content`
+- `primary`
+- `secondary`
+- `accent`
+- `info`
+- `success`
+- `warning`
+- `error`
+
+Why this matters:
+
+- Classes such as `bg-base-100`, `text-base-content`, `btn-primary`, notification badges, avatar fallback fills, and semantic colors must look exactly like they do in Lomir light mode.
+
+---
+
+## Important DaisyUI v5 Note
+
+One major implementation detail is easy to miss:
+
+- DaisyUI v5 did not behave correctly with the older top-level config style we initially tried.
+- The old custom theme setup allowed DaisyUI's built-in dark `prefers-color-scheme` rule to remain active.
+- That caused Firefox to keep showing dark styling even though the app was trying to force light mode.
+
+The working solution is:
+
+- configure DaisyUI directly in the `plugins` array
+- ship only `light --default`
+- override the built-in `light` theme with Lomir's actual light palette
+
+This detail is important if the theme setup is revisited later.
+
+---
+
+## Files Involved
+
+The temporary suspension currently depends on these files:
+
+- `index.html`
+- `src/index.css`
+- `src/main.jsx`
+- `src/App.jsx`
+- `src/hooks/useTheme.js`
+- `tailwind.config.js`
+
+If dark mode work starts in the future, these are the first files to revisit.
+
+---
+
+## Known Limitations
+
+This solution is designed to suppress normal browser and operating-system dark mode behavior.
+
+It does not guarantee control over:
+
+- browser extensions that forcibly restyle websites
+- external tools that inject their own dark-mode CSS
+
+Within standard browser behavior, the app should remain light-only.
+
+---
+
+## How To Reintroduce Dark Mode Later
+
+Dark mode should only be reintroduced when a full dark design has been defined and tested for accessibility.
+
+Recommended approach:
+
+### 1. Keep the current light theme as the reference
+
+Do not change the current light palette unless intentionally redesigning it.
+
+### 2. Create a real dark theme in DaisyUI
+
+Add a dedicated dark theme with explicit dark values, for example via `daisyuiTheme(...)`.
+
+Important:
+
+- define all required semantic tokens explicitly
+- do not rely on browser defaults
+- do not rely on incomplete partial overrides
+
+### 3. Decide the product behavior for theme selection
+
+Choose one of these strategies:
+
+- manual toggle only
+- follow system preference
+- manual override plus optional system default
+
+If system preference is enabled, it should only happen after the dark theme has been fully tested.
+
+### 4. Remove the temporary light-only locks
+
+When proper dark mode is ready, revisit and update:
+
+- `index.html`
+  - remove or change `<meta name="color-scheme" content="only light" />`
+- `src/index.css`
+  - remove or change `color-scheme: only light`
+- `src/main.jsx`
+  - stop forcing `data-theme="light"`
+- `src/App.jsx`
+  - stop hardcoding `data-theme="light"`
+- `src/hooks/useTheme.js`
+  - restore real theme switching logic
+- `tailwind.config.js`
+  - allow both light and dark themes
+
+### 5. Test the dark theme systematically
+
+Before shipping, test at minimum:
+
+- Chrome, Firefox, Safari
+- light OS preference
+- dark OS preference
+- hard refresh / first paint behavior
+- forms, buttons, badges, notifications, cards, modals, tooltips
+- avatar fallbacks
+- semantic colors like success, warning, error, and info
+- contrast and readability on all major screens
+
+### 6. Consider persistence only after the UI is ready
+
+If user theme preference should be stored:
+
+- local storage is sufficient for a simple client-side preference
+- backend persistence is only needed if the preference should follow the user across devices
+
+---
+
+## Practical Reimplementation Checklist
+
+When dark mode work begins, use this checklist:
+
+1. Design the full dark token set first.
+2. Implement the dark theme in DaisyUI with explicit values.
+3. Re-enable real theme switching in `useTheme`.
+4. Remove the temporary light-only meta/CSS guards.
+5. Decide whether to support system preference, manual toggle, or both.
+6. Test all major surfaces in both themes.
+7. Verify that light mode still looks exactly the same as before.
+
+---
+
+## Summary
+
+Dark mode is currently suspended on purpose because the app does not yet have a complete, accessible, user-friendly dark theme.
+
+The current implementation forces Lomir to remain in its existing light-mode appearance by:
+
+- locking the document to light mode
+- locking browser UI to light mode
+- locking the app theme state to light mode
+- removing DaisyUI's automatic dark theme behavior
+- overriding DaisyUI's `light` theme with Lomir's actual light palette
+
+This ensures that users with dark-mode browser or OS preferences still see the normal Lomir light theme until a proper dark mode is ready.

--- a/index.html
+++ b/index.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="lomirlite">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
+    <!-- Temporarily suppress browser/device dark mode until Lomir has a proper dark theme. -->
+    <meta name="color-scheme" content="only light" />
     <link rel="icon" type="image/svg+xml" href="/Lomir-logowordmark-square-color.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,7 @@ function AppLayout() {
     <TeamModalProvider>
       <UserModalProvider>
         <div
-          data-theme="lomirlite"
+          data-theme="light"
           style={{
             backgroundImage: `url(${backgroundImage})`,
             backgroundSize: "cover",

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -6,8 +6,8 @@ import Colors from '../utils/Colors';
  * Provides access to colors and theme utilities
  */
 export function useTheme() {
-  // Get the current theme (for future dark/light mode toggle)
-  const [theme, setTheme] = useState('lomirlite');
+  // Keep the app in DaisyUI's light theme until the accessible dark mode is implemented.
+  const [theme, setTheme] = useState('light');
   
   // Function to set a custom CSS variable at runtime
   const setCustomColor = (name, value) => {
@@ -20,12 +20,11 @@ export function useTheme() {
       .getPropertyValue(`--${name}`).trim();
   };
   
-  // Toggle between themes (for future implementation)
+  // Dark mode is intentionally suspended until the proper accessible theme is ready.
+  // Keep this light-only safeguard in place until the future dark theme is fully implemented.
   const toggleTheme = () => {
-    const newTheme = theme === 'lomirlite' ? 'lomirdark' : 'lomirlite';
-    setTheme(newTheme);
-    document.documentElement.setAttribute('data-theme', newTheme);
-    // You could load different CSS variable values here
+    setTheme('light');
+    document.documentElement.setAttribute('data-theme', 'light');
   };
   
   // Initialize theme on component mount

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,9 @@
 }
 
 :root {
+  /* Keep browser-painted UI in light mode until the app has an accessible dark theme. */
+  color-scheme: only light;
+
   /* Primary Brand Colors */
   --color-primary: #009213;
   --color-primary-focus: #036b0c;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,7 +5,8 @@ import "./index.css";
 
 function RootWrapper() {
   React.useEffect(() => {
-    document.documentElement.setAttribute("data-theme", "lomirlite");
+    // Keep the app in DaisyUI's light theme until the real dark mode is implemented.
+    document.documentElement.setAttribute("data-theme", "light");
   }, []);
 
   return <App />;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,6 @@
+import daisyui from "daisyui";
+import daisyuiTheme from "daisyui/theme/index.js";
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
@@ -61,81 +64,38 @@ export default {
       "2xl": "1536px",
     },
   },
-  plugins: [require("daisyui")],
-  daisyui: {
-    themes: [
-      {
-        lomirlite: {
-          primary: "var(--color-primary)",
-          "primary-focus": "var(--color-primary-focus)",
-          "primary-content": "var(--color-primary-content)",
-
-          secondary: "#bbeabf",
-          "secondary-focus": "#7ace82",
-          "secondary-content": "var(--color-primary-focus)",
-
-          accent: "#7ace82",
-          neutral: "#3D4451",
-
-          "base-100": "var(--color-background)",
-          "base-200": "var(--color-background-soft)",
-          "base-300": "#F1F5F9",
-          "base-content": "var(--color-text)",
-
-          info: "var(--color-info)",
-          "info-content": "#ffffff",
-
-          success: "var(--color-success)",
-          "success-content": "#ffffff",
-
-          warning: "var(--color-warning)",
-          "warning-content": "#ffffff",
-
-          error: "var(--color-error)",
-          "error-content": "#ffffff",
-
-          "font-family": "'Roboto', sans-serif",
-          "text-primary": "var(--color-primary-focus)",
-        },
-      },
-      // Optional: Add a dark theme version here for future use
-      /* Uncomment when dark mode is implemented
-      {
-        lomirdark: {
-          "primary": "var(--color-primary)",
-          "primary-focus": "var(--color-primary-focus)",
-          "primary-content": "var(--color-primary-content)",
-
-          "secondary": "#262B42",
-          "secondary-focus": "#1F2235",
-          "secondary-content": "var(--color-primary-content)",
-
-          "accent": "#373F67",
-          "neutral": "#1A1E2C",
-
-          "base-100": "#1C1F2E",
-          "base-200": "#16192A",
-          "base-300": "#131625",
-          "base-content": "#EAEDF6",
-
-          "info": "var(--color-info)",
-          "info-content": "#ffffff",
-          
-          "success": "var(--color-success)",
-          "success-content": "#ffffff",
-          
-          "warning": "var(--color-warning)",
-          "warning-content": "#ffffff",
-          
-          "error": "var(--color-error)",
-          "error-content": "#ffffff",
-
-          "font-family": "'Roboto', sans-serif",
-          "text-primary": "var(--color-primary-focus)",
-        },
-      },
-      */
-    ],
-    defaultTheme: "lomirlite",
-  },
+  plugins: [
+    daisyui({
+      // Dark mode is intentionally suspended for now.
+      // Ship only DaisyUI's light theme so it does not generate a prefers-color-scheme dark override.
+      // Revisit this when a tested, accessible dark theme is ready to ship.
+      themes: ["light --default"],
+    }),
+    daisyuiTheme({
+      // Preserve the existing Lomir light palette while dark mode is suspended.
+      // We override DaisyUI's built-in light theme instead of using a separate dark-enabled theme setup.
+      name: "light",
+      default: true,
+      prefersdark: false,
+      "color-scheme": "only light",
+      "--color-base-100": "#ffffff",
+      "--color-base-200": "#f8fafc",
+      "--color-base-300": "#F1F5F9",
+      "--color-base-content": "#033f05",
+      "--color-primary": "#009213",
+      "--color-primary-content": "#ffffff",
+      "--color-secondary": "#bbeabf",
+      "--color-secondary-content": "#036b0c",
+      "--color-accent": "#7ace82",
+      "--color-neutral": "#3D4451",
+      "--color-info": "#766aea",
+      "--color-info-content": "#ffffff",
+      "--color-success": "#009213",
+      "--color-success-content": "#ffffff",
+      "--color-warning": "#df385b",
+      "--color-warning-content": "#ffffff",
+      "--color-error": "#df385b",
+      "--color-error-content": "#ffffff",
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary

This PR temporarily suspends dark mode in Lomir and forces the app to render in the existing light theme across browsers and OS/browser dark-mode preferences.

The reason for this temporary change is that the app does not yet have a complete, tested, accessible dark theme. In its previous state, automatic dark-mode behavior caused legibility and contrast issues and led to inconsistent styling across browsers.

## What Changed

- Forced the app to use DaisyUI's `light` theme at the document and app level
- Suppressed browser/device dark-mode behavior via `color-scheme: only light`
- Configured DaisyUI to ship only the light theme so it no longer generates an automatic dark fallback
- Overrode DaisyUI's built-in `light` theme with Lomir's actual light-mode palette so the app keeps the same colors as before
- Locked the current theme hook to `light` so unfinished dark-mode logic cannot be activated accidentally
- Added documentation under `docs/DARK_MODE_SUSPENSION.md`

## Why This Approach

The goal of this PR is not to redesign theming yet. The goal is to make sure that users with dark-mode preferences still see the exact same Lomir light-mode appearance until a proper dark theme is implemented.

This keeps the UI stable and avoids unreadable combinations like light text on light surfaces or missing semantic fills caused by incomplete dark styling.

## Scope

Frontend only.

No backend changes are required for this temporary suspension.

## Testing

- Verified that the app now stays in light mode in different browsers even when browser/OS dark mode is enabled
- Verified that Lomir-specific light-theme colors are preserved
- Confirmed that automatic DaisyUI dark-mode CSS is no longer generated
- Ran `npm run build` successfully

## Documentation

Added:
- `docs/DARK_MODE_SUSPENSION.md`

This document explains:
- why dark mode is currently suspended
- how the suspension is implemented
- which files are involved
- how proper dark mode can be reintroduced later

## Follow-Up

A future dark-mode PR should:
- define a full accessible dark token set
- re-enable real theme switching
- remove the temporary light-only guards
- test all major surfaces in both themes before shipping
