### PR TITLE
feat: Demo data indicators + search filter toggle

### DIFF
--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -332,6 +332,15 @@ const BooleanSearchInput = ({
   );
 
   const renderCriteriaPill = (pill) => {
+    const pillLabelNode = pill.shortLabel ? (
+      <>
+        <span className="hidden sm:inline">{pill.label}</span>
+        <span className="sm:hidden">{pill.shortLabel}</span>
+      </>
+    ) : (
+      <span>{pill.label}</span>
+    );
+
     if (pill.type === "role") {
       return (
         <button
@@ -342,7 +351,7 @@ const BooleanSearchInput = ({
           title={`Remove ${pill.label}`}
         >
           <UserSearch size={12} className="flex-shrink-0" />
-          <span>{pill.label}</span>
+          {pillLabelNode}
           <span aria-hidden="true">×</span>
         </button>
       );
@@ -357,7 +366,7 @@ const BooleanSearchInput = ({
           title={`Remove ${pill.label}`}
         >
           <Users size={12} className="flex-shrink-0" />
-          <span>{pill.label}</span>
+          {pillLabelNode}
           <span aria-hidden="true">×</span>
         </button>
       );
@@ -370,7 +379,7 @@ const BooleanSearchInput = ({
         className="inline-flex items-center gap-1 rounded-full border border-[var(--color-primary)] bg-[#f0fdf4] px-2 py-0.5 text-xs font-bold text-[var(--color-primary)] transition-colors hover:border-[var(--color-primary-focus)] hover:bg-[#dcfce7] hover:text-[var(--color-primary-focus)]"
         title={`Remove ${pill.label}`}
       >
-        <span>{pill.label}</span>
+        {pillLabelNode}
         <span aria-hidden="true">x</span>
       </button>
     );

--- a/src/components/badges/AwardCard.jsx
+++ b/src/components/badges/AwardCard.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { format } from "date-fns";
 import {
   Users,
@@ -8,12 +8,19 @@ import {
   User,
   Tag,
   Award,
+  FlaskConical,
 } from "lucide-react";
+import Tooltip from "../common/Tooltip";
 import InlineUserLink from "../users/InlineUserLink";
 import { useTeamModalSafe } from "../../contexts/TeamModalContext";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
 import { getBadgeIcon } from "../../utils/badgeIconUtils";
+import {
+  getCachedChatTeamProfile,
+  mergeResolvedTeamData,
+} from "../../utils/chatEntityResolvers";
 import { useChildModalZIndex } from "../../contexts/ModalLayerContext";
+import { isSyntheticTeam, DEMO_TEAM_TOOLTIP } from "../../utils/userHelpers";
 import {
   getDisplayName as getDeletedUserDisplayName,
   isDeletedUser,
@@ -85,6 +92,25 @@ const AwardCard = ({
     award?.context_team_id ??
     (contextType === "team" ? (award?.contextId ?? award?.context_id) : null) ??
     null;
+  const baseTeam = award?.team ?? award?.contextTeam ?? award?.context_team ?? {};
+  const syntheticTeamFlag =
+    baseTeam?.is_synthetic ??
+    baseTeam?.isSynthetic ??
+    award?.teamIsSynthetic ??
+    award?.team_is_synthetic ??
+    award?.contextTeamIsSynthetic ??
+    award?.context_team_is_synthetic;
+  const teamObj = {
+    ...baseTeam,
+    id: baseTeam?.id ?? teamId,
+    name: baseTeam?.name ?? teamName,
+    is_synthetic:
+      baseTeam?.is_synthetic ?? baseTeam?.isSynthetic ?? syntheticTeamFlag,
+    isSynthetic:
+      baseTeam?.isSynthetic ?? baseTeam?.is_synthetic ?? syntheticTeamFlag,
+  };
+  const hasDirectTeamSyntheticFlag =
+    teamObj?.is_synthetic != null || teamObj?.isSynthetic != null;
 
   const tagName = award?.tagName ?? award?.tag_name ?? null;
 
@@ -172,6 +198,35 @@ const AwardCard = ({
 
   const { label: contextLabel, Icon: ContextIcon } =
     getContextMeta(contextType);
+  const [resolvedTeamProfile, setResolvedTeamProfile] = useState(null);
+
+  useEffect(() => {
+    if (!teamId || hasDirectTeamSyntheticFlag) {
+      setResolvedTeamProfile(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    getCachedChatTeamProfile(teamId)
+      .then((profile) => {
+        if (!cancelled) {
+          setResolvedTeamProfile(profile);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResolvedTeamProfile(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasDirectTeamSyntheticFlag, teamId]);
+
+  const resolvedTeam = mergeResolvedTeamData(teamObj, resolvedTeamProfile);
+  const isTeamSynthetic = isSyntheticTeam(resolvedTeam);
 
   // ============================================================
   // Render
@@ -285,6 +340,14 @@ const AwardCard = ({
                       >
                         {teamName}
                       </span>
+                      {isTeamSynthetic && (
+                        <Tooltip
+                          content={DEMO_TEAM_TOOLTIP}
+                          wrapperClassName="flex items-center text-base-content/50 ml-0.5"
+                        >
+                          <FlaskConical size={11} className="flex-shrink-0" />
+                        </Tooltip>
+                      )}
                     </>
                   ) : (
                     <span className="truncate">Team</span>
@@ -324,6 +387,14 @@ const AwardCard = ({
                 >
                   {teamName}
                 </span>
+                {isTeamSynthetic && (
+                  <Tooltip
+                    content={DEMO_TEAM_TOOLTIP}
+                    wrapperClassName="flex items-center text-base-content/50 ml-0.5"
+                  >
+                    <FlaskConical size={11} className="flex-shrink-0" />
+                  </Tooltip>
+                )}
               </span>
             )}
 

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -1,13 +1,21 @@
 import React, { useState, useEffect, useRef } from "react";
-import { getTeamInitials } from "../../utils/userHelpers";
+import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
 import { formatDistanceToNow } from "date-fns";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import UserAvatar from "../users/UserAvatar";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import {
   DELETED_USER_DISPLAY_NAME,
   getDisplayName as getDeletedUserDisplayName,
 } from "../../utils/deletedUser";
+import {
+  getCachedChatTeamProfile,
+  getCachedChatUserProfile,
+  getTeamAvatarUrl,
+  mergeResolvedTeamData,
+  mergeResolvedUserData,
+} from "../../utils/chatEntityResolvers";
 
 const ConversationList = ({
   conversations,
@@ -26,6 +34,8 @@ const ConversationList = ({
   // State for user details modal
   const [isUserModalOpen, setIsUserModalOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
+  const [resolvedConversationUsers, setResolvedConversationUsers] = useState({});
+  const [resolvedConversationTeams, setResolvedConversationTeams] = useState({});
 
   // Ref for the active conversation item
   const activeConversationRef = useRef(null);
@@ -43,6 +53,102 @@ const ConversationList = ({
       return () => clearTimeout(timer);
     }
   }, [activeConversationId]);
+
+  useEffect(() => {
+    const userIdsToFetch = [];
+    const teamIdsToFetch = [];
+
+    conversations.forEach((conversation) => {
+      if (conversation.type === "team") {
+        const team = conversation.team;
+        const teamId = team?.id ?? conversation.id;
+
+        if (
+          teamId != null &&
+          (!getTeamAvatarUrl(team) ||
+            (team?.is_synthetic == null && team?.isSynthetic == null))
+        ) {
+          teamIdsToFetch.push(teamId);
+        }
+
+        return;
+      }
+
+      const partner = conversation.partner || conversation.partnerUser;
+      const userId = partner?.id;
+
+      if (
+        userId != null &&
+        (!(partner?.avatar_url || partner?.avatarUrl) ||
+          (partner?.is_synthetic == null && partner?.isSynthetic == null))
+      ) {
+        userIdsToFetch.push(userId);
+      }
+    });
+
+    const uniqueUserIds = [...new Set(userIdsToFetch)];
+    const uniqueTeamIds = [...new Set(teamIdsToFetch)];
+
+    if (uniqueUserIds.length === 0 && uniqueTeamIds.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    if (uniqueUserIds.length > 0) {
+      Promise.allSettled(
+        uniqueUserIds.map(async (userId) => ({
+          userId,
+          profile: await getCachedChatUserProfile(userId),
+        })),
+      ).then((results) => {
+        if (cancelled) return;
+
+        const fetchedProfiles = {};
+
+        results.forEach((result) => {
+          if (result.status !== "fulfilled") return;
+          fetchedProfiles[String(result.value.userId)] = result.value.profile;
+        });
+
+        if (Object.keys(fetchedProfiles).length > 0) {
+          setResolvedConversationUsers((prev) => ({
+            ...prev,
+            ...fetchedProfiles,
+          }));
+        }
+      });
+    }
+
+    if (uniqueTeamIds.length > 0) {
+      Promise.allSettled(
+        uniqueTeamIds.map(async (teamId) => ({
+          teamId,
+          profile: await getCachedChatTeamProfile(teamId),
+        })),
+      ).then((results) => {
+        if (cancelled) return;
+
+        const fetchedProfiles = {};
+
+        results.forEach((result) => {
+          if (result.status !== "fulfilled") return;
+          fetchedProfiles[String(result.value.teamId)] = result.value.profile;
+        });
+
+        if (Object.keys(fetchedProfiles).length > 0) {
+          setResolvedConversationTeams((prev) => ({
+            ...prev,
+            ...fetchedProfiles,
+          }));
+        }
+      });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [conversations]);
 
   useEffect(() => {
     if (
@@ -114,9 +220,25 @@ const ConversationList = ({
         {conversations.map((conversation) => {
           // Handle both direct messages and team conversations
           const isTeam = conversation.type === "team";
-          const conversationData = isTeam
+          const rawConversationData = isTeam
             ? conversation.team
             : conversation.partner || conversation.partnerUser;
+          const conversationEntityId = isTeam
+            ? rawConversationData?.id ?? conversation.id
+            : rawConversationData?.id;
+          const conversationData = isTeam
+            ? mergeResolvedTeamData(
+                rawConversationData,
+                conversationEntityId != null
+                  ? resolvedConversationTeams[String(conversationEntityId)]
+                  : null,
+              )
+            : mergeResolvedUserData(
+                rawConversationData,
+                conversationEntityId != null
+                  ? resolvedConversationUsers[String(conversationEntityId)]
+                  : null,
+              );
           const directDisplayName = isTeam
             ? ""
             : getDeletedUserDisplayName(conversationData, "");
@@ -172,10 +294,10 @@ const ConversationList = ({
                   }
                 >
                   {isTeam ? (
-                    <div className="w-12 h-12 rounded-full relative">
-                      {conversationData?.avatarUrl ? (
+                    <div className="w-12 h-12 rounded-full relative overflow-hidden">
+                      {getTeamAvatarUrl(conversationData) ? (
                         <img
-                          src={conversationData.avatarUrl}
+                          src={getTeamAvatarUrl(conversationData)}
                           alt={displayName}
                           className="object-cover w-full h-full rounded-full"
                           onError={(e) => {
@@ -191,13 +313,18 @@ const ConversationList = ({
                       <div
                         className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                         style={{
-                          display: conversationData?.avatarUrl ? "none" : "flex",
+                          display: getTeamAvatarUrl(conversationData)
+                            ? "none"
+                            : "flex",
                         }}
                       >
                         <span className="text-lg font-medium">
                           {getTeamInitials(conversationData)}
                         </span>
                       </div>
+                      {isSyntheticTeam(conversationData) && (
+                        <DemoAvatarOverlay textClassName="text-[7px]" />
+                      )}
                     </div>
                   ) : (
                     <UserAvatar
@@ -206,6 +333,9 @@ const ConversationList = ({
                       sizeClass="w-12 h-12"
                       iconSize={24}
                       initialsClassName="text-lg font-medium"
+                      showDemoOverlay
+                      demoOverlayTextClassName="text-[7px]"
+                      demoOverlayTextTranslateClassName="-translate-y-[2px]"
                     />
                   )}
                   {isOnline && (

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -1,6 +1,9 @@
 import React, { useRef, useEffect, useState } from "react";
 import { format, isToday, isYesterday } from "date-fns";
-import { getUserInitials, getTeamInitials } from "../../utils/userHelpers";
+import {
+  getTeamInitials,
+  isSyntheticTeam,
+} from "../../utils/userHelpers";
 import {
   UserPlus,
   UserMinus,
@@ -20,6 +23,7 @@ import {
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import UserAvatar from "../users/UserAvatar";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { userService } from "../../services/userService";
 import {
   getFileExpirationStatus,
@@ -30,6 +34,13 @@ import {
   DELETED_USER_DISPLAY_NAME,
   getDisplayName as getDeletedUserDisplayName,
 } from "../../utils/deletedUser";
+import {
+  getCachedChatTeamProfile,
+  getCachedChatUserProfile,
+  getTeamAvatarUrl,
+  mergeResolvedTeamData,
+  mergeResolvedUserData,
+} from "../../utils/chatEntityResolvers";
 
 const parseIdNameToken = (token) => {
   const t = (token || "").trim();
@@ -418,6 +429,8 @@ const MessageDisplay = ({
   const [nameResolveError, setNameResolveError] = useState(null);
 
   const [nameToIdCache, setNameToIdCache] = useState({});
+  const [resolvedChatUsers, setResolvedChatUsers] = useState({});
+  const [resolvedChatTeams, setResolvedChatTeams] = useState({});
 
   useEffect(() => {
     const previousSnapshot = previousMessageSnapshotRef.current;
@@ -474,6 +487,96 @@ const MessageDisplay = ({
     teamMembersRefreshSignal,
   ]);
 
+  useEffect(() => {
+    const userIdsToFetch = [];
+
+    if (
+      conversationPartner?.id != null &&
+      !conversationPartner?.isDeletedUser &&
+      (!(conversationPartner?.avatar_url || conversationPartner?.avatarUrl) ||
+        (conversationPartner?.is_synthetic == null &&
+          conversationPartner?.isSynthetic == null))
+    ) {
+      userIdsToFetch.push(conversationPartner.id);
+    }
+
+    (teamMembers || []).forEach((member) => {
+      const memberId = member?.user_id ?? member?.userId ?? null;
+      if (memberId == null) return;
+
+      if (
+        !(member?.avatar_url || member?.avatarUrl) ||
+        (member?.is_synthetic == null && member?.isSynthetic == null)
+      ) {
+        userIdsToFetch.push(memberId);
+      }
+    });
+
+    const uniqueUserIds = [...new Set(userIdsToFetch)];
+
+    if (uniqueUserIds.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    Promise.allSettled(
+      uniqueUserIds.map(async (userId) => ({
+        userId,
+        profile: await getCachedChatUserProfile(userId),
+      })),
+    ).then((results) => {
+      if (cancelled) return;
+
+      const fetchedProfiles = {};
+
+      results.forEach((result) => {
+        if (result.status !== "fulfilled") return;
+        fetchedProfiles[String(result.value.userId)] = result.value.profile;
+      });
+
+      if (Object.keys(fetchedProfiles).length > 0) {
+        setResolvedChatUsers((prev) => ({
+          ...prev,
+          ...fetchedProfiles,
+        }));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationPartner, teamMembers]);
+
+  useEffect(() => {
+    const teamId = teamData?.id;
+
+    if (
+      teamId == null ||
+      (getTeamAvatarUrl(teamData) &&
+        (teamData?.is_synthetic != null || teamData?.isSynthetic != null))
+    ) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    getCachedChatTeamProfile(teamId)
+      .then((profile) => {
+        if (!cancelled) {
+          setResolvedChatTeams((prev) => ({
+            ...prev,
+            [String(teamId)]: profile,
+          }));
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [teamData]);
+
   // Handle team avatar/name click
   const handleTeamClick = () => {
     if (conversationType !== "team") return;
@@ -519,6 +622,24 @@ const MessageDisplay = ({
     setIsUserModalOpen(false);
     setSelectedUserId(null);
   };
+
+  const resolvedConversationPartner = mergeResolvedUserData(
+    conversationPartner,
+    conversationPartner?.id != null
+      ? resolvedChatUsers[String(conversationPartner.id)]
+      : null,
+  );
+
+  const resolvedTeamData = mergeResolvedTeamData(
+    teamData,
+    teamData?.id != null ? resolvedChatTeams[String(teamData.id)] : null,
+  );
+
+  const getResolvedUserData = (userData, userId = null) =>
+    mergeResolvedUserData(
+      userData,
+      userId != null ? resolvedChatUsers[String(userId)] : null,
+    );
 
   const getTeamMemberFullName = (m) => {
     const first = m.first_name ?? m.firstName;
@@ -694,7 +815,8 @@ const MessageDisplay = ({
       );
 
       if (member) {
-        return {
+        return getResolvedUserData(
+          {
           id: member.user_id || member.userId || senderId,
           username: member.username,
           firstName: member.first_name || member.firstName,
@@ -702,13 +824,15 @@ const MessageDisplay = ({
           avatarUrl: member.avatar_url || member.avatarUrl,
           isCurrentMember: true,
           isDeletedUser: false,
-        };
+          },
+          member.user_id || member.userId || senderId,
+        );
       }
     }
 
-    if (conversationPartner && senderId === conversationPartner.id) {
+    if (resolvedConversationPartner && senderId === resolvedConversationPartner.id) {
       return {
-        ...conversationPartner,
+        ...resolvedConversationPartner,
         isCurrentMember: true,
         isDeletedUser: false,
       };
@@ -735,10 +859,13 @@ const MessageDisplay = ({
         embeddedSender.id == null || !embeddedSender.username;
 
       if (hasMessageSenderInfo || isDeletedSender) {
-        return {
-          ...embeddedSender,
-          isDeletedUser: isDeletedSender,
-        };
+        return getResolvedUserData(
+          {
+            ...embeddedSender,
+            isDeletedUser: isDeletedSender,
+          },
+          embeddedSender.id,
+        );
       }
     }
 
@@ -797,6 +924,9 @@ const MessageDisplay = ({
           }
           iconSize={16}
           initialsClassName="text-sm font-medium event-message-text"
+          showDemoOverlay
+          demoOverlayTextClassName="text-[5px]"
+          demoOverlayTextTranslateClassName="-translate-y-[1px]"
         />
       );
     }
@@ -856,6 +986,73 @@ const MessageDisplay = ({
         }
       >
         {displayName}
+      </div>
+    );
+  };
+
+  const renderConversationPartnerAvatar = () => {
+    if (!resolvedConversationPartner) return null;
+
+    return (
+      <UserAvatar
+        user={resolvedConversationPartner}
+        sizeClass="w-16 h-16"
+        className="mb-2 mx-auto"
+        clickable
+        onClick={() => handleUserClick(resolvedConversationPartner.id)}
+        title={`View ${
+          resolvedConversationPartner.firstName ||
+          resolvedConversationPartner.username
+        } details`}
+        iconSize={24}
+        initialsClassName="text-xl font-medium"
+        showDemoOverlay
+        demoOverlayTextClassName="text-[9px]"
+        demoOverlayTextTranslateClassName="-translate-y-[4px]"
+      />
+    );
+  };
+
+  const renderTeamConversationAvatar = () => {
+    if (!resolvedTeamData) return null;
+
+    const teamAvatarUrl = getTeamAvatarUrl(resolvedTeamData);
+
+    return (
+      <div
+        className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
+        onClick={handleTeamClick}
+        title={`View ${resolvedTeamData.name} details`}
+      >
+        <div className="w-16 h-16 rounded-full mx-auto relative overflow-hidden">
+          {teamAvatarUrl ? (
+            <img
+              src={teamAvatarUrl}
+              alt={resolvedTeamData.name}
+              className="object-cover w-full h-full rounded-full"
+              onError={(e) => {
+                e.target.style.display = "none";
+                const fallback =
+                  e.target.parentElement.querySelector(".avatar-fallback");
+                if (fallback) fallback.style.display = "flex";
+              }}
+            />
+          ) : null}
+          <div
+            className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+            style={{ display: teamAvatarUrl ? "none" : "flex" }}
+          >
+            <span className="text-xl font-medium">
+              {getTeamInitials(resolvedTeamData)}
+            </span>
+          </div>
+          {isSyntheticTeam(resolvedTeamData) && (
+            <DemoAvatarOverlay
+              textClassName="text-[9px]"
+              textTranslateClassName="-translate-y-[4px]"
+            />
+          )}
+        </div>
       </div>
     );
   };
@@ -2006,96 +2203,34 @@ const MessageDisplay = ({
             <div className="mb-2 text-sm text-warning">{nameResolveError}</div>
           )}
 
-          {conversationPartner && conversationType === "direct" && (
+          {resolvedConversationPartner && conversationType === "direct" && (
             <div className="text-center pb-4 mb-4 border-b border-base-200">
-              <div
-                className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
-                onClick={() => handleUserClick(conversationPartner.id)}
-                title={`View ${
-                  conversationPartner.firstName || conversationPartner.username
-                } details`}
-              >
-                <div className="w-16 h-16 rounded-full mx-auto relative">
-                  {conversationPartner.avatarUrl ? (
-                    <img
-                      src={conversationPartner.avatarUrl}
-                      alt={conversationPartner.username}
-                      className="object-cover w-full h-full rounded-full"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        const fallback =
-                          e.target.parentElement.querySelector(
-                            ".avatar-fallback",
-                          );
-                        if (fallback) fallback.style.display = "flex";
-                      }}
-                    />
-                  ) : null}
-                  <div
-                    className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                    style={{
-                      display: conversationPartner.avatarUrl ? "none" : "flex",
-                    }}
-                  >
-                    <span className="text-xl font-medium">
-                      {getUserInitials(conversationPartner)}
-                    </span>
-                  </div>
-                </div>
-              </div>
+              {renderConversationPartnerAvatar()}
               <h3
                 className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
-                onClick={() => handleUserClick(conversationPartner.id)}
+                onClick={() => handleUserClick(resolvedConversationPartner.id)}
                 title={`View ${
-                  conversationPartner.firstName || conversationPartner.username
+                  resolvedConversationPartner.firstName ||
+                  resolvedConversationPartner.username
                 } details`}
               >
-                {conversationPartner.firstName && conversationPartner.lastName
-                  ? `${conversationPartner.firstName} ${conversationPartner.lastName}`
-                  : conversationPartner.username}
+                {resolvedConversationPartner.firstName &&
+                resolvedConversationPartner.lastName
+                  ? `${resolvedConversationPartner.firstName} ${resolvedConversationPartner.lastName}`
+                  : resolvedConversationPartner.username}
               </h3>
             </div>
           )}
 
-          {teamData && conversationType === "team" && (
+          {resolvedTeamData && conversationType === "team" && (
             <div className="text-center pb-4 mb-4 border-b border-base-200">
-              <div
-                className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
-                onClick={handleTeamClick}
-                title={`View ${teamData.name} details`}
-              >
-                <div className="w-16 h-16 rounded-full mx-auto relative">
-                  {teamData.avatarUrl ? (
-                    <img
-                      src={teamData.avatarUrl}
-                      alt={teamData.name}
-                      className="object-cover w-full h-full rounded-full"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        const fallback =
-                          e.target.parentElement.querySelector(
-                            ".avatar-fallback",
-                          );
-                        if (fallback) fallback.style.display = "flex";
-                      }}
-                    />
-                  ) : null}
-                  <div
-                    className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                    style={{ display: teamData.avatarUrl ? "none" : "flex" }}
-                  >
-                    <span className="text-xl font-medium">
-                      {getTeamInitials(teamData)}
-                    </span>
-                  </div>
-                </div>
-              </div>
+              {renderTeamConversationAvatar()}
               <h3
                 className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
                 onClick={handleTeamClick}
-                title={`View ${teamData.name} details`}
+                title={`View ${resolvedTeamData.name} details`}
               >
-                {teamData.name}
+                {resolvedTeamData.name}
               </h3>
             </div>
           )}
@@ -2174,97 +2309,35 @@ const MessageDisplay = ({
         )}
 
         {/* Show conversation partner header for direct messages - CLICKABLE */}
-        {conversationPartner && conversationType === "direct" && (
+        {resolvedConversationPartner && conversationType === "direct" && (
           <div className="text-center pb-4 mb-4 border-b border-base-200">
-            <div
-              className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
-              onClick={() => handleUserClick(conversationPartner.id)}
-              title={`View ${
-                conversationPartner.firstName || conversationPartner.username
-              } details`}
-            >
-              <div className="w-16 h-16 rounded-full mx-auto relative">
-                {conversationPartner.avatarUrl ? (
-                  <img
-                    src={conversationPartner.avatarUrl}
-                    alt={conversationPartner.username}
-                    className="object-cover w-full h-full rounded-full"
-                    onError={(e) => {
-                      e.target.style.display = "none";
-                      const fallback =
-                        e.target.parentElement.querySelector(
-                          ".avatar-fallback",
-                        );
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                ) : null}
-                <div
-                  className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                  style={{
-                    display: conversationPartner.avatarUrl ? "none" : "flex",
-                  }}
-                >
-                  <span className="text-xl font-medium">
-                    {getUserInitials(conversationPartner)}
-                  </span>
-                </div>
-              </div>
-            </div>
+            {renderConversationPartnerAvatar()}
             <h3
               className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
-              onClick={() => handleUserClick(conversationPartner.id)}
+              onClick={() => handleUserClick(resolvedConversationPartner.id)}
               title={`View ${
-                conversationPartner.firstName || conversationPartner.username
+                resolvedConversationPartner.firstName ||
+                resolvedConversationPartner.username
               } details`}
             >
-              {conversationPartner.firstName && conversationPartner.lastName
-                ? `${conversationPartner.firstName} ${conversationPartner.lastName}`
-                : conversationPartner.username}
+              {resolvedConversationPartner.firstName &&
+              resolvedConversationPartner.lastName
+                ? `${resolvedConversationPartner.firstName} ${resolvedConversationPartner.lastName}`
+                : resolvedConversationPartner.username}
             </h3>
           </div>
         )}
 
         {/* Show team header for team conversations - CLICKABLE */}
-        {teamData && conversationType === "team" && (
+        {resolvedTeamData && conversationType === "team" && (
           <div className="text-center pb-4 mb-4 border-b border-base-200">
-            <div
-              className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
-              onClick={handleTeamClick}
-              title={`View ${teamData.name} details`}
-            >
-              <div className="w-16 h-16 rounded-full mx-auto relative">
-                {teamData.avatarUrl ? (
-                  <img
-                    src={teamData.avatarUrl}
-                    alt={teamData.name}
-                    className="object-cover w-full h-full rounded-full"
-                    onError={(e) => {
-                      e.target.style.display = "none";
-                      const fallback =
-                        e.target.parentElement.querySelector(
-                          ".avatar-fallback",
-                        );
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                ) : null}
-                <div
-                  className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                  style={{ display: teamData.avatarUrl ? "none" : "flex" }}
-                >
-                  <span className="text-xl font-medium">
-                    {getTeamInitials(teamData)}
-                  </span>
-                </div>
-              </div>
-            </div>
+            {renderTeamConversationAvatar()}
             <h3
               className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
               onClick={handleTeamClick}
-              title={`View ${teamData.name} details`}
+              title={`View ${resolvedTeamData.name} details`}
             >
-              {teamData.name}
+              {resolvedTeamData.name}
             </h3>
           </div>
         )}

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -27,6 +27,7 @@ const Card = ({
   viewMode = "card",
   clickTooltip = null,
   imageOverlay = null,
+  imageInnerOverlay = null,
   imageReplacement = null,
   listEdgeRounding = true,
 }) => {
@@ -83,7 +84,7 @@ const Card = ({
       >
         <div className="avatar placeholder relative">
           <div
-            className={`${shapeClass} ${sizeClass} flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}
+            className={`${shapeClass} ${sizeClass} relative flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}
           >
             {imageReplacement ? (
               imageReplacement
@@ -99,6 +100,7 @@ const Card = ({
                 {fallbackContent}
               </span>
             )}
+            {!imageReplacement && imageInnerOverlay}
           </div>
           {!imageReplacement && imageOverlay}
         </div>
@@ -206,7 +208,7 @@ const Card = ({
       >
         {(image || imageFallback || imageReplacement) && (
           <div className="avatar placeholder flex-shrink-0 relative">
-            <div className={`rounded-full w-9 h-9 flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}>
+            <div className={`rounded-full w-9 h-9 relative flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}>
               {imageReplacement ? (
                 imageReplacement
               ) : typeof image === "string" &&
@@ -228,6 +230,7 @@ const Card = ({
                       : "?")}
                 </span>
               )}
+              {!imageReplacement && imageInnerOverlay}
             </div>
             {!imageReplacement && imageOverlay}
           </div>

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -96,6 +96,10 @@ const PersonRequestCard = ({
   const clickableTextStyles = clickable
     ? "cursor-pointer hover:text-primary transition-colors"
     : "";
+  const showUsername =
+    user?.username &&
+    (getDisplayName() !== user.username || isSyntheticUser(user));
+  const showDemoProfile = isSyntheticUser(user);
 
   // ============ Render ============
 
@@ -148,17 +152,28 @@ const PersonRequestCard = ({
             {getDisplayName()}
           </h4>
 
-          {/* Username (if different from display name) */}
-          {user?.username &&
-            (getDisplayName() !== user.username || isSyntheticUser(user)) && (
-            <p
-              className={`text-sm text-base-content/70 ${clickableTextStyles}`}
-              onClick={handleUserClick}
-              title={clickable ? "View profile" : undefined}
-            >
-              @{user.username}
-            </p>
-            )}
+          {(showUsername || showDemoProfile) && (
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              {showUsername && (
+                <p
+                  className={`text-xs text-base-content/70 ${clickableTextStyles}`}
+                  onClick={handleUserClick}
+                  title={clickable ? "View profile" : undefined}
+                >
+                  @{user.username}
+                </p>
+              )}
+              {showDemoProfile && (
+                <Tooltip
+                  content={DEMO_PROFILE_TOOLTIP}
+                  wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+                >
+                  <FlaskConical size={12} className="flex-shrink-0" />
+                  <span>Demo Profile</span>
+                </Tooltip>
+              )}
+            </div>
+          )}
 
           {/* Location if available and showLocation is true */}
           {showLocation && getPostalCode() && (
@@ -173,15 +188,6 @@ const PersonRequestCard = ({
                 displayType="short"
               />
             </div>
-          )}
-          {isSyntheticUser(user) && (
-            <Tooltip
-              content={DEMO_PROFILE_TOOLTIP}
-              wrapperClassName="flex items-start text-base-content/50 text-xs"
-            >
-              <FlaskConical className="h-3 w-auto mr-0.5 flex-shrink-0 mt-px" />
-              <span className="leading-[1.15]">Demo Profile</span>
-            </Tooltip>
           )}
         </div>
 

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -159,15 +159,6 @@ const PersonRequestCard = ({
               @{user.username}
             </p>
             )}
-          {isSyntheticUser(user) && (
-            <Tooltip
-              content={DEMO_PROFILE_TOOLTIP}
-              wrapperClassName="flex items-start text-base-content/50 text-xs"
-            >
-              <FlaskConical className="h-3 w-auto mr-0.5 flex-shrink-0 mt-px" />
-              <span className="leading-[1.15]">Demo Profile</span>
-            </Tooltip>
-          )}
 
           {/* Location if available and showLocation is true */}
           {showLocation && getPostalCode() && (
@@ -182,6 +173,15 @@ const PersonRequestCard = ({
                 displayType="short"
               />
             </div>
+          )}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50 text-xs"
+            >
+              <FlaskConical className="h-3 w-auto mr-0.5 flex-shrink-0 mt-px" />
+              <span className="leading-[1.15]">Demo Profile</span>
+            </Tooltip>
           )}
         </div>
 

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -1,8 +1,13 @@
 import React from "react";
-import { Calendar, MapPin } from "lucide-react";
+import { Calendar, MapPin, FlaskConical } from "lucide-react";
 import { format } from "date-fns";
 import LocationDisplay from "./LocationDisplay";
-import { getUserInitials } from "../../utils/userHelpers";
+import Tooltip from "./Tooltip";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  isSyntheticUser,
+} from "../../utils/userHelpers";
 
 /**
  * PersonRequestCard Component
@@ -142,7 +147,8 @@ const PersonRequestCard = ({
           </h4>
 
           {/* Username (if different from display name) */}
-          {user?.username && getDisplayName() !== user.username && (
+          {user?.username &&
+            (getDisplayName() !== user.username || isSyntheticUser(user)) && (
             <p
               className={`text-sm text-base-content/70 ${clickableTextStyles}`}
               onClick={handleUserClick}
@@ -150,6 +156,15 @@ const PersonRequestCard = ({
             >
               @{user.username}
             </p>
+            )}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50 text-xs"
+            >
+              <FlaskConical className="h-3 w-auto mr-0.5 flex-shrink-0 mt-px" />
+              <span className="leading-[1.15]">Demo Profile</span>
+            </Tooltip>
           )}
 
           {/* Location if available and showLocation is true */}

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -8,6 +8,7 @@ import {
   getUserInitials,
   isSyntheticUser,
 } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
 /**
  * PersonRequestCard Component
@@ -108,7 +109,7 @@ const PersonRequestCard = ({
           onClick={handleUserClick}
           title={clickable ? "View profile" : undefined}
         >
-          <div className="w-12 h-12 rounded-full relative">
+          <div className="w-12 h-12 rounded-full relative overflow-hidden">
             {getAvatarUrl() ? (
               <img
                 src={getAvatarUrl()}
@@ -133,6 +134,7 @@ const PersonRequestCard = ({
                 {getUserInitials(user)}
               </span>
             </div>
+            {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[8px]" />}
           </div>
         </div>
 

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -4,7 +4,8 @@ import { useAuth } from "../../contexts/AuthContext";
 import LomirLogo from "../../assets/images/Lomir-logowordmark-color.svg";
 import { Bell, MessageCircle, Search, User, Settings, LogOut } from "lucide-react";
 import Colors from "../../utils/Colors";
-import { getUserInitials } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import { getUserInitials, isSyntheticUser } from "../../utils/userHelpers";
 import { messageService } from "../../services/messageService";
 import { notificationService } from "../../services/notificationService";
 import socketService from "../../services/socketService";
@@ -303,7 +304,7 @@ const Navbar = () => {
                 tabIndex={0}
                 className="btn btn-circle avatar bg-primary text-white btn-sm sm:btn-md"
               >
-                <div className="rounded-full flex items-center justify-center text-sm sm:text-base">
+                <div className="rounded-full flex items-center justify-center text-sm sm:text-base relative overflow-hidden w-full h-full">
                   {(user.avatarUrl || user.avatar_url) && !imageError ? (
                     <img
                       src={user.avatarUrl || user.avatar_url}
@@ -313,6 +314,9 @@ const Navbar = () => {
                     />
                   ) : (
                     <span>{getUserInitials(user)}</span>
+                  )}
+                  {isSyntheticUser(user) && (
+                    <DemoAvatarOverlay textClassName="text-[7px]" />
                   )}
                 </div>
               </label>

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -11,11 +11,11 @@ import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
+import InlineUserLink from "../users/InlineUserLink";
 import VacantRoleCard from "./VacantRoleCard";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import {
   DEMO_TEAM_TOOLTIP,
-  getUserInitials,
   isSyntheticTeam,
 } from "../../utils/userHelpers";
 import Alert from "../common/Alert";
@@ -161,10 +161,6 @@ const TeamApplicationDetailsModal = ({
     return max === null || max === undefined ? "∞" : max;
   };
 
-  const getOwnerAvatar = () => {
-    return owner.avatar_url || owner.avatarUrl || null;
-  };
-
   const handleTeamClick = () => {
     if (team?.id) setIsTeamDetailsOpen(true);
   };
@@ -283,57 +279,11 @@ const TeamApplicationDetailsModal = ({
   const footer = (
     <div className="flex items-center justify-between gap-3">
       {/* Received by (left) */}
-      <div className="flex items-center text-xs text-base-content/60">
-        <span className="mr-1">Received by</span>
-
-        {/* Owner Avatar */}
-        <div
-          className="avatar cursor-pointer hover:opacity-80 transition-opacity mr-1"
-          onClick={() => handleUserClick(owner?.id)}
-          title="View profile"
-        >
-          <div className="w-4 h-4 rounded-full relative">
-            {getOwnerAvatar() ? (
-              <img
-                src={getOwnerAvatar()}
-                alt="Owner"
-                className="object-cover w-full h-full rounded-full"
-                onError={(e) => {
-                  e.target.style.display = "none";
-                  const fallback =
-                    e.target.parentElement.querySelector(".avatar-fallback");
-                  if (fallback) fallback.style.display = "flex";
-                }}
-              />
-            ) : null}
-
-            {/* Fallback initials */}
-            <div
-              className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-              style={{
-                display: getOwnerAvatar() ? "none" : "flex",
-                fontSize: "8px",
-              }}
-            >
-              <span className="font-medium">{getUserInitials(owner)}</span>
-            </div>
-          </div>
-        </div>
-
-        {/* Owner Name - consistent with TeamInvitationDetailsModal pattern */}
-        <span
-          className="font-medium text-base-content/80 cursor-pointer hover:text-primary transition-colors"
-          onClick={() => handleUserClick(owner?.id)}
-          title="View profile"
-        >
-          {(() => {
-            const firstName = owner.first_name || owner.firstName;
-            const lastName = owner.last_name || owner.lastName;
-            const full = `${firstName || ""} ${lastName || ""}`.trim();
-            return full.length > 0 ? full : "Unknown";
-          })()}
-        </span>
-      </div>
+      <InlineUserLink
+        label="Received by"
+        user={owner}
+        onOpenUser={handleUserClick}
+      />
 
       {/* Buttons (right) */}
       <div className="flex justify-end gap-2">

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -197,6 +197,32 @@ const TeamApplicationDetailsModal = ({
     application?.isInternalRoleApplication ?? application?.is_internal_role_application ?? false;
   const roleName =
     application?.role?.roleName ?? application?.role?.role_name ?? null;
+  const syntheticRoleFlag =
+    application?.role?.is_synthetic ??
+    application?.role?.isSynthetic ??
+    application?.role_is_synthetic ??
+    application?.roleIsSynthetic;
+  const roleForCard =
+    hydratedRole ??
+    (application?.role
+      ? {
+          ...application.role,
+          is_synthetic:
+            application.role.is_synthetic ??
+            application.role.isSynthetic ??
+            syntheticRoleFlag,
+          isSynthetic:
+            application.role.isSynthetic ??
+            application.role.is_synthetic ??
+            syntheticRoleFlag,
+        }
+      : {
+          id: application?.roleId,
+          roleName: application?.roleName ?? application?.role_name,
+          role_name: application?.role_name ?? application?.roleName,
+          is_synthetic: syntheticRoleFlag,
+          isSynthetic: syntheticRoleFlag,
+        });
 
   // Custom header
   const customHeader = (
@@ -388,7 +414,7 @@ const TeamApplicationDetailsModal = ({
         {(application?.role || application?.roleId) && (
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
             <VacantRoleCard
-              role={hydratedRole ?? application?.role ?? { id: application?.roleId }}
+              role={roleForCard}
               team={team}
               matchScore={roleMatchScore}
               matchDetails={roleMatchDetails}

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -1,11 +1,23 @@
 import React, { useState } from "react";
-import { Calendar, Users, X, SendHorizontal } from "lucide-react";
+import {
+  Calendar,
+  Users,
+  X,
+  SendHorizontal,
+  FlaskConical,
+} from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
+import Tooltip from "../common/Tooltip";
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import VacantRoleCard from "./VacantRoleCard";
-import { getUserInitials } from '../../utils/userHelpers';
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import {
+  DEMO_TEAM_TOOLTIP,
+  getUserInitials,
+  isSyntheticTeam,
+} from "../../utils/userHelpers";
 import Alert from "../common/Alert";
 import { format } from "date-fns";
 import { useHydratedRole } from "../../hooks/useHydratedRole";
@@ -47,7 +59,19 @@ const TeamApplicationDetailsModal = ({
   // ============ Helpers ============
 
   // Get team data from application
-  const team = application?.team || {};
+  const baseTeam = application?.team || {};
+  const syntheticTeamFlag =
+    baseTeam?.is_synthetic ??
+    baseTeam?.isSynthetic ??
+    application?.team_is_synthetic ??
+    application?.teamIsSynthetic;
+  const team = {
+    ...baseTeam,
+    is_synthetic:
+      baseTeam?.is_synthetic ?? baseTeam?.isSynthetic ?? syntheticTeamFlag,
+    isSynthetic:
+      baseTeam?.isSynthetic ?? baseTeam?.is_synthetic ?? syntheticTeamFlag,
+  };
   const roleId = application?.role?.id ?? application?.roleId ?? null;
   const teamId = team?.id ?? null;
   const {
@@ -201,10 +225,23 @@ const TeamApplicationDetailsModal = ({
     application?.role?.is_synthetic ??
     application?.role?.isSynthetic ??
     application?.role_is_synthetic ??
-    application?.roleIsSynthetic;
+    application?.roleIsSynthetic ??
+    application?.is_synthetic ??
+    application?.isSynthetic;
   const roleForCard =
-    hydratedRole ??
-    (application?.role
+    hydratedRole
+      ? {
+          ...hydratedRole,
+          is_synthetic:
+            hydratedRole.is_synthetic ??
+            hydratedRole.isSynthetic ??
+            syntheticRoleFlag,
+          isSynthetic:
+            hydratedRole.isSynthetic ??
+            hydratedRole.is_synthetic ??
+            syntheticRoleFlag,
+        }
+      : application?.role
       ? {
           ...application.role,
           is_synthetic:
@@ -222,7 +259,7 @@ const TeamApplicationDetailsModal = ({
           role_name: application?.role_name ?? application?.roleName,
           is_synthetic: syntheticRoleFlag,
           isSynthetic: syntheticRoleFlag,
-        });
+        };
 
   // Custom header
   const customHeader = (
@@ -356,7 +393,7 @@ const TeamApplicationDetailsModal = ({
             title="View team details"
           >
             <div className="avatar">
-              <div className="w-12 h-12 rounded-full relative">
+              <div className="w-12 h-12 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
                     src={getTeamAvatar()}
@@ -382,6 +419,13 @@ const TeamApplicationDetailsModal = ({
                     {getTeamInitials()}
                   </span>
                 </div>
+
+                {isSyntheticTeam(team) && (
+                  <DemoAvatarOverlay
+                    textClassName="text-[7px]"
+                    textTranslateClassName="-translate-y-[3px]"
+                  />
+                )}
               </div>
             </div>
 
@@ -389,10 +433,23 @@ const TeamApplicationDetailsModal = ({
               <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
                 {team.name || "Unknown Team"}
               </h4>
-              <p className="text-sm text-base-content/70 flex items-center">
-                <Users size={14} className="mr-1 text-primary" />
-                {getMemberCount()}/{getMaxMembers()}
-              </p>
+              <div className="text-sm text-base-content/70 flex items-center flex-wrap gap-x-1.5 gap-y-px">
+                <span className="flex items-center">
+                  <Users size={14} className="mr-1 text-primary" />
+                  <span>
+                    {getMemberCount()}/{getMaxMembers()}
+                  </span>
+                </span>
+                {isSyntheticTeam(team) && (
+                  <Tooltip
+                    content={DEMO_TEAM_TOOLTIP}
+                    wrapperClassName="flex items-center gap-1 text-base-content/50 text-sm"
+                  >
+                    <FlaskConical size={14} className="flex-shrink-0" />
+                    <span>Demo Team</span>
+                  </Tooltip>
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -494,7 +494,9 @@ const TeamApplicationsModal = ({
           application?.role?.is_synthetic ??
           application?.role?.isSynthetic ??
           application?.role_is_synthetic ??
-          application?.roleIsSynthetic;
+          application?.roleIsSynthetic ??
+          application?.is_synthetic ??
+          application?.isSynthetic;
         const roleOverride = roleId ? roleStatusOverrides[roleId] : null;
         const role =
           application?.role && roleId

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -490,11 +490,24 @@ const TeamApplicationsModal = ({
           application?.roleId ??
           application?.role_id ??
           null;
+        const syntheticRoleFlag =
+          application?.role?.is_synthetic ??
+          application?.role?.isSynthetic ??
+          application?.role_is_synthetic ??
+          application?.roleIsSynthetic;
         const roleOverride = roleId ? roleStatusOverrides[roleId] : null;
         const role =
           application?.role && roleId
             ? {
                 ...application.role,
+                is_synthetic:
+                  application.role.is_synthetic ??
+                  application.role.isSynthetic ??
+                  syntheticRoleFlag,
+                isSynthetic:
+                  application.role.isSynthetic ??
+                  application.role.is_synthetic ??
+                  syntheticRoleFlag,
                 status:
                   roleOverride?.status ??
                   application.role.status ??
@@ -510,7 +523,19 @@ const TeamApplicationsModal = ({
                   application.role.filled_by_user ??
                   null,
               }
-            : application?.role ?? null;
+            : application?.role
+              ? {
+                  ...application.role,
+                  is_synthetic:
+                    application.role.is_synthetic ??
+                    application.role.isSynthetic ??
+                    syntheticRoleFlag,
+                  isSynthetic:
+                    application.role.isSynthetic ??
+                    application.role.is_synthetic ??
+                    syntheticRoleFlag,
+                }
+              : null;
         const applicantRoleMatch =
           roleId != null && applicantId != null
             ? roleCandidateMatchMap[String(roleId)]?.[String(applicantId)] ?? null

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import Card from "../common/Card";
 import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
@@ -479,38 +479,136 @@ const TeamCard = ({
     };
   };
 
-  const normalizedData = getNormalizedData();
-  const roleData = isRoleApplicationVariant
-    ? application?.role ?? null
+  const normalizedData = useMemo(
+    () => getNormalizedData(),
+    [team, application, invitation, effectiveVariant],
+  );
+  const roleSource = isRoleApplicationVariant
+    ? application ?? null
     : isRoleInvitationVariant
-      ? invitation?.role ?? null
+      ? invitation ?? null
       : null;
+  const nestedRoleData = roleSource?.role ?? null;
+  const flatRoleName = roleSource?.roleName ?? roleSource?.role_name ?? null;
+  const flatRoleBio = roleSource?.bio ?? roleSource?.roleBio ?? null;
+  const flatRoleCity = roleSource?.city ?? null;
+  const flatRoleCountry = roleSource?.country ?? null;
+  const flatRoleTags = roleSource?.tags ?? [];
+  const flatRoleBadges = roleSource?.badges ?? [];
+  const flatRoleIsRemote =
+    roleSource?.isRemote ?? roleSource?.is_remote ?? undefined;
+  const syntheticRoleFlag = isRoleApplicationVariant
+    ? application?.role?.is_synthetic ??
+      application?.role?.isSynthetic ??
+      application?.role_is_synthetic ??
+      application?.roleIsSynthetic ??
+      application?.is_synthetic ??
+      application?.isSynthetic
+    : isRoleInvitationVariant
+      ? invitation?.role?.is_synthetic ??
+        invitation?.role?.isSynthetic ??
+        invitation?.role_is_synthetic ??
+        invitation?.roleIsSynthetic ??
+        invitation?.is_synthetic ??
+        invitation?.isSynthetic
+      : undefined;
+  const roleDataId = isRoleApplicationVariant
+    ? application?.role?.id ?? application?.roleId ?? application?.role_id ?? null
+    : isRoleInvitationVariant
+      ? invitation?.role?.id ?? invitation?.roleId ?? invitation?.role_id ?? null
+      : null;
+  const roleData = useMemo(() => {
+    if (!isRoleVariant) return null;
+
+    if (nestedRoleData) {
+      const needsFallbackFields =
+        (nestedRoleData.id == null && roleDataId != null) ||
+        (!nestedRoleData.roleName &&
+          !nestedRoleData.role_name &&
+          flatRoleName != null) ||
+        (nestedRoleData.bio == null &&
+          nestedRoleData.roleBio == null &&
+          flatRoleBio != null) ||
+        (nestedRoleData.city == null && flatRoleCity != null) ||
+        (nestedRoleData.country == null && flatRoleCountry != null) ||
+        (nestedRoleData.is_synthetic == null &&
+          nestedRoleData.isSynthetic == null &&
+          syntheticRoleFlag != null) ||
+        (nestedRoleData.tags == null && flatRoleTags.length > 0) ||
+        (nestedRoleData.badges == null && flatRoleBadges.length > 0);
+
+      if (!needsFallbackFields) {
+        return nestedRoleData;
+      }
+
+      return {
+        ...nestedRoleData,
+        id: nestedRoleData.id ?? roleDataId,
+        roleName: nestedRoleData.roleName ?? nestedRoleData.role_name ?? flatRoleName,
+        role_name: nestedRoleData.role_name ?? nestedRoleData.roleName ?? flatRoleName,
+        bio: nestedRoleData.bio ?? nestedRoleData.roleBio ?? flatRoleBio,
+        roleBio: nestedRoleData.roleBio ?? nestedRoleData.bio ?? flatRoleBio,
+        city: nestedRoleData.city ?? flatRoleCity,
+        country: nestedRoleData.country ?? flatRoleCountry,
+        is_remote:
+          nestedRoleData.is_remote ??
+          nestedRoleData.isRemote ??
+          flatRoleIsRemote,
+        isRemote:
+          nestedRoleData.isRemote ??
+          nestedRoleData.is_remote ??
+          flatRoleIsRemote,
+        tags: nestedRoleData.tags ?? flatRoleTags,
+        badges: nestedRoleData.badges ?? flatRoleBadges,
+        is_synthetic:
+          nestedRoleData.is_synthetic ??
+          nestedRoleData.isSynthetic ??
+          syntheticRoleFlag,
+        isSynthetic:
+          nestedRoleData.isSynthetic ??
+          nestedRoleData.is_synthetic ??
+          syntheticRoleFlag,
+      };
+    }
+
+    return {
+      id: roleDataId,
+      roleName: flatRoleName,
+      role_name: flatRoleName,
+      bio: flatRoleBio,
+      roleBio: flatRoleBio,
+      city: flatRoleCity,
+      country: flatRoleCountry,
+      is_remote: flatRoleIsRemote,
+      isRemote: flatRoleIsRemote,
+      tags: flatRoleTags,
+      badges: flatRoleBadges,
+      is_synthetic: syntheticRoleFlag,
+      isSynthetic: syntheticRoleFlag,
+    };
+  }, [
+    isRoleVariant,
+    nestedRoleData,
+    roleDataId,
+    flatRoleName,
+    flatRoleBio,
+    flatRoleCity,
+    flatRoleCountry,
+    flatRoleIsRemote,
+    flatRoleTags,
+    flatRoleBadges,
+    syntheticRoleFlag,
+  ]);
   const roleTeamData = isRoleApplicationVariant
     ? application?.team ?? null
     : isRoleInvitationVariant
       ? invitation?.team ?? null
-      : null;
-  const roleDataId = isRoleApplicationVariant
-    ? application?.role?.id ?? application?.roleId ?? null
-    : isRoleInvitationVariant
-      ? invitation?.role?.id ?? invitation?.roleId ?? null
       : null;
   const roleTeamId = isRoleApplicationVariant
     ? application?.team?.id ?? null
     : isRoleInvitationVariant
       ? invitation?.team?.id ?? null
       : null;
-  const syntheticRoleFlag = isRoleApplicationVariant
-    ? application?.role?.is_synthetic ??
-      application?.role?.isSynthetic ??
-      application?.role_is_synthetic ??
-      application?.roleIsSynthetic
-    : isRoleInvitationVariant
-      ? invitation?.role?.is_synthetic ??
-        invitation?.role?.isSynthetic ??
-        invitation?.role_is_synthetic ??
-        invitation?.roleIsSynthetic
-      : undefined;
 
   // ========= ALL HOOKS (useState, useAuth, useCallback, useEffect) =========
 
@@ -530,6 +628,8 @@ const TeamCard = ({
   const [isApplicationsModalOpen, setIsApplicationsModalOpen] = useState(false);
   const [pendingSentInvitations, setPendingSentInvitations] = useState([]);
   const [isInvitesModalOpen, setIsInvitesModalOpen] = useState(false);
+  const [pendingApplicationsLoaded, setPendingApplicationsLoaded] = useState(false);
+  const [pendingInvitationsLoaded, setPendingInvitationsLoaded] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [responses, setResponses] = useState({});
   const [isInvitationDetailsModalOpen, setIsInvitationDetailsModalOpen] =
@@ -560,7 +660,7 @@ const TeamCard = ({
 
   // Check if user is admin (owner or admin role can manage invitations)
   const isAdmin = userRole === "admin";
-  const canManageInvitations = isOwner || isAdmin;
+  const canManageInvitations = userRole === "owner" || isAdmin;
 
   // Update local team data when props change
   useEffect(() => {
@@ -674,8 +774,11 @@ const TeamCard = ({
       try {
         const response = await teamService.getTeamApplications(teamData.id);
         setPendingApplications(response.data || []);
+        setPendingApplicationsLoaded(true);
       } catch (error) {
         console.error("Error fetching applications:", error);
+        setPendingApplications([]);
+        setPendingApplicationsLoaded(true);
       }
     }
   }, [canManageInvitations, teamData?.id, effectiveVariant]);
@@ -686,21 +789,33 @@ const TeamCard = ({
       try {
         const response = await teamService.getTeamSentInvitations(teamData.id);
         setPendingSentInvitations(response.data || []);
+        setPendingInvitationsLoaded(true);
       } catch (error) {
         console.error("Error fetching sent invitations:", error);
         setPendingSentInvitations([]);
+        setPendingInvitationsLoaded(true);
       }
     }
   }, [canManageInvitations, teamData?.id, effectiveVariant]);
 
   useEffect(() => {
-    fetchPendingApplications();
-  }, [fetchPendingApplications]);
+    if (effectiveVariant !== "member" || !teamData?.id || !canManageInvitations) {
+      setPendingApplications([]);
+      setPendingSentInvitations([]);
+      setPendingApplicationsLoaded(false);
+      setPendingInvitationsLoaded(false);
+    }
+  }, [effectiveVariant, teamData?.id, canManageInvitations]);
 
-  // Fetch sent invitations
   useEffect(() => {
+    if (!isApplicationsModalOpen && !autoOpenApplications) return;
+    fetchPendingApplications();
+  }, [fetchPendingApplications, isApplicationsModalOpen, autoOpenApplications]);
+
+  useEffect(() => {
+    if (!isInvitesModalOpen) return;
     fetchSentInvitations();
-  }, [fetchSentInvitations]);
+  }, [fetchSentInvitations, isInvitesModalOpen]);
 
   useEffect(() => {
     const fetchCompleteTeamData = async () => {
@@ -963,7 +1078,7 @@ const TeamCard = ({
     return () => {
       isCancelled = true;
     };
-  }, [isRoleVariant, showMatchScore, roleDataId, roleTeamId, roleData, user]);
+  }, [isRoleVariant, showMatchScore, roleDataId, roleTeamId, user?.id]);
 
   // ================= GUARD CLAUSE – AFTER ALL HOOKS =================
 
@@ -1872,8 +1987,7 @@ const TeamCard = ({
   );
   const demoTeamData = isRoleVariant ? (roleTeamData ?? teamData) : teamData;
   const showDemoRoleIndicator =
-    isRoleVariant &&
-    (isSyntheticRole(roleData) || syntheticRoleFlag === true);
+    isRoleVariant && isSyntheticRole(roleData);
   const showDemoTeamIndicator =
     !showDemoRoleIndicator && isSyntheticTeam(demoTeamData);
   const showDemoIndicator = showDemoRoleIndicator || showDemoTeamIndicator;

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -660,7 +660,7 @@ const TeamCard = ({
 
   // Check if user is admin (owner or admin role can manage invitations)
   const isAdmin = userRole === "admin";
-  const canManageInvitations = userRole === "owner" || isAdmin;
+  const canManageInvitations = isOwner || isAdmin;
 
   // Update local team data when props change
   useEffect(() => {
@@ -808,14 +808,12 @@ const TeamCard = ({
   }, [effectiveVariant, teamData?.id, canManageInvitations]);
 
   useEffect(() => {
-    if (!isApplicationsModalOpen && !autoOpenApplications) return;
     fetchPendingApplications();
-  }, [fetchPendingApplications, isApplicationsModalOpen, autoOpenApplications]);
+  }, [fetchPendingApplications]);
 
   useEffect(() => {
-    if (!isInvitesModalOpen) return;
     fetchSentInvitations();
-  }, [fetchSentInvitations, isInvitesModalOpen]);
+  }, [fetchSentInvitations]);
 
   useEffect(() => {
     const fetchCompleteTeamData = async () => {

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -39,7 +39,12 @@ import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import { calculateDistanceKm } from "../../utils/locationUtils";
-import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
+import {
+  DEMO_ROLE_TOOLTIP,
+  DEMO_TEAM_TOOLTIP,
+  isSyntheticRole,
+  isSyntheticTeam,
+} from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
 const teamMemberBadgesCache = new Map();
@@ -495,6 +500,17 @@ const TeamCard = ({
     : isRoleInvitationVariant
       ? invitation?.team?.id ?? null
       : null;
+  const syntheticRoleFlag = isRoleApplicationVariant
+    ? application?.role?.is_synthetic ??
+      application?.role?.isSynthetic ??
+      application?.role_is_synthetic ??
+      application?.roleIsSynthetic
+    : isRoleInvitationVariant
+      ? invitation?.role?.is_synthetic ??
+        invitation?.role?.isSynthetic ??
+        invitation?.role_is_synthetic ??
+        invitation?.roleIsSynthetic
+      : undefined;
 
   // ========= ALL HOOKS (useState, useAuth, useCallback, useEffect) =========
 
@@ -1854,7 +1870,23 @@ const TeamCard = ({
   ) : (
     matchOverlay
   );
-  const demoAvatarOverlay = isSyntheticTeam(teamData) ? (
+  const demoTeamData = isRoleVariant ? (roleTeamData ?? teamData) : teamData;
+  const showDemoRoleIndicator =
+    isRoleVariant &&
+    (isSyntheticRole(roleData) || syntheticRoleFlag === true);
+  const showDemoTeamIndicator =
+    !showDemoRoleIndicator && isSyntheticTeam(demoTeamData);
+  const showDemoIndicator = showDemoRoleIndicator || showDemoTeamIndicator;
+  const demoTooltip = showDemoRoleIndicator
+    ? DEMO_ROLE_TOOLTIP
+    : DEMO_TEAM_TOOLTIP;
+  const demoLabel =
+    viewMode === "list" || viewMode === "mini"
+      ? "Demo"
+      : showDemoRoleIndicator
+        ? "Demo Role"
+        : "Demo Team";
+  const demoAvatarOverlay = showDemoIndicator ? (
     <DemoAvatarOverlay
       textClassName={
         viewMode === "list"
@@ -2051,13 +2083,12 @@ const TeamCard = ({
             )}
           </Tooltip>
         )}
-        {isSyntheticTeam(teamData) && (
+        {showDemoIndicator && (
           <Tooltip
-            content={DEMO_TEAM_TOOLTIP}
-            wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
+            content={demoTooltip}
+            wrapperClassName="flex items-center whitespace-nowrap text-base-content/50"
           >
             <FlaskConical size={11} className="flex-shrink-0" />
-            <span>Demo Team</span>
           </Tooltip>
         )}
       </span>
@@ -2541,19 +2572,6 @@ const TeamCard = ({
               </Tooltip>
             )}
 
-            {isSyntheticTeam(teamData) && (
-              <Tooltip
-                content={DEMO_TEAM_TOOLTIP}
-                wrapperClassName="flex items-center gap-1 text-base-content/50"
-              >
-                <FlaskConical
-                  size={viewMode === "mini" ? 12 : 14}
-                  className="flex-shrink-0"
-                />
-                <span>Demo Team</span>
-              </Tooltip>
-            )}
-
             {/* Pending role application indicator */}
             {!shouldMoveSearchResultRoleApplicationIndicator &&
               isPendingRoleApplicationForTeam && (
@@ -2622,6 +2640,18 @@ const TeamCard = ({
                   )}
                 </span>
               )}
+            {showDemoIndicator && (
+              <Tooltip
+                content={demoTooltip}
+                wrapperClassName="flex items-center gap-1 text-base-content/50"
+              >
+                <FlaskConical
+                  size={viewMode === "mini" ? 12 : 14}
+                  className="flex-shrink-0"
+                />
+                <span>{demoLabel}</span>
+              </Tooltip>
+            )}
           </span>
         }
         hoverable

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -18,6 +18,7 @@ import {
   MapPin,
   Ruler,
   Calendar,
+  FlaskConical,
 } from "lucide-react";
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
@@ -38,6 +39,8 @@ import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import { calculateDistanceKm } from "../../utils/locationUtils";
+import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
 const teamMemberBadgesCache = new Map();
 const viewerRoleProfileCache = new Map();
@@ -1851,6 +1854,24 @@ const TeamCard = ({
   ) : (
     matchOverlay
   );
+  const demoAvatarOverlay = isSyntheticTeam(teamData) ? (
+    <DemoAvatarOverlay
+      textClassName={
+        viewMode === "list"
+          ? "text-[5px]"
+          : viewMode === "mini"
+            ? "text-[9px]"
+            : "text-[10px]"
+      }
+      textTranslateClassName={
+        viewMode === "list"
+          ? "-translate-y-[2px]"
+          : viewMode === "mini"
+            ? "-translate-y-[4px]"
+            : "-translate-y-[4px]"
+      }
+    />
+  ) : null;
 
   // ============ LIST VIEW ============
 
@@ -2030,6 +2051,15 @@ const TeamCard = ({
             )}
           </Tooltip>
         )}
+        {isSyntheticTeam(teamData) && (
+          <Tooltip
+            content={DEMO_TEAM_TOOLTIP}
+            wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
+          >
+            <FlaskConical size={11} className="flex-shrink-0" />
+            <span>Demo Team</span>
+          </Tooltip>
+        )}
       </span>
     );
 
@@ -2047,6 +2077,7 @@ const TeamCard = ({
           className={listClassName}
           clickTooltip={cardClickTooltip}
           imageOverlay={avatarOverlay}
+          imageInnerOverlay={demoAvatarOverlay}
           listEdgeRounding={!disableListEdgeRounding}
       >
           <div
@@ -2510,6 +2541,19 @@ const TeamCard = ({
               </Tooltip>
             )}
 
+            {isSyntheticTeam(teamData) && (
+              <Tooltip
+                content={DEMO_TEAM_TOOLTIP}
+                wrapperClassName="flex items-center gap-1 text-base-content/50"
+              >
+                <FlaskConical
+                  size={viewMode === "mini" ? 12 : 14}
+                  className="flex-shrink-0"
+                />
+                <span>Demo Team</span>
+              </Tooltip>
+            )}
+
             {/* Pending role application indicator */}
             {!shouldMoveSearchResultRoleApplicationIndicator &&
               isPendingRoleApplicationForTeam && (
@@ -2606,6 +2650,7 @@ const TeamCard = ({
         }
         marginClassName={viewMode === "mini" ? "mb-2" : ""}
         imageOverlay={avatarOverlay}
+        imageInnerOverlay={demoAvatarOverlay}
       >
         {reminderNotice && (
           <Alert

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -14,6 +14,7 @@ import { userService } from "../../services/userService";
 import Button from "../common/Button";
 import SendMessageButton from "../common/SendMessageButton";
 import Alert from "../common/Alert";
+import Tooltip from "../common/Tooltip";
 import TagDisplay from "../common/TagDisplay";
 import LocationDisplay from "../common/LocationDisplay";
 import { uploadToImageKit } from "../../config/imagekit";
@@ -30,9 +31,11 @@ import {
   SendHorizontal,
   Archive,
   Check,
+  FlaskConical,
 } from "lucide-react";
 import VisibilityToggle from "../common/VisibilityToggle";
 import UserDetailsModal from "../users/UserDetailsModal";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import TagsDisplaySection from "../tags/TagsDisplaySection";
 import { UI_TEXT } from "../../constants/uiText";
 import { tagService } from "../../services/tagService";
@@ -57,6 +60,7 @@ import {
 } from "../../utils/teamMatchUtils";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { calculateDistanceKm } from "../../utils/locationUtils";
+import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
 
 const normalizeTeamTagIds = (team) => {
   const raw = team?.tags ?? team?.tags_json ?? team?.selectedTags ?? [];
@@ -1419,7 +1423,7 @@ const TeamDetailsModal = ({
                 {/* Team header with avatar */}
                 <div className="flex items-start space-x-4 mb-6">
                   <div className="avatar placeholder relative">
-                    <div className="bg-primary text-primary-content rounded-full w-16 h-16 flex items-center justify-center">
+                    <div className="bg-primary text-primary-content rounded-full w-16 h-16 relative flex items-center justify-center overflow-hidden">
                       {(team?.teamavatar_url || team?.teamavatarUrl) &&
                       !teamImageError ? (
                         <img
@@ -1430,6 +1434,12 @@ const TeamDetailsModal = ({
                         />
                       ) : (
                         <span className="text-xl">{getTeamInitials()}</span>
+                      )}
+                      {isSyntheticTeam(team) && (
+                        <DemoAvatarOverlay
+                          textClassName="text-[9px]"
+                          textTranslateClassName="-translate-y-[4px]"
+                        />
                       )}
                     </div>
                     {teamMatchTier && (
@@ -1496,6 +1506,16 @@ const TeamDetailsModal = ({
                             )}
                           </div>
                         )}
+
+                      {isSyntheticTeam(team) && (
+                        <Tooltip
+                          content={DEMO_TEAM_TOOLTIP}
+                          wrapperClassName="flex items-center gap-1 text-base-content/50 text-sm"
+                        >
+                          <FlaskConical size={14} className="flex-shrink-0" />
+                          <span>Demo Team</span>
+                        </Tooltip>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -222,6 +222,32 @@ const TeamInvitationDetailsModal = ({
     : hasRoleInvitation
       ? "You are invited for a role!"
       : "You are invited!";
+  const syntheticRoleFlag =
+    invitation?.role?.is_synthetic ??
+    invitation?.role?.isSynthetic ??
+    invitation?.role_is_synthetic ??
+    invitation?.roleIsSynthetic;
+  const roleForCard =
+    hydratedRole ??
+    (invitation?.role
+      ? {
+          ...invitation.role,
+          is_synthetic:
+            invitation.role.is_synthetic ??
+            invitation.role.isSynthetic ??
+            syntheticRoleFlag,
+          isSynthetic:
+            invitation.role.isSynthetic ??
+            invitation.role.is_synthetic ??
+            syntheticRoleFlag,
+        }
+      : {
+          id: invitation?.roleId ?? invitation?.role_id,
+          roleName: invitation?.roleName ?? invitation?.role_name,
+          role_name: invitation?.role_name ?? invitation?.roleName,
+          is_synthetic: syntheticRoleFlag,
+          isSynthetic: syntheticRoleFlag,
+        });
 
   // Custom header
   const customHeader = (
@@ -404,7 +430,7 @@ const TeamInvitationDetailsModal = ({
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <VacantRoleCard
-                role={hydratedRole ?? invitation?.role ?? { id: invitation?.roleId ?? invitation?.role_id }}
+                role={roleForCard}
                 team={team}
                 matchScore={roleMatchScore}
                 matchDetails={roleMatchDetails}

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -7,9 +7,11 @@ import {
   X,
   MailOpen,
   UserPlus,
+  FlaskConical,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
+import Tooltip from "../common/Tooltip";
 import UserDetailsModal from "../users/UserDetailsModal";
 import TeamDetailsModal from "./TeamDetailsModal";
 import VacantRoleCard from "./VacantRoleCard";
@@ -17,6 +19,8 @@ import Alert from "../common/Alert";
 import { format } from "date-fns";
 import InlineUserLink from "../users/InlineUserLink";
 import { useHydratedRole } from "../../hooks/useHydratedRole";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
 
 const extractRoleMatchData = (roleLike) => {
   const rawScore = roleLike?.matchScore ?? roleLike?.match_score ?? null;
@@ -62,7 +66,19 @@ const TeamInvitationDetailsModal = ({
   // ============ Helpers ============
 
   // Get team data from invitation
-  const team = invitation?.team || {};
+  const baseTeam = invitation?.team || {};
+  const syntheticTeamFlag =
+    baseTeam?.is_synthetic ??
+    baseTeam?.isSynthetic ??
+    invitation?.team_is_synthetic ??
+    invitation?.teamIsSynthetic;
+  const team = {
+    ...baseTeam,
+    is_synthetic:
+      baseTeam?.is_synthetic ?? baseTeam?.isSynthetic ?? syntheticTeamFlag,
+    isSynthetic:
+      baseTeam?.isSynthetic ?? baseTeam?.is_synthetic ?? syntheticTeamFlag,
+  };
   const roleId =
     invitation?.role?.id ?? invitation?.roleId ?? invitation?.role_id ?? null;
   const teamId = team?.id ?? null;
@@ -226,10 +242,23 @@ const TeamInvitationDetailsModal = ({
     invitation?.role?.is_synthetic ??
     invitation?.role?.isSynthetic ??
     invitation?.role_is_synthetic ??
-    invitation?.roleIsSynthetic;
+    invitation?.roleIsSynthetic ??
+    invitation?.is_synthetic ??
+    invitation?.isSynthetic;
   const roleForCard =
-    hydratedRole ??
-    (invitation?.role
+    hydratedRole
+      ? {
+          ...hydratedRole,
+          is_synthetic:
+            hydratedRole.is_synthetic ??
+            hydratedRole.isSynthetic ??
+            syntheticRoleFlag,
+          isSynthetic:
+            hydratedRole.isSynthetic ??
+            hydratedRole.is_synthetic ??
+            syntheticRoleFlag,
+        }
+      : invitation?.role
       ? {
           ...invitation.role,
           is_synthetic:
@@ -247,7 +276,7 @@ const TeamInvitationDetailsModal = ({
           role_name: invitation?.role_name ?? invitation?.roleName,
           is_synthetic: syntheticRoleFlag,
           isSynthetic: syntheticRoleFlag,
-        });
+        };
 
   // Custom header
   const customHeader = (
@@ -367,7 +396,7 @@ const TeamInvitationDetailsModal = ({
             title="View team details"
           >
             <div className="avatar">
-              <div className="w-12 h-12 rounded-full relative">
+              <div className="w-12 h-12 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
                     src={getTeamAvatar()}
@@ -393,6 +422,13 @@ const TeamInvitationDetailsModal = ({
                     {getTeamInitials()}
                   </span>
                 </div>
+
+                {isSyntheticTeam(team) && (
+                  <DemoAvatarOverlay
+                    textClassName="text-[7px]"
+                    textTranslateClassName="-translate-y-[3px]"
+                  />
+                )}
               </div>
             </div>
 
@@ -400,10 +436,23 @@ const TeamInvitationDetailsModal = ({
               <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
                 {team.name || "Unknown Team"}
               </h4>
-              <p className="text-sm text-base-content/70 flex items-center">
-                <Users size={14} className="mr-1 text-primary" />
-                {getMemberCount()}/{getMaxMembers()}
-              </p>
+              <div className="text-sm text-base-content/70 flex items-center flex-wrap gap-x-1.5 gap-y-px">
+                <span className="flex items-center">
+                  <Users size={14} className="mr-1 text-primary" />
+                  <span>
+                    {getMemberCount()}/{getMaxMembers()}
+                  </span>
+                </span>
+                {isSyntheticTeam(team) && (
+                  <Tooltip
+                    content={DEMO_TEAM_TOOLTIP}
+                    wrapperClassName="flex items-center gap-1 text-base-content/50 text-sm"
+                  >
+                    <FlaskConical size={14} className="flex-shrink-0" />
+                    <span>Demo Team</span>
+                  </Tooltip>
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -600,6 +600,30 @@ const TeamInvitesModal = ({
           invitation?.roleId ??
           invitation?.role_id ??
           null;
+        const syntheticRoleFlag =
+          invitation?.role?.is_synthetic ??
+          invitation?.role?.isSynthetic ??
+          invitation?.role_is_synthetic ??
+          invitation?.roleIsSynthetic;
+        const roleForCard = invitation?.role
+          ? {
+              ...invitation.role,
+              is_synthetic:
+                invitation.role.is_synthetic ??
+                invitation.role.isSynthetic ??
+                syntheticRoleFlag,
+              isSynthetic:
+                invitation.role.isSynthetic ??
+                invitation.role.is_synthetic ??
+                syntheticRoleFlag,
+            }
+          : {
+              id: invitation?.roleId ?? invitation?.role_id,
+              roleName: invitation?.roleName ?? invitation?.role_name,
+              role_name: invitation?.role_name ?? invitation?.roleName,
+              is_synthetic: syntheticRoleFlag,
+              isSynthetic: syntheticRoleFlag,
+            };
         const isSelfInvitation =
           currentUser?.id === (invitation.invitee?.id ?? invitation.invitee_id);
         const inviteeRoleMatch =
@@ -720,7 +744,7 @@ const TeamInvitesModal = ({
             {(invitation.role || invitation.roleId || invitation.role_id) && (
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-3">
                 <VacantRoleCard
-                  role={invitation.role || { id: invitation.roleId ?? invitation.role_id, roleName: invitation.roleName ?? invitation.role_name }}
+                  role={roleForCard}
                   team={{ id: teamId, name: teamName }}
                   matchScore={
                     inviteeRoleMatch?.matchScore ??

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -604,7 +604,9 @@ const TeamInvitesModal = ({
           invitation?.role?.is_synthetic ??
           invitation?.role?.isSynthetic ??
           invitation?.role_is_synthetic ??
-          invitation?.roleIsSynthetic;
+          invitation?.roleIsSynthetic ??
+          invitation?.is_synthetic ??
+          invitation?.isSynthetic;
         const roleForCard = invitation?.role
           ? {
               ...invitation.role,

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -1,15 +1,28 @@
 import React, { useState, useEffect, useRef } from "react";
-import { User, MapPin, Calendar, SendHorizontal } from "lucide-react";
+import {
+  User,
+  MapPin,
+  Calendar,
+  SendHorizontal,
+  FlaskConical,
+} from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
 import Button from "../common/Button";
+import Tooltip from "../common/Tooltip";
 import InlineUserLink, { InvitedByLink } from "../users/InlineUserLink";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import VacantRoleCard from "./VacantRoleCard";
 import { matchingService } from "../../services/matchingService";
 import { userService } from "../../services/userService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
-import { getUserInitials, getDisplayName } from "../../utils/userHelpers";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  getDisplayName,
+  isSyntheticUser,
+} from "../../utils/userHelpers";
 import { calculateDistanceKm } from "../../utils/locationUtils";
 import { format } from "date-fns";
 
@@ -646,6 +659,11 @@ const TeamInvitesModal = ({
           highlightUserId != null &&
           inviteeId != null &&
           String(inviteeId) === String(highlightUserId);
+        const showInviteeUsername =
+          invitation.invitee?.username &&
+          (getDisplayName(invitation.invitee) !== invitation.invitee?.username ||
+            isSyntheticUser(invitation.invitee));
+        const showInviteeDemoProfile = isSyntheticUser(invitation.invitee);
 
         return (
           <div
@@ -665,7 +683,7 @@ const TeamInvitesModal = ({
                 onClick={() => handleInviteeClick(invitation.invitee?.id)}
                 title="View profile"
               >
-                <div className="w-10 h-10 rounded-full relative">
+                <div className="w-10 h-10 rounded-full relative overflow-hidden">
                   {getAvatarUrl(invitation.invitee) ? (
                     <img
                       src={getAvatarUrl(invitation.invitee)}
@@ -694,6 +712,9 @@ const TeamInvitesModal = ({
                       {getUserInitials(invitation.invitee)}
                     </span>
                   </div>
+                  {isSyntheticUser(invitation.invitee) && (
+                    <DemoAvatarOverlay textClassName="text-[7px]" />
+                  )}
                 </div>
               </div>
 
@@ -707,11 +728,23 @@ const TeamInvitesModal = ({
                 >
                   {getDisplayName(invitation.invitee)}
                 </h4>
-                {/* Username */}
-                {invitation.invitee?.username && (
-                  <p className="text-sm text-base-content/70">
-                    @{invitation.invitee.username}
-                  </p>
+                {(showInviteeUsername || showInviteeDemoProfile) && (
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                    {showInviteeUsername && (
+                      <p className="text-xs text-base-content/70">
+                        @{invitation.invitee.username}
+                      </p>
+                    )}
+                    {showInviteeDemoProfile && (
+                      <Tooltip
+                        content={DEMO_PROFILE_TOOLTIP}
+                        wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+                      >
+                        <FlaskConical size={12} className="flex-shrink-0" />
+                        <span>Demo Profile</span>
+                      </Tooltip>
+                    )}
+                  </div>
                 )}
               </div>
 

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -1,12 +1,58 @@
-import React, { useState } from "react";
-import { Users, MapPin, Ruler, ChevronRight, ChevronUp, UserCheck } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import {
+  Users,
+  MapPin,
+  Ruler,
+  ChevronRight,
+  ChevronUp,
+  UserCheck,
+  FlaskConical,
+} from "lucide-react";
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import Alert from "../common/Alert";
 import { teamService } from "../../services/teamService";
+import { userService } from "../../services/userService";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import Tooltip from "../common/Tooltip";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import { DEMO_PROFILE_TOOLTIP, isSyntheticUser } from "../../utils/userHelpers";
+
+const memberSyntheticStatusCache = new Map();
+
+const extractProfilePayload = (response) => {
+  const payload = response?.data ?? response;
+
+  if (!payload) return null;
+  if (payload?.success !== undefined) return payload?.data ?? null;
+
+  return payload?.data?.data ?? payload?.data ?? payload;
+};
+
+const getCachedMemberSyntheticStatus = async (memberId) => {
+  const cacheKey = String(memberId);
+
+  if (memberSyntheticStatusCache.has(cacheKey)) {
+    return memberSyntheticStatusCache.get(cacheKey);
+  }
+
+  const request = (async () => {
+    const response = await userService.getUserById(memberId);
+    return isSyntheticUser(extractProfilePayload(response));
+  })();
+
+  memberSyntheticStatusCache.set(cacheKey, request);
+
+  try {
+    const result = await request;
+    memberSyntheticStatusCache.set(cacheKey, Promise.resolve(result));
+    return result;
+  } catch (error) {
+    memberSyntheticStatusCache.delete(cacheKey);
+    throw error;
+  }
+};
 
 /**
  * TeamMembersSection Component
@@ -31,6 +77,7 @@ const TeamMembersSection = ({
     message: null,
   });
   const [isExpanded, setIsExpanded] = useState(false);
+  const [syntheticMemberStatusMap, setSyntheticMemberStatusMap] = useState({});
   const COLLAPSED_COUNT = 4;
 
   // Helper function to get member initials (2 letters: "NK" for Nam Khoa)
@@ -49,6 +96,71 @@ const TeamMembersSection = ({
     }
     return "?";
   };
+
+  useEffect(() => {
+    const members = Array.isArray(team?.members) ? team.members : [];
+    const nextKnownStatuses = {};
+    const memberIdsToFetch = [];
+
+    members.forEach((member) => {
+      const memberId = member?.userId ?? member?.user_id ?? null;
+      if (memberId == null) return;
+
+      const cacheKey = String(memberId);
+      const hasInlineSyntheticFlag =
+        member?.is_synthetic != null || member?.isSynthetic != null;
+
+      if (hasInlineSyntheticFlag) {
+        const isDemoMember = isSyntheticUser(member);
+        nextKnownStatuses[cacheKey] = isDemoMember;
+        memberSyntheticStatusCache.set(cacheKey, Promise.resolve(isDemoMember));
+        return;
+      }
+
+      memberIdsToFetch.push(memberId);
+    });
+
+    if (Object.keys(nextKnownStatuses).length > 0) {
+      setSyntheticMemberStatusMap((prev) => ({
+        ...prev,
+        ...nextKnownStatuses,
+      }));
+    }
+
+    if (memberIdsToFetch.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    Promise.allSettled(
+      [...new Set(memberIdsToFetch)].map(async (memberId) => ({
+        memberId,
+        isSynthetic: await getCachedMemberSyntheticStatus(memberId),
+      })),
+    ).then((results) => {
+      if (cancelled) return;
+
+      const fetchedStatuses = {};
+
+      results.forEach((result) => {
+        if (result.status !== "fulfilled") return;
+
+        fetchedStatuses[String(result.value.memberId)] = result.value.isSynthetic;
+      });
+
+      if (Object.keys(fetchedStatuses).length > 0) {
+        setSyntheticMemberStatusMap((prev) => ({
+          ...prev,
+          ...fetchedStatuses,
+        }));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [team?.members]);
 
   // Early return if no members
   if (!team?.members || team.members.length === 0) {
@@ -92,6 +204,12 @@ const TeamMembersSection = ({
 
           // Determine if this member should be anonymized
           const anonymize = shouldAnonymizeMember(member);
+          const memberAvatarUrl =
+            !anonymize ? member.avatarUrl || member.avatar_url || null : null;
+          const memberSyntheticStatus =
+            memberId != null ? syntheticMemberStatusMap[String(memberId)] : undefined;
+          const showDemoAvatarOverlay =
+            memberSyntheticStatus ?? isSyntheticUser(member);
 
           // Find the filled role this member is filling (if any)
           const filledRole = roles.find((r) => {
@@ -101,6 +219,13 @@ const TeamMembersSection = ({
             return filledById != null && String(filledById) === String(memberId);
           });
           const filledRoleName = filledRole?.roleName ?? filledRole?.role_name ?? null;
+          const shouldShowMemberMetaRow =
+            showDemoAvatarOverlay ||
+            (!anonymize &&
+              (member.city ||
+                member.country ||
+                member.distance_km != null ||
+                filledRoleName));
 
           // Role management logic - Owners and admins can manage roles
           const currentUserMember = team.members?.find(
@@ -117,38 +242,34 @@ const TeamMembersSection = ({
               className="flex items-start bg-green-50 rounded-xl shadow p-4 gap-4 transition-all duration-200 hover:bg-green-100 hover:shadow-md"
             >
               <div className="avatar">
-                {!anonymize && (member.avatarUrl || member.avatar_url) ? (
-                  <div className="rounded-full w-12 h-12">
+                <div className="rounded-full w-12 h-12 relative overflow-hidden">
+                  {memberAvatarUrl ? (
                     <img
-                      src={member.avatarUrl || member.avatar_url}
+                      src={memberAvatarUrl}
                       alt={member.username}
-                      className="object-cover w-full h-full"
+                      className="object-cover w-full h-full rounded-full"
                       onError={(e) => {
-                        e.target.onerror = null;
-                        // Fall back to placeholder on error
                         e.target.style.display = "none";
-                        const parentDiv = e.target.parentNode;
-                        parentDiv.classList.add(
-                          "placeholder",
-                          "bg-primary",
-                          "text-primary-content",
-                        );
-                        const span = document.createElement("span");
-                        span.className = "text-lg";
-                        span.textContent = anonymize
-                          ? "PP"
-                          : getMemberInitials(member);
-                        parentDiv.appendChild(span);
+                        const fallback =
+                          e.target.parentElement.querySelector(
+                            ".avatar-fallback",
+                          );
+                        if (fallback) fallback.style.display = "flex";
                       }}
                     />
-                  </div>
-                ) : (
-                  <div className="placeholder bg-primary text-primary-content rounded-full w-12 h-12">
+                  ) : null}
+                  <div
+                    className="avatar-fallback placeholder bg-primary text-primary-content rounded-full w-full h-full absolute inset-0 flex items-center justify-center"
+                    style={{ display: memberAvatarUrl ? "none" : "flex" }}
+                  >
                     <span className="text-lg">
                       {anonymize ? "PP" : getMemberInitials(member)}
                     </span>
                   </div>
-                )}
+                  {showDemoAvatarOverlay && (
+                    <DemoAvatarOverlay textClassName="text-[8px]" />
+                  )}
+                </div>
               </div>
 
               <div className="flex-1 min-w-0 pt-[1px]">
@@ -241,33 +362,37 @@ const TeamMembersSection = ({
                     />
                   </div>
 
-                  {!anonymize &&
-                    (member.city ||
-                      member.country ||
-                      member.distance_km != null ||
-                      filledRoleName) && (
-                      <CardMetaRow>
-                        {(member.city || member.country) && (
-                          <CardMetaItem icon={MapPin}>
-                            {[member.city, member.country]
-                              .filter(Boolean)
-                              .join(", ")}
-                          </CardMetaItem>
-                        )}
+                  {shouldShowMemberMetaRow && (
+                    <CardMetaRow>
+                      {!anonymize && (member.city || member.country) && (
+                        <CardMetaItem icon={MapPin}>
+                          {[member.city, member.country].filter(Boolean).join(", ")}
+                        </CardMetaItem>
+                      )}
 
-                        {member.distance_km != null && (
-                          <CardMetaItem icon={Ruler} tone="muted" nowrap>
-                            {Math.round(member.distance_km)} km away
-                          </CardMetaItem>
-                        )}
+                      {showDemoAvatarOverlay && (
+                        <Tooltip
+                          content={DEMO_PROFILE_TOOLTIP}
+                          wrapperClassName="flex items-start gap-0.5 text-base-content/50"
+                        >
+                          <FlaskConical size={10} className="shrink-0 mt-[3px]" />
+                          <span className="leading-tight">Demo</span>
+                        </Tooltip>
+                      )}
 
-                        {filledRoleName && (
-                          <CardMetaItem icon={UserCheck} nowrap>
-                            {filledRoleName}
-                          </CardMetaItem>
-                        )}
-                      </CardMetaRow>
-                    )}
+                      {!anonymize && member.distance_km != null && (
+                        <CardMetaItem icon={Ruler} tone="muted" nowrap>
+                          {Math.round(member.distance_km)} km away
+                        </CardMetaItem>
+                      )}
+
+                      {!anonymize && filledRoleName && (
+                        <CardMetaItem icon={UserCheck} nowrap>
+                          {filledRoleName}
+                        </CardMetaItem>
+                      )}
+                    </CardMetaRow>
+                  )}
 
                   {!anonymize && member.tags?.length > 0 && (
                     <div className="flex flex-wrap gap-1 mt-1">

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -837,6 +837,15 @@ const VacantRoleCard = ({
       </span>
     </Tooltip>
   ) : null;
+  const demoRoleMetaItem = isSyntheticRole(role) ? (
+    <Tooltip
+      content={DEMO_ROLE_TOOLTIP}
+      wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
+    >
+      <FlaskConical size={12} className="flex-shrink-0" />
+      <span>{viewMode === "mini" ? "Demo" : "Demo Role"}</span>
+    </Tooltip>
+  ) : null;
 
   const renderMatchOverlay = ({ size, iconSize }) => {
     if (!matchTier) return null;
@@ -1294,15 +1303,6 @@ const VacantRoleCard = ({
                   {teamContext.name}
                 </p>
               )}
-              {isSyntheticRole(role) && (
-                <Tooltip
-                  content={DEMO_ROLE_TOOLTIP}
-                  wrapperClassName="mt-0.5 flex items-center gap-1 text-base-content/50 text-xs"
-                >
-                  <FlaskConical size={12} className="flex-shrink-0" />
-                  <span>{isMiniView ? "Demo" : "Demo Role"}</span>
-                </Tooltip>
-              )}
             </div>
 
             <div className="relative flex-shrink-0" data-dropdown-menu>
@@ -1424,17 +1424,20 @@ const VacantRoleCard = ({
               <div className="flex items-center gap-1 text-xs text-base-content/60">
                 <UserCheck size={12} className="shrink-0" />
                 <span className="truncate">{filledByText}</span>
+                {demoRoleMetaItem}
               </div>
-            ) : locationText ? (
+            ) : locationText || (!is_remote && max_distance_km) || demoRoleMetaItem ? (
               <div className="flex flex-wrap items-center gap-2 text-xs text-base-content/60">
-                <span className="flex items-center gap-1 min-w-0">
-                  {is_remote ? (
-                    <Globe size={12} className="shrink-0" />
-                  ) : (
-                    <MapPin size={12} className="shrink-0" />
-                  )}
-                  <span className="truncate">{locationText}</span>
-                </span>
+                {locationText && (
+                  <span className="flex items-center gap-1 min-w-0">
+                    {is_remote ? (
+                      <Globe size={12} className="shrink-0" />
+                    ) : (
+                      <MapPin size={12} className="shrink-0" />
+                    )}
+                    <span className="truncate">{locationText}</span>
+                  </span>
+                )}
 
                 {!is_remote && max_distance_km && (
                   <span className="flex items-center gap-1 text-base-content/50">
@@ -1442,23 +1445,28 @@ const VacantRoleCard = ({
                     <span>{max_distance_km} km</span>
                   </span>
                 )}
+                {demoRoleMetaItem}
               </div>
             ) : null
           ) : isFilled ? (
             <CardMetaRow>
               <CardMetaItem icon={UserCheck}>{filledByText}</CardMetaItem>
+              {demoRoleMetaItem}
             </CardMetaRow>
-          ) : locationText ? (
+          ) : locationText || (!is_remote && max_distance_km) || demoRoleMetaItem ? (
             <CardMetaRow>
-              <CardMetaItem icon={is_remote ? Globe : MapPin}>
-                {locationText}
-              </CardMetaItem>
+              {locationText && (
+                <CardMetaItem icon={is_remote ? Globe : MapPin}>
+                  {locationText}
+                </CardMetaItem>
+              )}
 
               {!is_remote && max_distance_km && (
                 <CardMetaItem icon={CircleDot} tone="muted" nowrap>
                   {max_distance_km} km
                 </CardMetaItem>
               )}
+              {demoRoleMetaItem}
             </CardMetaRow>
           ) : null}
         </div>

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -955,6 +955,12 @@ const VacantRoleCard = ({
       }
     />
   ) : null;
+  const compactDemoAvatarOverlay = isSyntheticRole(role) ? (
+    <DemoAvatarOverlay
+      textClassName={isMiniView ? "text-[6px]" : "text-[7px]"}
+      textTranslateClassName="-translate-y-[3px]"
+    />
+  ) : null;
 
   if (viewMode === "list") {
     const roundedDistanceKm = showDistance ? Math.round(rawDistanceKm) : null;
@@ -1237,7 +1243,7 @@ const VacantRoleCard = ({
                     {getUserInitials(filledUser)}
                   </span>
                 </div>
-                {isSyntheticRole(role) && demoAvatarOverlay}
+                {compactDemoAvatarOverlay}
                 {miniMatchOverlay}
               </div>
             </div>
@@ -1253,7 +1259,7 @@ const VacantRoleCard = ({
                   >
                     {pct}%
                   </span>
-                  {isSyntheticRole(role) && demoAvatarOverlay}
+                  {compactDemoAvatarOverlay}
                 </div>
               </div>
             </Tooltip>
@@ -1263,7 +1269,7 @@ const VacantRoleCard = ({
                 className={`${initialsAvatarClass} ${avatarSizeClass} rounded-full relative flex items-center justify-center overflow-hidden`}
               >
                 <span className={avatarTextClass}>{getRoleInitials()}</span>
-                {isSyntheticRole(role) && demoAvatarOverlay}
+                {compactDemoAvatarOverlay}
                 {miniMatchOverlay}
               </div>
             </div>

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -19,6 +19,7 @@ import {
   Sparkles,
   TrendingUp,
   TrendingDown,
+  FlaskConical,
 } from "lucide-react";
 import VacantRoleDetailsModal from "./VacantRoleDetailsModal";
 import Card from "../common/Card";
@@ -28,7 +29,13 @@ import CardMetaRow from "../common/CardMetaRow";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import Tooltip from "../common/Tooltip";
-import { getDisplayName, getUserInitials } from "../../utils/userHelpers";
+import {
+  DEMO_ROLE_TOOLTIP,
+  getDisplayName,
+  getUserInitials,
+  isSyntheticRole,
+} from "../../utils/userHelpers";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { resolveFilledRoleUser } from "../../utils/vacantRoleUtils";
 import {
   getMatchTier,
@@ -930,6 +937,24 @@ const VacantRoleCard = ({
       hideActions={hideActions && !usesSharedSearchCard}
     />
   );
+  const demoAvatarOverlay = isSyntheticRole(role) ? (
+    <DemoAvatarOverlay
+      textClassName={
+        viewMode === "list"
+          ? "text-[5px]"
+          : viewMode === "mini"
+            ? "text-[9px]"
+            : "text-[10px]"
+      }
+      textTranslateClassName={
+        viewMode === "list"
+          ? "-translate-y-[2px]"
+          : viewMode === "mini"
+            ? "-translate-y-[4px]"
+            : "-translate-y-[4px]"
+      }
+    />
+  ) : null;
 
   if (viewMode === "list") {
     const roundedDistanceKm = showDistance ? Math.round(rawDistanceKm) : null;
@@ -950,13 +975,22 @@ const VacantRoleCard = ({
       postedDateSubtitleItem ||
       teamSubtitleItem ||
       roleInvitationSubtitleItem ||
-      roleApplicationSubtitleItem ? (
+      roleApplicationSubtitleItem ||
+      isSyntheticRole(role) ? (
         <span className="flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden whitespace-nowrap text-base-content/60">
           {scoreSubtitleItem}
           {postedDateSubtitleItem}
           {roleInvitationSubtitleItem}
           {roleApplicationSubtitleItem}
           {teamSubtitleItem}
+          {isSyntheticRole(role) && (
+            <Tooltip
+              content={DEMO_ROLE_TOOLTIP}
+              wrapperClassName="flex items-center whitespace-nowrap text-base-content/50"
+            >
+              <FlaskConical size={11} className="flex-shrink-0" />
+            </Tooltip>
+          )}
         </span>
       ) : null;
 
@@ -970,6 +1004,7 @@ const VacantRoleCard = ({
           imageOverlay={
             searchResultTypeOverlay ?? renderMatchOverlay({ size: 14, iconSize: 7 })
           }
+          imageInnerOverlay={demoAvatarOverlay}
           onClick={() => setIsDetailsOpen(true)}
           viewMode="list"
           titleClassName="text-sm font-semibold"
@@ -1061,6 +1096,18 @@ const VacantRoleCard = ({
         {roleInvitationSubtitleItem}
         {roleApplicationSubtitleItem}
         {miniLocationSubtitleItem}
+        {isSyntheticRole(role) && (
+          <Tooltip
+            content={DEMO_ROLE_TOOLTIP}
+            wrapperClassName="flex items-center gap-1 text-base-content/50"
+          >
+            <FlaskConical
+              size={viewMode === "mini" ? 12 : 14}
+              className="flex-shrink-0"
+            />
+            <span>{viewMode === "mini" ? "Demo" : "Demo Role"}</span>
+          </Tooltip>
+        )}
       </span>
     );
 
@@ -1103,6 +1150,7 @@ const VacantRoleCard = ({
             searchResultTypeOverlay ??
             (matchTier ? renderMatchOverlay({ size: 20, iconSize: 10 }) : null)
           }
+          imageInnerOverlay={demoAvatarOverlay}
         >
           {viewMode !== "mini" && (
             <p className="text-base-content/80 mb-4">
@@ -1167,7 +1215,7 @@ const VacantRoleCard = ({
         <div className="flex-shrink-0">
           {isFilled && filledUser ? (
             <div className="avatar">
-              <div className={`${avatarSizeClass} rounded-full relative`}>
+              <div className={`${avatarSizeClass} rounded-full relative overflow-hidden`}>
                 {filledUserAvatarUrl ? (
                   <img
                     src={filledUserAvatarUrl}
@@ -1189,6 +1237,7 @@ const VacantRoleCard = ({
                     {getUserInitials(filledUser)}
                   </span>
                 </div>
+                {isSyntheticRole(role) && demoAvatarOverlay}
                 {miniMatchOverlay}
               </div>
             </div>
@@ -1204,15 +1253,17 @@ const VacantRoleCard = ({
                   >
                     {pct}%
                   </span>
+                  {isSyntheticRole(role) && demoAvatarOverlay}
                 </div>
               </div>
             </Tooltip>
           ) : (
             <div className="avatar placeholder">
               <div
-                className={`${initialsAvatarClass} ${avatarSizeClass} rounded-full relative flex items-center justify-center`}
+                className={`${initialsAvatarClass} ${avatarSizeClass} rounded-full relative flex items-center justify-center overflow-hidden`}
               >
                 <span className={avatarTextClass}>{getRoleInitials()}</span>
+                {isSyntheticRole(role) && demoAvatarOverlay}
                 {miniMatchOverlay}
               </div>
             </div>
@@ -1236,6 +1287,15 @@ const VacantRoleCard = ({
                 <p className="text-xs text-base-content/50 mt-0.5 truncate">
                   {teamContext.name}
                 </p>
+              )}
+              {isSyntheticRole(role) && (
+                <Tooltip
+                  content={DEMO_ROLE_TOOLTIP}
+                  wrapperClassName="mt-0.5 flex items-center gap-1 text-base-content/50 text-xs"
+                >
+                  <FlaskConical size={12} className="flex-shrink-0" />
+                  <span>{isMiniView ? "Demo" : "Demo Role"}</span>
+                </Tooltip>
               )}
             </div>
 

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -50,10 +50,12 @@ import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import {
+  DEMO_PROFILE_TOOLTIP,
   DEMO_ROLE_TOOLTIP,
   getDisplayName,
   getUserInitials,
   isSyntheticRole,
+  isSyntheticUser,
 } from "../../utils/userHelpers";
 import {
   calculateDistanceKm,
@@ -2783,6 +2785,7 @@ const VacantRoleDetailsModal = ({
                     member.avatarUrl ?? member.avatar_url ?? null;
                   const displayName = getDisplayName(member);
                   const initials = getUserInitials(member);
+                  const showDemoAvatarOverlay = isSyntheticUser(member);
                   const memberScore =
                     memberRow.matchScore != null
                       ? Number(memberRow.matchScore)
@@ -2817,7 +2820,7 @@ const VacantRoleDetailsModal = ({
                         onClick={() => handleTeamMemberClick(memberRow)}
                       >
                         <div className="avatar relative flex-shrink-0">
-                          <div className="w-12 h-12 rounded-full">
+                          <div className="w-12 h-12 rounded-full relative overflow-hidden">
                             {avatarUrl ? (
                               <img
                                 src={avatarUrl}
@@ -2837,6 +2840,9 @@ const VacantRoleDetailsModal = ({
                             >
                               <span className="text-lg">{initials}</span>
                             </div>
+                            {showDemoAvatarOverlay && (
+                              <DemoAvatarOverlay textClassName="text-[8px]" />
+                            )}
                           </div>
                           {MemberMatchIcon && (
                             <div
@@ -2877,6 +2883,18 @@ const VacantRoleDetailsModal = ({
                               <CardMetaItem icon={MapPin}>
                                 {locationLabel}
                               </CardMetaItem>
+                              {showDemoAvatarOverlay && (
+                                <Tooltip
+                                  content={DEMO_PROFILE_TOOLTIP}
+                                  wrapperClassName="flex items-start gap-0.5 text-base-content/50"
+                                >
+                                  <FlaskConical
+                                    size={10}
+                                    className="shrink-0 mt-[3px]"
+                                  />
+                                  <span className="leading-tight">Demo</span>
+                                </Tooltip>
+                              )}
                             </CardMetaRow>
                           </div>
                         </div>

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -15,6 +15,7 @@ import {
   ChevronRight,
   ChevronUp,
   SendHorizontal,
+  FlaskConical,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import {
@@ -33,6 +34,7 @@ import {
 } from "../../constants/badgeConstants";
 import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import TeamApplicationButton from "./TeamApplicationButton";
@@ -47,7 +49,12 @@ import { matchingService } from "../../services/matchingService";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { getMatchTier } from "../../utils/matchScoreUtils";
-import { getDisplayName, getUserInitials } from "../../utils/userHelpers";
+import {
+  DEMO_ROLE_TOOLTIP,
+  getDisplayName,
+  getUserInitials,
+  isSyntheticRole,
+} from "../../utils/userHelpers";
 import {
   calculateDistanceKm,
   normalizeLocationData,
@@ -1447,6 +1454,12 @@ const VacantRoleDetailsModal = ({
   };
 
   const modalStatusTitle = isFilledRole ? "Filled Role" : "Vacant Role";
+  const demoAvatarOverlay = isSyntheticRole(displayRole) ? (
+    <DemoAvatarOverlay
+      textClassName="text-[9px]"
+      textTranslateClassName="-translate-y-[4px]"
+    />
+  ) : null;
   const ModalStatusIcon = isFilledRole ? UserCheck : UserSearch;
   const summarySuffix = isComparisonSelf
     ? " with you"
@@ -1735,7 +1748,7 @@ const VacantRoleDetailsModal = ({
             {isFilledRole ? (
               <Tooltip content={filledRoleUser?.id ? `Click to view ${filledRoleDisplayName || "this user"}'s profile` : undefined}>
               <div
-                className={`w-20 h-20 rounded-full ${filledRoleUser?.id ? "cursor-pointer" : ""}`}
+                className={`w-20 h-20 rounded-full relative overflow-hidden ${filledRoleUser?.id ? "cursor-pointer" : ""}`}
                 onClick={filledRoleUser?.id ? handleFilledUserClick : undefined}
                 role={filledRoleUser?.id ? "button" : undefined}
                 tabIndex={filledRoleUser?.id ? 0 : undefined}
@@ -1764,6 +1777,7 @@ const VacantRoleDetailsModal = ({
                       : getRoleInitials()}
                   </span>
                 </div>
+                {demoAvatarOverlay}
               </div>
               </Tooltip>
             ) : effectivePct !== null ? (
@@ -1780,10 +1794,12 @@ const VacantRoleDetailsModal = ({
                 <span className="relative text-2xl font-bold">
                   {effectivePct}%
                 </span>
+                {demoAvatarOverlay}
               </div>
             ) : (
-              <div className="bg-amber-500 text-white rounded-full w-20 h-20 flex items-center justify-center">
+              <div className="bg-amber-500 text-white rounded-full w-20 h-20 relative flex items-center justify-center overflow-hidden">
                 <span className="text-2xl">{getRoleInitials()}</span>
+                {demoAvatarOverlay}
               </div>
             )}
             {isFilledRole && MatchTierIcon && (
@@ -1871,6 +1887,16 @@ const VacantRoleDetailsModal = ({
                   </span>
                 ) : null}
               </div>
+            )}
+
+            {isSyntheticRole(displayRole) && (
+              <Tooltip
+                content={DEMO_ROLE_TOOLTIP}
+                wrapperClassName="mt-1 flex items-center gap-1 text-base-content/50 text-xs"
+              >
+                <FlaskConical size={12} className="flex-shrink-0" />
+                <span>Demo Role</span>
+              </Tooltip>
             )}
           </div>
         </div>

--- a/src/components/users/DemoAvatarOverlay.jsx
+++ b/src/components/users/DemoAvatarOverlay.jsx
@@ -5,12 +5,15 @@ const DemoAvatarOverlay = ({
   textTranslateClassName = "-translate-y-[2px]",
 }) => {
   return (
-    <div className="absolute inset-x-0 bottom-0 z-10 h-[30%] bg-black/35 flex items-center justify-center pointer-events-none">
-      <span
-        className={`${textTranslateClassName} font-semibold uppercase tracking-[0.12em] leading-none text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.55)] ${textClassName}`}
-      >
-        Demo
-      </span>
+    <div className="absolute inset-0 z-10 pointer-events-none">
+      <div className="absolute inset-x-0 bottom-0 h-[30%] bg-gradient-to-t from-black/55 to-transparent" />
+      <div className="absolute inset-x-0 bottom-0 z-10 flex justify-center pb-[2px]">
+        <span
+          className={`${textTranslateClassName} font-semibold uppercase tracking-[0.12em] leading-none text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.55)] ${textClassName}`}
+        >
+          DEMO
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/components/users/DemoAvatarOverlay.jsx
+++ b/src/components/users/DemoAvatarOverlay.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const DemoAvatarOverlay = ({
+  textClassName = "text-[10px]",
+  textTranslateClassName = "-translate-y-[2px]",
+}) => {
+  return (
+    <div className="absolute inset-x-0 bottom-0 z-10 h-[30%] bg-black/35 flex items-center justify-center pointer-events-none">
+      <span
+        className={`${textTranslateClassName} font-semibold uppercase tracking-[0.12em] leading-none text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.55)] ${textClassName}`}
+      >
+        Demo
+      </span>
+    </div>
+  );
+};
+
+export default DemoAvatarOverlay;

--- a/src/components/users/InlineUserLink.jsx
+++ b/src/components/users/InlineUserLink.jsx
@@ -1,10 +1,80 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { FlaskConical } from "lucide-react";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
+import { userService } from "../../services/userService";
+import Tooltip from "../common/Tooltip";
+import { DEMO_PROFILE_TOOLTIP } from "../../utils/userHelpers";
 import {
   getDisplayName,
   isDeletedUser,
 } from "../../utils/deletedUser";
 import UserAvatar from "./UserAvatar";
+
+const inlineUserProfileCache = new Map();
+
+const extractProfilePayload = (response) => {
+  const payload = response?.data ?? response;
+
+  if (!payload) return null;
+  if (payload?.success !== undefined) return payload?.data ?? null;
+
+  return payload?.data?.data ?? payload?.data ?? payload;
+};
+
+const getCachedInlineUserProfile = async (userId) => {
+  const cacheKey = String(userId);
+
+  if (inlineUserProfileCache.has(cacheKey)) {
+    return inlineUserProfileCache.get(cacheKey);
+  }
+
+  const request = (async () => {
+    const response = await userService.getUserById(userId);
+    return extractProfilePayload(response);
+  })();
+
+  inlineUserProfileCache.set(cacheKey, request);
+
+  try {
+    const result = await request;
+    inlineUserProfileCache.set(cacheKey, Promise.resolve(result));
+    return result;
+  } catch (error) {
+    inlineUserProfileCache.delete(cacheKey);
+    throw error;
+  }
+};
+
+const mergeInlineUserData = (user, profile) => {
+  if (!profile) return user;
+
+  const resolvedAvatarUrl =
+    user?.avatar_url ??
+    user?.avatarUrl ??
+    profile?.avatar_url ??
+    profile?.avatarUrl ??
+    null;
+  const resolvedSyntheticStatus =
+    user?.is_synthetic ??
+    user?.isSynthetic ??
+    profile?.is_synthetic ??
+    profile?.isSynthetic ??
+    undefined;
+
+  return {
+    ...profile,
+    ...user,
+    avatar_url: resolvedAvatarUrl,
+    avatarUrl:
+      user?.avatarUrl ??
+      user?.avatar_url ??
+      profile?.avatarUrl ??
+      profile?.avatar_url ??
+      null,
+    is_synthetic: resolvedSyntheticStatus,
+    isSynthetic: resolvedSyntheticStatus,
+  };
+};
 
 /**
  * InlineUserLink Component
@@ -47,16 +117,49 @@ const InlineUserLink = ({
 }) => {
   // Try to get global modal context (returns null if not available)
   const userModalContext = useUserModalSafe();
-
-  if (!user) return null;
+  const [resolvedInlineProfile, setResolvedInlineProfile] = useState(null);
 
   // Normalize user ID from various possible field names
   const userId = user?.id || user?.user_id || user?.userId;
-  const name = getDisplayName(user) || "Unknown";
   const isFormerUser = isDeletedUser(user);
+  const hasInlineAvatar = Boolean(user?.avatar_url || user?.avatarUrl);
+  const hasInlineSyntheticFlag =
+    user?.is_synthetic != null || user?.isSynthetic != null;
+  const needsInlineHydration =
+    !isFormerUser && Boolean(userId) && (!hasInlineAvatar || !hasInlineSyntheticFlag);
+
+  useEffect(() => {
+    if (!needsInlineHydration) {
+      setResolvedInlineProfile(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    getCachedInlineUserProfile(userId)
+      .then((profile) => {
+        if (!cancelled) {
+          setResolvedInlineProfile(profile);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResolvedInlineProfile(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [needsInlineHydration, userId]);
+
+  if (!user) return null;
 
   // Determine if we can handle clicks
   const canClick = !isFormerUser && userId && (userModalContext || onOpenUser);
+  const inlineUser = mergeInlineUserData(user, resolvedInlineProfile);
+  const name = getDisplayName(inlineUser) || "Unknown";
+  const showDemoIndicator = !isFormerUser && Boolean(inlineUser?.is_synthetic || inlineUser?.isSynthetic);
 
   const handleClick = (e) => {
     if (!canClick) return;
@@ -82,7 +185,7 @@ const InlineUserLink = ({
       {/* Avatar */}
       {showAvatar && (
         <UserAvatar
-          user={user}
+          user={inlineUser}
           deleted={isFormerUser}
           sizeClass={avatarSize}
           className="mr-1"
@@ -108,6 +211,14 @@ const InlineUserLink = ({
       >
         {name}
       </span>
+      {showDemoIndicator && (
+        <Tooltip
+          content={DEMO_PROFILE_TOOLTIP}
+          wrapperClassName="ml-1 flex items-center text-base-content/50"
+        >
+          <FlaskConical size={10} className="shrink-0" />
+        </Tooltip>
+      )}
     </div>
   );
 };

--- a/src/components/users/UserAvatar.jsx
+++ b/src/components/users/UserAvatar.jsx
@@ -31,7 +31,7 @@ const UserAvatar = ({
       onClick={clickable ? onClick : undefined}
       title={title}
     >
-      <div className={`${sizeClass} rounded-full relative`}>
+      <div className={`${sizeClass} rounded-full relative overflow-hidden`}>
         {avatarUrl ? (
           <img
             src={avatarUrl}

--- a/src/components/users/UserAvatar.jsx
+++ b/src/components/users/UserAvatar.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { User } from "lucide-react";
-import { getUserInitials } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "./DemoAvatarOverlay";
+import { getUserInitials, isSyntheticUser } from "../../utils/userHelpers";
 import {
   getDisplayName,
   isDeletedUser,
@@ -17,11 +18,16 @@ const UserAvatar = ({
   title,
   iconSize = 12,
   initialsClassName = "text-[10px] font-medium",
+  showDemoOverlay = false,
+  demoOverlayTextClassName = "text-[7px]",
+  demoOverlayTextTranslateClassName = "-translate-y-[2px]",
 }) => {
   const isFormerUser = deleted || isDeletedUser(user);
   const avatarUrl =
     !isFormerUser && (user?.avatar_url || user?.avatarUrl || null);
   const displayName = getDisplayName(user, DELETED_USER_DISPLAY_NAME);
+  const showSyntheticOverlay =
+    showDemoOverlay && !isFormerUser && isSyntheticUser(user);
 
   return (
     <div
@@ -60,6 +66,13 @@ const UserAvatar = ({
             <span className={initialsClassName}>{getUserInitials(user)}</span>
           )}
         </div>
+
+        {showSyntheticOverlay && (
+          <DemoAvatarOverlay
+            textClassName={demoOverlayTextClassName}
+            textTranslateClassName={demoOverlayTextTranslateClassName}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -264,15 +264,6 @@ const UserCard = ({
       <span className="flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden whitespace-nowrap text-base-content/60">
         {scoreSubtitleItem}
         {user.username && <span>@{user.username}</span>}
-        {isSyntheticUser(user) && (
-          <Tooltip
-            content={DEMO_PROFILE_TOOLTIP}
-            wrapperClassName="flex items-center gap-0.5 whitespace-nowrap text-base-content/50"
-          >
-            <FlaskConical className="h-[11px] w-auto flex-shrink-0" />
-            <span>Demo</span>
-          </Tooltip>
-        )}
         {shouldShowVisibilityIcon() && (
           <Tooltip content={isUserProfilePublic() ? "Public Profile - visible for everyone" : "Private Profile - only visible for you"}>
             {isUserProfilePublic() ? (
@@ -280,6 +271,14 @@ const UserCard = ({
             ) : (
               <EyeClosed size={11} className="text-gray-500" />
             )}
+          </Tooltip>
+        )}
+        {isSyntheticUser(user) && (
+          <Tooltip
+            content={DEMO_PROFILE_TOOLTIP}
+            wrapperClassName="flex items-center whitespace-nowrap text-base-content/50"
+          >
+            <FlaskConical className="h-[11px] w-auto flex-shrink-0" />
           </Tooltip>
         )}
       </span>
@@ -357,19 +356,6 @@ const UserCard = ({
         >
           {scoreSubtitleItem}
           {user.username && <span>@{user.username}</span>}
-          {isSyntheticUser(user) && (
-            <Tooltip
-              content={DEMO_PROFILE_TOOLTIP}
-              wrapperClassName="flex items-start text-base-content/50"
-            >
-              <FlaskConical
-                className={`w-auto mr-0.5 flex-shrink-0 ${viewMode === "mini" ? "h-3 mt-px" : "h-[13px] mt-px"}`}
-              />
-              <span className="leading-[1.15]">
-                {viewMode === "mini" ? "Demo" : "Demo Profile"}
-              </span>
-            </Tooltip>
-          )}
           {shouldShowVisibilityIcon() && (
             <Tooltip
               content={
@@ -407,6 +393,19 @@ const UserCard = ({
                 </span>
               </span>
             )}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50"
+            >
+              <FlaskConical
+                className={`w-auto mr-0.5 flex-shrink-0 ${viewMode === "mini" ? "h-3 mt-px" : "h-[13px] mt-px"}`}
+              />
+              <span className="leading-[1.15]">
+                {viewMode === "mini" ? "Demo" : "Demo Profile"}
+              </span>
+            </Tooltip>
+          )}
         </span>
       }
       hoverable

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -214,7 +214,13 @@ const UserCard = ({
             ? "text-[9px]"
             : "text-[10px]"
       }
-      textTranslateClassName={viewMode === "list" ? "-translate-y-px" : undefined}
+      textTranslateClassName={
+        viewMode === "list"
+          ? "-translate-y-[2px]"
+          : viewMode === "mini"
+            ? "-translate-y-[4px]"
+            : "-translate-y-[4px]"
+      }
     />
   ) : null;
 

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -2,10 +2,24 @@ import React from "react";
 import Card from "../common/Card";
 import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
-import { Eye, EyeClosed, MapPin, Globe, Tag, Award, Ruler, User } from "lucide-react";
+import {
+  Eye,
+  EyeClosed,
+  MapPin,
+  Globe,
+  Tag,
+  Award,
+  Ruler,
+  User,
+  FlaskConical,
+} from "lucide-react";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
-import { getUserInitials } from "../../utils/userHelpers";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  isSyntheticUser,
+} from "../../utils/userHelpers";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
@@ -222,10 +236,24 @@ const UserCard = ({
         ? visibleBadges.join(", ") + (remainingBadges > 0 ? ` +${remainingBadges}` : "")
         : "";
 
-    const listSubtitle = (scoreSubtitleItem || user.username || shouldShowVisibilityIcon()) ? (
-      <span className="flex items-center gap-1">
+    const listSubtitle = (
+      scoreSubtitleItem ||
+      user.username ||
+      isSyntheticUser(user) ||
+      shouldShowVisibilityIcon()
+    ) ? (
+      <span className="flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden whitespace-nowrap text-base-content/60">
         {scoreSubtitleItem}
         {user.username && <span>@{user.username}</span>}
+        {isSyntheticUser(user) && (
+          <Tooltip
+            content={DEMO_PROFILE_TOOLTIP}
+            wrapperClassName="flex items-center gap-0.5 whitespace-nowrap text-base-content/50"
+          >
+            <FlaskConical className="h-[11px] w-auto flex-shrink-0" />
+            <span>Demo</span>
+          </Tooltip>
+        )}
         {shouldShowVisibilityIcon() && (
           <Tooltip content={isUserProfilePublic() ? "Public Profile - visible for everyone" : "Private Profile - only visible for you"}>
             {isUserProfilePublic() ? (
@@ -305,10 +333,23 @@ const UserCard = ({
       title={displayName()}
       subtitle={
         <span
-          className={`flex items-center flex-wrap text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-0.5 w-full" : "text-sm gap-1.5"}`}
+          className={`flex items-center flex-wrap leading-snug text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-px w-full" : "text-sm gap-x-1.5 gap-y-px"}`}
         >
           {scoreSubtitleItem}
           {user.username && <span>@{user.username}</span>}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50"
+            >
+              <FlaskConical
+                className={`w-auto mr-0.5 flex-shrink-0 ${viewMode === "mini" ? "h-3 mt-px" : "h-[13px] mt-px"}`}
+              />
+              <span className="leading-[1.15]">
+                {viewMode === "mini" ? "Demo" : "Demo Profile"}
+              </span>
+            </Tooltip>
+          )}
           {shouldShowVisibilityIcon() && (
             <Tooltip
               content={

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -20,6 +20,7 @@ import {
   getUserInitials,
   isSyntheticUser,
 } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "./DemoAvatarOverlay";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
@@ -204,6 +205,18 @@ const UserCard = ({
   ) : (
     matchOverlay
   );
+  const demoAvatarOverlay = isSyntheticUser(user) ? (
+    <DemoAvatarOverlay
+      textClassName={
+        viewMode === "list"
+          ? "text-[5px]"
+          : viewMode === "mini"
+            ? "text-[9px]"
+            : "text-[10px]"
+      }
+      textTranslateClassName={viewMode === "list" ? "-translate-y-px" : undefined}
+    />
+  ) : null;
 
   // ============ LIST VIEW ============
   if (viewMode === "list") {
@@ -278,6 +291,7 @@ const UserCard = ({
         className=""
         clickTooltip="Click to view User details"
         imageOverlay={avatarOverlay}
+        imageInnerOverlay={demoAvatarOverlay}
       >
         <div className="w-56 flex-shrink-0 flex items-center gap-3 overflow-hidden">
           <div className="w-16 flex-shrink-0 overflow-hidden">
@@ -414,6 +428,7 @@ const UserCard = ({
       }
       marginClassName={viewMode === "mini" ? "mb-2" : ""}
       imageOverlay={avatarOverlay}
+      imageInnerOverlay={demoAvatarOverlay}
     >
       {viewMode !== "mini" && (user.bio || user.biography) && (
         <p className="text-base-content/80 mb-4">

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -1,6 +1,17 @@
 import React, { useState } from "react";
-import { Eye, EyeClosed, Calendar, UserCheck } from "lucide-react";
-import { getUserInitials } from "../../utils/userHelpers";
+import Tooltip from "../common/Tooltip";
+import {
+  Eye,
+  EyeClosed,
+  Calendar,
+  UserCheck,
+  FlaskConical,
+} from "lucide-react";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  isSyntheticUser,
+} from "../../utils/userHelpers";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { format } from "date-fns";
 
@@ -122,6 +133,15 @@ const UserProfileHeaderSection = ({
         </h1>
         <div className="flex items-center flex-wrap gap-x-3 gap-y-0.5 text-sm">
           <span className="text-base-content/70">@{user?.username}</span>
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50 text-sm"
+            >
+              <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
+              <span className="leading-[1.15]">Demo Profile</span>
+            </Tooltip>
+          )}
 
           {filledRoleName && (
             <span className="flex items-center gap-1 text-base-content/70">

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -112,7 +112,12 @@ const UserProfileHeaderSection = ({
               <span className="text-2xl">{getUserInitials(user)}</span>
             </div>
           )}
-          {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[9px]" />}
+          {isSyntheticUser(user) && (
+            <DemoAvatarOverlay
+              textClassName="text-[9px]"
+              textTranslateClassName="-translate-y-[4px]"
+            />
+          )}
         </div>
         {matchTier && (
           <div

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -12,6 +12,7 @@ import {
   getUserInitials,
   isSyntheticUser,
 } from "../../utils/userHelpers";
+import DemoAvatarOverlay from "./DemoAvatarOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { format } from "date-fns";
 
@@ -98,7 +99,7 @@ const UserProfileHeaderSection = ({
     <div className={`flex items-start space-x-4 ${className}`}>
       {/* Avatar */}
       <div className="avatar relative">
-        <div className="w-20 h-20 rounded-full">
+        <div className="w-20 h-20 rounded-full relative overflow-hidden">
           {getProfileImage() && !imageError ? (
             <img
               src={getProfileImage()}
@@ -111,6 +112,7 @@ const UserProfileHeaderSection = ({
               <span className="text-2xl">{getUserInitials(user)}</span>
             </div>
           )}
+          {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[9px]" />}
         </div>
         {matchTier && (
           <div

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -140,15 +140,6 @@ const UserProfileHeaderSection = ({
         </h1>
         <div className="flex items-center flex-wrap gap-x-3 gap-y-0.5 text-sm">
           <span className="text-base-content/70">@{user?.username}</span>
-          {isSyntheticUser(user) && (
-            <Tooltip
-              content={DEMO_PROFILE_TOOLTIP}
-              wrapperClassName="flex items-start text-base-content/50 text-sm"
-            >
-              <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
-              <span className="leading-[1.15]">Demo Profile</span>
-            </Tooltip>
-          )}
 
           {filledRoleName && (
             <span className="flex items-center gap-1 text-base-content/70">
@@ -175,6 +166,15 @@ const UserProfileHeaderSection = ({
                 </>
               )}
             </div>
+          )}
+          {isSyntheticUser(user) && (
+            <Tooltip
+              content={DEMO_PROFILE_TOOLTIP}
+              wrapperClassName="flex items-start text-base-content/50 text-sm"
+            >
+              <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
+              <span className="leading-[1.15]">Demo Profile</span>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -240,6 +240,14 @@ export const AuthProvider = ({ children }) => {
         newUser.is_public = userData.isPublic;
       }
 
+      if (userData.is_synthetic !== undefined) {
+        newUser.is_synthetic = userData.is_synthetic;
+        newUser.isSynthetic = userData.is_synthetic;
+      } else if (userData.isSynthetic !== undefined) {
+        newUser.isSynthetic = userData.isSynthetic;
+        newUser.is_synthetic = userData.isSynthetic;
+      }
+
       // Ensure we don't override with undefined values
       if (newUser.is_public === undefined && newUser.isPublic === undefined) {
         // Keep the existing values if both are undefined

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -194,6 +194,10 @@ const Chat = () => {
                     firstName: userData.firstName || userData.first_name,
                     lastName: userData.lastName || userData.last_name,
                     avatarUrl: userData.avatarUrl || userData.avatar_url,
+                    isSynthetic:
+                      userData.isSynthetic ?? userData.is_synthetic ?? undefined,
+                    is_synthetic:
+                      userData.is_synthetic ?? userData.isSynthetic ?? undefined,
                   },
                   lastMessage: "Start your conversation...",
                   updatedAt: new Date().toISOString(),
@@ -275,6 +279,25 @@ const Chat = () => {
               if (teamDetails?.data?.members) {
                 conversationDetails.data.team = {
                   ...conversationDetails.data.team,
+                  avatarUrl:
+                    conversationDetails.data.team.avatarUrl ||
+                    conversationDetails.data.team.teamavatarUrl ||
+                    conversationDetails.data.team.teamavatar_url ||
+                    teamDetails.data.avatarUrl ||
+                    teamDetails.data.teamavatarUrl ||
+                    teamDetails.data.teamavatar_url,
+                  isSynthetic:
+                    conversationDetails.data.team.isSynthetic ??
+                    conversationDetails.data.team.is_synthetic ??
+                    teamDetails.data.isSynthetic ??
+                    teamDetails.data.is_synthetic ??
+                    undefined,
+                  is_synthetic:
+                    conversationDetails.data.team.is_synthetic ??
+                    conversationDetails.data.team.isSynthetic ??
+                    teamDetails.data.is_synthetic ??
+                    teamDetails.data.isSynthetic ??
+                    undefined,
                   members: teamDetails.data.members,
                 };
               }
@@ -302,6 +325,14 @@ const Chat = () => {
                     id: conversationDetails.data.team.id,
                     name: conversationDetails.data.team.name,
                     avatarUrl: conversationDetails.data.team.avatarUrl,
+                    isSynthetic:
+                      conversationDetails.data.team.isSynthetic ??
+                      conversationDetails.data.team.is_synthetic ??
+                      undefined,
+                    is_synthetic:
+                      conversationDetails.data.team.is_synthetic ??
+                      conversationDetails.data.team.isSynthetic ??
+                      undefined,
                   },
                   lastMessage: "Start your team conversation...",
                   updatedAt: new Date().toISOString(),
@@ -342,6 +373,25 @@ const Chat = () => {
               if (teamDetails?.data?.members) {
                 conversationDetails.data.team = {
                   ...conversationDetails.data.team,
+                  avatarUrl:
+                    conversationDetails.data.team.avatarUrl ||
+                    conversationDetails.data.team.teamavatarUrl ||
+                    conversationDetails.data.team.teamavatar_url ||
+                    teamDetails.data.avatarUrl ||
+                    teamDetails.data.teamavatarUrl ||
+                    teamDetails.data.teamavatar_url,
+                  isSynthetic:
+                    conversationDetails.data.team.isSynthetic ??
+                    conversationDetails.data.team.is_synthetic ??
+                    teamDetails.data.isSynthetic ??
+                    teamDetails.data.is_synthetic ??
+                    undefined,
+                  is_synthetic:
+                    conversationDetails.data.team.is_synthetic ??
+                    conversationDetails.data.team.isSynthetic ??
+                    teamDetails.data.is_synthetic ??
+                    teamDetails.data.isSynthetic ??
+                    undefined,
                   members: teamDetails.data.members,
                 };
               }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,13 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import { Users, Handshake, MessageCircle } from "lucide-react"; // Correct way to import icons
 import { Link } from "react-router-dom";
-import PageContainer from "../components/layout/PageContainer";
 import Section from "../components/layout/Section";
 import InfoCard from "../components/common/InfoCard";
+import CreateTeamModal from "../components/teams/CreateTeamModal";
 import { useAuth } from "../contexts/AuthContext";
 
 const Home = () => {
   const { isAuthenticated } = useAuth();
+  const [isCreateTeamModalOpen, setIsCreateTeamModalOpen] = useState(false);
+
+  const handleTeamCreated = () => undefined;
 
   return (
     <div className="align-items-center text-center space-y-12">
@@ -40,12 +43,13 @@ const Home = () => {
                   >
                     Browse Teams
                   </Link>
-                  <Link
-                    to="/teams/create"
+                  <button
+                    type="button"
+                    onClick={() => setIsCreateTeamModalOpen(true)}
                     className="btn btn-outline btn-primary"
                   >
                     Create Team
-                  </Link>
+                  </button>
                 </>
               )}
             </div>
@@ -96,6 +100,12 @@ const Home = () => {
           </InfoCard>
         </div>
       </Section>
+
+      <CreateTeamModal
+        isOpen={isCreateTeamModalOpen}
+        onClose={() => setIsCreateTeamModalOpen(false)}
+        onTeamCreated={handleTeamCreated}
+      />
     </div>
   );
 };

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -962,7 +962,7 @@ const Profile = () => {
                     ) : (
                       <span className="text-4xl">{getUserInitials(user)}</span>
                     )}
-                    {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[11px]" />}
+                    {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[14px]" textTranslateClassName="-translate-y-[7px]" />}
                   </div>
                 </div>
               </div>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -44,6 +44,7 @@ import {
   getUserInitials,
   isSyntheticUser,
 } from "../utils/userHelpers";
+import DemoAvatarOverlay from "../components/users/DemoAvatarOverlay";
 import Modal from "../components/common/Modal";
 import LocationInput from "../components/common/LocationInput";
 import { format } from "date-fns";
@@ -950,7 +951,7 @@ const Profile = () => {
               {/* Avatar */}
               <div className="mb-4 md:mb-0 md:mr-8 flex-shrink-0">
                 <div className="avatar placeholder">
-                  <div className="bg-primary text-primary-content rounded-full w-32 h-32">
+                  <div className="bg-primary text-primary-content rounded-full w-32 h-32 relative overflow-hidden">
                     {(user.avatarUrl || user.avatar_url) && !imageError ? (
                       <img
                         src={user.avatarUrl || user.avatar_url}
@@ -961,6 +962,7 @@ const Profile = () => {
                     ) : (
                       <span className="text-4xl">{getUserInitials(user)}</span>
                     )}
+                    {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[11px]" />}
                   </div>
                 </div>
               </div>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -978,15 +978,6 @@ const Profile = () => {
                 {/* Username, visibility, and date in one row */}
                 <div className="flex items-center text-base flex-wrap gap-x-4 gap-y-1">
                   <span className="text-base-content/70">@{user.username}</span>
-                  {isSyntheticUser(user) && (
-                    <Tooltip
-                      content={DEMO_PROFILE_TOOLTIP}
-                      wrapperClassName="flex items-start text-base-content/50"
-                    >
-                      <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
-                      <span className="leading-[1.15]">Demo Profile</span>
-                    </Tooltip>
-                  )}
                   <div
                     className="flex items-center text-base-content/70 tooltip tooltip-bottom tooltip-lomir cursor-help"
                     data-tip={
@@ -1007,6 +998,15 @@ const Profile = () => {
                       </>
                     )}
                   </div>
+                  {isSyntheticUser(user) && (
+                    <Tooltip
+                      content={DEMO_PROFILE_TOOLTIP}
+                      wrapperClassName="flex items-start text-base-content/50"
+                    >
+                      <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
+                      <span className="leading-[1.15]">Demo Profile</span>
+                    </Tooltip>
+                  )}
                 </div>
               </div>
 

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -9,6 +9,7 @@ import Card from "../components/common/Card";
 import Button from "../components/common/Button";
 import DataDisplay from "../components/common/DataDisplay";
 import Alert from "../components/common/Alert";
+import Tooltip from "../components/common/Tooltip";
 import { uploadToImageKit } from "../config/imagekit";
 import {
   Mail,
@@ -21,6 +22,7 @@ import {
   Camera,
   Tag,
   Calendar,
+  FlaskConical,
 } from "lucide-react";
 import useAwardModals from "../hooks/useAwardModals";
 import { CATEGORY_COLORS } from "../constants/badgeConstants";
@@ -37,7 +39,11 @@ import LocationDisplay from "../components/common/LocationDisplay";
 import { geocodingService } from "../services/geocodingService";
 import { useLocationAutoFill } from "../hooks/useLocationAutoFill";
 import ImageUploader from "../components/common/ImageUploader";
-import { getUserInitials } from "../utils/userHelpers";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  getUserInitials,
+  isSyntheticUser,
+} from "../utils/userHelpers";
 import Modal from "../components/common/Modal";
 import LocationInput from "../components/common/LocationInput";
 import { format } from "date-fns";
@@ -970,6 +976,15 @@ const Profile = () => {
                 {/* Username, visibility, and date in one row */}
                 <div className="flex items-center text-base flex-wrap gap-x-4 gap-y-1">
                   <span className="text-base-content/70">@{user.username}</span>
+                  {isSyntheticUser(user) && (
+                    <Tooltip
+                      content={DEMO_PROFILE_TOOLTIP}
+                      wrapperClassName="flex items-start text-base-content/50"
+                    >
+                      <FlaskConical className="h-3.5 w-auto mr-0.5 flex-shrink-0 mt-px" />
+                      <span className="leading-[1.15]">Demo Profile</span>
+                    </Tooltip>
+                  )}
                   <div
                     className="flex items-center text-base-content/70 tooltip tooltip-bottom tooltip-lomir cursor-help"
                     data-tip={

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -16,11 +16,13 @@ import VacantRoleCard from "../components/teams/VacantRoleCard";
 import UserCard from "../components/users/UserCard";
 import Pagination from "../components/common/Pagination";
 import BooleanSearchInput from "../components/BooleanSearchInput";
+import Tooltip from "../components/common/Tooltip";
 import {
   User,
   UserSearch,
   Users2,
   Clock,
+  FlaskConical,
   Sparkles,
   ArrowDownAZ,
   ArrowUpZA,
@@ -121,6 +123,7 @@ const SearchPage = () => {
   const [userHasCoordinates, setUserHasCoordinates] = useState(false);
   const [openRolesOnly, setOpenRolesOnly] = useState(false);
   const [includeOwnTeams, setIncludeOwnTeams] = useState(true);
+  const [includeDemoData, setIncludeDemoData] = useState(true);
 
   // ===== CAPACITY FILTER STATE =====
   const [capacityMode, setCapacityMode] = useState("spots");
@@ -679,6 +682,7 @@ const SearchPage = () => {
     maxDistance,
     effectiveOpenRolesOnly,
     effectiveIncludeOwnTeams,
+    includeDemoData,
     matchRoleId,
     matchRoleName,
     excludeTeamId,
@@ -703,6 +707,7 @@ const SearchPage = () => {
           maxDistance,
           effectiveOpenRolesOnly,
           effectiveIncludeOwnTeams,
+          includeDemoData,
           capacityMode,
           filterTagIds,
           filterBadgeIds,
@@ -766,6 +771,7 @@ const SearchPage = () => {
     openRolesOnly,
     effectiveOpenRolesOnly,
     effectiveIncludeOwnTeams,
+    includeDemoData,
     capacityMode,
     hasSearched,
     searchQuery,
@@ -858,11 +864,32 @@ const SearchPage = () => {
         .filter(Boolean)
         .map((button) => button.getBoundingClientRect().top);
       const submenuHeight = submenuEl?.offsetHeight || 30;
+      const submenuItemRects = submenuEl
+        ? Array.from(
+            submenuEl.querySelectorAll('[data-submenu-item="true"]'),
+          ).map((item) => item.getBoundingClientRect())
+        : [];
+      const visibleSubmenuItemRects = submenuItemRects.filter(
+        (rect) => rect.width > 0 && rect.height > 0,
+      );
       const submenuWidth = submenuEl?.offsetWidth || 0;
 
       const submenuTop = anchorRect.bottom + 6;
       const anchorMidY = anchorRect.top + anchorRect.height / 2;
-      const submenuMidY = submenuTop + submenuHeight / 2;
+      const submenuAnchorHeight =
+        visibleSubmenuItemRects.length > 0
+          ? (() => {
+              const firstRowTop = Math.min(
+                ...visibleSubmenuItemRects.map((rect) => rect.top),
+              );
+              const firstRowRects = visibleSubmenuItemRects.filter(
+                (rect) => Math.abs(rect.top - firstRowTop) < 2,
+              );
+
+              return Math.max(...firstRowRects.map((rect) => rect.bottom)) - firstRowTop;
+            })()
+          : submenuHeight;
+      const submenuMidY = submenuTop + submenuAnchorHeight / 2;
       const firstRowTop =
         visibleButtonTops.length > 0
           ? Math.min(...visibleButtonTops)
@@ -1216,6 +1243,10 @@ const SearchPage = () => {
         setIncludeOwnTeams(true);
         setCurrentPage(1);
         break;
+      case "includeDemoData":
+        setIncludeDemoData(true);
+        setCurrentPage(1);
+        break;
       case "matchRole":
         setMatchRoleId(null);
         setMatchRoleName(null);
@@ -1290,6 +1321,7 @@ const SearchPage = () => {
     maxDistance !== null ||
     effectiveOpenRolesOnly ||
     !effectiveIncludeOwnTeams ||
+    !includeDemoData ||
     (sortBy === "capacity" && capacityMode !== "spots") ||
     (customDistanceInput && customDistanceInput.trim() !== "");
 
@@ -1309,6 +1341,7 @@ const SearchPage = () => {
         {activeSubmenuKey === "capacity" && (
           <div className="flex items-center justify-end gap-3 pr-1">
             <button
+              data-submenu-item="true"
               type="button"
               onClick={() => handleCapacityModeChange("roles")}
               disabled={loading}
@@ -1324,6 +1357,7 @@ const SearchPage = () => {
             </button>
 
             <button
+              data-submenu-item="true"
               type="button"
               onClick={handleOpenRolesOnlyToggle}
               disabled={loading}
@@ -1339,24 +1373,30 @@ const SearchPage = () => {
         )}
 
         {activeSubmenuKey === DISTANCE_SUBMENU_TYPE && (
-          <div className="flex items-center justify-end flex-wrap gap-1 pr-1">
-            {distancePresets.map((km) => (
-              <button
-                key={km}
-                type="button"
-                onClick={() => handleDistancePreset(km)}
-                disabled={loading}
-                className={`px-1 py-0.5 text-xs rounded transition-colors ${
-                  maxDistance === km
-                    ? "text-[var(--color-primary)] font-bold"
-                    : "text-[var(--color-primary-focus)] hover:text-[var(--color-primary-focus)] hover:font-medium"
-                }`}
-              >
-                {km}km
-              </button>
-            ))}
+          <div className="flex items-center justify-end flex-wrap gap-x-[5px] gap-y-1 pr-1">
+            <div className="hidden sm:contents">
+              {distancePresets.map((km) => (
+                <button
+                  data-submenu-item="true"
+                  key={km}
+                  type="button"
+                  onClick={() => handleDistancePreset(km)}
+                  disabled={loading}
+                  className={`px-1 text-xs leading-none rounded transition-colors ${
+                    maxDistance === km
+                      ? "text-[var(--color-primary)] font-bold"
+                      : "text-[var(--color-primary-focus)] hover:text-[var(--color-primary-focus)] hover:font-medium"
+                  }`}
+                >
+                  {km}km
+                </button>
+              ))}
+            </div>
 
-            <div className="flex items-center gap-0.5">
+            <div
+              data-submenu-item="true"
+              className="flex h-4 items-center gap-0.5"
+            >
               <input
                 type="number"
                 min="1"
@@ -1371,7 +1411,7 @@ const SearchPage = () => {
                     (customDistanceInput?.length || 0) + 2,
                   )}ch`,
                 }}
-                className={`px-1 py-0.5 text-xs rounded border transition-colors
+                className={`h-4 px-1 text-xs leading-none rounded border transition-colors
                 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none
                 ${
                   maxDistance && !distancePresets.includes(maxDistance)
@@ -1381,7 +1421,7 @@ const SearchPage = () => {
                 bg-transparent focus:outline-none focus:border-[var(--color-success)]`}
                 disabled={loading}
               />
-              <span className="text-xs text-[var(--color-primary-focus)]">
+              <span className="text-xs leading-none text-[var(--color-primary-focus)]">
                 km
               </span>
             </div>
@@ -1581,11 +1621,11 @@ const SearchPage = () => {
 
             {showSortDropdown && (
               <div className="mt-2 py-1 pl-11">
-                <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-start sm:gap-4">
+                <div className="flex flex-row flex-wrap items-start gap-x-3 gap-y-[6px]">
                   <div
                     role="group"
                     aria-label="Sort options"
-                    className="flex items-center gap-3 flex-wrap"
+                    className="contents"
                   >
                     {visibleSortOptions.map((option) => {
                       const { isActive, IconComponent, label, shortLabel } =
@@ -1595,10 +1635,11 @@ const SearchPage = () => {
                           sortDir,
                           isCapacitySpotsSort,
                         });
-
-                      return (
+                      const optionTooltip = option.teamsOnly
+                        ? "Teams only"
+                        : undefined;
+                      const optionButton = (
                         <button
-                          key={option.value}
                           ref={(node) => {
                             sortButtonRefs.current[option.value] = node;
                           }}
@@ -1612,12 +1653,26 @@ const SearchPage = () => {
                               : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
                           }`}
                           disabled={loading}
-                          title={option.teamsOnly ? "Teams only" : ""}
+                          aria-label={optionTooltip ? `${label} - ${optionTooltip}` : undefined}
                         >
                           <IconComponent className="w-3.5 h-3.5 shrink-0" />
                           <span className="hidden sm:inline">{label}</span>
                           <span className="sm:hidden">{shortLabel}</span>
                         </button>
+                      );
+
+                      return optionTooltip ? (
+                        <Tooltip
+                          key={option.value}
+                          content={optionTooltip}
+                          wrapperClassName="inline-flex items-center shrink-0"
+                        >
+                          {optionButton}
+                        </Tooltip>
+                      ) : (
+                        <React.Fragment key={option.value}>
+                          {optionButton}
+                        </React.Fragment>
                       );
                     })}
                   </div>
@@ -1626,37 +1681,83 @@ const SearchPage = () => {
                     <div
                       role="group"
                       aria-label="Search filters"
-                      className="flex items-center gap-3 flex-wrap pt-1 sm:pt-0"
+                      className="contents"
+                    >
+                      <Tooltip
+                        content={
+                          effectiveIncludeOwnTeams
+                            ? "Include My Teams"
+                            : "Exclude My Teams"
+                        }
+                        wrapperClassName="inline-flex items-center shrink-0"
+                      >
+                        <button
+                          type="button"
+                          onClick={handleIncludeOwnTeamsToggle}
+                          className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
+                            !effectiveIncludeOwnTeams
+                              ? "text-[var(--color-primary)] font-bold"
+                              : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
+                          }`}
+                          disabled={loading}
+                          aria-label={
+                            effectiveIncludeOwnTeams
+                              ? "Include My Teams"
+                              : "Exclude My Teams"
+                          }
+                        >
+                          <IncludeOwnTeamsIcon className="w-3.5 h-3.5 shrink-0" />
+                          <span>
+                            {effectiveIncludeOwnTeams
+                              ? "+ My Teams"
+                              : "- My Teams"}
+                          </span>
+                        </button>
+                      </Tooltip>
+                    </div>
+                  )}
+
+                  <div
+                    role="group"
+                    aria-label="Demo data filter"
+                    className="contents"
+                  >
+                    <Tooltip
+                      content={
+                        includeDemoData
+                          ? "Include test/demo profiles, roles and teams"
+                          : "Show only real users, roles and teams"
+                      }
+                      wrapperClassName="inline-flex items-center shrink-0"
                     >
                       <button
                         type="button"
-                        onClick={handleIncludeOwnTeamsToggle}
+                        onClick={() => {
+                          setIncludeDemoData((prev) => !prev);
+                          setCurrentPage(1);
+                        }}
                         className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
-                          !effectiveIncludeOwnTeams
+                          !includeDemoData
                             ? "text-[var(--color-primary)] font-bold"
                             : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
                         }`}
                         disabled={loading}
-                        title={
-                          effectiveIncludeOwnTeams
-                            ? "Include My Teams"
-                            : "Exclude My Teams"
-                        }
                         aria-label={
-                          effectiveIncludeOwnTeams
-                            ? "Include My Teams"
-                            : "Exclude My Teams"
+                          includeDemoData
+                            ? "Include test/demo profiles, roles and teams"
+                            : "Show only real users, roles and teams"
                         }
                       >
-                        <IncludeOwnTeamsIcon className="w-3.5 h-3.5 shrink-0" />
-                        <span>
-                          {effectiveIncludeOwnTeams
-                            ? "+ My Teams"
-                            : "- My Teams"}
+                        <FlaskConical className="w-3.5 h-3.5 shrink-0" />
+                        <span className="hidden sm:inline">
+                          {includeDemoData ? "+ Demo Data" : "- Demo Data"}
+                        </span>
+                        <span className="sm:hidden">
+                          {includeDemoData ? "+ Demo" : "- Demo"}
                         </span>
                       </button>
-                    </div>
-                  )}
+                    </Tooltip>
+                  </div>
                 </div>
               </div>
             )}

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -246,6 +246,8 @@ const SearchPage = () => {
       labelDesc: "Name (Z-A)",
       shortLabelAsc: "A-Z",
       shortLabelDesc: "Z-A",
+      tooltipAsc: "Sort alphabetically from A to Z",
+      tooltipDesc: "Sort alphabetically from Z to A",
       iconAsc: ArrowDownAZ,
       iconDesc: ArrowUpZA,
       teamsOnly: false,
@@ -257,6 +259,8 @@ const SearchPage = () => {
       labelDesc: "Active",
       shortLabelAsc: "Inactive",
       shortLabelDesc: "Active",
+      tooltipAsc: "Show the least recently active results first",
+      tooltipDesc: "Show the most recently active results first",
       iconAsc: Clock,
       iconDesc: Clock,
       teamsOnly: false,
@@ -268,6 +272,8 @@ const SearchPage = () => {
       labelDesc: "Newest",
       shortLabelAsc: "Oldest",
       shortLabelDesc: "Newest",
+      tooltipAsc: "Show the oldest results first",
+      tooltipDesc: "Show the newest results first",
       iconAsc: Sparkles,
       iconDesc: Sparkles,
       teamsOnly: false,
@@ -277,6 +283,7 @@ const SearchPage = () => {
       defaultDir: "asc",
       labelAsc: "Best Match",
       shortLabelAsc: "Match",
+      tooltipAsc: "Sort results by how well they match your profile",
       iconAsc: Target,
       authOnly: true,
     },
@@ -289,6 +296,9 @@ const SearchPage = () => {
       shortLabelAsc: "Near",
       shortLabelDesc: "Far",
       shortLabelRemote: "Remote",
+      tooltipAsc: "Show the nearest results first",
+      tooltipDesc: "Show the farthest results first",
+      tooltipRemote: "Show remote-friendly results first",
       iconAsc: MapPin,
       iconDesc: MapPin,
       iconRemote: Globe,
@@ -300,6 +310,8 @@ const SearchPage = () => {
       labelDesc: "Most Spots",
       shortLabelAsc: "Full",
       shortLabelDesc: "Spots",
+      tooltipAsc: "Show teams with the fewest open spots first\nTeams only",
+      tooltipDesc: "Show teams with the most open spots first\nTeams only",
       iconAsc: UserMinus,
       iconDesc: UserPlus,
       teamsOnly: true,
@@ -1628,16 +1640,19 @@ const SearchPage = () => {
                     className="contents"
                   >
                     {visibleSortOptions.map((option) => {
-                      const { isActive, IconComponent, label, shortLabel } =
+                      const {
+                        isActive,
+                        IconComponent,
+                        label,
+                        shortLabel,
+                        tooltip,
+                      } =
                         getSortOptionDisplay({
                           option,
                           sortBy,
                           sortDir,
                           isCapacitySpotsSort,
                         });
-                      const optionTooltip = option.teamsOnly
-                        ? "Teams only"
-                        : undefined;
                       const optionButton = (
                         <button
                           ref={(node) => {
@@ -1653,7 +1668,7 @@ const SearchPage = () => {
                               : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
                           }`}
                           disabled={loading}
-                          aria-label={optionTooltip ? `${label} - ${optionTooltip}` : undefined}
+                          aria-label={tooltip ? `${label} - ${tooltip}` : label}
                         >
                           <IconComponent className="w-3.5 h-3.5 shrink-0" />
                           <span className="hidden sm:inline">{label}</span>
@@ -1661,10 +1676,10 @@ const SearchPage = () => {
                         </button>
                       );
 
-                      return optionTooltip ? (
+                      return tooltip ? (
                         <Tooltip
                           key={option.value}
-                          content={optionTooltip}
+                          content={tooltip}
                           wrapperClassName="inline-flex items-center shrink-0"
                         >
                           {optionButton}

--- a/src/pages/searchPageHelpers.js
+++ b/src/pages/searchPageHelpers.js
@@ -66,6 +66,7 @@ export const getActiveCriteriaPills = ({
   maxDistance,
   effectiveOpenRolesOnly,
   effectiveIncludeOwnTeams,
+  includeDemoData,
   matchRoleId,
   matchRoleName,
   excludeTeamId,
@@ -129,6 +130,13 @@ export const getActiveCriteriaPills = ({
     });
   }
 
+  if (!includeDemoData) {
+    pills.push({
+      key: "includeDemoData",
+      label: "Exclude Demo Data",
+    });
+  }
+
   if (matchRoleId && matchRoleName) {
     pills.unshift({
       key: "matchRole",
@@ -159,6 +167,7 @@ export const buildSearchRequestCriteria = ({
   maxDistance,
   effectiveOpenRolesOnly,
   effectiveIncludeOwnTeams,
+  includeDemoData,
   capacityMode,
   filterTagIds,
   filterBadgeIds,
@@ -175,6 +184,7 @@ export const buildSearchRequestCriteria = ({
   maxDistance,
   openRolesOnly: effectiveOpenRolesOnly,
   excludeOwnTeams: !effectiveIncludeOwnTeams,
+  includeDemoData,
   capacityMode,
   tagIds: filterTagIds,
   badgeIds: filterBadgeIds,

--- a/src/pages/searchPageHelpers.js
+++ b/src/pages/searchPageHelpers.js
@@ -37,6 +37,7 @@ export const getSortOptionDisplay = ({
       IconComponent: option.iconAsc,
       label: option.labelAsc,
       shortLabel: option.shortLabelAsc,
+      tooltip: option.tooltipAsc,
     };
   }
 
@@ -47,6 +48,7 @@ export const getSortOptionDisplay = ({
       IconComponent: option.iconRemote,
       label: option.labelRemote,
       shortLabel: option.shortLabelRemote,
+      tooltip: option.tooltipRemote,
     };
   }
 
@@ -56,6 +58,7 @@ export const getSortOptionDisplay = ({
     IconComponent: option.iconDesc,
     label: option.labelDesc,
     shortLabel: option.shortLabelDesc,
+    tooltip: option.tooltipDesc,
   };
 };
 
@@ -109,6 +112,8 @@ export const getActiveCriteriaPills = ({
           : sortDir === "desc"
             ? "Farthest"
             : "Nearest",
+      shortLabel:
+        sortDir === "remote" ? "Remote" : sortDir === "desc" ? "Far" : "Near",
     });
   }
 

--- a/src/services/searchService.js
+++ b/src/services/searchService.js
@@ -81,6 +81,7 @@ const buildSearchParams = ({
   badgeIds = [],
   roleId = null,
   excludeTeamId = null,
+  includeDemoData = true,
 } = {}) => {
   const params = {
     authenticated: isAuthenticated,
@@ -90,6 +91,7 @@ const buildSearchParams = ({
     sortBy,
     sortDir,
     openRolesOnly,
+    includeDemoData: String(includeDemoData),
   };
 
   if (query) params.query = query;

--- a/src/utils/chatEntityResolvers.js
+++ b/src/utils/chatEntityResolvers.js
@@ -1,0 +1,115 @@
+import { teamService } from "../services/teamService";
+import { userService } from "../services/userService";
+
+const chatUserProfileCache = new Map();
+const chatTeamProfileCache = new Map();
+
+export const extractEntityPayload = (response) => {
+  const payload = response?.data ?? response;
+
+  if (!payload) return null;
+  if (payload?.success !== undefined) return payload?.data ?? null;
+
+  return payload?.data?.data ?? payload?.data ?? payload;
+};
+
+const getCachedEntity = async (cache, cacheKey, loader) => {
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey);
+  }
+
+  const request = loader();
+  cache.set(cacheKey, request);
+
+  try {
+    const result = await request;
+    cache.set(cacheKey, Promise.resolve(result));
+    return result;
+  } catch (error) {
+    cache.delete(cacheKey);
+    throw error;
+  }
+};
+
+export const getCachedChatUserProfile = async (userId) =>
+  getCachedEntity(chatUserProfileCache, String(userId), async () => {
+    const response = await userService.getUserById(userId);
+    return extractEntityPayload(response);
+  });
+
+export const getCachedChatTeamProfile = async (teamId) =>
+  getCachedEntity(chatTeamProfileCache, String(teamId), async () => {
+    const response = await teamService.getTeamById(teamId);
+    return extractEntityPayload(response);
+  });
+
+export const getTeamAvatarUrl = (team) =>
+  team?.avatarUrl ??
+  team?.avatar_url ??
+  team?.teamavatarUrl ??
+  team?.teamavatar_url ??
+  null;
+
+export const mergeResolvedUserData = (user, profile) => {
+  if (!profile) return user;
+
+  const resolvedAvatarUrl =
+    user?.avatar_url ??
+    user?.avatarUrl ??
+    profile?.avatar_url ??
+    profile?.avatarUrl ??
+    null;
+  const resolvedSyntheticStatus =
+    user?.is_synthetic ??
+    user?.isSynthetic ??
+    profile?.is_synthetic ??
+    profile?.isSynthetic ??
+    undefined;
+
+  return {
+    ...profile,
+    ...user,
+    avatar_url: resolvedAvatarUrl,
+    avatarUrl:
+      user?.avatarUrl ??
+      user?.avatar_url ??
+      profile?.avatarUrl ??
+      profile?.avatar_url ??
+      null,
+    is_synthetic: resolvedSyntheticStatus,
+    isSynthetic: resolvedSyntheticStatus,
+  };
+};
+
+export const mergeResolvedTeamData = (team, profile) => {
+  if (!profile) return team;
+
+  const resolvedAvatarUrl = getTeamAvatarUrl(team) ?? getTeamAvatarUrl(profile);
+  const resolvedSyntheticStatus =
+    team?.is_synthetic ??
+    team?.isSynthetic ??
+    profile?.is_synthetic ??
+    profile?.isSynthetic ??
+    undefined;
+
+  return {
+    ...profile,
+    ...team,
+    avatarUrl: resolvedAvatarUrl,
+    avatar_url: resolvedAvatarUrl,
+    teamavatarUrl:
+      team?.teamavatarUrl ??
+      team?.teamavatar_url ??
+      profile?.teamavatarUrl ??
+      profile?.teamavatar_url ??
+      resolvedAvatarUrl,
+    teamavatar_url:
+      team?.teamavatar_url ??
+      team?.teamavatarUrl ??
+      profile?.teamavatar_url ??
+      profile?.teamavatarUrl ??
+      resolvedAvatarUrl,
+    is_synthetic: resolvedSyntheticStatus,
+    isSynthetic: resolvedSyntheticStatus,
+  };
+};

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -78,8 +78,20 @@ export const isSyntheticTeam = (team) => {
   return team.is_synthetic === true || team.isSynthetic === true;
 };
 
+/**
+ * Check if a vacant role is a synthetic/demo role
+ * Handles both snake_case (from API) and camelCase (from frontend state)
+ */
+export const isSyntheticRole = (role) => {
+  if (!role) return false;
+  return role.is_synthetic === true || role.isSynthetic === true;
+};
+
 export const DEMO_PROFILE_TOOLTIP =
   "Demo Profile: For testing purposes, no real person";
 
 export const DEMO_TEAM_TOOLTIP =
   "Demo Team: for testing purposes, no real team";
+
+export const DEMO_ROLE_TOOLTIP =
+  "Demo Role: for testing purposes, no real role";

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -1,3 +1,14 @@
+const hasTruthySyntheticFlag = (value) => {
+  if (value === true || value === 1) return true;
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "1";
+  }
+
+  return false;
+};
+
 /**
  * Get user initials for avatar fallback
  * Returns 2 letters for users with first and last name (e.g., "VL" for Valentina Lopez)
@@ -66,7 +77,10 @@ export const getDisplayName = (user) => {
  */
 export const isSyntheticUser = (user) => {
   if (!user) return false;
-  return user.is_synthetic === true || user.isSynthetic === true;
+  return (
+    hasTruthySyntheticFlag(user.is_synthetic) ||
+    hasTruthySyntheticFlag(user.isSynthetic)
+  );
 };
 
 /**
@@ -75,7 +89,10 @@ export const isSyntheticUser = (user) => {
  */
 export const isSyntheticTeam = (team) => {
   if (!team) return false;
-  return team.is_synthetic === true || team.isSynthetic === true;
+  return (
+    hasTruthySyntheticFlag(team.is_synthetic) ||
+    hasTruthySyntheticFlag(team.isSynthetic)
+  );
 };
 
 /**
@@ -84,7 +101,10 @@ export const isSyntheticTeam = (team) => {
  */
 export const isSyntheticRole = (role) => {
   if (!role) return false;
-  return role.is_synthetic === true || role.isSynthetic === true;
+  return (
+    hasTruthySyntheticFlag(role.is_synthetic) ||
+    hasTruthySyntheticFlag(role.isSynthetic)
+  );
 };
 
 export const DEMO_PROFILE_TOOLTIP =

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -59,3 +59,15 @@ export const getDisplayName = (user) => {
   if (fullName.length > 0) return fullName;
   return user.username || "Unknown";
 };
+
+/**
+ * Check if a user is a synthetic/demo user
+ * Handles both snake_case (from API) and camelCase (from frontend state)
+ */
+export const isSyntheticUser = (user) => {
+  if (!user) return false;
+  return user.is_synthetic === true || user.isSynthetic === true;
+};
+
+export const DEMO_PROFILE_TOOLTIP =
+  "Demo Profile: For testing purposes, no real person";

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -69,5 +69,17 @@ export const isSyntheticUser = (user) => {
   return user.is_synthetic === true || user.isSynthetic === true;
 };
 
+/**
+ * Check if a team is a synthetic/demo team
+ * Handles both snake_case (from API) and camelCase (from frontend state)
+ */
+export const isSyntheticTeam = (team) => {
+  if (!team) return false;
+  return team.is_synthetic === true || team.isSynthetic === true;
+};
+
 export const DEMO_PROFILE_TOOLTIP =
   "Demo Profile: For testing purposes, no real person";
+
+export const DEMO_TEAM_TOOLTIP =
+  "Demo Team: for testing purposes, no real team";


### PR DESCRIPTION
# feat: Demo data indicators + search filter toggle

## Summary

Introduces visual indicators for synthetic/demo data throughout the UI and adds a search filter toggle so users can include or exclude demo profiles, teams, and roles from results.

## Changes

### Demo data indicators
- **`DemoAvatarOverlay`** — semi-transparent overlay rendered on avatars of synthetic users, teams, and roles across all views (cards, modals, chat, profile headers)
- **`userHelpers.js`** — added `isSyntheticUser()`, `isSyntheticTeam()`, `isSyntheticRole()` helpers with snake_case/camelCase normalization, plus tooltip constants (`DEMO_PROFILE_TOOLTIP`, `DEMO_TEAM_TOOLTIP`, `DEMO_ROLE_TOOLTIP`)
- **`FlaskConical` icon + tooltip** shown next to team/user names in detail modals (`TeamDetailsModal`, `TeamInvitationDetailsModal`, `TeamApplicationDetailsModal`, `UserDetailsModal`) and inline links (`InlineUserLink`)
- **`UserAvatar`** — accepts `showDemoOverlay` prop to conditionally render the overlay
- **`TeamCard` / `UserCard`** — display demo label ("Demo Team" / "Demo Role" / "Demo") with overlay in card and list views
- **Chat** — demo overlays on conversation partner and team avatars in `MessageDisplay`

### Search filter toggle (`SearchPage`)
- New `includeDemoData` state (default `true`)
- Toggle button placed after the "+ My Teams" filter: `FlaskConical` icon with `+ Demo Data` / `- Demo Data` label
- Tooltips: "Include test/demo profiles, roles and teams" / "Show only real users, roles and teams"
- Passes `includeDemoData` query param to backend via `searchService.js`
- Filter icon turns primary color when demo data is excluded (`isSortModified` updated)
- Active pill removal support via `handleActivePillRemove`
- Visible to all users (authenticated and unauthenticated)

### Affected components
- `SearchPage`, `BooleanSearchInput`
- `TeamCard`, `UserCard`, `VacantRoleCard`
- `TeamDetailsModal`, `TeamInvitationDetailsModal`, `TeamApplicationDetailsModal`
- `UserDetailsModal`, `UserProfileHeaderSection`, `UserAvatar`
- `InlineUserLink`, `MessageDisplay`
- `DemoAvatarOverlay` (new)
- `userHelpers.js`
- `searchService.js`

## Benefits
- Demo data is clearly labeled so real users aren't confused by test profiles
- One-click toggle to see only real content — useful as the platform grows
- Consistent visual language (flask icon + overlay) across all surfaces
- No impact on existing functionality — demo data included by default