### PR TITLE
Add demo overlays to profile and navbar avatars

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -4,7 +4,8 @@ import { useAuth } from "../../contexts/AuthContext";
 import LomirLogo from "../../assets/images/Lomir-logowordmark-color.svg";
 import { Bell, MessageCircle, Search, User, Settings, LogOut } from "lucide-react";
 import Colors from "../../utils/Colors";
-import { getUserInitials } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import { getUserInitials, isSyntheticUser } from "../../utils/userHelpers";
 import { messageService } from "../../services/messageService";
 import { notificationService } from "../../services/notificationService";
 import socketService from "../../services/socketService";
@@ -303,7 +304,7 @@ const Navbar = () => {
                 tabIndex={0}
                 className="btn btn-circle avatar bg-primary text-white btn-sm sm:btn-md"
               >
-                <div className="rounded-full flex items-center justify-center text-sm sm:text-base">
+                <div className="rounded-full flex items-center justify-center text-sm sm:text-base relative overflow-hidden w-full h-full">
                   {(user.avatarUrl || user.avatar_url) && !imageError ? (
                     <img
                       src={user.avatarUrl || user.avatar_url}
@@ -313,6 +314,9 @@ const Navbar = () => {
                     />
                   ) : (
                     <span>{getUserInitials(user)}</span>
+                  )}
+                  {isSyntheticUser(user) && (
+                    <DemoAvatarOverlay textClassName="text-[7px]" />
                   )}
                 </div>
               </label>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -962,7 +962,7 @@ const Profile = () => {
                     ) : (
                       <span className="text-4xl">{getUserInitials(user)}</span>
                     )}
-                    {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[11px]" />}
+                    {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[14px]" textTranslateClassName="-translate-y-[7px]" />}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

This PR improves the visibility and consistency of demo-user avatar labeling across the app.

- increases the `DEMO` label size on the profile page avatar by updating the view-mode `DemoAvatarOverlay`
- moves the profile page `DEMO` label slightly higher for better positioning
- adds the existing transparent gradient `DemoAvatarOverlay` to the authenticated user's small avatar in the navbar
- limits the navbar overlay to synthetic/demo users only

## Why

Demo accounts should be clearly identifiable in both the profile page and the navbar. This keeps the visual treatment more consistent and makes the demo status easier to notice at a glance.

## Testing

- UI-only change
- automated tests not run
- verified locally by checking the updated profile avatar and navbar avatar behavior for synthetic users
