### PR TITLE
Visual indicators for synthetic/demo data

### DIFF
--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -1,13 +1,21 @@
 import React, { useState, useEffect, useRef } from "react";
-import { getTeamInitials } from "../../utils/userHelpers";
+import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
 import { formatDistanceToNow } from "date-fns";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import UserAvatar from "../users/UserAvatar";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import {
   DELETED_USER_DISPLAY_NAME,
   getDisplayName as getDeletedUserDisplayName,
 } from "../../utils/deletedUser";
+import {
+  getCachedChatTeamProfile,
+  getCachedChatUserProfile,
+  getTeamAvatarUrl,
+  mergeResolvedTeamData,
+  mergeResolvedUserData,
+} from "../../utils/chatEntityResolvers";
 
 const ConversationList = ({
   conversations,
@@ -26,6 +34,8 @@ const ConversationList = ({
   // State for user details modal
   const [isUserModalOpen, setIsUserModalOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
+  const [resolvedConversationUsers, setResolvedConversationUsers] = useState({});
+  const [resolvedConversationTeams, setResolvedConversationTeams] = useState({});
 
   // Ref for the active conversation item
   const activeConversationRef = useRef(null);
@@ -43,6 +53,102 @@ const ConversationList = ({
       return () => clearTimeout(timer);
     }
   }, [activeConversationId]);
+
+  useEffect(() => {
+    const userIdsToFetch = [];
+    const teamIdsToFetch = [];
+
+    conversations.forEach((conversation) => {
+      if (conversation.type === "team") {
+        const team = conversation.team;
+        const teamId = team?.id ?? conversation.id;
+
+        if (
+          teamId != null &&
+          (!getTeamAvatarUrl(team) ||
+            (team?.is_synthetic == null && team?.isSynthetic == null))
+        ) {
+          teamIdsToFetch.push(teamId);
+        }
+
+        return;
+      }
+
+      const partner = conversation.partner || conversation.partnerUser;
+      const userId = partner?.id;
+
+      if (
+        userId != null &&
+        (!(partner?.avatar_url || partner?.avatarUrl) ||
+          (partner?.is_synthetic == null && partner?.isSynthetic == null))
+      ) {
+        userIdsToFetch.push(userId);
+      }
+    });
+
+    const uniqueUserIds = [...new Set(userIdsToFetch)];
+    const uniqueTeamIds = [...new Set(teamIdsToFetch)];
+
+    if (uniqueUserIds.length === 0 && uniqueTeamIds.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    if (uniqueUserIds.length > 0) {
+      Promise.allSettled(
+        uniqueUserIds.map(async (userId) => ({
+          userId,
+          profile: await getCachedChatUserProfile(userId),
+        })),
+      ).then((results) => {
+        if (cancelled) return;
+
+        const fetchedProfiles = {};
+
+        results.forEach((result) => {
+          if (result.status !== "fulfilled") return;
+          fetchedProfiles[String(result.value.userId)] = result.value.profile;
+        });
+
+        if (Object.keys(fetchedProfiles).length > 0) {
+          setResolvedConversationUsers((prev) => ({
+            ...prev,
+            ...fetchedProfiles,
+          }));
+        }
+      });
+    }
+
+    if (uniqueTeamIds.length > 0) {
+      Promise.allSettled(
+        uniqueTeamIds.map(async (teamId) => ({
+          teamId,
+          profile: await getCachedChatTeamProfile(teamId),
+        })),
+      ).then((results) => {
+        if (cancelled) return;
+
+        const fetchedProfiles = {};
+
+        results.forEach((result) => {
+          if (result.status !== "fulfilled") return;
+          fetchedProfiles[String(result.value.teamId)] = result.value.profile;
+        });
+
+        if (Object.keys(fetchedProfiles).length > 0) {
+          setResolvedConversationTeams((prev) => ({
+            ...prev,
+            ...fetchedProfiles,
+          }));
+        }
+      });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [conversations]);
 
   useEffect(() => {
     if (
@@ -114,9 +220,25 @@ const ConversationList = ({
         {conversations.map((conversation) => {
           // Handle both direct messages and team conversations
           const isTeam = conversation.type === "team";
-          const conversationData = isTeam
+          const rawConversationData = isTeam
             ? conversation.team
             : conversation.partner || conversation.partnerUser;
+          const conversationEntityId = isTeam
+            ? rawConversationData?.id ?? conversation.id
+            : rawConversationData?.id;
+          const conversationData = isTeam
+            ? mergeResolvedTeamData(
+                rawConversationData,
+                conversationEntityId != null
+                  ? resolvedConversationTeams[String(conversationEntityId)]
+                  : null,
+              )
+            : mergeResolvedUserData(
+                rawConversationData,
+                conversationEntityId != null
+                  ? resolvedConversationUsers[String(conversationEntityId)]
+                  : null,
+              );
           const directDisplayName = isTeam
             ? ""
             : getDeletedUserDisplayName(conversationData, "");
@@ -172,10 +294,10 @@ const ConversationList = ({
                   }
                 >
                   {isTeam ? (
-                    <div className="w-12 h-12 rounded-full relative">
-                      {conversationData?.avatarUrl ? (
+                    <div className="w-12 h-12 rounded-full relative overflow-hidden">
+                      {getTeamAvatarUrl(conversationData) ? (
                         <img
-                          src={conversationData.avatarUrl}
+                          src={getTeamAvatarUrl(conversationData)}
                           alt={displayName}
                           className="object-cover w-full h-full rounded-full"
                           onError={(e) => {
@@ -191,13 +313,18 @@ const ConversationList = ({
                       <div
                         className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                         style={{
-                          display: conversationData?.avatarUrl ? "none" : "flex",
+                          display: getTeamAvatarUrl(conversationData)
+                            ? "none"
+                            : "flex",
                         }}
                       >
                         <span className="text-lg font-medium">
                           {getTeamInitials(conversationData)}
                         </span>
                       </div>
+                      {isSyntheticTeam(conversationData) && (
+                        <DemoAvatarOverlay textClassName="text-[7px]" />
+                      )}
                     </div>
                   ) : (
                     <UserAvatar
@@ -206,6 +333,9 @@ const ConversationList = ({
                       sizeClass="w-12 h-12"
                       iconSize={24}
                       initialsClassName="text-lg font-medium"
+                      showDemoOverlay
+                      demoOverlayTextClassName="text-[7px]"
+                      demoOverlayTextTranslateClassName="-translate-y-[2px]"
                     />
                   )}
                   {isOnline && (

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -1,6 +1,9 @@
 import React, { useRef, useEffect, useState } from "react";
 import { format, isToday, isYesterday } from "date-fns";
-import { getUserInitials, getTeamInitials } from "../../utils/userHelpers";
+import {
+  getTeamInitials,
+  isSyntheticTeam,
+} from "../../utils/userHelpers";
 import {
   UserPlus,
   UserMinus,
@@ -20,6 +23,7 @@ import {
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import UserAvatar from "../users/UserAvatar";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { userService } from "../../services/userService";
 import {
   getFileExpirationStatus,
@@ -30,6 +34,13 @@ import {
   DELETED_USER_DISPLAY_NAME,
   getDisplayName as getDeletedUserDisplayName,
 } from "../../utils/deletedUser";
+import {
+  getCachedChatTeamProfile,
+  getCachedChatUserProfile,
+  getTeamAvatarUrl,
+  mergeResolvedTeamData,
+  mergeResolvedUserData,
+} from "../../utils/chatEntityResolvers";
 
 const parseIdNameToken = (token) => {
   const t = (token || "").trim();
@@ -418,6 +429,8 @@ const MessageDisplay = ({
   const [nameResolveError, setNameResolveError] = useState(null);
 
   const [nameToIdCache, setNameToIdCache] = useState({});
+  const [resolvedChatUsers, setResolvedChatUsers] = useState({});
+  const [resolvedChatTeams, setResolvedChatTeams] = useState({});
 
   useEffect(() => {
     const previousSnapshot = previousMessageSnapshotRef.current;
@@ -474,6 +487,96 @@ const MessageDisplay = ({
     teamMembersRefreshSignal,
   ]);
 
+  useEffect(() => {
+    const userIdsToFetch = [];
+
+    if (
+      conversationPartner?.id != null &&
+      !conversationPartner?.isDeletedUser &&
+      (!(conversationPartner?.avatar_url || conversationPartner?.avatarUrl) ||
+        (conversationPartner?.is_synthetic == null &&
+          conversationPartner?.isSynthetic == null))
+    ) {
+      userIdsToFetch.push(conversationPartner.id);
+    }
+
+    (teamMembers || []).forEach((member) => {
+      const memberId = member?.user_id ?? member?.userId ?? null;
+      if (memberId == null) return;
+
+      if (
+        !(member?.avatar_url || member?.avatarUrl) ||
+        (member?.is_synthetic == null && member?.isSynthetic == null)
+      ) {
+        userIdsToFetch.push(memberId);
+      }
+    });
+
+    const uniqueUserIds = [...new Set(userIdsToFetch)];
+
+    if (uniqueUserIds.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    Promise.allSettled(
+      uniqueUserIds.map(async (userId) => ({
+        userId,
+        profile: await getCachedChatUserProfile(userId),
+      })),
+    ).then((results) => {
+      if (cancelled) return;
+
+      const fetchedProfiles = {};
+
+      results.forEach((result) => {
+        if (result.status !== "fulfilled") return;
+        fetchedProfiles[String(result.value.userId)] = result.value.profile;
+      });
+
+      if (Object.keys(fetchedProfiles).length > 0) {
+        setResolvedChatUsers((prev) => ({
+          ...prev,
+          ...fetchedProfiles,
+        }));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationPartner, teamMembers]);
+
+  useEffect(() => {
+    const teamId = teamData?.id;
+
+    if (
+      teamId == null ||
+      (getTeamAvatarUrl(teamData) &&
+        (teamData?.is_synthetic != null || teamData?.isSynthetic != null))
+    ) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    getCachedChatTeamProfile(teamId)
+      .then((profile) => {
+        if (!cancelled) {
+          setResolvedChatTeams((prev) => ({
+            ...prev,
+            [String(teamId)]: profile,
+          }));
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [teamData]);
+
   // Handle team avatar/name click
   const handleTeamClick = () => {
     if (conversationType !== "team") return;
@@ -519,6 +622,24 @@ const MessageDisplay = ({
     setIsUserModalOpen(false);
     setSelectedUserId(null);
   };
+
+  const resolvedConversationPartner = mergeResolvedUserData(
+    conversationPartner,
+    conversationPartner?.id != null
+      ? resolvedChatUsers[String(conversationPartner.id)]
+      : null,
+  );
+
+  const resolvedTeamData = mergeResolvedTeamData(
+    teamData,
+    teamData?.id != null ? resolvedChatTeams[String(teamData.id)] : null,
+  );
+
+  const getResolvedUserData = (userData, userId = null) =>
+    mergeResolvedUserData(
+      userData,
+      userId != null ? resolvedChatUsers[String(userId)] : null,
+    );
 
   const getTeamMemberFullName = (m) => {
     const first = m.first_name ?? m.firstName;
@@ -694,7 +815,8 @@ const MessageDisplay = ({
       );
 
       if (member) {
-        return {
+        return getResolvedUserData(
+          {
           id: member.user_id || member.userId || senderId,
           username: member.username,
           firstName: member.first_name || member.firstName,
@@ -702,13 +824,15 @@ const MessageDisplay = ({
           avatarUrl: member.avatar_url || member.avatarUrl,
           isCurrentMember: true,
           isDeletedUser: false,
-        };
+          },
+          member.user_id || member.userId || senderId,
+        );
       }
     }
 
-    if (conversationPartner && senderId === conversationPartner.id) {
+    if (resolvedConversationPartner && senderId === resolvedConversationPartner.id) {
       return {
-        ...conversationPartner,
+        ...resolvedConversationPartner,
         isCurrentMember: true,
         isDeletedUser: false,
       };
@@ -735,10 +859,13 @@ const MessageDisplay = ({
         embeddedSender.id == null || !embeddedSender.username;
 
       if (hasMessageSenderInfo || isDeletedSender) {
-        return {
-          ...embeddedSender,
-          isDeletedUser: isDeletedSender,
-        };
+        return getResolvedUserData(
+          {
+            ...embeddedSender,
+            isDeletedUser: isDeletedSender,
+          },
+          embeddedSender.id,
+        );
       }
     }
 
@@ -797,6 +924,9 @@ const MessageDisplay = ({
           }
           iconSize={16}
           initialsClassName="text-sm font-medium event-message-text"
+          showDemoOverlay
+          demoOverlayTextClassName="text-[5px]"
+          demoOverlayTextTranslateClassName="-translate-y-[1px]"
         />
       );
     }
@@ -856,6 +986,73 @@ const MessageDisplay = ({
         }
       >
         {displayName}
+      </div>
+    );
+  };
+
+  const renderConversationPartnerAvatar = () => {
+    if (!resolvedConversationPartner) return null;
+
+    return (
+      <UserAvatar
+        user={resolvedConversationPartner}
+        sizeClass="w-16 h-16"
+        className="mb-2 mx-auto"
+        clickable
+        onClick={() => handleUserClick(resolvedConversationPartner.id)}
+        title={`View ${
+          resolvedConversationPartner.firstName ||
+          resolvedConversationPartner.username
+        } details`}
+        iconSize={24}
+        initialsClassName="text-xl font-medium"
+        showDemoOverlay
+        demoOverlayTextClassName="text-[9px]"
+        demoOverlayTextTranslateClassName="-translate-y-[4px]"
+      />
+    );
+  };
+
+  const renderTeamConversationAvatar = () => {
+    if (!resolvedTeamData) return null;
+
+    const teamAvatarUrl = getTeamAvatarUrl(resolvedTeamData);
+
+    return (
+      <div
+        className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
+        onClick={handleTeamClick}
+        title={`View ${resolvedTeamData.name} details`}
+      >
+        <div className="w-16 h-16 rounded-full mx-auto relative overflow-hidden">
+          {teamAvatarUrl ? (
+            <img
+              src={teamAvatarUrl}
+              alt={resolvedTeamData.name}
+              className="object-cover w-full h-full rounded-full"
+              onError={(e) => {
+                e.target.style.display = "none";
+                const fallback =
+                  e.target.parentElement.querySelector(".avatar-fallback");
+                if (fallback) fallback.style.display = "flex";
+              }}
+            />
+          ) : null}
+          <div
+            className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+            style={{ display: teamAvatarUrl ? "none" : "flex" }}
+          >
+            <span className="text-xl font-medium">
+              {getTeamInitials(resolvedTeamData)}
+            </span>
+          </div>
+          {isSyntheticTeam(resolvedTeamData) && (
+            <DemoAvatarOverlay
+              textClassName="text-[9px]"
+              textTranslateClassName="-translate-y-[4px]"
+            />
+          )}
+        </div>
       </div>
     );
   };
@@ -2006,96 +2203,34 @@ const MessageDisplay = ({
             <div className="mb-2 text-sm text-warning">{nameResolveError}</div>
           )}
 
-          {conversationPartner && conversationType === "direct" && (
+          {resolvedConversationPartner && conversationType === "direct" && (
             <div className="text-center pb-4 mb-4 border-b border-base-200">
-              <div
-                className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
-                onClick={() => handleUserClick(conversationPartner.id)}
-                title={`View ${
-                  conversationPartner.firstName || conversationPartner.username
-                } details`}
-              >
-                <div className="w-16 h-16 rounded-full mx-auto relative">
-                  {conversationPartner.avatarUrl ? (
-                    <img
-                      src={conversationPartner.avatarUrl}
-                      alt={conversationPartner.username}
-                      className="object-cover w-full h-full rounded-full"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        const fallback =
-                          e.target.parentElement.querySelector(
-                            ".avatar-fallback",
-                          );
-                        if (fallback) fallback.style.display = "flex";
-                      }}
-                    />
-                  ) : null}
-                  <div
-                    className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                    style={{
-                      display: conversationPartner.avatarUrl ? "none" : "flex",
-                    }}
-                  >
-                    <span className="text-xl font-medium">
-                      {getUserInitials(conversationPartner)}
-                    </span>
-                  </div>
-                </div>
-              </div>
+              {renderConversationPartnerAvatar()}
               <h3
                 className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
-                onClick={() => handleUserClick(conversationPartner.id)}
+                onClick={() => handleUserClick(resolvedConversationPartner.id)}
                 title={`View ${
-                  conversationPartner.firstName || conversationPartner.username
+                  resolvedConversationPartner.firstName ||
+                  resolvedConversationPartner.username
                 } details`}
               >
-                {conversationPartner.firstName && conversationPartner.lastName
-                  ? `${conversationPartner.firstName} ${conversationPartner.lastName}`
-                  : conversationPartner.username}
+                {resolvedConversationPartner.firstName &&
+                resolvedConversationPartner.lastName
+                  ? `${resolvedConversationPartner.firstName} ${resolvedConversationPartner.lastName}`
+                  : resolvedConversationPartner.username}
               </h3>
             </div>
           )}
 
-          {teamData && conversationType === "team" && (
+          {resolvedTeamData && conversationType === "team" && (
             <div className="text-center pb-4 mb-4 border-b border-base-200">
-              <div
-                className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
-                onClick={handleTeamClick}
-                title={`View ${teamData.name} details`}
-              >
-                <div className="w-16 h-16 rounded-full mx-auto relative">
-                  {teamData.avatarUrl ? (
-                    <img
-                      src={teamData.avatarUrl}
-                      alt={teamData.name}
-                      className="object-cover w-full h-full rounded-full"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        const fallback =
-                          e.target.parentElement.querySelector(
-                            ".avatar-fallback",
-                          );
-                        if (fallback) fallback.style.display = "flex";
-                      }}
-                    />
-                  ) : null}
-                  <div
-                    className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                    style={{ display: teamData.avatarUrl ? "none" : "flex" }}
-                  >
-                    <span className="text-xl font-medium">
-                      {getTeamInitials(teamData)}
-                    </span>
-                  </div>
-                </div>
-              </div>
+              {renderTeamConversationAvatar()}
               <h3
                 className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
                 onClick={handleTeamClick}
-                title={`View ${teamData.name} details`}
+                title={`View ${resolvedTeamData.name} details`}
               >
-                {teamData.name}
+                {resolvedTeamData.name}
               </h3>
             </div>
           )}
@@ -2174,97 +2309,35 @@ const MessageDisplay = ({
         )}
 
         {/* Show conversation partner header for direct messages - CLICKABLE */}
-        {conversationPartner && conversationType === "direct" && (
+        {resolvedConversationPartner && conversationType === "direct" && (
           <div className="text-center pb-4 mb-4 border-b border-base-200">
-            <div
-              className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
-              onClick={() => handleUserClick(conversationPartner.id)}
-              title={`View ${
-                conversationPartner.firstName || conversationPartner.username
-              } details`}
-            >
-              <div className="w-16 h-16 rounded-full mx-auto relative">
-                {conversationPartner.avatarUrl ? (
-                  <img
-                    src={conversationPartner.avatarUrl}
-                    alt={conversationPartner.username}
-                    className="object-cover w-full h-full rounded-full"
-                    onError={(e) => {
-                      e.target.style.display = "none";
-                      const fallback =
-                        e.target.parentElement.querySelector(
-                          ".avatar-fallback",
-                        );
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                ) : null}
-                <div
-                  className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                  style={{
-                    display: conversationPartner.avatarUrl ? "none" : "flex",
-                  }}
-                >
-                  <span className="text-xl font-medium">
-                    {getUserInitials(conversationPartner)}
-                  </span>
-                </div>
-              </div>
-            </div>
+            {renderConversationPartnerAvatar()}
             <h3
               className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
-              onClick={() => handleUserClick(conversationPartner.id)}
+              onClick={() => handleUserClick(resolvedConversationPartner.id)}
               title={`View ${
-                conversationPartner.firstName || conversationPartner.username
+                resolvedConversationPartner.firstName ||
+                resolvedConversationPartner.username
               } details`}
             >
-              {conversationPartner.firstName && conversationPartner.lastName
-                ? `${conversationPartner.firstName} ${conversationPartner.lastName}`
-                : conversationPartner.username}
+              {resolvedConversationPartner.firstName &&
+              resolvedConversationPartner.lastName
+                ? `${resolvedConversationPartner.firstName} ${resolvedConversationPartner.lastName}`
+                : resolvedConversationPartner.username}
             </h3>
           </div>
         )}
 
         {/* Show team header for team conversations - CLICKABLE */}
-        {teamData && conversationType === "team" && (
+        {resolvedTeamData && conversationType === "team" && (
           <div className="text-center pb-4 mb-4 border-b border-base-200">
-            <div
-              className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
-              onClick={handleTeamClick}
-              title={`View ${teamData.name} details`}
-            >
-              <div className="w-16 h-16 rounded-full mx-auto relative">
-                {teamData.avatarUrl ? (
-                  <img
-                    src={teamData.avatarUrl}
-                    alt={teamData.name}
-                    className="object-cover w-full h-full rounded-full"
-                    onError={(e) => {
-                      e.target.style.display = "none";
-                      const fallback =
-                        e.target.parentElement.querySelector(
-                          ".avatar-fallback",
-                        );
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                ) : null}
-                <div
-                  className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                  style={{ display: teamData.avatarUrl ? "none" : "flex" }}
-                >
-                  <span className="text-xl font-medium">
-                    {getTeamInitials(teamData)}
-                  </span>
-                </div>
-              </div>
-            </div>
+            {renderTeamConversationAvatar()}
             <h3
               className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
               onClick={handleTeamClick}
-              title={`View ${teamData.name} details`}
+              title={`View ${resolvedTeamData.name} details`}
             >
-              {teamData.name}
+              {resolvedTeamData.name}
             </h3>
           </div>
         )}

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -96,6 +96,10 @@ const PersonRequestCard = ({
   const clickableTextStyles = clickable
     ? "cursor-pointer hover:text-primary transition-colors"
     : "";
+  const showUsername =
+    user?.username &&
+    (getDisplayName() !== user.username || isSyntheticUser(user));
+  const showDemoProfile = isSyntheticUser(user);
 
   // ============ Render ============
 
@@ -148,17 +152,28 @@ const PersonRequestCard = ({
             {getDisplayName()}
           </h4>
 
-          {/* Username (if different from display name) */}
-          {user?.username &&
-            (getDisplayName() !== user.username || isSyntheticUser(user)) && (
-            <p
-              className={`text-sm text-base-content/70 ${clickableTextStyles}`}
-              onClick={handleUserClick}
-              title={clickable ? "View profile" : undefined}
-            >
-              @{user.username}
-            </p>
-            )}
+          {(showUsername || showDemoProfile) && (
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              {showUsername && (
+                <p
+                  className={`text-xs text-base-content/70 ${clickableTextStyles}`}
+                  onClick={handleUserClick}
+                  title={clickable ? "View profile" : undefined}
+                >
+                  @{user.username}
+                </p>
+              )}
+              {showDemoProfile && (
+                <Tooltip
+                  content={DEMO_PROFILE_TOOLTIP}
+                  wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+                >
+                  <FlaskConical size={12} className="flex-shrink-0" />
+                  <span>Demo Profile</span>
+                </Tooltip>
+              )}
+            </div>
+          )}
 
           {/* Location if available and showLocation is true */}
           {showLocation && getPostalCode() && (
@@ -173,15 +188,6 @@ const PersonRequestCard = ({
                 displayType="short"
               />
             </div>
-          )}
-          {isSyntheticUser(user) && (
-            <Tooltip
-              content={DEMO_PROFILE_TOOLTIP}
-              wrapperClassName="flex items-start text-base-content/50 text-xs"
-            >
-              <FlaskConical className="h-3 w-auto mr-0.5 flex-shrink-0 mt-px" />
-              <span className="leading-[1.15]">Demo Profile</span>
-            </Tooltip>
           )}
         </div>
 

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -159,15 +159,6 @@ const PersonRequestCard = ({
               @{user.username}
             </p>
             )}
-          {isSyntheticUser(user) && (
-            <Tooltip
-              content={DEMO_PROFILE_TOOLTIP}
-              wrapperClassName="flex items-start text-base-content/50 text-xs"
-            >
-              <FlaskConical className="h-3 w-auto mr-0.5 flex-shrink-0 mt-px" />
-              <span className="leading-[1.15]">Demo Profile</span>
-            </Tooltip>
-          )}
 
           {/* Location if available and showLocation is true */}
           {showLocation && getPostalCode() && (
@@ -182,6 +173,15 @@ const PersonRequestCard = ({
                 displayType="short"
               />
             </div>
+          )}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50 text-xs"
+            >
+              <FlaskConical className="h-3 w-auto mr-0.5 flex-shrink-0 mt-px" />
+              <span className="leading-[1.15]">Demo Profile</span>
+            </Tooltip>
           )}
         </div>
 

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -11,11 +11,11 @@ import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
+import InlineUserLink from "../users/InlineUserLink";
 import VacantRoleCard from "./VacantRoleCard";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import {
   DEMO_TEAM_TOOLTIP,
-  getUserInitials,
   isSyntheticTeam,
 } from "../../utils/userHelpers";
 import Alert from "../common/Alert";
@@ -161,10 +161,6 @@ const TeamApplicationDetailsModal = ({
     return max === null || max === undefined ? "∞" : max;
   };
 
-  const getOwnerAvatar = () => {
-    return owner.avatar_url || owner.avatarUrl || null;
-  };
-
   const handleTeamClick = () => {
     if (team?.id) setIsTeamDetailsOpen(true);
   };
@@ -283,57 +279,11 @@ const TeamApplicationDetailsModal = ({
   const footer = (
     <div className="flex items-center justify-between gap-3">
       {/* Received by (left) */}
-      <div className="flex items-center text-xs text-base-content/60">
-        <span className="mr-1">Received by</span>
-
-        {/* Owner Avatar */}
-        <div
-          className="avatar cursor-pointer hover:opacity-80 transition-opacity mr-1"
-          onClick={() => handleUserClick(owner?.id)}
-          title="View profile"
-        >
-          <div className="w-4 h-4 rounded-full relative">
-            {getOwnerAvatar() ? (
-              <img
-                src={getOwnerAvatar()}
-                alt="Owner"
-                className="object-cover w-full h-full rounded-full"
-                onError={(e) => {
-                  e.target.style.display = "none";
-                  const fallback =
-                    e.target.parentElement.querySelector(".avatar-fallback");
-                  if (fallback) fallback.style.display = "flex";
-                }}
-              />
-            ) : null}
-
-            {/* Fallback initials */}
-            <div
-              className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-              style={{
-                display: getOwnerAvatar() ? "none" : "flex",
-                fontSize: "8px",
-              }}
-            >
-              <span className="font-medium">{getUserInitials(owner)}</span>
-            </div>
-          </div>
-        </div>
-
-        {/* Owner Name - consistent with TeamInvitationDetailsModal pattern */}
-        <span
-          className="font-medium text-base-content/80 cursor-pointer hover:text-primary transition-colors"
-          onClick={() => handleUserClick(owner?.id)}
-          title="View profile"
-        >
-          {(() => {
-            const firstName = owner.first_name || owner.firstName;
-            const lastName = owner.last_name || owner.lastName;
-            const full = `${firstName || ""} ${lastName || ""}`.trim();
-            return full.length > 0 ? full : "Unknown";
-          })()}
-        </span>
-      </div>
+      <InlineUserLink
+        label="Received by"
+        user={owner}
+        onOpenUser={handleUserClick}
+      />
 
       {/* Buttons (right) */}
       <div className="flex justify-end gap-2">

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -197,6 +197,32 @@ const TeamApplicationDetailsModal = ({
     application?.isInternalRoleApplication ?? application?.is_internal_role_application ?? false;
   const roleName =
     application?.role?.roleName ?? application?.role?.role_name ?? null;
+  const syntheticRoleFlag =
+    application?.role?.is_synthetic ??
+    application?.role?.isSynthetic ??
+    application?.role_is_synthetic ??
+    application?.roleIsSynthetic;
+  const roleForCard =
+    hydratedRole ??
+    (application?.role
+      ? {
+          ...application.role,
+          is_synthetic:
+            application.role.is_synthetic ??
+            application.role.isSynthetic ??
+            syntheticRoleFlag,
+          isSynthetic:
+            application.role.isSynthetic ??
+            application.role.is_synthetic ??
+            syntheticRoleFlag,
+        }
+      : {
+          id: application?.roleId,
+          roleName: application?.roleName ?? application?.role_name,
+          role_name: application?.role_name ?? application?.roleName,
+          is_synthetic: syntheticRoleFlag,
+          isSynthetic: syntheticRoleFlag,
+        });
 
   // Custom header
   const customHeader = (
@@ -388,7 +414,7 @@ const TeamApplicationDetailsModal = ({
         {(application?.role || application?.roleId) && (
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
             <VacantRoleCard
-              role={hydratedRole ?? application?.role ?? { id: application?.roleId }}
+              role={roleForCard}
               team={team}
               matchScore={roleMatchScore}
               matchDetails={roleMatchDetails}

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -1,11 +1,23 @@
 import React, { useState } from "react";
-import { Calendar, Users, X, SendHorizontal } from "lucide-react";
+import {
+  Calendar,
+  Users,
+  X,
+  SendHorizontal,
+  FlaskConical,
+} from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
+import Tooltip from "../common/Tooltip";
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import VacantRoleCard from "./VacantRoleCard";
-import { getUserInitials } from '../../utils/userHelpers';
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import {
+  DEMO_TEAM_TOOLTIP,
+  getUserInitials,
+  isSyntheticTeam,
+} from "../../utils/userHelpers";
 import Alert from "../common/Alert";
 import { format } from "date-fns";
 import { useHydratedRole } from "../../hooks/useHydratedRole";
@@ -47,7 +59,19 @@ const TeamApplicationDetailsModal = ({
   // ============ Helpers ============
 
   // Get team data from application
-  const team = application?.team || {};
+  const baseTeam = application?.team || {};
+  const syntheticTeamFlag =
+    baseTeam?.is_synthetic ??
+    baseTeam?.isSynthetic ??
+    application?.team_is_synthetic ??
+    application?.teamIsSynthetic;
+  const team = {
+    ...baseTeam,
+    is_synthetic:
+      baseTeam?.is_synthetic ?? baseTeam?.isSynthetic ?? syntheticTeamFlag,
+    isSynthetic:
+      baseTeam?.isSynthetic ?? baseTeam?.is_synthetic ?? syntheticTeamFlag,
+  };
   const roleId = application?.role?.id ?? application?.roleId ?? null;
   const teamId = team?.id ?? null;
   const {
@@ -201,10 +225,23 @@ const TeamApplicationDetailsModal = ({
     application?.role?.is_synthetic ??
     application?.role?.isSynthetic ??
     application?.role_is_synthetic ??
-    application?.roleIsSynthetic;
+    application?.roleIsSynthetic ??
+    application?.is_synthetic ??
+    application?.isSynthetic;
   const roleForCard =
-    hydratedRole ??
-    (application?.role
+    hydratedRole
+      ? {
+          ...hydratedRole,
+          is_synthetic:
+            hydratedRole.is_synthetic ??
+            hydratedRole.isSynthetic ??
+            syntheticRoleFlag,
+          isSynthetic:
+            hydratedRole.isSynthetic ??
+            hydratedRole.is_synthetic ??
+            syntheticRoleFlag,
+        }
+      : application?.role
       ? {
           ...application.role,
           is_synthetic:
@@ -222,7 +259,7 @@ const TeamApplicationDetailsModal = ({
           role_name: application?.role_name ?? application?.roleName,
           is_synthetic: syntheticRoleFlag,
           isSynthetic: syntheticRoleFlag,
-        });
+        };
 
   // Custom header
   const customHeader = (
@@ -356,7 +393,7 @@ const TeamApplicationDetailsModal = ({
             title="View team details"
           >
             <div className="avatar">
-              <div className="w-12 h-12 rounded-full relative">
+              <div className="w-12 h-12 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
                     src={getTeamAvatar()}
@@ -382,6 +419,13 @@ const TeamApplicationDetailsModal = ({
                     {getTeamInitials()}
                   </span>
                 </div>
+
+                {isSyntheticTeam(team) && (
+                  <DemoAvatarOverlay
+                    textClassName="text-[7px]"
+                    textTranslateClassName="-translate-y-[3px]"
+                  />
+                )}
               </div>
             </div>
 
@@ -389,10 +433,23 @@ const TeamApplicationDetailsModal = ({
               <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
                 {team.name || "Unknown Team"}
               </h4>
-              <p className="text-sm text-base-content/70 flex items-center">
-                <Users size={14} className="mr-1 text-primary" />
-                {getMemberCount()}/{getMaxMembers()}
-              </p>
+              <div className="text-sm text-base-content/70 flex items-center flex-wrap gap-x-1.5 gap-y-px">
+                <span className="flex items-center">
+                  <Users size={14} className="mr-1 text-primary" />
+                  <span>
+                    {getMemberCount()}/{getMaxMembers()}
+                  </span>
+                </span>
+                {isSyntheticTeam(team) && (
+                  <Tooltip
+                    content={DEMO_TEAM_TOOLTIP}
+                    wrapperClassName="flex items-center gap-1 text-base-content/50 text-sm"
+                  >
+                    <FlaskConical size={14} className="flex-shrink-0" />
+                    <span>Demo Team</span>
+                  </Tooltip>
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -494,7 +494,9 @@ const TeamApplicationsModal = ({
           application?.role?.is_synthetic ??
           application?.role?.isSynthetic ??
           application?.role_is_synthetic ??
-          application?.roleIsSynthetic;
+          application?.roleIsSynthetic ??
+          application?.is_synthetic ??
+          application?.isSynthetic;
         const roleOverride = roleId ? roleStatusOverrides[roleId] : null;
         const role =
           application?.role && roleId

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -490,11 +490,24 @@ const TeamApplicationsModal = ({
           application?.roleId ??
           application?.role_id ??
           null;
+        const syntheticRoleFlag =
+          application?.role?.is_synthetic ??
+          application?.role?.isSynthetic ??
+          application?.role_is_synthetic ??
+          application?.roleIsSynthetic;
         const roleOverride = roleId ? roleStatusOverrides[roleId] : null;
         const role =
           application?.role && roleId
             ? {
                 ...application.role,
+                is_synthetic:
+                  application.role.is_synthetic ??
+                  application.role.isSynthetic ??
+                  syntheticRoleFlag,
+                isSynthetic:
+                  application.role.isSynthetic ??
+                  application.role.is_synthetic ??
+                  syntheticRoleFlag,
                 status:
                   roleOverride?.status ??
                   application.role.status ??
@@ -510,7 +523,19 @@ const TeamApplicationsModal = ({
                   application.role.filled_by_user ??
                   null,
               }
-            : application?.role ?? null;
+            : application?.role
+              ? {
+                  ...application.role,
+                  is_synthetic:
+                    application.role.is_synthetic ??
+                    application.role.isSynthetic ??
+                    syntheticRoleFlag,
+                  isSynthetic:
+                    application.role.isSynthetic ??
+                    application.role.is_synthetic ??
+                    syntheticRoleFlag,
+                }
+              : null;
         const applicantRoleMatch =
           roleId != null && applicantId != null
             ? roleCandidateMatchMap[String(roleId)]?.[String(applicantId)] ?? null

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import Card from "../common/Card";
 import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
@@ -479,38 +479,136 @@ const TeamCard = ({
     };
   };
 
-  const normalizedData = getNormalizedData();
-  const roleData = isRoleApplicationVariant
-    ? application?.role ?? null
+  const normalizedData = useMemo(
+    () => getNormalizedData(),
+    [team, application, invitation, effectiveVariant],
+  );
+  const roleSource = isRoleApplicationVariant
+    ? application ?? null
     : isRoleInvitationVariant
-      ? invitation?.role ?? null
+      ? invitation ?? null
       : null;
+  const nestedRoleData = roleSource?.role ?? null;
+  const flatRoleName = roleSource?.roleName ?? roleSource?.role_name ?? null;
+  const flatRoleBio = roleSource?.bio ?? roleSource?.roleBio ?? null;
+  const flatRoleCity = roleSource?.city ?? null;
+  const flatRoleCountry = roleSource?.country ?? null;
+  const flatRoleTags = roleSource?.tags ?? [];
+  const flatRoleBadges = roleSource?.badges ?? [];
+  const flatRoleIsRemote =
+    roleSource?.isRemote ?? roleSource?.is_remote ?? undefined;
+  const syntheticRoleFlag = isRoleApplicationVariant
+    ? application?.role?.is_synthetic ??
+      application?.role?.isSynthetic ??
+      application?.role_is_synthetic ??
+      application?.roleIsSynthetic ??
+      application?.is_synthetic ??
+      application?.isSynthetic
+    : isRoleInvitationVariant
+      ? invitation?.role?.is_synthetic ??
+        invitation?.role?.isSynthetic ??
+        invitation?.role_is_synthetic ??
+        invitation?.roleIsSynthetic ??
+        invitation?.is_synthetic ??
+        invitation?.isSynthetic
+      : undefined;
+  const roleDataId = isRoleApplicationVariant
+    ? application?.role?.id ?? application?.roleId ?? application?.role_id ?? null
+    : isRoleInvitationVariant
+      ? invitation?.role?.id ?? invitation?.roleId ?? invitation?.role_id ?? null
+      : null;
+  const roleData = useMemo(() => {
+    if (!isRoleVariant) return null;
+
+    if (nestedRoleData) {
+      const needsFallbackFields =
+        (nestedRoleData.id == null && roleDataId != null) ||
+        (!nestedRoleData.roleName &&
+          !nestedRoleData.role_name &&
+          flatRoleName != null) ||
+        (nestedRoleData.bio == null &&
+          nestedRoleData.roleBio == null &&
+          flatRoleBio != null) ||
+        (nestedRoleData.city == null && flatRoleCity != null) ||
+        (nestedRoleData.country == null && flatRoleCountry != null) ||
+        (nestedRoleData.is_synthetic == null &&
+          nestedRoleData.isSynthetic == null &&
+          syntheticRoleFlag != null) ||
+        (nestedRoleData.tags == null && flatRoleTags.length > 0) ||
+        (nestedRoleData.badges == null && flatRoleBadges.length > 0);
+
+      if (!needsFallbackFields) {
+        return nestedRoleData;
+      }
+
+      return {
+        ...nestedRoleData,
+        id: nestedRoleData.id ?? roleDataId,
+        roleName: nestedRoleData.roleName ?? nestedRoleData.role_name ?? flatRoleName,
+        role_name: nestedRoleData.role_name ?? nestedRoleData.roleName ?? flatRoleName,
+        bio: nestedRoleData.bio ?? nestedRoleData.roleBio ?? flatRoleBio,
+        roleBio: nestedRoleData.roleBio ?? nestedRoleData.bio ?? flatRoleBio,
+        city: nestedRoleData.city ?? flatRoleCity,
+        country: nestedRoleData.country ?? flatRoleCountry,
+        is_remote:
+          nestedRoleData.is_remote ??
+          nestedRoleData.isRemote ??
+          flatRoleIsRemote,
+        isRemote:
+          nestedRoleData.isRemote ??
+          nestedRoleData.is_remote ??
+          flatRoleIsRemote,
+        tags: nestedRoleData.tags ?? flatRoleTags,
+        badges: nestedRoleData.badges ?? flatRoleBadges,
+        is_synthetic:
+          nestedRoleData.is_synthetic ??
+          nestedRoleData.isSynthetic ??
+          syntheticRoleFlag,
+        isSynthetic:
+          nestedRoleData.isSynthetic ??
+          nestedRoleData.is_synthetic ??
+          syntheticRoleFlag,
+      };
+    }
+
+    return {
+      id: roleDataId,
+      roleName: flatRoleName,
+      role_name: flatRoleName,
+      bio: flatRoleBio,
+      roleBio: flatRoleBio,
+      city: flatRoleCity,
+      country: flatRoleCountry,
+      is_remote: flatRoleIsRemote,
+      isRemote: flatRoleIsRemote,
+      tags: flatRoleTags,
+      badges: flatRoleBadges,
+      is_synthetic: syntheticRoleFlag,
+      isSynthetic: syntheticRoleFlag,
+    };
+  }, [
+    isRoleVariant,
+    nestedRoleData,
+    roleDataId,
+    flatRoleName,
+    flatRoleBio,
+    flatRoleCity,
+    flatRoleCountry,
+    flatRoleIsRemote,
+    flatRoleTags,
+    flatRoleBadges,
+    syntheticRoleFlag,
+  ]);
   const roleTeamData = isRoleApplicationVariant
     ? application?.team ?? null
     : isRoleInvitationVariant
       ? invitation?.team ?? null
-      : null;
-  const roleDataId = isRoleApplicationVariant
-    ? application?.role?.id ?? application?.roleId ?? null
-    : isRoleInvitationVariant
-      ? invitation?.role?.id ?? invitation?.roleId ?? null
       : null;
   const roleTeamId = isRoleApplicationVariant
     ? application?.team?.id ?? null
     : isRoleInvitationVariant
       ? invitation?.team?.id ?? null
       : null;
-  const syntheticRoleFlag = isRoleApplicationVariant
-    ? application?.role?.is_synthetic ??
-      application?.role?.isSynthetic ??
-      application?.role_is_synthetic ??
-      application?.roleIsSynthetic
-    : isRoleInvitationVariant
-      ? invitation?.role?.is_synthetic ??
-        invitation?.role?.isSynthetic ??
-        invitation?.role_is_synthetic ??
-        invitation?.roleIsSynthetic
-      : undefined;
 
   // ========= ALL HOOKS (useState, useAuth, useCallback, useEffect) =========
 
@@ -530,6 +628,8 @@ const TeamCard = ({
   const [isApplicationsModalOpen, setIsApplicationsModalOpen] = useState(false);
   const [pendingSentInvitations, setPendingSentInvitations] = useState([]);
   const [isInvitesModalOpen, setIsInvitesModalOpen] = useState(false);
+  const [pendingApplicationsLoaded, setPendingApplicationsLoaded] = useState(false);
+  const [pendingInvitationsLoaded, setPendingInvitationsLoaded] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [responses, setResponses] = useState({});
   const [isInvitationDetailsModalOpen, setIsInvitationDetailsModalOpen] =
@@ -560,7 +660,7 @@ const TeamCard = ({
 
   // Check if user is admin (owner or admin role can manage invitations)
   const isAdmin = userRole === "admin";
-  const canManageInvitations = isOwner || isAdmin;
+  const canManageInvitations = userRole === "owner" || isAdmin;
 
   // Update local team data when props change
   useEffect(() => {
@@ -674,8 +774,11 @@ const TeamCard = ({
       try {
         const response = await teamService.getTeamApplications(teamData.id);
         setPendingApplications(response.data || []);
+        setPendingApplicationsLoaded(true);
       } catch (error) {
         console.error("Error fetching applications:", error);
+        setPendingApplications([]);
+        setPendingApplicationsLoaded(true);
       }
     }
   }, [canManageInvitations, teamData?.id, effectiveVariant]);
@@ -686,21 +789,33 @@ const TeamCard = ({
       try {
         const response = await teamService.getTeamSentInvitations(teamData.id);
         setPendingSentInvitations(response.data || []);
+        setPendingInvitationsLoaded(true);
       } catch (error) {
         console.error("Error fetching sent invitations:", error);
         setPendingSentInvitations([]);
+        setPendingInvitationsLoaded(true);
       }
     }
   }, [canManageInvitations, teamData?.id, effectiveVariant]);
 
   useEffect(() => {
-    fetchPendingApplications();
-  }, [fetchPendingApplications]);
+    if (effectiveVariant !== "member" || !teamData?.id || !canManageInvitations) {
+      setPendingApplications([]);
+      setPendingSentInvitations([]);
+      setPendingApplicationsLoaded(false);
+      setPendingInvitationsLoaded(false);
+    }
+  }, [effectiveVariant, teamData?.id, canManageInvitations]);
 
-  // Fetch sent invitations
   useEffect(() => {
+    if (!isApplicationsModalOpen && !autoOpenApplications) return;
+    fetchPendingApplications();
+  }, [fetchPendingApplications, isApplicationsModalOpen, autoOpenApplications]);
+
+  useEffect(() => {
+    if (!isInvitesModalOpen) return;
     fetchSentInvitations();
-  }, [fetchSentInvitations]);
+  }, [fetchSentInvitations, isInvitesModalOpen]);
 
   useEffect(() => {
     const fetchCompleteTeamData = async () => {
@@ -963,7 +1078,7 @@ const TeamCard = ({
     return () => {
       isCancelled = true;
     };
-  }, [isRoleVariant, showMatchScore, roleDataId, roleTeamId, roleData, user]);
+  }, [isRoleVariant, showMatchScore, roleDataId, roleTeamId, user?.id]);
 
   // ================= GUARD CLAUSE – AFTER ALL HOOKS =================
 
@@ -1872,8 +1987,7 @@ const TeamCard = ({
   );
   const demoTeamData = isRoleVariant ? (roleTeamData ?? teamData) : teamData;
   const showDemoRoleIndicator =
-    isRoleVariant &&
-    (isSyntheticRole(roleData) || syntheticRoleFlag === true);
+    isRoleVariant && isSyntheticRole(roleData);
   const showDemoTeamIndicator =
     !showDemoRoleIndicator && isSyntheticTeam(demoTeamData);
   const showDemoIndicator = showDemoRoleIndicator || showDemoTeamIndicator;

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -660,7 +660,7 @@ const TeamCard = ({
 
   // Check if user is admin (owner or admin role can manage invitations)
   const isAdmin = userRole === "admin";
-  const canManageInvitations = userRole === "owner" || isAdmin;
+  const canManageInvitations = isOwner || isAdmin;
 
   // Update local team data when props change
   useEffect(() => {
@@ -808,14 +808,12 @@ const TeamCard = ({
   }, [effectiveVariant, teamData?.id, canManageInvitations]);
 
   useEffect(() => {
-    if (!isApplicationsModalOpen && !autoOpenApplications) return;
     fetchPendingApplications();
-  }, [fetchPendingApplications, isApplicationsModalOpen, autoOpenApplications]);
+  }, [fetchPendingApplications]);
 
   useEffect(() => {
-    if (!isInvitesModalOpen) return;
     fetchSentInvitations();
-  }, [fetchSentInvitations, isInvitesModalOpen]);
+  }, [fetchSentInvitations]);
 
   useEffect(() => {
     const fetchCompleteTeamData = async () => {

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -39,7 +39,12 @@ import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import { calculateDistanceKm } from "../../utils/locationUtils";
-import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
+import {
+  DEMO_ROLE_TOOLTIP,
+  DEMO_TEAM_TOOLTIP,
+  isSyntheticRole,
+  isSyntheticTeam,
+} from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
 const teamMemberBadgesCache = new Map();
@@ -495,6 +500,17 @@ const TeamCard = ({
     : isRoleInvitationVariant
       ? invitation?.team?.id ?? null
       : null;
+  const syntheticRoleFlag = isRoleApplicationVariant
+    ? application?.role?.is_synthetic ??
+      application?.role?.isSynthetic ??
+      application?.role_is_synthetic ??
+      application?.roleIsSynthetic
+    : isRoleInvitationVariant
+      ? invitation?.role?.is_synthetic ??
+        invitation?.role?.isSynthetic ??
+        invitation?.role_is_synthetic ??
+        invitation?.roleIsSynthetic
+      : undefined;
 
   // ========= ALL HOOKS (useState, useAuth, useCallback, useEffect) =========
 
@@ -1854,7 +1870,23 @@ const TeamCard = ({
   ) : (
     matchOverlay
   );
-  const demoAvatarOverlay = isSyntheticTeam(teamData) ? (
+  const demoTeamData = isRoleVariant ? (roleTeamData ?? teamData) : teamData;
+  const showDemoRoleIndicator =
+    isRoleVariant &&
+    (isSyntheticRole(roleData) || syntheticRoleFlag === true);
+  const showDemoTeamIndicator =
+    !showDemoRoleIndicator && isSyntheticTeam(demoTeamData);
+  const showDemoIndicator = showDemoRoleIndicator || showDemoTeamIndicator;
+  const demoTooltip = showDemoRoleIndicator
+    ? DEMO_ROLE_TOOLTIP
+    : DEMO_TEAM_TOOLTIP;
+  const demoLabel =
+    viewMode === "list" || viewMode === "mini"
+      ? "Demo"
+      : showDemoRoleIndicator
+        ? "Demo Role"
+        : "Demo Team";
+  const demoAvatarOverlay = showDemoIndicator ? (
     <DemoAvatarOverlay
       textClassName={
         viewMode === "list"
@@ -2051,13 +2083,12 @@ const TeamCard = ({
             )}
           </Tooltip>
         )}
-        {isSyntheticTeam(teamData) && (
+        {showDemoIndicator && (
           <Tooltip
-            content={DEMO_TEAM_TOOLTIP}
-            wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
+            content={demoTooltip}
+            wrapperClassName="flex items-center whitespace-nowrap text-base-content/50"
           >
             <FlaskConical size={11} className="flex-shrink-0" />
-            <span>Demo Team</span>
           </Tooltip>
         )}
       </span>
@@ -2541,19 +2572,6 @@ const TeamCard = ({
               </Tooltip>
             )}
 
-            {isSyntheticTeam(teamData) && (
-              <Tooltip
-                content={DEMO_TEAM_TOOLTIP}
-                wrapperClassName="flex items-center gap-1 text-base-content/50"
-              >
-                <FlaskConical
-                  size={viewMode === "mini" ? 12 : 14}
-                  className="flex-shrink-0"
-                />
-                <span>Demo Team</span>
-              </Tooltip>
-            )}
-
             {/* Pending role application indicator */}
             {!shouldMoveSearchResultRoleApplicationIndicator &&
               isPendingRoleApplicationForTeam && (
@@ -2622,6 +2640,18 @@ const TeamCard = ({
                   )}
                 </span>
               )}
+            {showDemoIndicator && (
+              <Tooltip
+                content={demoTooltip}
+                wrapperClassName="flex items-center gap-1 text-base-content/50"
+              >
+                <FlaskConical
+                  size={viewMode === "mini" ? 12 : 14}
+                  className="flex-shrink-0"
+                />
+                <span>{demoLabel}</span>
+              </Tooltip>
+            )}
           </span>
         }
         hoverable

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -222,6 +222,32 @@ const TeamInvitationDetailsModal = ({
     : hasRoleInvitation
       ? "You are invited for a role!"
       : "You are invited!";
+  const syntheticRoleFlag =
+    invitation?.role?.is_synthetic ??
+    invitation?.role?.isSynthetic ??
+    invitation?.role_is_synthetic ??
+    invitation?.roleIsSynthetic;
+  const roleForCard =
+    hydratedRole ??
+    (invitation?.role
+      ? {
+          ...invitation.role,
+          is_synthetic:
+            invitation.role.is_synthetic ??
+            invitation.role.isSynthetic ??
+            syntheticRoleFlag,
+          isSynthetic:
+            invitation.role.isSynthetic ??
+            invitation.role.is_synthetic ??
+            syntheticRoleFlag,
+        }
+      : {
+          id: invitation?.roleId ?? invitation?.role_id,
+          roleName: invitation?.roleName ?? invitation?.role_name,
+          role_name: invitation?.role_name ?? invitation?.roleName,
+          is_synthetic: syntheticRoleFlag,
+          isSynthetic: syntheticRoleFlag,
+        });
 
   // Custom header
   const customHeader = (
@@ -404,7 +430,7 @@ const TeamInvitationDetailsModal = ({
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <VacantRoleCard
-                role={hydratedRole ?? invitation?.role ?? { id: invitation?.roleId ?? invitation?.role_id }}
+                role={roleForCard}
                 team={team}
                 matchScore={roleMatchScore}
                 matchDetails={roleMatchDetails}

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -7,9 +7,11 @@ import {
   X,
   MailOpen,
   UserPlus,
+  FlaskConical,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
+import Tooltip from "../common/Tooltip";
 import UserDetailsModal from "../users/UserDetailsModal";
 import TeamDetailsModal from "./TeamDetailsModal";
 import VacantRoleCard from "./VacantRoleCard";
@@ -17,6 +19,8 @@ import Alert from "../common/Alert";
 import { format } from "date-fns";
 import InlineUserLink from "../users/InlineUserLink";
 import { useHydratedRole } from "../../hooks/useHydratedRole";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
 
 const extractRoleMatchData = (roleLike) => {
   const rawScore = roleLike?.matchScore ?? roleLike?.match_score ?? null;
@@ -62,7 +66,19 @@ const TeamInvitationDetailsModal = ({
   // ============ Helpers ============
 
   // Get team data from invitation
-  const team = invitation?.team || {};
+  const baseTeam = invitation?.team || {};
+  const syntheticTeamFlag =
+    baseTeam?.is_synthetic ??
+    baseTeam?.isSynthetic ??
+    invitation?.team_is_synthetic ??
+    invitation?.teamIsSynthetic;
+  const team = {
+    ...baseTeam,
+    is_synthetic:
+      baseTeam?.is_synthetic ?? baseTeam?.isSynthetic ?? syntheticTeamFlag,
+    isSynthetic:
+      baseTeam?.isSynthetic ?? baseTeam?.is_synthetic ?? syntheticTeamFlag,
+  };
   const roleId =
     invitation?.role?.id ?? invitation?.roleId ?? invitation?.role_id ?? null;
   const teamId = team?.id ?? null;
@@ -226,10 +242,23 @@ const TeamInvitationDetailsModal = ({
     invitation?.role?.is_synthetic ??
     invitation?.role?.isSynthetic ??
     invitation?.role_is_synthetic ??
-    invitation?.roleIsSynthetic;
+    invitation?.roleIsSynthetic ??
+    invitation?.is_synthetic ??
+    invitation?.isSynthetic;
   const roleForCard =
-    hydratedRole ??
-    (invitation?.role
+    hydratedRole
+      ? {
+          ...hydratedRole,
+          is_synthetic:
+            hydratedRole.is_synthetic ??
+            hydratedRole.isSynthetic ??
+            syntheticRoleFlag,
+          isSynthetic:
+            hydratedRole.isSynthetic ??
+            hydratedRole.is_synthetic ??
+            syntheticRoleFlag,
+        }
+      : invitation?.role
       ? {
           ...invitation.role,
           is_synthetic:
@@ -247,7 +276,7 @@ const TeamInvitationDetailsModal = ({
           role_name: invitation?.role_name ?? invitation?.roleName,
           is_synthetic: syntheticRoleFlag,
           isSynthetic: syntheticRoleFlag,
-        });
+        };
 
   // Custom header
   const customHeader = (
@@ -367,7 +396,7 @@ const TeamInvitationDetailsModal = ({
             title="View team details"
           >
             <div className="avatar">
-              <div className="w-12 h-12 rounded-full relative">
+              <div className="w-12 h-12 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
                     src={getTeamAvatar()}
@@ -393,6 +422,13 @@ const TeamInvitationDetailsModal = ({
                     {getTeamInitials()}
                   </span>
                 </div>
+
+                {isSyntheticTeam(team) && (
+                  <DemoAvatarOverlay
+                    textClassName="text-[7px]"
+                    textTranslateClassName="-translate-y-[3px]"
+                  />
+                )}
               </div>
             </div>
 
@@ -400,10 +436,23 @@ const TeamInvitationDetailsModal = ({
               <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
                 {team.name || "Unknown Team"}
               </h4>
-              <p className="text-sm text-base-content/70 flex items-center">
-                <Users size={14} className="mr-1 text-primary" />
-                {getMemberCount()}/{getMaxMembers()}
-              </p>
+              <div className="text-sm text-base-content/70 flex items-center flex-wrap gap-x-1.5 gap-y-px">
+                <span className="flex items-center">
+                  <Users size={14} className="mr-1 text-primary" />
+                  <span>
+                    {getMemberCount()}/{getMaxMembers()}
+                  </span>
+                </span>
+                {isSyntheticTeam(team) && (
+                  <Tooltip
+                    content={DEMO_TEAM_TOOLTIP}
+                    wrapperClassName="flex items-center gap-1 text-base-content/50 text-sm"
+                  >
+                    <FlaskConical size={14} className="flex-shrink-0" />
+                    <span>Demo Team</span>
+                  </Tooltip>
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -600,6 +600,30 @@ const TeamInvitesModal = ({
           invitation?.roleId ??
           invitation?.role_id ??
           null;
+        const syntheticRoleFlag =
+          invitation?.role?.is_synthetic ??
+          invitation?.role?.isSynthetic ??
+          invitation?.role_is_synthetic ??
+          invitation?.roleIsSynthetic;
+        const roleForCard = invitation?.role
+          ? {
+              ...invitation.role,
+              is_synthetic:
+                invitation.role.is_synthetic ??
+                invitation.role.isSynthetic ??
+                syntheticRoleFlag,
+              isSynthetic:
+                invitation.role.isSynthetic ??
+                invitation.role.is_synthetic ??
+                syntheticRoleFlag,
+            }
+          : {
+              id: invitation?.roleId ?? invitation?.role_id,
+              roleName: invitation?.roleName ?? invitation?.role_name,
+              role_name: invitation?.role_name ?? invitation?.roleName,
+              is_synthetic: syntheticRoleFlag,
+              isSynthetic: syntheticRoleFlag,
+            };
         const isSelfInvitation =
           currentUser?.id === (invitation.invitee?.id ?? invitation.invitee_id);
         const inviteeRoleMatch =
@@ -720,7 +744,7 @@ const TeamInvitesModal = ({
             {(invitation.role || invitation.roleId || invitation.role_id) && (
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-3">
                 <VacantRoleCard
-                  role={invitation.role || { id: invitation.roleId ?? invitation.role_id, roleName: invitation.roleName ?? invitation.role_name }}
+                  role={roleForCard}
                   team={{ id: teamId, name: teamName }}
                   matchScore={
                     inviteeRoleMatch?.matchScore ??

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -604,7 +604,9 @@ const TeamInvitesModal = ({
           invitation?.role?.is_synthetic ??
           invitation?.role?.isSynthetic ??
           invitation?.role_is_synthetic ??
-          invitation?.roleIsSynthetic;
+          invitation?.roleIsSynthetic ??
+          invitation?.is_synthetic ??
+          invitation?.isSynthetic;
         const roleForCard = invitation?.role
           ? {
               ...invitation.role,

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -1,15 +1,28 @@
 import React, { useState, useEffect, useRef } from "react";
-import { User, MapPin, Calendar, SendHorizontal } from "lucide-react";
+import {
+  User,
+  MapPin,
+  Calendar,
+  SendHorizontal,
+  FlaskConical,
+} from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
 import Button from "../common/Button";
+import Tooltip from "../common/Tooltip";
 import InlineUserLink, { InvitedByLink } from "../users/InlineUserLink";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import VacantRoleCard from "./VacantRoleCard";
 import { matchingService } from "../../services/matchingService";
 import { userService } from "../../services/userService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
-import { getUserInitials, getDisplayName } from "../../utils/userHelpers";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  getDisplayName,
+  isSyntheticUser,
+} from "../../utils/userHelpers";
 import { calculateDistanceKm } from "../../utils/locationUtils";
 import { format } from "date-fns";
 
@@ -646,6 +659,11 @@ const TeamInvitesModal = ({
           highlightUserId != null &&
           inviteeId != null &&
           String(inviteeId) === String(highlightUserId);
+        const showInviteeUsername =
+          invitation.invitee?.username &&
+          (getDisplayName(invitation.invitee) !== invitation.invitee?.username ||
+            isSyntheticUser(invitation.invitee));
+        const showInviteeDemoProfile = isSyntheticUser(invitation.invitee);
 
         return (
           <div
@@ -665,7 +683,7 @@ const TeamInvitesModal = ({
                 onClick={() => handleInviteeClick(invitation.invitee?.id)}
                 title="View profile"
               >
-                <div className="w-10 h-10 rounded-full relative">
+                <div className="w-10 h-10 rounded-full relative overflow-hidden">
                   {getAvatarUrl(invitation.invitee) ? (
                     <img
                       src={getAvatarUrl(invitation.invitee)}
@@ -694,6 +712,9 @@ const TeamInvitesModal = ({
                       {getUserInitials(invitation.invitee)}
                     </span>
                   </div>
+                  {isSyntheticUser(invitation.invitee) && (
+                    <DemoAvatarOverlay textClassName="text-[7px]" />
+                  )}
                 </div>
               </div>
 
@@ -707,11 +728,23 @@ const TeamInvitesModal = ({
                 >
                   {getDisplayName(invitation.invitee)}
                 </h4>
-                {/* Username */}
-                {invitation.invitee?.username && (
-                  <p className="text-sm text-base-content/70">
-                    @{invitation.invitee.username}
-                  </p>
+                {(showInviteeUsername || showInviteeDemoProfile) && (
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                    {showInviteeUsername && (
+                      <p className="text-xs text-base-content/70">
+                        @{invitation.invitee.username}
+                      </p>
+                    )}
+                    {showInviteeDemoProfile && (
+                      <Tooltip
+                        content={DEMO_PROFILE_TOOLTIP}
+                        wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+                      >
+                        <FlaskConical size={12} className="flex-shrink-0" />
+                        <span>Demo Profile</span>
+                      </Tooltip>
+                    )}
+                  </div>
                 )}
               </div>
 

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -1,12 +1,58 @@
-import React, { useState } from "react";
-import { Users, MapPin, Ruler, ChevronRight, ChevronUp, UserCheck } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import {
+  Users,
+  MapPin,
+  Ruler,
+  ChevronRight,
+  ChevronUp,
+  UserCheck,
+  FlaskConical,
+} from "lucide-react";
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import Alert from "../common/Alert";
 import { teamService } from "../../services/teamService";
+import { userService } from "../../services/userService";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import Tooltip from "../common/Tooltip";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import { DEMO_PROFILE_TOOLTIP, isSyntheticUser } from "../../utils/userHelpers";
+
+const memberSyntheticStatusCache = new Map();
+
+const extractProfilePayload = (response) => {
+  const payload = response?.data ?? response;
+
+  if (!payload) return null;
+  if (payload?.success !== undefined) return payload?.data ?? null;
+
+  return payload?.data?.data ?? payload?.data ?? payload;
+};
+
+const getCachedMemberSyntheticStatus = async (memberId) => {
+  const cacheKey = String(memberId);
+
+  if (memberSyntheticStatusCache.has(cacheKey)) {
+    return memberSyntheticStatusCache.get(cacheKey);
+  }
+
+  const request = (async () => {
+    const response = await userService.getUserById(memberId);
+    return isSyntheticUser(extractProfilePayload(response));
+  })();
+
+  memberSyntheticStatusCache.set(cacheKey, request);
+
+  try {
+    const result = await request;
+    memberSyntheticStatusCache.set(cacheKey, Promise.resolve(result));
+    return result;
+  } catch (error) {
+    memberSyntheticStatusCache.delete(cacheKey);
+    throw error;
+  }
+};
 
 /**
  * TeamMembersSection Component
@@ -31,6 +77,7 @@ const TeamMembersSection = ({
     message: null,
   });
   const [isExpanded, setIsExpanded] = useState(false);
+  const [syntheticMemberStatusMap, setSyntheticMemberStatusMap] = useState({});
   const COLLAPSED_COUNT = 4;
 
   // Helper function to get member initials (2 letters: "NK" for Nam Khoa)
@@ -49,6 +96,71 @@ const TeamMembersSection = ({
     }
     return "?";
   };
+
+  useEffect(() => {
+    const members = Array.isArray(team?.members) ? team.members : [];
+    const nextKnownStatuses = {};
+    const memberIdsToFetch = [];
+
+    members.forEach((member) => {
+      const memberId = member?.userId ?? member?.user_id ?? null;
+      if (memberId == null) return;
+
+      const cacheKey = String(memberId);
+      const hasInlineSyntheticFlag =
+        member?.is_synthetic != null || member?.isSynthetic != null;
+
+      if (hasInlineSyntheticFlag) {
+        const isDemoMember = isSyntheticUser(member);
+        nextKnownStatuses[cacheKey] = isDemoMember;
+        memberSyntheticStatusCache.set(cacheKey, Promise.resolve(isDemoMember));
+        return;
+      }
+
+      memberIdsToFetch.push(memberId);
+    });
+
+    if (Object.keys(nextKnownStatuses).length > 0) {
+      setSyntheticMemberStatusMap((prev) => ({
+        ...prev,
+        ...nextKnownStatuses,
+      }));
+    }
+
+    if (memberIdsToFetch.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    Promise.allSettled(
+      [...new Set(memberIdsToFetch)].map(async (memberId) => ({
+        memberId,
+        isSynthetic: await getCachedMemberSyntheticStatus(memberId),
+      })),
+    ).then((results) => {
+      if (cancelled) return;
+
+      const fetchedStatuses = {};
+
+      results.forEach((result) => {
+        if (result.status !== "fulfilled") return;
+
+        fetchedStatuses[String(result.value.memberId)] = result.value.isSynthetic;
+      });
+
+      if (Object.keys(fetchedStatuses).length > 0) {
+        setSyntheticMemberStatusMap((prev) => ({
+          ...prev,
+          ...fetchedStatuses,
+        }));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [team?.members]);
 
   // Early return if no members
   if (!team?.members || team.members.length === 0) {
@@ -92,6 +204,12 @@ const TeamMembersSection = ({
 
           // Determine if this member should be anonymized
           const anonymize = shouldAnonymizeMember(member);
+          const memberAvatarUrl =
+            !anonymize ? member.avatarUrl || member.avatar_url || null : null;
+          const memberSyntheticStatus =
+            memberId != null ? syntheticMemberStatusMap[String(memberId)] : undefined;
+          const showDemoAvatarOverlay =
+            memberSyntheticStatus ?? isSyntheticUser(member);
 
           // Find the filled role this member is filling (if any)
           const filledRole = roles.find((r) => {
@@ -101,6 +219,13 @@ const TeamMembersSection = ({
             return filledById != null && String(filledById) === String(memberId);
           });
           const filledRoleName = filledRole?.roleName ?? filledRole?.role_name ?? null;
+          const shouldShowMemberMetaRow =
+            showDemoAvatarOverlay ||
+            (!anonymize &&
+              (member.city ||
+                member.country ||
+                member.distance_km != null ||
+                filledRoleName));
 
           // Role management logic - Owners and admins can manage roles
           const currentUserMember = team.members?.find(
@@ -117,38 +242,34 @@ const TeamMembersSection = ({
               className="flex items-start bg-green-50 rounded-xl shadow p-4 gap-4 transition-all duration-200 hover:bg-green-100 hover:shadow-md"
             >
               <div className="avatar">
-                {!anonymize && (member.avatarUrl || member.avatar_url) ? (
-                  <div className="rounded-full w-12 h-12">
+                <div className="rounded-full w-12 h-12 relative overflow-hidden">
+                  {memberAvatarUrl ? (
                     <img
-                      src={member.avatarUrl || member.avatar_url}
+                      src={memberAvatarUrl}
                       alt={member.username}
-                      className="object-cover w-full h-full"
+                      className="object-cover w-full h-full rounded-full"
                       onError={(e) => {
-                        e.target.onerror = null;
-                        // Fall back to placeholder on error
                         e.target.style.display = "none";
-                        const parentDiv = e.target.parentNode;
-                        parentDiv.classList.add(
-                          "placeholder",
-                          "bg-primary",
-                          "text-primary-content",
-                        );
-                        const span = document.createElement("span");
-                        span.className = "text-lg";
-                        span.textContent = anonymize
-                          ? "PP"
-                          : getMemberInitials(member);
-                        parentDiv.appendChild(span);
+                        const fallback =
+                          e.target.parentElement.querySelector(
+                            ".avatar-fallback",
+                          );
+                        if (fallback) fallback.style.display = "flex";
                       }}
                     />
-                  </div>
-                ) : (
-                  <div className="placeholder bg-primary text-primary-content rounded-full w-12 h-12">
+                  ) : null}
+                  <div
+                    className="avatar-fallback placeholder bg-primary text-primary-content rounded-full w-full h-full absolute inset-0 flex items-center justify-center"
+                    style={{ display: memberAvatarUrl ? "none" : "flex" }}
+                  >
                     <span className="text-lg">
                       {anonymize ? "PP" : getMemberInitials(member)}
                     </span>
                   </div>
-                )}
+                  {showDemoAvatarOverlay && (
+                    <DemoAvatarOverlay textClassName="text-[8px]" />
+                  )}
+                </div>
               </div>
 
               <div className="flex-1 min-w-0 pt-[1px]">
@@ -241,33 +362,37 @@ const TeamMembersSection = ({
                     />
                   </div>
 
-                  {!anonymize &&
-                    (member.city ||
-                      member.country ||
-                      member.distance_km != null ||
-                      filledRoleName) && (
-                      <CardMetaRow>
-                        {(member.city || member.country) && (
-                          <CardMetaItem icon={MapPin}>
-                            {[member.city, member.country]
-                              .filter(Boolean)
-                              .join(", ")}
-                          </CardMetaItem>
-                        )}
+                  {shouldShowMemberMetaRow && (
+                    <CardMetaRow>
+                      {!anonymize && (member.city || member.country) && (
+                        <CardMetaItem icon={MapPin}>
+                          {[member.city, member.country].filter(Boolean).join(", ")}
+                        </CardMetaItem>
+                      )}
 
-                        {member.distance_km != null && (
-                          <CardMetaItem icon={Ruler} tone="muted" nowrap>
-                            {Math.round(member.distance_km)} km away
-                          </CardMetaItem>
-                        )}
+                      {showDemoAvatarOverlay && (
+                        <Tooltip
+                          content={DEMO_PROFILE_TOOLTIP}
+                          wrapperClassName="flex items-start gap-0.5 text-base-content/50"
+                        >
+                          <FlaskConical size={10} className="shrink-0 mt-[3px]" />
+                          <span className="leading-tight">Demo</span>
+                        </Tooltip>
+                      )}
 
-                        {filledRoleName && (
-                          <CardMetaItem icon={UserCheck} nowrap>
-                            {filledRoleName}
-                          </CardMetaItem>
-                        )}
-                      </CardMetaRow>
-                    )}
+                      {!anonymize && member.distance_km != null && (
+                        <CardMetaItem icon={Ruler} tone="muted" nowrap>
+                          {Math.round(member.distance_km)} km away
+                        </CardMetaItem>
+                      )}
+
+                      {!anonymize && filledRoleName && (
+                        <CardMetaItem icon={UserCheck} nowrap>
+                          {filledRoleName}
+                        </CardMetaItem>
+                      )}
+                    </CardMetaRow>
+                  )}
 
                   {!anonymize && member.tags?.length > 0 && (
                     <div className="flex flex-wrap gap-1 mt-1">

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -837,6 +837,15 @@ const VacantRoleCard = ({
       </span>
     </Tooltip>
   ) : null;
+  const demoRoleMetaItem = isSyntheticRole(role) ? (
+    <Tooltip
+      content={DEMO_ROLE_TOOLTIP}
+      wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
+    >
+      <FlaskConical size={12} className="flex-shrink-0" />
+      <span>{viewMode === "mini" ? "Demo" : "Demo Role"}</span>
+    </Tooltip>
+  ) : null;
 
   const renderMatchOverlay = ({ size, iconSize }) => {
     if (!matchTier) return null;
@@ -1294,15 +1303,6 @@ const VacantRoleCard = ({
                   {teamContext.name}
                 </p>
               )}
-              {isSyntheticRole(role) && (
-                <Tooltip
-                  content={DEMO_ROLE_TOOLTIP}
-                  wrapperClassName="mt-0.5 flex items-center gap-1 text-base-content/50 text-xs"
-                >
-                  <FlaskConical size={12} className="flex-shrink-0" />
-                  <span>{isMiniView ? "Demo" : "Demo Role"}</span>
-                </Tooltip>
-              )}
             </div>
 
             <div className="relative flex-shrink-0" data-dropdown-menu>
@@ -1424,17 +1424,20 @@ const VacantRoleCard = ({
               <div className="flex items-center gap-1 text-xs text-base-content/60">
                 <UserCheck size={12} className="shrink-0" />
                 <span className="truncate">{filledByText}</span>
+                {demoRoleMetaItem}
               </div>
-            ) : locationText ? (
+            ) : locationText || (!is_remote && max_distance_km) || demoRoleMetaItem ? (
               <div className="flex flex-wrap items-center gap-2 text-xs text-base-content/60">
-                <span className="flex items-center gap-1 min-w-0">
-                  {is_remote ? (
-                    <Globe size={12} className="shrink-0" />
-                  ) : (
-                    <MapPin size={12} className="shrink-0" />
-                  )}
-                  <span className="truncate">{locationText}</span>
-                </span>
+                {locationText && (
+                  <span className="flex items-center gap-1 min-w-0">
+                    {is_remote ? (
+                      <Globe size={12} className="shrink-0" />
+                    ) : (
+                      <MapPin size={12} className="shrink-0" />
+                    )}
+                    <span className="truncate">{locationText}</span>
+                  </span>
+                )}
 
                 {!is_remote && max_distance_km && (
                   <span className="flex items-center gap-1 text-base-content/50">
@@ -1442,23 +1445,28 @@ const VacantRoleCard = ({
                     <span>{max_distance_km} km</span>
                   </span>
                 )}
+                {demoRoleMetaItem}
               </div>
             ) : null
           ) : isFilled ? (
             <CardMetaRow>
               <CardMetaItem icon={UserCheck}>{filledByText}</CardMetaItem>
+              {demoRoleMetaItem}
             </CardMetaRow>
-          ) : locationText ? (
+          ) : locationText || (!is_remote && max_distance_km) || demoRoleMetaItem ? (
             <CardMetaRow>
-              <CardMetaItem icon={is_remote ? Globe : MapPin}>
-                {locationText}
-              </CardMetaItem>
+              {locationText && (
+                <CardMetaItem icon={is_remote ? Globe : MapPin}>
+                  {locationText}
+                </CardMetaItem>
+              )}
 
               {!is_remote && max_distance_km && (
                 <CardMetaItem icon={CircleDot} tone="muted" nowrap>
                   {max_distance_km} km
                 </CardMetaItem>
               )}
+              {demoRoleMetaItem}
             </CardMetaRow>
           ) : null}
         </div>

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -955,6 +955,12 @@ const VacantRoleCard = ({
       }
     />
   ) : null;
+  const compactDemoAvatarOverlay = isSyntheticRole(role) ? (
+    <DemoAvatarOverlay
+      textClassName={isMiniView ? "text-[6px]" : "text-[7px]"}
+      textTranslateClassName="-translate-y-[3px]"
+    />
+  ) : null;
 
   if (viewMode === "list") {
     const roundedDistanceKm = showDistance ? Math.round(rawDistanceKm) : null;
@@ -1237,7 +1243,7 @@ const VacantRoleCard = ({
                     {getUserInitials(filledUser)}
                   </span>
                 </div>
-                {isSyntheticRole(role) && demoAvatarOverlay}
+                {compactDemoAvatarOverlay}
                 {miniMatchOverlay}
               </div>
             </div>
@@ -1253,7 +1259,7 @@ const VacantRoleCard = ({
                   >
                     {pct}%
                   </span>
-                  {isSyntheticRole(role) && demoAvatarOverlay}
+                  {compactDemoAvatarOverlay}
                 </div>
               </div>
             </Tooltip>
@@ -1263,7 +1269,7 @@ const VacantRoleCard = ({
                 className={`${initialsAvatarClass} ${avatarSizeClass} rounded-full relative flex items-center justify-center overflow-hidden`}
               >
                 <span className={avatarTextClass}>{getRoleInitials()}</span>
-                {isSyntheticRole(role) && demoAvatarOverlay}
+                {compactDemoAvatarOverlay}
                 {miniMatchOverlay}
               </div>
             </div>

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -19,6 +19,7 @@ import {
   Sparkles,
   TrendingUp,
   TrendingDown,
+  FlaskConical,
 } from "lucide-react";
 import VacantRoleDetailsModal from "./VacantRoleDetailsModal";
 import Card from "../common/Card";
@@ -28,7 +29,13 @@ import CardMetaRow from "../common/CardMetaRow";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import Tooltip from "../common/Tooltip";
-import { getDisplayName, getUserInitials } from "../../utils/userHelpers";
+import {
+  DEMO_ROLE_TOOLTIP,
+  getDisplayName,
+  getUserInitials,
+  isSyntheticRole,
+} from "../../utils/userHelpers";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { resolveFilledRoleUser } from "../../utils/vacantRoleUtils";
 import {
   getMatchTier,
@@ -930,6 +937,24 @@ const VacantRoleCard = ({
       hideActions={hideActions && !usesSharedSearchCard}
     />
   );
+  const demoAvatarOverlay = isSyntheticRole(role) ? (
+    <DemoAvatarOverlay
+      textClassName={
+        viewMode === "list"
+          ? "text-[5px]"
+          : viewMode === "mini"
+            ? "text-[9px]"
+            : "text-[10px]"
+      }
+      textTranslateClassName={
+        viewMode === "list"
+          ? "-translate-y-[2px]"
+          : viewMode === "mini"
+            ? "-translate-y-[4px]"
+            : "-translate-y-[4px]"
+      }
+    />
+  ) : null;
 
   if (viewMode === "list") {
     const roundedDistanceKm = showDistance ? Math.round(rawDistanceKm) : null;
@@ -950,13 +975,22 @@ const VacantRoleCard = ({
       postedDateSubtitleItem ||
       teamSubtitleItem ||
       roleInvitationSubtitleItem ||
-      roleApplicationSubtitleItem ? (
+      roleApplicationSubtitleItem ||
+      isSyntheticRole(role) ? (
         <span className="flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden whitespace-nowrap text-base-content/60">
           {scoreSubtitleItem}
           {postedDateSubtitleItem}
           {roleInvitationSubtitleItem}
           {roleApplicationSubtitleItem}
           {teamSubtitleItem}
+          {isSyntheticRole(role) && (
+            <Tooltip
+              content={DEMO_ROLE_TOOLTIP}
+              wrapperClassName="flex items-center whitespace-nowrap text-base-content/50"
+            >
+              <FlaskConical size={11} className="flex-shrink-0" />
+            </Tooltip>
+          )}
         </span>
       ) : null;
 
@@ -970,6 +1004,7 @@ const VacantRoleCard = ({
           imageOverlay={
             searchResultTypeOverlay ?? renderMatchOverlay({ size: 14, iconSize: 7 })
           }
+          imageInnerOverlay={demoAvatarOverlay}
           onClick={() => setIsDetailsOpen(true)}
           viewMode="list"
           titleClassName="text-sm font-semibold"
@@ -1061,6 +1096,18 @@ const VacantRoleCard = ({
         {roleInvitationSubtitleItem}
         {roleApplicationSubtitleItem}
         {miniLocationSubtitleItem}
+        {isSyntheticRole(role) && (
+          <Tooltip
+            content={DEMO_ROLE_TOOLTIP}
+            wrapperClassName="flex items-center gap-1 text-base-content/50"
+          >
+            <FlaskConical
+              size={viewMode === "mini" ? 12 : 14}
+              className="flex-shrink-0"
+            />
+            <span>{viewMode === "mini" ? "Demo" : "Demo Role"}</span>
+          </Tooltip>
+        )}
       </span>
     );
 
@@ -1103,6 +1150,7 @@ const VacantRoleCard = ({
             searchResultTypeOverlay ??
             (matchTier ? renderMatchOverlay({ size: 20, iconSize: 10 }) : null)
           }
+          imageInnerOverlay={demoAvatarOverlay}
         >
           {viewMode !== "mini" && (
             <p className="text-base-content/80 mb-4">
@@ -1167,7 +1215,7 @@ const VacantRoleCard = ({
         <div className="flex-shrink-0">
           {isFilled && filledUser ? (
             <div className="avatar">
-              <div className={`${avatarSizeClass} rounded-full relative`}>
+              <div className={`${avatarSizeClass} rounded-full relative overflow-hidden`}>
                 {filledUserAvatarUrl ? (
                   <img
                     src={filledUserAvatarUrl}
@@ -1189,6 +1237,7 @@ const VacantRoleCard = ({
                     {getUserInitials(filledUser)}
                   </span>
                 </div>
+                {isSyntheticRole(role) && demoAvatarOverlay}
                 {miniMatchOverlay}
               </div>
             </div>
@@ -1204,15 +1253,17 @@ const VacantRoleCard = ({
                   >
                     {pct}%
                   </span>
+                  {isSyntheticRole(role) && demoAvatarOverlay}
                 </div>
               </div>
             </Tooltip>
           ) : (
             <div className="avatar placeholder">
               <div
-                className={`${initialsAvatarClass} ${avatarSizeClass} rounded-full relative flex items-center justify-center`}
+                className={`${initialsAvatarClass} ${avatarSizeClass} rounded-full relative flex items-center justify-center overflow-hidden`}
               >
                 <span className={avatarTextClass}>{getRoleInitials()}</span>
+                {isSyntheticRole(role) && demoAvatarOverlay}
                 {miniMatchOverlay}
               </div>
             </div>
@@ -1236,6 +1287,15 @@ const VacantRoleCard = ({
                 <p className="text-xs text-base-content/50 mt-0.5 truncate">
                   {teamContext.name}
                 </p>
+              )}
+              {isSyntheticRole(role) && (
+                <Tooltip
+                  content={DEMO_ROLE_TOOLTIP}
+                  wrapperClassName="mt-0.5 flex items-center gap-1 text-base-content/50 text-xs"
+                >
+                  <FlaskConical size={12} className="flex-shrink-0" />
+                  <span>{isMiniView ? "Demo" : "Demo Role"}</span>
+                </Tooltip>
               )}
             </div>
 

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -50,10 +50,12 @@ import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import {
+  DEMO_PROFILE_TOOLTIP,
   DEMO_ROLE_TOOLTIP,
   getDisplayName,
   getUserInitials,
   isSyntheticRole,
+  isSyntheticUser,
 } from "../../utils/userHelpers";
 import {
   calculateDistanceKm,
@@ -2783,6 +2785,7 @@ const VacantRoleDetailsModal = ({
                     member.avatarUrl ?? member.avatar_url ?? null;
                   const displayName = getDisplayName(member);
                   const initials = getUserInitials(member);
+                  const showDemoAvatarOverlay = isSyntheticUser(member);
                   const memberScore =
                     memberRow.matchScore != null
                       ? Number(memberRow.matchScore)
@@ -2817,7 +2820,7 @@ const VacantRoleDetailsModal = ({
                         onClick={() => handleTeamMemberClick(memberRow)}
                       >
                         <div className="avatar relative flex-shrink-0">
-                          <div className="w-12 h-12 rounded-full">
+                          <div className="w-12 h-12 rounded-full relative overflow-hidden">
                             {avatarUrl ? (
                               <img
                                 src={avatarUrl}
@@ -2837,6 +2840,9 @@ const VacantRoleDetailsModal = ({
                             >
                               <span className="text-lg">{initials}</span>
                             </div>
+                            {showDemoAvatarOverlay && (
+                              <DemoAvatarOverlay textClassName="text-[8px]" />
+                            )}
                           </div>
                           {MemberMatchIcon && (
                             <div
@@ -2877,6 +2883,18 @@ const VacantRoleDetailsModal = ({
                               <CardMetaItem icon={MapPin}>
                                 {locationLabel}
                               </CardMetaItem>
+                              {showDemoAvatarOverlay && (
+                                <Tooltip
+                                  content={DEMO_PROFILE_TOOLTIP}
+                                  wrapperClassName="flex items-start gap-0.5 text-base-content/50"
+                                >
+                                  <FlaskConical
+                                    size={10}
+                                    className="shrink-0 mt-[3px]"
+                                  />
+                                  <span className="leading-tight">Demo</span>
+                                </Tooltip>
+                              )}
                             </CardMetaRow>
                           </div>
                         </div>

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -15,6 +15,7 @@ import {
   ChevronRight,
   ChevronUp,
   SendHorizontal,
+  FlaskConical,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import {
@@ -33,6 +34,7 @@ import {
 } from "../../constants/badgeConstants";
 import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import TeamApplicationButton from "./TeamApplicationButton";
@@ -47,7 +49,12 @@ import { matchingService } from "../../services/matchingService";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { getMatchTier } from "../../utils/matchScoreUtils";
-import { getDisplayName, getUserInitials } from "../../utils/userHelpers";
+import {
+  DEMO_ROLE_TOOLTIP,
+  getDisplayName,
+  getUserInitials,
+  isSyntheticRole,
+} from "../../utils/userHelpers";
 import {
   calculateDistanceKm,
   normalizeLocationData,
@@ -1447,6 +1454,12 @@ const VacantRoleDetailsModal = ({
   };
 
   const modalStatusTitle = isFilledRole ? "Filled Role" : "Vacant Role";
+  const demoAvatarOverlay = isSyntheticRole(displayRole) ? (
+    <DemoAvatarOverlay
+      textClassName="text-[9px]"
+      textTranslateClassName="-translate-y-[4px]"
+    />
+  ) : null;
   const ModalStatusIcon = isFilledRole ? UserCheck : UserSearch;
   const summarySuffix = isComparisonSelf
     ? " with you"
@@ -1735,7 +1748,7 @@ const VacantRoleDetailsModal = ({
             {isFilledRole ? (
               <Tooltip content={filledRoleUser?.id ? `Click to view ${filledRoleDisplayName || "this user"}'s profile` : undefined}>
               <div
-                className={`w-20 h-20 rounded-full ${filledRoleUser?.id ? "cursor-pointer" : ""}`}
+                className={`w-20 h-20 rounded-full relative overflow-hidden ${filledRoleUser?.id ? "cursor-pointer" : ""}`}
                 onClick={filledRoleUser?.id ? handleFilledUserClick : undefined}
                 role={filledRoleUser?.id ? "button" : undefined}
                 tabIndex={filledRoleUser?.id ? 0 : undefined}
@@ -1764,6 +1777,7 @@ const VacantRoleDetailsModal = ({
                       : getRoleInitials()}
                   </span>
                 </div>
+                {demoAvatarOverlay}
               </div>
               </Tooltip>
             ) : effectivePct !== null ? (
@@ -1780,10 +1794,12 @@ const VacantRoleDetailsModal = ({
                 <span className="relative text-2xl font-bold">
                   {effectivePct}%
                 </span>
+                {demoAvatarOverlay}
               </div>
             ) : (
-              <div className="bg-amber-500 text-white rounded-full w-20 h-20 flex items-center justify-center">
+              <div className="bg-amber-500 text-white rounded-full w-20 h-20 relative flex items-center justify-center overflow-hidden">
                 <span className="text-2xl">{getRoleInitials()}</span>
+                {demoAvatarOverlay}
               </div>
             )}
             {isFilledRole && MatchTierIcon && (
@@ -1871,6 +1887,16 @@ const VacantRoleDetailsModal = ({
                   </span>
                 ) : null}
               </div>
+            )}
+
+            {isSyntheticRole(displayRole) && (
+              <Tooltip
+                content={DEMO_ROLE_TOOLTIP}
+                wrapperClassName="mt-1 flex items-center gap-1 text-base-content/50 text-xs"
+              >
+                <FlaskConical size={12} className="flex-shrink-0" />
+                <span>Demo Role</span>
+              </Tooltip>
             )}
           </div>
         </div>

--- a/src/components/users/InlineUserLink.jsx
+++ b/src/components/users/InlineUserLink.jsx
@@ -1,10 +1,80 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { FlaskConical } from "lucide-react";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
+import { userService } from "../../services/userService";
+import Tooltip from "../common/Tooltip";
+import { DEMO_PROFILE_TOOLTIP } from "../../utils/userHelpers";
 import {
   getDisplayName,
   isDeletedUser,
 } from "../../utils/deletedUser";
 import UserAvatar from "./UserAvatar";
+
+const inlineUserProfileCache = new Map();
+
+const extractProfilePayload = (response) => {
+  const payload = response?.data ?? response;
+
+  if (!payload) return null;
+  if (payload?.success !== undefined) return payload?.data ?? null;
+
+  return payload?.data?.data ?? payload?.data ?? payload;
+};
+
+const getCachedInlineUserProfile = async (userId) => {
+  const cacheKey = String(userId);
+
+  if (inlineUserProfileCache.has(cacheKey)) {
+    return inlineUserProfileCache.get(cacheKey);
+  }
+
+  const request = (async () => {
+    const response = await userService.getUserById(userId);
+    return extractProfilePayload(response);
+  })();
+
+  inlineUserProfileCache.set(cacheKey, request);
+
+  try {
+    const result = await request;
+    inlineUserProfileCache.set(cacheKey, Promise.resolve(result));
+    return result;
+  } catch (error) {
+    inlineUserProfileCache.delete(cacheKey);
+    throw error;
+  }
+};
+
+const mergeInlineUserData = (user, profile) => {
+  if (!profile) return user;
+
+  const resolvedAvatarUrl =
+    user?.avatar_url ??
+    user?.avatarUrl ??
+    profile?.avatar_url ??
+    profile?.avatarUrl ??
+    null;
+  const resolvedSyntheticStatus =
+    user?.is_synthetic ??
+    user?.isSynthetic ??
+    profile?.is_synthetic ??
+    profile?.isSynthetic ??
+    undefined;
+
+  return {
+    ...profile,
+    ...user,
+    avatar_url: resolvedAvatarUrl,
+    avatarUrl:
+      user?.avatarUrl ??
+      user?.avatar_url ??
+      profile?.avatarUrl ??
+      profile?.avatar_url ??
+      null,
+    is_synthetic: resolvedSyntheticStatus,
+    isSynthetic: resolvedSyntheticStatus,
+  };
+};
 
 /**
  * InlineUserLink Component
@@ -47,16 +117,49 @@ const InlineUserLink = ({
 }) => {
   // Try to get global modal context (returns null if not available)
   const userModalContext = useUserModalSafe();
-
-  if (!user) return null;
+  const [resolvedInlineProfile, setResolvedInlineProfile] = useState(null);
 
   // Normalize user ID from various possible field names
   const userId = user?.id || user?.user_id || user?.userId;
-  const name = getDisplayName(user) || "Unknown";
   const isFormerUser = isDeletedUser(user);
+  const hasInlineAvatar = Boolean(user?.avatar_url || user?.avatarUrl);
+  const hasInlineSyntheticFlag =
+    user?.is_synthetic != null || user?.isSynthetic != null;
+  const needsInlineHydration =
+    !isFormerUser && Boolean(userId) && (!hasInlineAvatar || !hasInlineSyntheticFlag);
+
+  useEffect(() => {
+    if (!needsInlineHydration) {
+      setResolvedInlineProfile(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    getCachedInlineUserProfile(userId)
+      .then((profile) => {
+        if (!cancelled) {
+          setResolvedInlineProfile(profile);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResolvedInlineProfile(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [needsInlineHydration, userId]);
+
+  if (!user) return null;
 
   // Determine if we can handle clicks
   const canClick = !isFormerUser && userId && (userModalContext || onOpenUser);
+  const inlineUser = mergeInlineUserData(user, resolvedInlineProfile);
+  const name = getDisplayName(inlineUser) || "Unknown";
+  const showDemoIndicator = !isFormerUser && Boolean(inlineUser?.is_synthetic || inlineUser?.isSynthetic);
 
   const handleClick = (e) => {
     if (!canClick) return;
@@ -82,7 +185,7 @@ const InlineUserLink = ({
       {/* Avatar */}
       {showAvatar && (
         <UserAvatar
-          user={user}
+          user={inlineUser}
           deleted={isFormerUser}
           sizeClass={avatarSize}
           className="mr-1"
@@ -108,6 +211,14 @@ const InlineUserLink = ({
       >
         {name}
       </span>
+      {showDemoIndicator && (
+        <Tooltip
+          content={DEMO_PROFILE_TOOLTIP}
+          wrapperClassName="ml-1 flex items-center text-base-content/50"
+        >
+          <FlaskConical size={10} className="shrink-0" />
+        </Tooltip>
+      )}
     </div>
   );
 };

--- a/src/components/users/UserAvatar.jsx
+++ b/src/components/users/UserAvatar.jsx
@@ -31,7 +31,7 @@ const UserAvatar = ({
       onClick={clickable ? onClick : undefined}
       title={title}
     >
-      <div className={`${sizeClass} rounded-full relative`}>
+      <div className={`${sizeClass} rounded-full relative overflow-hidden`}>
         {avatarUrl ? (
           <img
             src={avatarUrl}

--- a/src/components/users/UserAvatar.jsx
+++ b/src/components/users/UserAvatar.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { User } from "lucide-react";
-import { getUserInitials } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "./DemoAvatarOverlay";
+import { getUserInitials, isSyntheticUser } from "../../utils/userHelpers";
 import {
   getDisplayName,
   isDeletedUser,
@@ -17,11 +18,16 @@ const UserAvatar = ({
   title,
   iconSize = 12,
   initialsClassName = "text-[10px] font-medium",
+  showDemoOverlay = false,
+  demoOverlayTextClassName = "text-[7px]",
+  demoOverlayTextTranslateClassName = "-translate-y-[2px]",
 }) => {
   const isFormerUser = deleted || isDeletedUser(user);
   const avatarUrl =
     !isFormerUser && (user?.avatar_url || user?.avatarUrl || null);
   const displayName = getDisplayName(user, DELETED_USER_DISPLAY_NAME);
+  const showSyntheticOverlay =
+    showDemoOverlay && !isFormerUser && isSyntheticUser(user);
 
   return (
     <div
@@ -60,6 +66,13 @@ const UserAvatar = ({
             <span className={initialsClassName}>{getUserInitials(user)}</span>
           )}
         </div>
+
+        {showSyntheticOverlay && (
+          <DemoAvatarOverlay
+            textClassName={demoOverlayTextClassName}
+            textTranslateClassName={demoOverlayTextTranslateClassName}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -264,15 +264,6 @@ const UserCard = ({
       <span className="flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden whitespace-nowrap text-base-content/60">
         {scoreSubtitleItem}
         {user.username && <span>@{user.username}</span>}
-        {isSyntheticUser(user) && (
-          <Tooltip
-            content={DEMO_PROFILE_TOOLTIP}
-            wrapperClassName="flex items-center gap-0.5 whitespace-nowrap text-base-content/50"
-          >
-            <FlaskConical className="h-[11px] w-auto flex-shrink-0" />
-            <span>Demo</span>
-          </Tooltip>
-        )}
         {shouldShowVisibilityIcon() && (
           <Tooltip content={isUserProfilePublic() ? "Public Profile - visible for everyone" : "Private Profile - only visible for you"}>
             {isUserProfilePublic() ? (
@@ -280,6 +271,14 @@ const UserCard = ({
             ) : (
               <EyeClosed size={11} className="text-gray-500" />
             )}
+          </Tooltip>
+        )}
+        {isSyntheticUser(user) && (
+          <Tooltip
+            content={DEMO_PROFILE_TOOLTIP}
+            wrapperClassName="flex items-center whitespace-nowrap text-base-content/50"
+          >
+            <FlaskConical className="h-[11px] w-auto flex-shrink-0" />
           </Tooltip>
         )}
       </span>
@@ -357,19 +356,6 @@ const UserCard = ({
         >
           {scoreSubtitleItem}
           {user.username && <span>@{user.username}</span>}
-          {isSyntheticUser(user) && (
-            <Tooltip
-              content={DEMO_PROFILE_TOOLTIP}
-              wrapperClassName="flex items-start text-base-content/50"
-            >
-              <FlaskConical
-                className={`w-auto mr-0.5 flex-shrink-0 ${viewMode === "mini" ? "h-3 mt-px" : "h-[13px] mt-px"}`}
-              />
-              <span className="leading-[1.15]">
-                {viewMode === "mini" ? "Demo" : "Demo Profile"}
-              </span>
-            </Tooltip>
-          )}
           {shouldShowVisibilityIcon() && (
             <Tooltip
               content={
@@ -407,6 +393,19 @@ const UserCard = ({
                 </span>
               </span>
             )}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50"
+            >
+              <FlaskConical
+                className={`w-auto mr-0.5 flex-shrink-0 ${viewMode === "mini" ? "h-3 mt-px" : "h-[13px] mt-px"}`}
+              />
+              <span className="leading-[1.15]">
+                {viewMode === "mini" ? "Demo" : "Demo Profile"}
+              </span>
+            </Tooltip>
+          )}
         </span>
       }
       hoverable

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -140,15 +140,6 @@ const UserProfileHeaderSection = ({
         </h1>
         <div className="flex items-center flex-wrap gap-x-3 gap-y-0.5 text-sm">
           <span className="text-base-content/70">@{user?.username}</span>
-          {isSyntheticUser(user) && (
-            <Tooltip
-              content={DEMO_PROFILE_TOOLTIP}
-              wrapperClassName="flex items-start text-base-content/50 text-sm"
-            >
-              <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
-              <span className="leading-[1.15]">Demo Profile</span>
-            </Tooltip>
-          )}
 
           {filledRoleName && (
             <span className="flex items-center gap-1 text-base-content/70">
@@ -175,6 +166,15 @@ const UserProfileHeaderSection = ({
                 </>
               )}
             </div>
+          )}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50 text-sm"
+            >
+              <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
+              <span className="leading-[1.15]">Demo Profile</span>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -194,6 +194,10 @@ const Chat = () => {
                     firstName: userData.firstName || userData.first_name,
                     lastName: userData.lastName || userData.last_name,
                     avatarUrl: userData.avatarUrl || userData.avatar_url,
+                    isSynthetic:
+                      userData.isSynthetic ?? userData.is_synthetic ?? undefined,
+                    is_synthetic:
+                      userData.is_synthetic ?? userData.isSynthetic ?? undefined,
                   },
                   lastMessage: "Start your conversation...",
                   updatedAt: new Date().toISOString(),
@@ -275,6 +279,25 @@ const Chat = () => {
               if (teamDetails?.data?.members) {
                 conversationDetails.data.team = {
                   ...conversationDetails.data.team,
+                  avatarUrl:
+                    conversationDetails.data.team.avatarUrl ||
+                    conversationDetails.data.team.teamavatarUrl ||
+                    conversationDetails.data.team.teamavatar_url ||
+                    teamDetails.data.avatarUrl ||
+                    teamDetails.data.teamavatarUrl ||
+                    teamDetails.data.teamavatar_url,
+                  isSynthetic:
+                    conversationDetails.data.team.isSynthetic ??
+                    conversationDetails.data.team.is_synthetic ??
+                    teamDetails.data.isSynthetic ??
+                    teamDetails.data.is_synthetic ??
+                    undefined,
+                  is_synthetic:
+                    conversationDetails.data.team.is_synthetic ??
+                    conversationDetails.data.team.isSynthetic ??
+                    teamDetails.data.is_synthetic ??
+                    teamDetails.data.isSynthetic ??
+                    undefined,
                   members: teamDetails.data.members,
                 };
               }
@@ -302,6 +325,14 @@ const Chat = () => {
                     id: conversationDetails.data.team.id,
                     name: conversationDetails.data.team.name,
                     avatarUrl: conversationDetails.data.team.avatarUrl,
+                    isSynthetic:
+                      conversationDetails.data.team.isSynthetic ??
+                      conversationDetails.data.team.is_synthetic ??
+                      undefined,
+                    is_synthetic:
+                      conversationDetails.data.team.is_synthetic ??
+                      conversationDetails.data.team.isSynthetic ??
+                      undefined,
                   },
                   lastMessage: "Start your team conversation...",
                   updatedAt: new Date().toISOString(),
@@ -342,6 +373,25 @@ const Chat = () => {
               if (teamDetails?.data?.members) {
                 conversationDetails.data.team = {
                   ...conversationDetails.data.team,
+                  avatarUrl:
+                    conversationDetails.data.team.avatarUrl ||
+                    conversationDetails.data.team.teamavatarUrl ||
+                    conversationDetails.data.team.teamavatar_url ||
+                    teamDetails.data.avatarUrl ||
+                    teamDetails.data.teamavatarUrl ||
+                    teamDetails.data.teamavatar_url,
+                  isSynthetic:
+                    conversationDetails.data.team.isSynthetic ??
+                    conversationDetails.data.team.is_synthetic ??
+                    teamDetails.data.isSynthetic ??
+                    teamDetails.data.is_synthetic ??
+                    undefined,
+                  is_synthetic:
+                    conversationDetails.data.team.is_synthetic ??
+                    conversationDetails.data.team.isSynthetic ??
+                    teamDetails.data.is_synthetic ??
+                    teamDetails.data.isSynthetic ??
+                    undefined,
                   members: teamDetails.data.members,
                 };
               }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -978,15 +978,6 @@ const Profile = () => {
                 {/* Username, visibility, and date in one row */}
                 <div className="flex items-center text-base flex-wrap gap-x-4 gap-y-1">
                   <span className="text-base-content/70">@{user.username}</span>
-                  {isSyntheticUser(user) && (
-                    <Tooltip
-                      content={DEMO_PROFILE_TOOLTIP}
-                      wrapperClassName="flex items-start text-base-content/50"
-                    >
-                      <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
-                      <span className="leading-[1.15]">Demo Profile</span>
-                    </Tooltip>
-                  )}
                   <div
                     className="flex items-center text-base-content/70 tooltip tooltip-bottom tooltip-lomir cursor-help"
                     data-tip={
@@ -1007,6 +998,15 @@ const Profile = () => {
                       </>
                     )}
                   </div>
+                  {isSyntheticUser(user) && (
+                    <Tooltip
+                      content={DEMO_PROFILE_TOOLTIP}
+                      wrapperClassName="flex items-start text-base-content/50"
+                    >
+                      <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
+                      <span className="leading-[1.15]">Demo Profile</span>
+                    </Tooltip>
+                  )}
                 </div>
               </div>
 

--- a/src/utils/chatEntityResolvers.js
+++ b/src/utils/chatEntityResolvers.js
@@ -1,0 +1,115 @@
+import { teamService } from "../services/teamService";
+import { userService } from "../services/userService";
+
+const chatUserProfileCache = new Map();
+const chatTeamProfileCache = new Map();
+
+export const extractEntityPayload = (response) => {
+  const payload = response?.data ?? response;
+
+  if (!payload) return null;
+  if (payload?.success !== undefined) return payload?.data ?? null;
+
+  return payload?.data?.data ?? payload?.data ?? payload;
+};
+
+const getCachedEntity = async (cache, cacheKey, loader) => {
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey);
+  }
+
+  const request = loader();
+  cache.set(cacheKey, request);
+
+  try {
+    const result = await request;
+    cache.set(cacheKey, Promise.resolve(result));
+    return result;
+  } catch (error) {
+    cache.delete(cacheKey);
+    throw error;
+  }
+};
+
+export const getCachedChatUserProfile = async (userId) =>
+  getCachedEntity(chatUserProfileCache, String(userId), async () => {
+    const response = await userService.getUserById(userId);
+    return extractEntityPayload(response);
+  });
+
+export const getCachedChatTeamProfile = async (teamId) =>
+  getCachedEntity(chatTeamProfileCache, String(teamId), async () => {
+    const response = await teamService.getTeamById(teamId);
+    return extractEntityPayload(response);
+  });
+
+export const getTeamAvatarUrl = (team) =>
+  team?.avatarUrl ??
+  team?.avatar_url ??
+  team?.teamavatarUrl ??
+  team?.teamavatar_url ??
+  null;
+
+export const mergeResolvedUserData = (user, profile) => {
+  if (!profile) return user;
+
+  const resolvedAvatarUrl =
+    user?.avatar_url ??
+    user?.avatarUrl ??
+    profile?.avatar_url ??
+    profile?.avatarUrl ??
+    null;
+  const resolvedSyntheticStatus =
+    user?.is_synthetic ??
+    user?.isSynthetic ??
+    profile?.is_synthetic ??
+    profile?.isSynthetic ??
+    undefined;
+
+  return {
+    ...profile,
+    ...user,
+    avatar_url: resolvedAvatarUrl,
+    avatarUrl:
+      user?.avatarUrl ??
+      user?.avatar_url ??
+      profile?.avatarUrl ??
+      profile?.avatar_url ??
+      null,
+    is_synthetic: resolvedSyntheticStatus,
+    isSynthetic: resolvedSyntheticStatus,
+  };
+};
+
+export const mergeResolvedTeamData = (team, profile) => {
+  if (!profile) return team;
+
+  const resolvedAvatarUrl = getTeamAvatarUrl(team) ?? getTeamAvatarUrl(profile);
+  const resolvedSyntheticStatus =
+    team?.is_synthetic ??
+    team?.isSynthetic ??
+    profile?.is_synthetic ??
+    profile?.isSynthetic ??
+    undefined;
+
+  return {
+    ...profile,
+    ...team,
+    avatarUrl: resolvedAvatarUrl,
+    avatar_url: resolvedAvatarUrl,
+    teamavatarUrl:
+      team?.teamavatarUrl ??
+      team?.teamavatar_url ??
+      profile?.teamavatarUrl ??
+      profile?.teamavatar_url ??
+      resolvedAvatarUrl,
+    teamavatar_url:
+      team?.teamavatar_url ??
+      team?.teamavatarUrl ??
+      profile?.teamavatar_url ??
+      profile?.teamavatarUrl ??
+      resolvedAvatarUrl,
+    is_synthetic: resolvedSyntheticStatus,
+    isSynthetic: resolvedSyntheticStatus,
+  };
+};

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -78,8 +78,20 @@ export const isSyntheticTeam = (team) => {
   return team.is_synthetic === true || team.isSynthetic === true;
 };
 
+/**
+ * Check if a vacant role is a synthetic/demo role
+ * Handles both snake_case (from API) and camelCase (from frontend state)
+ */
+export const isSyntheticRole = (role) => {
+  if (!role) return false;
+  return role.is_synthetic === true || role.isSynthetic === true;
+};
+
 export const DEMO_PROFILE_TOOLTIP =
   "Demo Profile: For testing purposes, no real person";
 
 export const DEMO_TEAM_TOOLTIP =
   "Demo Team: for testing purposes, no real team";
+
+export const DEMO_ROLE_TOOLTIP =
+  "Demo Role: for testing purposes, no real role";

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -1,3 +1,14 @@
+const hasTruthySyntheticFlag = (value) => {
+  if (value === true || value === 1) return true;
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "1";
+  }
+
+  return false;
+};
+
 /**
  * Get user initials for avatar fallback
  * Returns 2 letters for users with first and last name (e.g., "VL" for Valentina Lopez)
@@ -66,7 +77,10 @@ export const getDisplayName = (user) => {
  */
 export const isSyntheticUser = (user) => {
   if (!user) return false;
-  return user.is_synthetic === true || user.isSynthetic === true;
+  return (
+    hasTruthySyntheticFlag(user.is_synthetic) ||
+    hasTruthySyntheticFlag(user.isSynthetic)
+  );
 };
 
 /**
@@ -75,7 +89,10 @@ export const isSyntheticUser = (user) => {
  */
 export const isSyntheticTeam = (team) => {
   if (!team) return false;
-  return team.is_synthetic === true || team.isSynthetic === true;
+  return (
+    hasTruthySyntheticFlag(team.is_synthetic) ||
+    hasTruthySyntheticFlag(team.isSynthetic)
+  );
 };
 
 /**
@@ -84,7 +101,10 @@ export const isSyntheticTeam = (team) => {
  */
 export const isSyntheticRole = (role) => {
   if (!role) return false;
-  return role.is_synthetic === true || role.isSynthetic === true;
+  return (
+    hasTruthySyntheticFlag(role.is_synthetic) ||
+    hasTruthySyntheticFlag(role.isSynthetic)
+  );
 };
 
 export const DEMO_PROFILE_TOOLTIP =


### PR DESCRIPTION
Summary
Adds visual "Demo" indicators across the app so real test users can distinguish synthetic seed data from real users, teams, and roles. Uses a consistent design pattern: a DEMO label overlay on avatar images and a FlaskConical icon with tooltip in subtitle lines.
Changes
New components

DemoAvatarOverlay (src/components/users/DemoAvatarOverlay.jsx) — Reusable overlay that renders a "DEMO" label at the bottom of avatar images with a gradient backdrop. Configurable text size for different avatar sizes (list/mini/card views).

New utilities

isSyntheticUser, isSyntheticTeam, isSyntheticRole (src/utils/userHelpers.js) — Helper functions that check both snake_case and camelCase property formats with robust type coercion via hasTruthySyntheticFlag
DEMO_PROFILE_TOOLTIP, DEMO_TEAM_TOOLTIP, DEMO_ROLE_TOOLTIP — Centralized tooltip text constants

Updated components
User indicators

UserCard — DEMO avatar overlay + FlaskConical "Demo Profile" in subtitle (card, mini, list views)
UserProfileHeaderSection — DEMO avatar overlay + "Demo Profile" subline in user detail modals
PersonRequestCard — DEMO avatar overlay + "Demo Profile" subline (used by TeamApplicationsModal)
Profile.jsx — DEMO overlay on own profile page avatar
TeamInvitesModal — DEMO avatar overlay + "Demo Profile" subline on invitee cards (custom inline layout)

Team indicators

TeamCard — DEMO avatar overlay + FlaskConical "Demo Team" in subtitle; smart logic shows "Demo Role" for role variants, falls back to "Demo Team"; shortens to "Demo" in list/mini views
TeamApplicationDetailsModal — DEMO overlay on team avatar
TeamInvitationDetailsModal — DEMO overlay on team avatar

Role indicators

VacantRoleCard — DEMO avatar overlay + FlaskConical "Demo Role" in subtitle across all three render paths (list, search card, filled/open card)
VacantRoleDetailsModal — DEMO overlay on role avatar in detail view

Auth context

AuthContext.jsx — Added is_synthetic/isSynthetic property sync in updateUser (matching existing pattern for is_public/isPublic)

Bug fix

TeamCard.jsx — Reverted accidental regression that changed application/invitation fetching from eager to lazy (notification badge counts were always 0). Reverted canManageInvitations to use isOwner instead of userRole === "owner" to avoid async timing issues.

Design decisions

Icon: FlaskConical from lucide-react — communicates "test/sample data" without implying bot/automation
Style: Plain inline text (text-base-content/50), no background pill — subtle and informative
Avatar overlay: Gradient-to-black at bottom with white "DEMO" text, scales per view mode
Tooltips: Explain the indicator on hover for clarity
No filtering: Synthetic data is labeled but never hidden from search or matching results