### PR TITLE
Feature/mark synth users

### DIFF
--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -27,6 +27,7 @@ const Card = ({
   viewMode = "card",
   clickTooltip = null,
   imageOverlay = null,
+  imageInnerOverlay = null,
   imageReplacement = null,
   listEdgeRounding = true,
 }) => {
@@ -83,7 +84,7 @@ const Card = ({
       >
         <div className="avatar placeholder relative">
           <div
-            className={`${shapeClass} ${sizeClass} flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}
+            className={`${shapeClass} ${sizeClass} relative flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}
           >
             {imageReplacement ? (
               imageReplacement
@@ -99,6 +100,7 @@ const Card = ({
                 {fallbackContent}
               </span>
             )}
+            {!imageReplacement && imageInnerOverlay}
           </div>
           {!imageReplacement && imageOverlay}
         </div>
@@ -206,7 +208,7 @@ const Card = ({
       >
         {(image || imageFallback || imageReplacement) && (
           <div className="avatar placeholder flex-shrink-0 relative">
-            <div className={`rounded-full w-9 h-9 flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}>
+            <div className={`rounded-full w-9 h-9 relative flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}>
               {imageReplacement ? (
                 imageReplacement
               ) : typeof image === "string" &&
@@ -228,6 +230,7 @@ const Card = ({
                       : "?")}
                 </span>
               )}
+              {!imageReplacement && imageInnerOverlay}
             </div>
             {!imageReplacement && imageOverlay}
           </div>

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -1,8 +1,13 @@
 import React from "react";
-import { Calendar, MapPin } from "lucide-react";
+import { Calendar, MapPin, FlaskConical } from "lucide-react";
 import { format } from "date-fns";
 import LocationDisplay from "./LocationDisplay";
-import { getUserInitials } from "../../utils/userHelpers";
+import Tooltip from "./Tooltip";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  isSyntheticUser,
+} from "../../utils/userHelpers";
 
 /**
  * PersonRequestCard Component
@@ -142,7 +147,8 @@ const PersonRequestCard = ({
           </h4>
 
           {/* Username (if different from display name) */}
-          {user?.username && getDisplayName() !== user.username && (
+          {user?.username &&
+            (getDisplayName() !== user.username || isSyntheticUser(user)) && (
             <p
               className={`text-sm text-base-content/70 ${clickableTextStyles}`}
               onClick={handleUserClick}
@@ -150,6 +156,15 @@ const PersonRequestCard = ({
             >
               @{user.username}
             </p>
+            )}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50 text-xs"
+            >
+              <FlaskConical className="h-3 w-auto mr-0.5 flex-shrink-0 mt-px" />
+              <span className="leading-[1.15]">Demo Profile</span>
+            </Tooltip>
           )}
 
           {/* Location if available and showLocation is true */}

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -8,6 +8,7 @@ import {
   getUserInitials,
   isSyntheticUser,
 } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
 /**
  * PersonRequestCard Component
@@ -108,7 +109,7 @@ const PersonRequestCard = ({
           onClick={handleUserClick}
           title={clickable ? "View profile" : undefined}
         >
-          <div className="w-12 h-12 rounded-full relative">
+          <div className="w-12 h-12 rounded-full relative overflow-hidden">
             {getAvatarUrl() ? (
               <img
                 src={getAvatarUrl()}
@@ -133,6 +134,7 @@ const PersonRequestCard = ({
                 {getUserInitials(user)}
               </span>
             </div>
+            {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[8px]" />}
           </div>
         </div>
 

--- a/src/components/users/DemoAvatarOverlay.jsx
+++ b/src/components/users/DemoAvatarOverlay.jsx
@@ -5,12 +5,15 @@ const DemoAvatarOverlay = ({
   textTranslateClassName = "-translate-y-[2px]",
 }) => {
   return (
-    <div className="absolute inset-x-0 bottom-0 z-10 h-[30%] bg-black/35 flex items-center justify-center pointer-events-none">
-      <span
-        className={`${textTranslateClassName} font-semibold uppercase tracking-[0.12em] leading-none text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.55)] ${textClassName}`}
-      >
-        Demo
-      </span>
+    <div className="absolute inset-0 z-10 pointer-events-none">
+      <div className="absolute inset-x-0 bottom-0 h-[30%] bg-gradient-to-t from-black/55 to-transparent" />
+      <div className="absolute inset-x-0 bottom-0 z-10 flex justify-center pb-[2px]">
+        <span
+          className={`${textTranslateClassName} font-semibold uppercase tracking-[0.12em] leading-none text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.55)] ${textClassName}`}
+        >
+          DEMO
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/components/users/DemoAvatarOverlay.jsx
+++ b/src/components/users/DemoAvatarOverlay.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const DemoAvatarOverlay = ({
+  textClassName = "text-[10px]",
+  textTranslateClassName = "-translate-y-[2px]",
+}) => {
+  return (
+    <div className="absolute inset-x-0 bottom-0 z-10 h-[30%] bg-black/35 flex items-center justify-center pointer-events-none">
+      <span
+        className={`${textTranslateClassName} font-semibold uppercase tracking-[0.12em] leading-none text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.55)] ${textClassName}`}
+      >
+        Demo
+      </span>
+    </div>
+  );
+};
+
+export default DemoAvatarOverlay;

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -214,7 +214,13 @@ const UserCard = ({
             ? "text-[9px]"
             : "text-[10px]"
       }
-      textTranslateClassName={viewMode === "list" ? "-translate-y-px" : undefined}
+      textTranslateClassName={
+        viewMode === "list"
+          ? "-translate-y-[2px]"
+          : viewMode === "mini"
+            ? "-translate-y-[4px]"
+            : "-translate-y-[4px]"
+      }
     />
   ) : null;
 

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -2,10 +2,24 @@ import React from "react";
 import Card from "../common/Card";
 import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
-import { Eye, EyeClosed, MapPin, Globe, Tag, Award, Ruler, User } from "lucide-react";
+import {
+  Eye,
+  EyeClosed,
+  MapPin,
+  Globe,
+  Tag,
+  Award,
+  Ruler,
+  User,
+  FlaskConical,
+} from "lucide-react";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
-import { getUserInitials } from "../../utils/userHelpers";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  isSyntheticUser,
+} from "../../utils/userHelpers";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
@@ -222,10 +236,24 @@ const UserCard = ({
         ? visibleBadges.join(", ") + (remainingBadges > 0 ? ` +${remainingBadges}` : "")
         : "";
 
-    const listSubtitle = (scoreSubtitleItem || user.username || shouldShowVisibilityIcon()) ? (
-      <span className="flex items-center gap-1">
+    const listSubtitle = (
+      scoreSubtitleItem ||
+      user.username ||
+      isSyntheticUser(user) ||
+      shouldShowVisibilityIcon()
+    ) ? (
+      <span className="flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden whitespace-nowrap text-base-content/60">
         {scoreSubtitleItem}
         {user.username && <span>@{user.username}</span>}
+        {isSyntheticUser(user) && (
+          <Tooltip
+            content={DEMO_PROFILE_TOOLTIP}
+            wrapperClassName="flex items-center gap-0.5 whitespace-nowrap text-base-content/50"
+          >
+            <FlaskConical className="h-[11px] w-auto flex-shrink-0" />
+            <span>Demo</span>
+          </Tooltip>
+        )}
         {shouldShowVisibilityIcon() && (
           <Tooltip content={isUserProfilePublic() ? "Public Profile - visible for everyone" : "Private Profile - only visible for you"}>
             {isUserProfilePublic() ? (
@@ -305,10 +333,23 @@ const UserCard = ({
       title={displayName()}
       subtitle={
         <span
-          className={`flex items-center flex-wrap text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-0.5 w-full" : "text-sm gap-1.5"}`}
+          className={`flex items-center flex-wrap leading-snug text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-px w-full" : "text-sm gap-x-1.5 gap-y-px"}`}
         >
           {scoreSubtitleItem}
           {user.username && <span>@{user.username}</span>}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50"
+            >
+              <FlaskConical
+                className={`w-auto mr-0.5 flex-shrink-0 ${viewMode === "mini" ? "h-3 mt-px" : "h-[13px] mt-px"}`}
+              />
+              <span className="leading-[1.15]">
+                {viewMode === "mini" ? "Demo" : "Demo Profile"}
+              </span>
+            </Tooltip>
+          )}
           {shouldShowVisibilityIcon() && (
             <Tooltip
               content={

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -20,6 +20,7 @@ import {
   getUserInitials,
   isSyntheticUser,
 } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "./DemoAvatarOverlay";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
@@ -204,6 +205,18 @@ const UserCard = ({
   ) : (
     matchOverlay
   );
+  const demoAvatarOverlay = isSyntheticUser(user) ? (
+    <DemoAvatarOverlay
+      textClassName={
+        viewMode === "list"
+          ? "text-[5px]"
+          : viewMode === "mini"
+            ? "text-[9px]"
+            : "text-[10px]"
+      }
+      textTranslateClassName={viewMode === "list" ? "-translate-y-px" : undefined}
+    />
+  ) : null;
 
   // ============ LIST VIEW ============
   if (viewMode === "list") {
@@ -278,6 +291,7 @@ const UserCard = ({
         className=""
         clickTooltip="Click to view User details"
         imageOverlay={avatarOverlay}
+        imageInnerOverlay={demoAvatarOverlay}
       >
         <div className="w-56 flex-shrink-0 flex items-center gap-3 overflow-hidden">
           <div className="w-16 flex-shrink-0 overflow-hidden">
@@ -414,6 +428,7 @@ const UserCard = ({
       }
       marginClassName={viewMode === "mini" ? "mb-2" : ""}
       imageOverlay={avatarOverlay}
+      imageInnerOverlay={demoAvatarOverlay}
     >
       {viewMode !== "mini" && (user.bio || user.biography) && (
         <p className="text-base-content/80 mb-4">

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -1,6 +1,17 @@
 import React, { useState } from "react";
-import { Eye, EyeClosed, Calendar, UserCheck } from "lucide-react";
-import { getUserInitials } from "../../utils/userHelpers";
+import Tooltip from "../common/Tooltip";
+import {
+  Eye,
+  EyeClosed,
+  Calendar,
+  UserCheck,
+  FlaskConical,
+} from "lucide-react";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  isSyntheticUser,
+} from "../../utils/userHelpers";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { format } from "date-fns";
 
@@ -122,6 +133,15 @@ const UserProfileHeaderSection = ({
         </h1>
         <div className="flex items-center flex-wrap gap-x-3 gap-y-0.5 text-sm">
           <span className="text-base-content/70">@{user?.username}</span>
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50 text-sm"
+            >
+              <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
+              <span className="leading-[1.15]">Demo Profile</span>
+            </Tooltip>
+          )}
 
           {filledRoleName && (
             <span className="flex items-center gap-1 text-base-content/70">

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -112,7 +112,12 @@ const UserProfileHeaderSection = ({
               <span className="text-2xl">{getUserInitials(user)}</span>
             </div>
           )}
-          {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[9px]" />}
+          {isSyntheticUser(user) && (
+            <DemoAvatarOverlay
+              textClassName="text-[9px]"
+              textTranslateClassName="-translate-y-[4px]"
+            />
+          )}
         </div>
         {matchTier && (
           <div

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -12,6 +12,7 @@ import {
   getUserInitials,
   isSyntheticUser,
 } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "./DemoAvatarOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { format } from "date-fns";
 
@@ -98,7 +99,7 @@ const UserProfileHeaderSection = ({
     <div className={`flex items-start space-x-4 ${className}`}>
       {/* Avatar */}
       <div className="avatar relative">
-        <div className="w-20 h-20 rounded-full">
+        <div className="w-20 h-20 rounded-full relative overflow-hidden">
           {getProfileImage() && !imageError ? (
             <img
               src={getProfileImage()}
@@ -111,6 +112,7 @@ const UserProfileHeaderSection = ({
               <span className="text-2xl">{getUserInitials(user)}</span>
             </div>
           )}
+          {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[9px]" />}
         </div>
         {matchTier && (
           <div

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -240,6 +240,14 @@ export const AuthProvider = ({ children }) => {
         newUser.is_public = userData.isPublic;
       }
 
+      if (userData.is_synthetic !== undefined) {
+        newUser.is_synthetic = userData.is_synthetic;
+        newUser.isSynthetic = userData.is_synthetic;
+      } else if (userData.isSynthetic !== undefined) {
+        newUser.isSynthetic = userData.isSynthetic;
+        newUser.is_synthetic = userData.isSynthetic;
+      }
+
       // Ensure we don't override with undefined values
       if (newUser.is_public === undefined && newUser.isPublic === undefined) {
         // Keep the existing values if both are undefined

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -44,6 +44,7 @@ import {
   getUserInitials,
   isSyntheticUser,
 } from "../utils/userHelpers";
+import DemoAvatarOverlay from "../components/users/DemoAvatarOverlay";
 import Modal from "../components/common/Modal";
 import LocationInput from "../components/common/LocationInput";
 import { format } from "date-fns";
@@ -950,7 +951,7 @@ const Profile = () => {
               {/* Avatar */}
               <div className="mb-4 md:mb-0 md:mr-8 flex-shrink-0">
                 <div className="avatar placeholder">
-                  <div className="bg-primary text-primary-content rounded-full w-32 h-32">
+                  <div className="bg-primary text-primary-content rounded-full w-32 h-32 relative overflow-hidden">
                     {(user.avatarUrl || user.avatar_url) && !imageError ? (
                       <img
                         src={user.avatarUrl || user.avatar_url}
@@ -961,6 +962,7 @@ const Profile = () => {
                     ) : (
                       <span className="text-4xl">{getUserInitials(user)}</span>
                     )}
+                    {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[11px]" />}
                   </div>
                 </div>
               </div>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -9,6 +9,7 @@ import Card from "../components/common/Card";
 import Button from "../components/common/Button";
 import DataDisplay from "../components/common/DataDisplay";
 import Alert from "../components/common/Alert";
+import Tooltip from "../components/common/Tooltip";
 import { uploadToImageKit } from "../config/imagekit";
 import {
   Mail,
@@ -21,6 +22,7 @@ import {
   Camera,
   Tag,
   Calendar,
+  FlaskConical,
 } from "lucide-react";
 import useAwardModals from "../hooks/useAwardModals";
 import { CATEGORY_COLORS } from "../constants/badgeConstants";
@@ -37,7 +39,11 @@ import LocationDisplay from "../components/common/LocationDisplay";
 import { geocodingService } from "../services/geocodingService";
 import { useLocationAutoFill } from "../hooks/useLocationAutoFill";
 import ImageUploader from "../components/common/ImageUploader";
-import { getUserInitials } from "../utils/userHelpers";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  isSyntheticUser,
+} from "../utils/userHelpers";
 import Modal from "../components/common/Modal";
 import LocationInput from "../components/common/LocationInput";
 import { format } from "date-fns";
@@ -970,6 +976,15 @@ const Profile = () => {
                 {/* Username, visibility, and date in one row */}
                 <div className="flex items-center text-base flex-wrap gap-x-4 gap-y-1">
                   <span className="text-base-content/70">@{user.username}</span>
+                  {isSyntheticUser(user) && (
+                    <Tooltip
+                      content={DEMO_PROFILE_TOOLTIP}
+                      wrapperClassName="flex items-start text-base-content/50"
+                    >
+                      <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
+                      <span className="leading-[1.15]">Demo Profile</span>
+                    </Tooltip>
+                  )}
                   <div
                     className="flex items-center text-base-content/70 tooltip tooltip-bottom tooltip-lomir cursor-help"
                     data-tip={

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -59,3 +59,15 @@ export const getDisplayName = (user) => {
   if (fullName.length > 0) return fullName;
   return user.username || "Unknown";
 };
+
+/**
+ * Check if a user is a synthetic/demo user
+ * Handles both snake_case (from API) and camelCase (from frontend state)
+ */
+export const isSyntheticUser = (user) => {
+  if (!user) return false;
+  return user.is_synthetic === true || user.isSynthetic === true;
+};
+
+export const DEMO_PROFILE_TOOLTIP =
+  "Demo Profile: For testing purposes, no real person";


### PR DESCRIPTION
## Summary

This PR adds clear but subtle frontend indicators for synthetic users ("demo profiles") so testers can distinguish them from real users without changing search behavior or API requests.

The UI now labels synthetic users in profile subtitles and on avatar images across the main user-related surfaces, while supporting both backend field formats: `is_synthetic` and `isSynthetic`.

## What changed

- Added a shared `isSyntheticUser(user)` helper in `src/utils/userHelpers.js`
- Added shared tooltip copy:
  - `Demo Profile: For testing purposes, no real person`
- Updated `AuthContext.updateUser` to keep `is_synthetic` and `isSynthetic` in sync
- Added inline demo indicators with `FlaskConical` icon in:
  - user cards
  - user profile header modals
  - person request/application cards
  - profile page view mode
- Added a reusable `DemoAvatarOverlay` component for synthetic user avatars
- Extended the shared `Card` component with `imageInnerOverlay` so avatar overlays can render inside the clipped round image
- Added a subtle bottom gradient overlay plus `DEMO` label on synthetic user avatars
- Tuned subtitle spacing, icon alignment, and overlay positioning for:
  - list view
  - mini card view
  - regular card view
  - user detail modals

## UX details

- Synthetic users are labeled, not filtered out
- The indicator is intentionally calm and non-warning in style
- List and mini card subtitle labels use the shorter `Demo` text
- Full card/profile surfaces use `Demo Profile`
- Avatar overlays stay clipped to the circular image shape

## Testing

- `npm run build`
- Targeted ESLint on changed files/components
