### PR TITLE
Fix Home page Create Team button to use CreateTeamModal

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,13 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import { Users, Handshake, MessageCircle } from "lucide-react"; // Correct way to import icons
 import { Link } from "react-router-dom";
-import PageContainer from "../components/layout/PageContainer";
 import Section from "../components/layout/Section";
 import InfoCard from "../components/common/InfoCard";
+import CreateTeamModal from "../components/teams/CreateTeamModal";
 import { useAuth } from "../contexts/AuthContext";
 
 const Home = () => {
   const { isAuthenticated } = useAuth();
+  const [isCreateTeamModalOpen, setIsCreateTeamModalOpen] = useState(false);
+
+  const handleTeamCreated = () => undefined;
 
   return (
     <div className="align-items-center text-center space-y-12">
@@ -40,12 +43,13 @@ const Home = () => {
                   >
                     Browse Teams
                   </Link>
-                  <Link
-                    to="/teams/create"
+                  <button
+                    type="button"
+                    onClick={() => setIsCreateTeamModalOpen(true)}
                     className="btn btn-outline btn-primary"
                   >
                     Create Team
-                  </Link>
+                  </button>
                 </>
               )}
             </div>
@@ -96,6 +100,12 @@ const Home = () => {
           </InfoCard>
         </div>
       </Section>
+
+      <CreateTeamModal
+        isOpen={isCreateTeamModalOpen}
+        onClose={() => setIsCreateTeamModalOpen(false)}
+        onTeamCreated={handleTeamCreated}
+      />
     </div>
   );
 };


### PR DESCRIPTION
This updates the logged-in Create Team button on the Home page to use the same modal flow as + Create New Team on MyTeams.

Instead of linking to /teams/create, the Home page now:

imports CreateTeamModal
manages isCreateTeamModalOpen with local state
opens the modal on button click
renders CreateTeamModal with the same isOpen, onClose, and onTeamCreated pattern used on MyTeams
This keeps team creation behavior consistent across both entry points and preserves the modal’s existing success/navigation handling.

Files changed

src/pages/Home.jsx
Testing

Verified src/pages/Home.jsx passes ESLint
Verified app builds successfully with npm run build
Notes

No other functionality was changed
The Home page now reuses the existing shared team-creation flow instead of navigating to a separate route