### PR TITLE
Add demo indicators for synthetic teams

### DIFF
--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -18,6 +18,7 @@ import {
   MapPin,
   Ruler,
   Calendar,
+  FlaskConical,
 } from "lucide-react";
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
@@ -38,6 +39,8 @@ import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import { calculateDistanceKm } from "../../utils/locationUtils";
+import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
 const teamMemberBadgesCache = new Map();
 const viewerRoleProfileCache = new Map();
@@ -1851,6 +1854,24 @@ const TeamCard = ({
   ) : (
     matchOverlay
   );
+  const demoAvatarOverlay = isSyntheticTeam(teamData) ? (
+    <DemoAvatarOverlay
+      textClassName={
+        viewMode === "list"
+          ? "text-[5px]"
+          : viewMode === "mini"
+            ? "text-[9px]"
+            : "text-[10px]"
+      }
+      textTranslateClassName={
+        viewMode === "list"
+          ? "-translate-y-[2px]"
+          : viewMode === "mini"
+            ? "-translate-y-[4px]"
+            : "-translate-y-[4px]"
+      }
+    />
+  ) : null;
 
   // ============ LIST VIEW ============
 
@@ -2030,6 +2051,15 @@ const TeamCard = ({
             )}
           </Tooltip>
         )}
+        {isSyntheticTeam(teamData) && (
+          <Tooltip
+            content={DEMO_TEAM_TOOLTIP}
+            wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
+          >
+            <FlaskConical size={11} className="flex-shrink-0" />
+            <span>Demo Team</span>
+          </Tooltip>
+        )}
       </span>
     );
 
@@ -2047,6 +2077,7 @@ const TeamCard = ({
           className={listClassName}
           clickTooltip={cardClickTooltip}
           imageOverlay={avatarOverlay}
+          imageInnerOverlay={demoAvatarOverlay}
           listEdgeRounding={!disableListEdgeRounding}
       >
           <div
@@ -2510,6 +2541,19 @@ const TeamCard = ({
               </Tooltip>
             )}
 
+            {isSyntheticTeam(teamData) && (
+              <Tooltip
+                content={DEMO_TEAM_TOOLTIP}
+                wrapperClassName="flex items-center gap-1 text-base-content/50"
+              >
+                <FlaskConical
+                  size={viewMode === "mini" ? 12 : 14}
+                  className="flex-shrink-0"
+                />
+                <span>Demo Team</span>
+              </Tooltip>
+            )}
+
             {/* Pending role application indicator */}
             {!shouldMoveSearchResultRoleApplicationIndicator &&
               isPendingRoleApplicationForTeam && (
@@ -2606,6 +2650,7 @@ const TeamCard = ({
         }
         marginClassName={viewMode === "mini" ? "mb-2" : ""}
         imageOverlay={avatarOverlay}
+        imageInnerOverlay={demoAvatarOverlay}
       >
         {reminderNotice && (
           <Alert

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -14,6 +14,7 @@ import { userService } from "../../services/userService";
 import Button from "../common/Button";
 import SendMessageButton from "../common/SendMessageButton";
 import Alert from "../common/Alert";
+import Tooltip from "../common/Tooltip";
 import TagDisplay from "../common/TagDisplay";
 import LocationDisplay from "../common/LocationDisplay";
 import { uploadToImageKit } from "../../config/imagekit";
@@ -30,9 +31,11 @@ import {
   SendHorizontal,
   Archive,
   Check,
+  FlaskConical,
 } from "lucide-react";
 import VisibilityToggle from "../common/VisibilityToggle";
 import UserDetailsModal from "../users/UserDetailsModal";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import TagsDisplaySection from "../tags/TagsDisplaySection";
 import { UI_TEXT } from "../../constants/uiText";
 import { tagService } from "../../services/tagService";
@@ -57,6 +60,7 @@ import {
 } from "../../utils/teamMatchUtils";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { calculateDistanceKm } from "../../utils/locationUtils";
+import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
 
 const normalizeTeamTagIds = (team) => {
   const raw = team?.tags ?? team?.tags_json ?? team?.selectedTags ?? [];
@@ -1419,7 +1423,7 @@ const TeamDetailsModal = ({
                 {/* Team header with avatar */}
                 <div className="flex items-start space-x-4 mb-6">
                   <div className="avatar placeholder relative">
-                    <div className="bg-primary text-primary-content rounded-full w-16 h-16 flex items-center justify-center">
+                    <div className="bg-primary text-primary-content rounded-full w-16 h-16 relative flex items-center justify-center overflow-hidden">
                       {(team?.teamavatar_url || team?.teamavatarUrl) &&
                       !teamImageError ? (
                         <img
@@ -1430,6 +1434,12 @@ const TeamDetailsModal = ({
                         />
                       ) : (
                         <span className="text-xl">{getTeamInitials()}</span>
+                      )}
+                      {isSyntheticTeam(team) && (
+                        <DemoAvatarOverlay
+                          textClassName="text-[9px]"
+                          textTranslateClassName="-translate-y-[4px]"
+                        />
                       )}
                     </div>
                     {teamMatchTier && (
@@ -1496,6 +1506,16 @@ const TeamDetailsModal = ({
                             )}
                           </div>
                         )}
+
+                      {isSyntheticTeam(team) && (
+                        <Tooltip
+                          content={DEMO_TEAM_TOOLTIP}
+                          wrapperClassName="flex items-center gap-1 text-base-content/50 text-sm"
+                        >
+                          <FlaskConical size={14} className="flex-shrink-0" />
+                          <span>Demo Team</span>
+                        </Tooltip>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -69,5 +69,17 @@ export const isSyntheticUser = (user) => {
   return user.is_synthetic === true || user.isSynthetic === true;
 };
 
+/**
+ * Check if a team is a synthetic/demo team
+ * Handles both snake_case (from API) and camelCase (from frontend state)
+ */
+export const isSyntheticTeam = (team) => {
+  if (!team) return false;
+  return team.is_synthetic === true || team.isSynthetic === true;
+};
+
 export const DEMO_PROFILE_TOOLTIP =
   "Demo Profile: For testing purposes, no real person";
+
+export const DEMO_TEAM_TOOLTIP =
+  "Demo Team: for testing purposes, no real team";


### PR DESCRIPTION
## Summary

This PR adds frontend demo indicators for synthetic teams so testers can clearly distinguish demo teams from real ones without changing any search or fetch behavior.

Synthetic teams now show:
- an inline `FlaskConical + Demo Team` indicator in team sublines
- a `DEMO` overlay on the team avatar image
- a tooltip explaining that the team is only for testing

## What changed

- Added `isSyntheticTeam(team)` in `src/utils/userHelpers.js`
- Added shared tooltip text:
  - `Demo Team: for testing purposes, no real team`
- Updated `TeamCard` to show the demo-team indicator in:
  - list view
  - card view
  - mini card view
- Updated `TeamCard` to reuse the existing avatar `DEMO` overlay for synthetic teams in:
  - list view
  - card view
  - mini card view
- Updated `TeamDetailsModal` to show:
  - the inline `Demo Team` indicator in the header/meta row
  - the same avatar `DEMO` overlay on the team image

## Notes

- This only labels synthetic teams; it does not hide or filter them
- No API calls or fetch logic were changed
- The team indicator matches the existing demo-user pattern visually and behaviorally

## Testing

- `npm run build`
