### PR TITLE
Polish search map view popups, legends, and unmapped results

### DIFF
--- a/src/components/badges/BadgeAwardModal.jsx
+++ b/src/components/badges/BadgeAwardModal.jsx
@@ -413,7 +413,7 @@ const BadgeAwardModal = ({
           />
         ) : null}
         <div
-          className="w-7 h-7 rounded-full bg-primary text-primary-content flex items-center justify-center font-medium text-xs"
+          className="w-7 h-7 rounded-full bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center font-medium text-xs"
           style={{ display: awardeeAvatar ? "none" : "flex" }}
         >
           {getUserInitials({

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -311,7 +311,7 @@ const ConversationList = ({
                         />
                       ) : null}
                       <div
-                        className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                        className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                         style={{
                           display: getTeamAvatarUrl(conversationData)
                             ? "none"

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -1039,7 +1039,7 @@ const MessageDisplay = ({
             />
           ) : null}
           <div
-            className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+            className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
             style={{ display: teamAvatarUrl ? "none" : "flex" }}
           >
             <span className="text-xl font-medium">

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -84,7 +84,7 @@ const Card = ({
       >
         <div className="avatar placeholder relative">
           <div
-            className={`${shapeClass} ${sizeClass} relative flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}
+            className={`${shapeClass} ${sizeClass} relative flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-[var(--color-primary-focus)] text-primary-content"}`}
           >
             {imageReplacement ? (
               imageReplacement
@@ -208,7 +208,7 @@ const Card = ({
       >
         {(image || imageFallback || imageReplacement) && (
           <div className="avatar placeholder flex-shrink-0 relative">
-            <div className={`rounded-full w-9 h-9 relative flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-primary text-primary-content"}`}>
+            <div className={`rounded-full w-9 h-9 relative flex items-center justify-center overflow-hidden ${imageReplacement ? "" : "bg-[var(--color-primary-focus)] text-primary-content"}`}>
               {imageReplacement ? (
                 imageReplacement
               ) : typeof image === "string" &&
@@ -238,7 +238,7 @@ const Card = ({
 
         <div className="min-w-0 flex-1">
           <Tooltip content={title} wrapperClassName="block min-w-0 overflow-hidden">
-            <div className="font-medium text-sm text-primary truncate">{title}</div>
+            <div className="font-medium text-sm text-[var(--color-primary-focus)] truncate">{title}</div>
           </Tooltip>
           {subtitle && (
             <div className="text-xs text-base-content/60 mt-px">{subtitle}</div>
@@ -334,7 +334,7 @@ const Card = ({
 
               <div className="min-w-0 flex-1">
                 <h3
-                  className={`font-medium text-primary leading-[120%] mb-1 ${titleClassName || "text-lg"}`}
+                  className={`font-medium text-[var(--color-primary-focus)] leading-[120%] mb-1 ${titleClassName || "text-lg"}`}
                 >
                   {title}
                 </h3>

--- a/src/components/common/ImageUploader.jsx
+++ b/src/components/common/ImageUploader.jsx
@@ -270,7 +270,7 @@ const ImageUploader = ({
             className={`
               w-full h-full flex items-center justify-center overflow-hidden
               ${shapeClasses[finalShape]}
-              ${hasImage ? "" : "bg-primary text-primary-content"}
+              ${hasImage ? "" : "bg-[var(--color-primary-focus)] text-primary-content"}
             `}
           >
             {loading ? (

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -129,7 +129,7 @@ const PersonRequestCard = ({
             ) : null}
             {/* Fallback initials */}
             <div
-              className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+              className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
               style={{
                 display: getAvatarUrl() ? "none" : "flex",
               }}

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -69,7 +69,7 @@ const TYPE_META = {
 
 const DEFAULT_CENTER = [51.1657, 10.4515];
 const LOCATION_NOT_AVAILABLE = "Location not available";
-const POPUP_SUBLINE_ICON_SIZE = 12;
+const POPUP_SUBLINE_ICON_SIZE = 10;
 const POPUP_SUBLINE_ICON_CLASS = "inline-flex h-3 w-3 items-center justify-center";
 const COUNTRY_COORDINATE_BOUNDS = {
   DE: { minLat: 47.2, maxLat: 55.2, minLng: 5.7, maxLng: 15.1 },
@@ -624,7 +624,7 @@ const PopupAvatar = ({ point, backgroundColor = null }) => {
 
   return (
     <span
-      className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full text-sm font-bold text-white shadow-soft ring-2 ring-white"
+      className="relative flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full text-sm font-bold text-white shadow-soft ring-2 ring-white"
       style={{ backgroundColor: backgroundColor ?? meta.color }}
       aria-hidden="true"
     >
@@ -805,9 +805,9 @@ const TeamMetaLine = ({ point, withTooltips = true }) => {
   const roleTooltip = getTeamRoleTooltip(point.currentUserRole);
 
   return (
-    <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] font-medium text-base-content/60">
+    <div className="mt-0.5 flex flex-wrap items-center gap-1 text-[11px] font-medium text-base-content/60">
       <TeamMetaItem tooltip={`${point.memberCount} of ${point.maxMembers} members`} withTooltip={withTooltips}>
-        <Users size={12} className={point.currentUserRole ? "text-success" : ""} aria-hidden="true" />
+        <Users size={10} className={point.currentUserRole ? "text-success" : ""} aria-hidden="true" />
         <span>{memberLabel}</span>
       </TeamMetaItem>
       {point.openRoleCount > 0 && (
@@ -815,13 +815,13 @@ const TeamMetaLine = ({ point, withTooltips = true }) => {
           tooltip={`${point.openRoleCount} open ${point.openRoleCount === 1 ? "role" : "roles"} posted in this team`}
           withTooltip={withTooltips}
         >
-          <UserSearch size={12} className="text-orange-500" aria-hidden="true" />
+          <UserSearch size={10} className="text-orange-500" aria-hidden="true" />
           <span>{point.openRoleCount}</span>
         </TeamMetaItem>
       )}
       {point.currentUserRole && (
         <TeamMetaItem tooltip={roleTooltip} withTooltip={withTooltips}>
-          <TeamRoleIcon role={point.currentUserRole} size={12} />
+          <TeamRoleIcon role={point.currentUserRole} size={10} />
         </TeamMetaItem>
       )}
       {point.currentUserRole && (
@@ -834,11 +834,32 @@ const TeamMetaLine = ({ point, withTooltips = true }) => {
           withTooltip={withTooltips}
         >
           {point.isPublic ? (
-            <EyeIcon size={12} className="text-green-600" aria-hidden="true" />
+            <EyeIcon size={10} className="text-green-600" aria-hidden="true" />
           ) : (
-            <EyeClosed size={12} className="text-gray-500" aria-hidden="true" />
+            <EyeClosed size={10} className="text-gray-500" aria-hidden="true" />
           )}
         </TeamMetaItem>
+      )}
+    </div>
+  );
+};
+
+const UserSubline = ({ point }) => {
+  if (point.type !== "user") return null;
+  if (!point.username && !point.isOwnProfile) return null;
+
+  return (
+    <div className="mt-0.5 flex items-center gap-0.5 text-[11px] font-medium text-base-content/60">
+      {point.username && <span>@{point.username}</span>}
+      {point.isOwnProfile && (
+        <Tooltip content={point.isPublicProfile ? "Public Profile - visible for everyone" : "Private Profile - only visible for you"}>
+          <span className="inline-flex">
+            {point.isPublicProfile
+              ? <EyeIcon size={10} className="text-green-600" aria-hidden="true" />
+              : <EyeClosed size={10} className="text-gray-500" aria-hidden="true" />
+            }
+          </span>
+        </Tooltip>
       )}
     </div>
   );
@@ -853,11 +874,11 @@ const RoleSubline = ({ point }) => {
   if (!isValidDate && !point.hasApplied && !point.hasInvitation) return null;
 
   return (
-    <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] font-medium text-base-content/60">
+    <div className="mt-0.5 flex flex-wrap items-center gap-1 text-[11px] font-medium text-base-content/60">
       {isValidDate && (
         <Tooltip content={`Posted ${format(postedDate, "MMM d, yyyy")}`}>
           <span className="inline-flex items-center gap-1">
-            <Calendar size={12} aria-hidden="true" />
+            <Calendar size={10} aria-hidden="true" />
             <span>{format(postedDate, "MM/dd/yy")}</span>
           </span>
         </Tooltip>
@@ -865,14 +886,14 @@ const RoleSubline = ({ point }) => {
       {point.hasApplied && (
         <Tooltip content="You applied for this role">
           <span className="inline-flex">
-            <SendHorizontal size={12} className="text-orange-500" aria-hidden="true" />
+            <SendHorizontal size={10} className="text-orange-500" aria-hidden="true" />
           </span>
         </Tooltip>
       )}
       {point.hasInvitation && (
         <Tooltip content="You were invited to fill this role">
           <span className="inline-flex">
-            <Mail size={12} className="text-orange-500" aria-hidden="true" />
+            <Mail size={10} className="text-orange-500" aria-hidden="true" />
           </span>
         </Tooltip>
       )}
@@ -884,7 +905,7 @@ const MapPopupCard = ({ point, onOpenPoint }) => {
   const map = useMap();
 
   return (
-    <div className="inline-block max-w-80 align-top">
+    <div className="inline-block max-w-[22rem] align-top">
       <div className="mb-2 flex items-center justify-between text-base-content/70">
         <EntityMetaLine point={point} />
         <button
@@ -893,31 +914,17 @@ const MapPopupCard = ({ point, onOpenPoint }) => {
           aria-label="Close"
           className="ml-2 flex items-center justify-center text-base-content/40 hover:text-base-content/70"
         >
-          <X size={POPUP_SUBLINE_ICON_SIZE} />
+          <X size={10} />
         </button>
       </div>
 
       <div className="flex items-center gap-2">
         <PopupAvatar point={point} backgroundColor="var(--color-primary-focus)" />
         <div className="min-w-0 flex-1">
-          <h3 className="line-clamp-2 break-words text-[17px] font-medium leading-[1.1] text-[var(--color-primary-focus)]">
+          <h3 className="truncate text-[15px] font-medium leading-[1.1] text-[var(--color-primary-focus)]">
             {point.name}
           </h3>
-          {point.type === "user" && (point.username || point.isOwnProfile) && (
-            <div className="mt-1.5 flex items-center gap-1.5 text-[11px] font-medium text-base-content/60">
-              {point.username && <span>@{point.username}</span>}
-              {point.isOwnProfile && (
-                <Tooltip content={point.isPublicProfile ? "Public Profile - visible for everyone" : "Private Profile - only visible for you"}>
-                  <span className="inline-flex">
-                    {point.isPublicProfile
-                      ? <EyeIcon size={12} className="text-green-600" aria-hidden="true" />
-                      : <EyeClosed size={12} className="text-gray-500" aria-hidden="true" />
-                    }
-                  </span>
-                </Tooltip>
-              )}
-            </div>
-          )}
+          <UserSubline point={point} />
           <TeamMetaLine point={point} />
           <RoleSubline point={point} />
         </div>
@@ -1164,7 +1171,7 @@ const SearchMapView = ({
                     className="lomir-map-popup"
                     closeButton={false}
                     minWidth={0}
-                    maxWidth={320}
+                    maxWidth={352}
                   >
                     <MapPopupCard point={point} onOpenPoint={openPoint} />
                   </Popup>
@@ -1190,7 +1197,7 @@ const SearchMapView = ({
                       style={{ backgroundColor: meta.color }}
                       aria-hidden="true"
                     >
-                      <meta.Icon size={12} strokeWidth={2.25} className="block text-white" />
+                      <meta.Icon size={10} strokeWidth={2.25} className="block text-white" />
                     </span>
                     {meta.label}
                   </span>
@@ -1244,9 +1251,10 @@ const SearchMapView = ({
                         <div className="mt-1 flex items-center gap-1.5">
                           <PopupAvatar point={point} backgroundColor="var(--color-primary-focus)" />
                           <div className="min-w-0 flex-1">
-                            <h5 className="line-clamp-2 break-words text-[17px] font-medium leading-[1.1] text-[var(--color-primary-focus)]">
+                            <h5 className="truncate text-[15px] font-medium leading-[1.1] text-[var(--color-primary-focus)]">
                               {point.name}
                             </h5>
+                            <UserSubline point={point} />
                             <TeamMetaLine point={point} withTooltips={false} />
                             <RoleSubline point={point} />
                           </div>

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -14,6 +14,7 @@ import {
   FlaskConical,
   Globe,
   MapPin,
+  MapPinX,
   Ruler,
   Users,
   User,
@@ -31,6 +32,7 @@ import {
   isSyntheticTeam,
   isSyntheticUser,
 } from "../../utils/userHelpers";
+import { getCountryCode, getCountryDisplayName } from "../../utils/locationUtils";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import Tooltip from "../common/Tooltip";
 
@@ -56,13 +58,33 @@ const TYPE_META = {
 };
 
 const DEFAULT_CENTER = [51.1657, 10.4515];
+const LOCATION_NOT_AVAILABLE = "Location not available";
 const POPUP_SUBLINE_ICON_SIZE = 12;
 const POPUP_SUBLINE_ICON_CLASS = "inline-flex h-3 w-3 items-center justify-center";
+const COUNTRY_COORDINATE_BOUNDS = {
+  DE: { minLat: 47.2, maxLat: 55.2, minLng: 5.7, maxLng: 15.1 },
+  FR: { minLat: 41.2, maxLat: 51.2, minLng: -5.6, maxLng: 9.7 },
+};
+const CITY_COUNTRY_FALLBACKS = {
+  berlin: "DE",
+  frankfurt: "DE",
+  "frankfurt am main": "DE",
+};
+const CITY_COORDINATE_FALLBACKS = {
+  berlin: { lat: 52.52, lng: 13.405 },
+  frankfurt: { lat: 50.1109, lng: 8.6821 },
+  "frankfurt am main": { lat: 50.1109, lng: 8.6821 },
+};
 
 const toNumber = (value) => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 };
+
+const firstPresent = (...values) =>
+  values.find((value) => value !== undefined && value !== null && value !== "") ?? null;
+
+const normalizeLocationKey = (value) => String(value ?? "").trim().toLowerCase();
 
 const escapeHtml = (value) =>
   String(value ?? "")
@@ -81,8 +103,21 @@ const isValidCoordinate = (lat, lng) =>
   lng <= 180;
 
 const getLatLng = (item) => {
-  const lat = toNumber(item?.latitude ?? item?.lat);
-  const lng = toNumber(item?.longitude ?? item?.lng ?? item?.lon);
+  const lat = toNumber(firstPresent(
+    item?.latitude,
+    item?.lat,
+    item?.location?.latitude,
+    item?.roleLocation?.latitude,
+    item?.role_location?.latitude,
+  ));
+  const lng = toNumber(firstPresent(
+    item?.longitude,
+    item?.lng,
+    item?.lon,
+    item?.location?.longitude,
+    item?.roleLocation?.longitude,
+    item?.role_location?.longitude,
+  ));
 
   return isValidCoordinate(lat, lng) ? { lat, lng } : null;
 };
@@ -98,15 +133,83 @@ const getDisplayName = (item, type) => {
   return [firstName, lastName].filter(Boolean).join(" ") || item.username || "Person";
 };
 
+const getItemCity = (item) =>
+  firstPresent(
+    item.city,
+    item.location_city,
+    item.locationCity,
+    item.roleCity,
+    item.role_city,
+    item.roleLocation?.city,
+    item.role_location?.city,
+    item.location?.city,
+    item.role?.city,
+  );
+
 const getLocationLabel = (item) => {
   if (item.is_remote ?? item.isRemote) return "Remote";
 
-  const city = item.city || item.location_city;
-  const country = item.country || item.location_country;
-  const state = item.state || item.location_state;
-  const parts = [city, country || state].filter(Boolean);
+  const city = getItemCity(item);
+  const country = firstPresent(
+    item.country,
+    item.location_country,
+    item.locationCountry,
+    item.roleCountry,
+    item.role_country,
+    item.roleLocation?.country,
+    item.role_location?.country,
+    item.location?.country,
+    item.role?.country,
+  );
+  const state = firstPresent(
+    item.state,
+    item.location_state,
+    item.locationState,
+    item.roleState,
+    item.role_state,
+    item.roleLocation?.state,
+    item.role_location?.state,
+    item.location?.state,
+    item.role?.state,
+  );
+  const countryLabel = country
+    ? getCountryDisplayName(getCountryCode(country) ?? country)
+    : null;
+  const parts = [city, state, countryLabel].filter(Boolean);
 
-  return parts.length > 0 ? parts.join(", ") : "Location not available";
+  return parts.length > 0 ? parts.join(", ") : LOCATION_NOT_AVAILABLE;
+};
+
+const getItemCountryCode = (item) =>
+  getCountryCode(firstPresent(
+    item?.country,
+    item?.location_country,
+    item?.locationCountry,
+    item?.roleCountry,
+    item?.role_country,
+    item?.roleLocation?.country,
+    item?.role_location?.country,
+    item?.location?.country,
+    item?.role?.country,
+  )) ?? CITY_COUNTRY_FALLBACKS[normalizeLocationKey(getItemCity(item))] ?? null;
+
+const getCityCoordinateFallback = (item) =>
+  CITY_COORDINATE_FALLBACKS[normalizeLocationKey(getItemCity(item))] ?? null;
+
+const getItemMaxDistanceKm = (item) =>
+  toNumber(firstPresent(item?.maxDistanceKm, item?.max_distance_km, item?.role?.maxDistanceKm, item?.role?.max_distance_km));
+
+const coordinatesMatchCountry = (lat, lng, countryCode) => {
+  if (!countryCode) return true;
+  const bounds = COUNTRY_COORDINATE_BOUNDS[countryCode];
+  if (!bounds) return true;
+
+  return (
+    lat >= bounds.minLat &&
+    lat <= bounds.maxLat &&
+    lng >= bounds.minLng &&
+    lng <= bounds.maxLng
+  );
 };
 
 const getDistanceLabel = (item) => {
@@ -216,10 +319,39 @@ const normalizeMapPoint = (item) => {
         : item.first_name || item.firstName || item.username
           ? "user"
           : "team";
-  const lat = toNumber(item.latitude ?? item.lat);
-  const lng = toNumber(item.longitude ?? item.lng ?? item.lon);
-  const hasCoordinates = isValidCoordinate(lat, lng);
+  const lat = toNumber(firstPresent(
+    item.latitude,
+    item.lat,
+    item.location?.latitude,
+    item.roleLocation?.latitude,
+    item.role_location?.latitude,
+  ));
+  const lng = toNumber(firstPresent(
+    item.longitude,
+    item.lng,
+    item.lon,
+    item.location?.longitude,
+    item.roleLocation?.longitude,
+    item.role_location?.longitude,
+  ));
   const isRemote = Boolean(item.is_remote ?? item.isRemote);
+  const locationLabel = getLocationLabel(item);
+  const countryCode = getItemCountryCode(item);
+  const rawCoordinatesAreUsable =
+    !isRemote &&
+    locationLabel !== LOCATION_NOT_AVAILABLE &&
+    isValidCoordinate(lat, lng) &&
+    coordinatesMatchCountry(lat, lng, countryCode);
+  const cityCoordinateFallback = !isRemote ? getCityCoordinateFallback(item) : null;
+  const shouldUseCityCoordinateFallback =
+    !rawCoordinatesAreUsable &&
+    locationLabel !== LOCATION_NOT_AVAILABLE &&
+    Boolean(cityCoordinateFallback);
+  const mapLat = rawCoordinatesAreUsable ? lat : cityCoordinateFallback?.lat ?? lat;
+  const mapLng = rawCoordinatesAreUsable ? lng : cityCoordinateFallback?.lng ?? lng;
+  const hasCoordinates =
+    rawCoordinatesAreUsable ||
+    shouldUseCityCoordinateFallback;
   const avatarData = getAvatarData(item, type);
 
   return {
@@ -227,13 +359,15 @@ const normalizeMapPoint = (item) => {
     rawId: item.id ?? item.roleId ?? item.role_id,
     type,
     item,
-    lat,
-    lng,
+    lat: mapLat,
+    lng: mapLng,
     hasCoordinates,
     isRemote,
     name: getDisplayName(item, type),
-    locationLabel: getLocationLabel(item),
-    distanceLabel: getDistanceLabel(item),
+    locationLabel,
+    countryCode,
+    maxDistanceKm: getItemMaxDistanceKm(item),
+    distanceLabel: shouldUseCityCoordinateFallback ? null : getDistanceLabel(item),
     teamName: item.teamName ?? item.team_name ?? item.team?.name ?? null,
     imageUrl: avatarData.imageUrl,
     initials: avatarData.initials,
@@ -266,21 +400,6 @@ const MapBounds = ({ points, proximityCenter = null, proximityRadiusKm = null })
   }, [map, points, proximityCenter, proximityRadiusKm]);
 
   return null;
-};
-
-const TypeBadge = ({ type }) => {
-  const meta = TYPE_META[type] ?? TYPE_META.team;
-  const Icon = meta.Icon;
-
-  return (
-    <span
-      className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-bold"
-      style={{ color: meta.color, borderColor: meta.color, backgroundColor: meta.background }}
-    >
-      <Icon size={12} aria-hidden="true" />
-      {meta.label}
-    </span>
-  );
 };
 
 const MarkerTooltipContent = ({ point }) => {
@@ -368,34 +487,89 @@ const BreakableName = ({ name }) => {
   return <>{words[0]}<br />{words.slice(1).join(" ")}</>;
 };
 
-const MapPopupCard = ({ point, onOpenPoint }) => {
-  const map = useMap();
+const EntityMetaLine = ({ point }) => {
   const meta = TYPE_META[point.type] ?? TYPE_META.team;
   const Icon = meta.Icon;
 
   return (
+    <div className="flex items-center gap-0.5 text-[11px] font-medium text-base-content/70">
+      <Tooltip
+        content={getTypeTooltipLabel(point.type)}
+        wrapperClassName={POPUP_SUBLINE_ICON_CLASS}
+      >
+        <Icon size={POPUP_SUBLINE_ICON_SIZE} strokeWidth={2.25} aria-hidden="true" />
+      </Tooltip>
+      <span>{meta.label}</span>
+      {point.isDemo && (
+        <>
+          <Tooltip
+            content={getDemoLabel(point.type)}
+            wrapperClassName={`ml-1.5 overflow-hidden ${POPUP_SUBLINE_ICON_CLASS}`}
+          >
+            <FlaskConical size={POPUP_SUBLINE_ICON_SIZE} strokeWidth={2.25} aria-hidden="true" />
+          </Tooltip>
+          <span>Demo</span>
+        </>
+      )}
+    </div>
+  );
+};
+
+const LocationIcon = ({ point, size = 13, className = "" }) => {
+  if (point.isRemote) return <Globe size={size} className={className} aria-hidden="true" />;
+  if (point.locationLabel === LOCATION_NOT_AVAILABLE) {
+    return <MapPinX size={size} className={className} aria-hidden="true" />;
+  }
+  return <MapPin size={size} className={className} aria-hidden="true" />;
+};
+
+const getDetailsTooltipLabel = (type) => {
+  if (type === "team") return "Click to view team details";
+  if (type === "role") return "Click to view role details";
+  return "Click to view user details";
+};
+
+const getLocationStatusTooltipLabel = (point) => {
+  const entityLabel = TYPE_META[point.type]?.label ?? TYPE_META.team.label;
+  if (point.isRemote) return `Remote ${entityLabel}`;
+  const radiusLabel =
+    point.type === "role" && point.maxDistanceKm
+      ? `\nwithin ${point.maxDistanceKm} km from Role Location`
+      : "";
+  if (point.countryCode) {
+    return `${entityLabel} in ${point.locationLabel}${radiusLabel}`;
+  }
+  if (point.locationLabel !== LOCATION_NOT_AVAILABLE) {
+    return `${entityLabel} in ${point.locationLabel}${radiusLabel}`;
+  }
+  return `${entityLabel} without Location info`;
+};
+
+const LocationStatusIndicator = ({ point }) => {
+  if (point.countryCode && point.locationLabel !== LOCATION_NOT_AVAILABLE && !point.isRemote) {
+    return (
+      <span className="rounded-full border border-[var(--color-primary-focus)] px-1.5 py-0.5 text-[10px] font-medium leading-none text-[var(--color-primary-focus)]">
+        {point.countryCode}
+      </span>
+    );
+  }
+
+  return (
+    <LocationIcon
+      point={point}
+      size={14}
+      className="text-[var(--color-primary-focus)]"
+    />
+  );
+};
+
+const MapPopupCard = ({ point, onOpenPoint }) => {
+  const map = useMap();
+
+  return (
     <div className="inline-block max-w-60 align-top">
       <div className="mb-2 flex items-center justify-between text-base-content/70">
-        <div className="flex items-center gap-0.5 text-[11px] font-medium">
-          <Tooltip
-            content={getTypeTooltipLabel(point.type)}
-            wrapperClassName={POPUP_SUBLINE_ICON_CLASS}
-          >
-            <Icon size={POPUP_SUBLINE_ICON_SIZE} strokeWidth={2.25} aria-hidden="true" />
-          </Tooltip>
-          <span>{meta.label}</span>
-          {point.isDemo && (
-            <>
-              <Tooltip
-                content={getDemoLabel(point.type)}
-                wrapperClassName={`ml-1.5 overflow-hidden ${POPUP_SUBLINE_ICON_CLASS}`}
-              >
-                <FlaskConical size={POPUP_SUBLINE_ICON_SIZE} strokeWidth={2.25} aria-hidden="true" />
-              </Tooltip>
-              <span>Demo</span>
-            </>
-          )}
-        </div>
+        <EntityMetaLine point={point} />
         <button
           type="button"
           onClick={() => map.closePopup()}
@@ -406,10 +580,10 @@ const MapPopupCard = ({ point, onOpenPoint }) => {
         </button>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2">
         <PopupAvatar point={point} />
         <div className="min-w-0 flex-1">
-          <h3 className="line-clamp-2 break-words text-[17px] font-bold leading-[1.1] text-base-content">
+          <h3 className="line-clamp-2 break-words text-[17px] font-medium leading-[1.1] text-[var(--color-primary-focus)]">
             <BreakableName name={point.name} />
           </h3>
         </div>
@@ -423,7 +597,7 @@ const MapPopupCard = ({ point, onOpenPoint }) => {
           </div>
         )}
         <div className="flex items-center gap-1.5">
-          {point.isRemote ? <Globe size={13} /> : <MapPin size={13} />}
+          <LocationIcon point={point} />
           <span>{point.locationLabel}</span>
         </div>
         {point.distanceLabel && (
@@ -464,6 +638,7 @@ const SearchMapView = ({
   const teamModal = useTeamModalSafe();
   const userModal = useUserModalSafe();
   const [selectedRolePoint, setSelectedRolePoint] = useState(null);
+  const [activeStatusTooltipPointId, setActiveStatusTooltipPointId] = useState(null);
 
   const normalizedPoints = useMemo(
     () => items.map(normalizeMapPoint).filter(Boolean),
@@ -593,12 +768,14 @@ const SearchMapView = ({
             {searchType === "all" && (
               <div className="mt-3 flex flex-wrap gap-2">
                 {Object.entries(TYPE_META).map(([type, meta]) => (
-                  <span key={type} className="inline-flex items-center gap-1 text-xs text-base-content/70">
+                  <span key={type} className="inline-flex items-center gap-1.5 text-xs text-base-content/70">
                     <span
-                      className="h-2.5 w-2.5 rounded-full"
+                      className="inline-flex h-5 w-5 flex-none items-center justify-center rounded-full"
                       style={{ backgroundColor: meta.color }}
                       aria-hidden="true"
-                    />
+                    >
+                      <meta.Icon size={12} strokeWidth={2.25} className="block text-white" />
+                    </span>
                     {meta.label}
                   </span>
                 ))}
@@ -607,28 +784,61 @@ const SearchMapView = ({
 
             {fallbackPoints.length > 0 && (
               <div className="mt-5 flex min-h-0 flex-1 flex-col">
-                <h4 className="text-xs font-bold uppercase tracking-wide text-base-content/60">
-                  Remote or unmapped
-                </h4>
+                <div className="flex items-center justify-between gap-2">
+                  <h4 className="text-sm font-bold text-base-content">
+                    Remote or unmapped
+                  </h4>
+                  <span className="text-xs text-base-content/60">
+                    {fallbackPoints.length}/{normalizedPoints.length}
+                  </span>
+                </div>
                 <div className="mt-2 min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
                   {fallbackPoints.map((point) => (
-                    <button
+                    <Tooltip
                       key={point.id}
-                      type="button"
-                      onClick={() => openPoint(point)}
-                      className="w-full rounded-lg border border-base-200 bg-white/80 p-2 text-left transition hover:border-[var(--color-primary)] hover:bg-[#f0fdf4] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+                      content={
+                        activeStatusTooltipPointId === point.id
+                          ? null
+                          : getDetailsTooltipLabel(point.type)
+                      }
+                      wrapperClassName="block"
                     >
-                      <div className="flex items-center justify-between gap-2">
-                        <TypeBadge type={point.type} />
-                        {point.isRemote && <Globe size={14} className="text-[var(--color-primary)]" />}
-                      </div>
-                      <p className="mt-1 truncate text-xs font-bold text-base-content">
-                        {point.name}
-                      </p>
-                      <p className="truncate text-[11px] text-base-content/60">
-                        {point.teamName || point.locationLabel}
-                      </p>
-                    </button>
+                      <button
+                        type="button"
+                        onClick={() => openPoint(point)}
+                        className="w-full rounded-lg border border-base-200 bg-white/80 p-2 text-left shadow-soft transition-all duration-300 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <EntityMetaLine point={point} />
+                          <span
+                            className="inline-flex"
+                            onMouseEnter={() => setActiveStatusTooltipPointId(point.id)}
+                            onMouseLeave={() => setActiveStatusTooltipPointId(null)}
+                            onFocus={() => setActiveStatusTooltipPointId(point.id)}
+                            onBlur={() => setActiveStatusTooltipPointId(null)}
+                          >
+                            <Tooltip
+                              content={getLocationStatusTooltipLabel(point)}
+                              wrapperClassName="inline-flex items-center"
+                            >
+                              <LocationStatusIndicator point={point} />
+                            </Tooltip>
+                          </span>
+                        </div>
+                        <div className="mt-1 flex items-center gap-1.5">
+                          <PopupAvatar point={point} />
+                          <h5 className="line-clamp-2 min-w-0 flex-1 break-words text-[17px] font-medium leading-[1.1] text-[var(--color-primary-focus)]">
+                            <BreakableName name={point.name} />
+                          </h5>
+                        </div>
+                        {point.type === "role" && point.teamName && (
+                          <div className="mt-3 flex items-center gap-1.5 text-xs text-base-content/70">
+                            <Users size={13} />
+                            <span className="min-w-0 flex-1 truncate">{point.teamName}</span>
+                          </div>
+                        )}
+                      </button>
+                    </Tooltip>
                   ))}
                 </div>
               </div>

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   Circle,
   MapContainer,
@@ -11,19 +11,29 @@ import {
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import {
+  Calendar,
+  Crown,
+  EyeClosed,
+  EyeIcon,
   FlaskConical,
   Globe,
+  Mail,
   MapPin,
   MapPinX,
   Ruler,
+  SendHorizontal,
+  ShieldCheck,
   Users,
   User,
   UserSearch,
   X,
 } from "lucide-react";
+import { format } from "date-fns";
 import VacantRoleDetailsModal from "../teams/VacantRoleDetailsModal";
 import { useTeamModalSafe } from "../../contexts/TeamModalContext";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
+import { useAuth } from "../../contexts/AuthContext";
+import { teamService } from "../../services/teamService";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import {
   getTeamInitials,
@@ -86,6 +96,14 @@ const firstPresent = (...values) =>
 
 const normalizeLocationKey = (value) => String(value ?? "").trim().toLowerCase();
 
+const normalizeRoleValue = (value) => {
+  const role = String(value ?? "").trim().toLowerCase();
+  return ["owner", "admin", "member"].includes(role) ? role : null;
+};
+
+const isTruthyValue = (value) =>
+  value === true || value === 1 || value === "true" || value === "1";
+
 const escapeHtml = (value) =>
   String(value ?? "")
     .replaceAll("&", "&amp;")
@@ -132,6 +150,17 @@ const getDisplayName = (item, type) => {
   const lastName = item.last_name || item.lastName || "";
   return [firstName, lastName].filter(Boolean).join(" ") || item.username || "Person";
 };
+
+const getMapPointType = (item) =>
+  item._resultType === "team" || item._resultType === "user" || item._resultType === "role"
+    ? item._resultType
+    : item.roleName || item.role_name
+      ? "role"
+      : item.first_name || item.firstName || item.username
+        ? "user"
+        : "team";
+
+const getTeamItemId = (item) => firstPresent(item?.id, item?.teamId, item?.team_id);
 
 const getItemCity = (item) =>
   firstPresent(
@@ -199,6 +228,77 @@ const getCityCoordinateFallback = (item) =>
 const getItemMaxDistanceKm = (item) =>
   toNumber(firstPresent(item?.maxDistanceKm, item?.max_distance_km, item?.role?.maxDistanceKm, item?.role?.max_distance_km));
 
+const getTeamMemberCount = (item) => {
+  const count = firstPresent(
+    item?.current_members_count,
+    item?.currentMembersCount,
+    item?.member_count,
+    item?.memberCount,
+    item?.members_count,
+    item?.membersCount,
+    Array.isArray(item?.members) ? item.members.length : null,
+  );
+
+  return toNumber(count) ?? 0;
+};
+
+const getTeamMaxMembers = (item) =>
+  firstPresent(item?.max_members, item?.maxMembers) ?? "∞";
+
+const getTeamOpenRoleCount = (item) => {
+  const count = firstPresent(
+    item?.open_role_count,
+    item?.openRoleCount,
+    item?.open_roles_count,
+    item?.openRolesCount,
+    item?.vacant_role_count,
+    item?.vacantRoleCount,
+    item?.vacant_roles_count,
+    item?.vacantRolesCount,
+    Array.isArray(item?.openRoles) ? item.openRoles.length : null,
+    Array.isArray(item?.open_roles) ? item.open_roles.length : null,
+    Array.isArray(item?.vacantRoles) ? item.vacantRoles.length : null,
+    Array.isArray(item?.vacant_roles) ? item.vacant_roles.length : null,
+  );
+
+  return toNumber(count) ?? 0;
+};
+
+const getTeamViewerRole = (item, viewerUser = null) => {
+  if (!item || !viewerUser?.id) return null;
+
+  if (String(item.owner_id ?? item.ownerId ?? "") === String(viewerUser.id)) {
+    return "owner";
+  }
+
+  const directRole = normalizeRoleValue(firstPresent(
+    item.currentUserRole,
+    item.current_user_role,
+    item.userRole,
+    item.user_role,
+    item.viewerRole,
+    item.viewer_role,
+    item.membershipRole,
+    item.membership_role,
+  ));
+
+  if (directRole) return directRole;
+
+  if (Array.isArray(item.members)) {
+    const viewerMember = item.members.find(
+      (member) =>
+        String(member.user_id ?? member.userId ?? member.id ?? "") === String(viewerUser.id),
+    );
+
+    return normalizeRoleValue(viewerMember?.role);
+  }
+
+  return null;
+};
+
+const getTeamIsPublic = (item) =>
+  isTruthyValue(firstPresent(item?.is_public, item?.isPublic));
+
 const coordinatesMatchCountry = (lat, lng, countryCode) => {
   if (!countryCode) return true;
   const bounds = COUNTRY_COORDINATE_BOUNDS[countryCode];
@@ -225,6 +325,77 @@ const getDistanceLabel = (item) => {
   if (distance < 1) return `${distance.toFixed(1)} km away`;
   return `${Math.round(distance)} km away`;
 };
+
+const INACTIVE_APPLICATION_STATUSES = new Set(["withdrawn", "rejected", "declined", "cancelled", "canceled"]);
+const INACTIVE_INVITATION_STATUSES = new Set(["withdrawn", "revoked", "declined", "cancelled", "canceled"]);
+
+const getRoleHasApplied = (item) => {
+  if (isTruthyValue(firstPresent(
+    item.hasAppliedToRole, item.has_applied_to_role,
+    item.hasApplied, item.has_applied,
+    item.isApplied, item.is_applied,
+    item.viewerHasApplied, item.viewer_has_applied,
+    item.hasPendingApplication, item.has_pending_application,
+    item.hasPendingRoleApplication, item.has_pending_role_application,
+    item.isPendingApplication, item.is_pending_application,
+    item.currentUserHasApplied, item.current_user_has_applied,
+  ))) return true;
+  const appObj = firstPresent(
+    item.currentUserRoleApplication, item.current_user_role_application,
+    item.currentUserApplication, item.current_user_application,
+    item.pendingRoleApplication, item.pending_role_application,
+    item.pendingApplication, item.pending_application,
+    item.roleApplication, item.role_application,
+    item.application,
+  );
+  if (appObj) {
+    const status = String(appObj.status ?? appObj.applicationStatus ?? appObj.application_status ?? "").toLowerCase();
+    return status !== "" && !INACTIVE_APPLICATION_STATUSES.has(status);
+  }
+  return false;
+};
+
+const getRoleHasInvitation = (item) => {
+  if (isTruthyValue(firstPresent(
+    item.hasRoleInvitation, item.has_role_invitation,
+    item.hasInvitationToRole, item.has_invitation_to_role,
+    item.hasInvitation, item.has_invitation,
+    item.isInvitedToRole, item.is_invited_to_role,
+    item.viewerHasInvitation, item.viewer_has_invitation,
+    item.currentUserHasInvitation, item.current_user_has_invitation,
+  ))) return true;
+  const invObj = firstPresent(
+    item.currentUserRoleInvitation, item.current_user_role_invitation,
+    item.currentUserInvitation, item.current_user_invitation,
+    item.pendingRoleInvitation, item.pending_role_invitation,
+    item.pendingInvitation, item.pending_invitation,
+    item.roleInvitation, item.role_invitation,
+    item.invitation,
+  );
+  if (invObj) {
+    const status = String(invObj.status ?? invObj.invitationStatus ?? invObj.invitation_status ?? "").toLowerCase();
+    return status !== "" && !INACTIVE_INVITATION_STATUSES.has(status);
+  }
+  return false;
+};
+
+const getRoleIsViewerTeamMember = (item) => {
+  if (isTruthyValue(firstPresent(
+    item.isTeamMember, item.is_team_member,
+    item.isCurrentUserTeamMember,
+    item.viewerIsTeamMember, item.viewer_is_team_member,
+    item.memberOfTeam, item.member_of_team,
+    item.currentUserIsTeamMember, item.current_user_is_team_member,
+  ))) return true;
+  return normalizeRoleValue(firstPresent(
+    item.userRole, item.user_role,
+    item.viewerRole, item.viewer_role,
+    item.currentUserRole, item.current_user_role,
+  )) !== null;
+};
+
+const getRolePostedAt = (item) =>
+  firstPresent(item.postedAt, item.posted_at, item.createdAt, item.created_at);
 
 const getRoleInitials = (item) => {
   const name = item.roleName ?? item.role_name ?? item.title ?? "Vacant Role";
@@ -308,17 +479,22 @@ const buildMarkerIcon = (point) => {
   });
 };
 
-const normalizeMapPoint = (item) => {
+const matchesRoleItem = (entry, roleRawId, roleTeamId, roleNameStr) => {
+  const entryRoleId = entry.role?.id ?? entry.roleId ?? entry.role_id ?? null;
+  if (entryRoleId != null && roleRawId != null && String(entryRoleId) === String(roleRawId)) return true;
+  const entryTeamId = entry.team?.id ?? entry.teamId ?? entry.team_id ?? null;
+  const entryRoleName = entry.role?.roleName ?? entry.role?.role_name ?? entry.roleName ?? entry.role_name ?? null;
+  return (
+    roleTeamId != null && entryTeamId != null && String(entryTeamId) === String(roleTeamId) &&
+    typeof entryRoleName === "string" && typeof roleNameStr === "string" &&
+    entryRoleName.trim().toLowerCase() === roleNameStr.trim().toLowerCase()
+  );
+};
+
+const normalizeMapPoint = (item, viewerUser = null, fetchedTeamRoles = {}, fetchedApplications = [], fetchedInvitations = []) => {
   if (!item) return null;
 
-  const type =
-    item._resultType === "team" || item._resultType === "user" || item._resultType === "role"
-      ? item._resultType
-      : item.roleName || item.role_name
-        ? "role"
-        : item.first_name || item.firstName || item.username
-          ? "user"
-          : "team";
+  const type = getMapPointType(item);
   const lat = toNumber(firstPresent(
     item.latitude,
     item.lat,
@@ -353,10 +529,19 @@ const normalizeMapPoint = (item) => {
     rawCoordinatesAreUsable ||
     shouldUseCityCoordinateFallback;
   const avatarData = getAvatarData(item, type);
+  const rawId = type === "team" ? getTeamItemId(item) : item.id ?? item.roleId ?? item.role_id;
+  const fetchedTeamRole =
+    type === "team" && rawId !== undefined && rawId !== null
+      ? fetchedTeamRoles[String(rawId)]
+      : null;
+  const currentUserRole =
+    type === "team"
+      ? normalizeRoleValue(fetchedTeamRole) ?? getTeamViewerRole(item, viewerUser)
+      : null;
 
   return {
-    id: `${type}-${item.id ?? item.roleId ?? item.role_id ?? getDisplayName(item, type)}`,
-    rawId: item.id ?? item.roleId ?? item.role_id,
+    id: `${type}-${rawId ?? getDisplayName(item, type)}`,
+    rawId,
     type,
     item,
     lat: mapLat,
@@ -369,9 +554,29 @@ const normalizeMapPoint = (item) => {
     maxDistanceKm: getItemMaxDistanceKm(item),
     distanceLabel: shouldUseCityCoordinateFallback ? null : getDistanceLabel(item),
     teamName: item.teamName ?? item.team_name ?? item.team?.name ?? null,
+    memberCount: type === "team" ? getTeamMemberCount(item) : null,
+    maxMembers: type === "team" ? getTeamMaxMembers(item) : null,
+    openRoleCount: type === "team" ? getTeamOpenRoleCount(item) : null,
+    currentUserRole,
+    isPublic: type === "team" ? getTeamIsPublic(item) : null,
     imageUrl: avatarData.imageUrl,
     initials: avatarData.initials,
     isDemo: isDemoPoint(item, type),
+    username: type === "user" ? (item.username ?? null) : null,
+    isPublicProfile: type === "user" ? isTruthyValue(firstPresent(item?.is_public, item?.isPublic)) : null,
+    isOwnProfile: type === "user" && rawId != null && viewerUser?.id != null
+      ? String(rawId) === String(viewerUser.id)
+      : false,
+    postedAt: type === "role" ? getRolePostedAt(item) : null,
+    hasApplied: type === "role" ? (
+      getRoleHasApplied(item) ||
+      fetchedApplications.some((app) => matchesRoleItem(app, rawId, item.teamId ?? item.team_id ?? item.team?.id, getDisplayName(item, "role")))
+    ) : false,
+    hasInvitation: type === "role" ? (
+      getRoleHasInvitation(item) ||
+      fetchedInvitations.some((inv) => matchesRoleItem(inv, rawId, item.teamId ?? item.team_id ?? item.team?.id, getDisplayName(item, "role")))
+    ) : false,
+    isViewerTeamMember: type === "role" ? getRoleIsViewerTeamMember(item) : false,
   };
 };
 
@@ -414,13 +619,13 @@ const MarkerTooltipContent = ({ point }) => {
   );
 };
 
-const PopupAvatar = ({ point }) => {
+const PopupAvatar = ({ point, backgroundColor = null }) => {
   const meta = TYPE_META[point.type] ?? TYPE_META.team;
 
   return (
     <span
       className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full text-sm font-bold text-white shadow-soft ring-2 ring-white"
-      style={{ backgroundColor: meta.color }}
+      style={{ backgroundColor: backgroundColor ?? meta.color }}
       aria-hidden="true"
     >
       <span>{point.initials}</span>
@@ -481,11 +686,6 @@ const PopupDemoIcon = ({ point }) => {
   );
 };
 
-const BreakableName = ({ name }) => {
-  const words = name.trim().split(/\s+/);
-  if (words.length < 2) return <>{name}</>;
-  return <>{words[0]}<br />{words.slice(1).join(" ")}</>;
-};
 
 const EntityMetaLine = ({ point }) => {
   const meta = TYPE_META[point.type] ?? TYPE_META.team;
@@ -563,11 +763,128 @@ const LocationStatusIndicator = ({ point }) => {
   );
 };
 
+const TeamMetaItem = ({ tooltip = null, children, withTooltip = true }) => {
+  if (!withTooltip || !tooltip) {
+    return <span className="inline-flex items-center gap-0.5">{children}</span>;
+  }
+
+  return (
+    <Tooltip content={tooltip}>
+      <span className="inline-flex items-center gap-0.5">{children}</span>
+    </Tooltip>
+  );
+};
+
+const TeamRoleIcon = ({ role, size = 13 }) => {
+  if (role === "owner") {
+    return <Crown size={size} className="text-[var(--color-role-owner-bg)]" aria-hidden="true" />;
+  }
+
+  if (role === "admin") {
+    return <ShieldCheck size={size} className="text-[var(--color-role-admin-bg)]" aria-hidden="true" />;
+  }
+
+  if (role === "member") {
+    return <User size={size} className="text-[var(--color-role-member-bg)]" aria-hidden="true" />;
+  }
+
+  return null;
+};
+
+const getTeamRoleTooltip = (role) => {
+  if (role === "owner") return "You are the owner of this team";
+  if (role === "admin") return "You are an admin of this team";
+  if (role === "member") return "You are a member of this team";
+  return null;
+};
+
+const TeamMetaLine = ({ point, withTooltips = true }) => {
+  if (point.type !== "team") return null;
+
+  const memberLabel = `${point.memberCount}/${point.maxMembers}`;
+  const roleTooltip = getTeamRoleTooltip(point.currentUserRole);
+
+  return (
+    <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] font-medium text-base-content/60">
+      <TeamMetaItem tooltip={`${point.memberCount} of ${point.maxMembers} members`} withTooltip={withTooltips}>
+        <Users size={12} className={point.currentUserRole ? "text-success" : ""} aria-hidden="true" />
+        <span>{memberLabel}</span>
+      </TeamMetaItem>
+      {point.openRoleCount > 0 && (
+        <TeamMetaItem
+          tooltip={`${point.openRoleCount} open ${point.openRoleCount === 1 ? "role" : "roles"} posted in this team`}
+          withTooltip={withTooltips}
+        >
+          <UserSearch size={12} className="text-orange-500" aria-hidden="true" />
+          <span>{point.openRoleCount}</span>
+        </TeamMetaItem>
+      )}
+      {point.currentUserRole && (
+        <TeamMetaItem tooltip={roleTooltip} withTooltip={withTooltips}>
+          <TeamRoleIcon role={point.currentUserRole} size={12} />
+        </TeamMetaItem>
+      )}
+      {point.currentUserRole && (
+        <TeamMetaItem
+          tooltip={
+            point.isPublic
+              ? "Public Team - visible for everyone"
+              : "Private Team - only visible for Members"
+          }
+          withTooltip={withTooltips}
+        >
+          {point.isPublic ? (
+            <EyeIcon size={12} className="text-green-600" aria-hidden="true" />
+          ) : (
+            <EyeClosed size={12} className="text-gray-500" aria-hidden="true" />
+          )}
+        </TeamMetaItem>
+      )}
+    </div>
+  );
+};
+
+const RoleSubline = ({ point }) => {
+  if (point.type !== "role") return null;
+
+  const postedDate = point.postedAt ? new Date(point.postedAt) : null;
+  const isValidDate = postedDate && !isNaN(postedDate);
+
+  if (!isValidDate && !point.hasApplied && !point.hasInvitation) return null;
+
+  return (
+    <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] font-medium text-base-content/60">
+      {isValidDate && (
+        <Tooltip content={`Posted ${format(postedDate, "MMM d, yyyy")}`}>
+          <span className="inline-flex items-center gap-1">
+            <Calendar size={12} aria-hidden="true" />
+            <span>{format(postedDate, "MM/dd/yy")}</span>
+          </span>
+        </Tooltip>
+      )}
+      {point.hasApplied && (
+        <Tooltip content="You applied for this role">
+          <span className="inline-flex">
+            <SendHorizontal size={12} className="text-orange-500" aria-hidden="true" />
+          </span>
+        </Tooltip>
+      )}
+      {point.hasInvitation && (
+        <Tooltip content="You were invited to fill this role">
+          <span className="inline-flex">
+            <Mail size={12} className="text-orange-500" aria-hidden="true" />
+          </span>
+        </Tooltip>
+      )}
+    </div>
+  );
+};
+
 const MapPopupCard = ({ point, onOpenPoint }) => {
   const map = useMap();
 
   return (
-    <div className="inline-block max-w-60 align-top">
+    <div className="inline-block max-w-80 align-top">
       <div className="mb-2 flex items-center justify-between text-base-content/70">
         <EntityMetaLine point={point} />
         <button
@@ -581,18 +898,35 @@ const MapPopupCard = ({ point, onOpenPoint }) => {
       </div>
 
       <div className="flex items-center gap-2">
-        <PopupAvatar point={point} />
+        <PopupAvatar point={point} backgroundColor="var(--color-primary-focus)" />
         <div className="min-w-0 flex-1">
           <h3 className="line-clamp-2 break-words text-[17px] font-medium leading-[1.1] text-[var(--color-primary-focus)]">
-            <BreakableName name={point.name} />
+            {point.name}
           </h3>
+          {point.type === "user" && (point.username || point.isOwnProfile) && (
+            <div className="mt-1.5 flex items-center gap-1.5 text-[11px] font-medium text-base-content/60">
+              {point.username && <span>@{point.username}</span>}
+              {point.isOwnProfile && (
+                <Tooltip content={point.isPublicProfile ? "Public Profile - visible for everyone" : "Private Profile - only visible for you"}>
+                  <span className="inline-flex">
+                    {point.isPublicProfile
+                      ? <EyeIcon size={12} className="text-green-600" aria-hidden="true" />
+                      : <EyeClosed size={12} className="text-gray-500" aria-hidden="true" />
+                    }
+                  </span>
+                </Tooltip>
+              )}
+            </div>
+          )}
+          <TeamMetaLine point={point} />
+          <RoleSubline point={point} />
         </div>
       </div>
 
       <div className="mt-3 space-y-0.5 text-xs text-base-content/70">
         {point.teamName && (
-          <div className="flex items-center gap-1.5">
-            <Users size={13} />
+          <div className={`flex items-center gap-1.5 ${point.type === "role" && point.isViewerTeamMember ? "text-success" : ""}`}>
+            <Users size={13} aria-hidden="true" />
             <span>{point.teamName}</span>
           </div>
         )}
@@ -637,12 +971,94 @@ const SearchMapView = ({
 }) => {
   const teamModal = useTeamModalSafe();
   const userModal = useUserModalSafe();
+  const authContext = useAuth();
+  const authUserId = authContext?.user?.id ?? null;
   const [selectedRolePoint, setSelectedRolePoint] = useState(null);
   const [activeStatusTooltipPointId, setActiveStatusTooltipPointId] = useState(null);
+  const [fetchedTeamRoles, setFetchedTeamRoles] = useState({});
+  const [fetchedApplications, setFetchedApplications] = useState([]);
+  const [fetchedInvitations, setFetchedInvitations] = useState([]);
+
+  useEffect(() => {
+    if (!authUserId) return;
+
+    let isActive = true;
+
+    const fetchUserRoleData = async () => {
+      try {
+        const [appsResponse, invResponse] = await Promise.all([
+          teamService.getUserPendingApplications(),
+          teamService.getUserReceivedInvitations(),
+        ]);
+        if (!isActive) return;
+        setFetchedApplications(Array.isArray(appsResponse?.data) ? appsResponse.data : []);
+        setFetchedInvitations(Array.isArray(invResponse?.data) ? invResponse.data : []);
+      } catch {
+        // silent fail — icon simply won't show if fetch fails
+      }
+    };
+
+    fetchUserRoleData();
+
+    return () => { isActive = false; };
+  }, [authUserId]);
+
+  useEffect(() => {
+    if (!authUserId) return;
+
+    const seenTeamIds = new Set();
+
+    const teamItemsNeedingRole = items.filter((item) => {
+      if (getMapPointType(item) !== "team") return false;
+      const teamId = getTeamItemId(item);
+      if (teamId === null) return false;
+      const teamKey = String(teamId);
+      if (seenTeamIds.has(teamKey)) return false;
+      seenTeamIds.add(teamKey);
+      if (Object.prototype.hasOwnProperty.call(fetchedTeamRoles, teamKey)) return false;
+      return !getTeamViewerRole(item, { id: authUserId });
+    });
+
+    if (teamItemsNeedingRole.length === 0) return;
+
+    let isActive = true;
+
+    const fetchTeamRoles = async () => {
+      const entries = await Promise.all(
+        teamItemsNeedingRole.map(async (teamItem) => {
+          const teamId = getTeamItemId(teamItem);
+          const response = await teamService.getUserRoleInTeam(teamId, authUserId);
+          const payload = response?.data ?? response;
+          const data = payload?.data ?? payload;
+
+          return [String(teamId), normalizeRoleValue(data?.role ?? payload?.role)];
+        }),
+      );
+
+      if (!isActive) return;
+
+      setFetchedTeamRoles((previousRoles) => {
+        const nextRoles = { ...previousRoles };
+        entries.forEach(([teamId, role]) => {
+          nextRoles[teamId] = role;
+        });
+        return nextRoles;
+      });
+    };
+
+    fetchTeamRoles();
+
+    return () => {
+      isActive = false;
+    };
+  }, [authUserId, fetchedTeamRoles, items]);
 
   const normalizedPoints = useMemo(
-    () => items.map(normalizeMapPoint).filter(Boolean),
-    [items],
+    () =>
+      items
+        .map((item) => normalizeMapPoint(item, { id: authUserId }, fetchedTeamRoles, fetchedApplications, fetchedInvitations))
+        .filter(Boolean),
+    [authUserId, fetchedTeamRoles, fetchedApplications, fetchedInvitations, items],
   );
   const markerPoints = normalizedPoints.filter((point) => point.hasCoordinates);
   const fallbackPoints = normalizedPoints.filter((point) => !point.hasCoordinates);
@@ -748,7 +1164,7 @@ const SearchMapView = ({
                     className="lomir-map-popup"
                     closeButton={false}
                     minWidth={0}
-                    maxWidth={260}
+                    maxWidth={320}
                   >
                     <MapPopupCard point={point} onOpenPoint={openPoint} />
                   </Popup>
@@ -826,14 +1242,18 @@ const SearchMapView = ({
                           </span>
                         </div>
                         <div className="mt-1 flex items-center gap-1.5">
-                          <PopupAvatar point={point} />
-                          <h5 className="line-clamp-2 min-w-0 flex-1 break-words text-[17px] font-medium leading-[1.1] text-[var(--color-primary-focus)]">
-                            <BreakableName name={point.name} />
-                          </h5>
+                          <PopupAvatar point={point} backgroundColor="var(--color-primary-focus)" />
+                          <div className="min-w-0 flex-1">
+                            <h5 className="line-clamp-2 break-words text-[17px] font-medium leading-[1.1] text-[var(--color-primary-focus)]">
+                              {point.name}
+                            </h5>
+                            <TeamMetaLine point={point} withTooltips={false} />
+                            <RoleSubline point={point} />
+                          </div>
                         </div>
-                        {point.type === "role" && point.teamName && (
-                          <div className="mt-3 flex items-center gap-1.5 text-xs text-base-content/70">
-                            <Users size={13} />
+                        {point.teamName && (
+                          <div className={`mt-2 flex items-center gap-1.5 text-xs ${point.type === "role" && point.isViewerTeamMember ? "text-success" : "text-base-content/70"}`}>
+                            <Users size={13} aria-hidden="true" />
                             <span className="min-w-0 flex-1 truncate">{point.teamName}</span>
                           </div>
                         )}

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -362,7 +362,7 @@ const TeamApplicationDetailsModal = ({
 
                 {/* Fallback initials */}
                 <div
-                  className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                  className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                   style={{ display: getTeamAvatar() ? "none" : "flex" }}
                 >
                   <span className="text-lg font-medium">

--- a/src/components/teams/TeamApplicationModal.jsx
+++ b/src/components/teams/TeamApplicationModal.jsx
@@ -291,7 +291,7 @@ const TeamApplicationModal = ({
                   ) : null}
 
                   <div
-                    className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                    className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                     style={{ display: getTeamAvatar() ? "none" : "flex" }}
                   >
                     <span className="text-lg font-medium">

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -1423,7 +1423,7 @@ const TeamDetailsModal = ({
                 {/* Team header with avatar */}
                 <div className="flex items-start space-x-4 mb-6">
                   <div className="avatar placeholder relative">
-                    <div className="bg-primary text-primary-content rounded-full w-16 h-16 relative flex items-center justify-center overflow-hidden">
+                    <div className="bg-[var(--color-primary-focus)] text-primary-content rounded-full w-16 h-16 relative flex items-center justify-center overflow-hidden">
                       {(team?.teamavatar_url || team?.teamavatarUrl) &&
                       !teamImageError ? (
                         <img

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -415,7 +415,7 @@ const TeamInvitationDetailsModal = ({
 
                 {/* Fallback initials */}
                 <div
-                  className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                  className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                   style={{ display: getTeamAvatar() ? "none" : "flex" }}
                 >
                   <span className="text-lg font-medium">

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -980,7 +980,7 @@ const TeamInviteModal = ({
                   />
                 ) : null}
                 <div
-                  className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                  className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                   style={{
                     display: inviteeAvatar ? "none" : "flex",
                   }}
@@ -1099,7 +1099,7 @@ const TeamInviteModal = ({
                             />
                           ) : null}
                           <div
-                            className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                            className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                             style={{
                               display: getTeamAvatarUrl(team) ? "none" : "flex",
                             }}

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -701,7 +701,7 @@ const TeamInvitesModal = ({
                   ) : null}
                   {/* Fallback initials */}
                   <div
-                    className="avatar-fallback bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                    className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                     style={{
                       display: getAvatarUrl(invitation.invitee)
                         ? "none"

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -259,7 +259,7 @@ const TeamMembersSection = ({
                     />
                   ) : null}
                   <div
-                    className="avatar-fallback placeholder bg-primary text-primary-content rounded-full w-full h-full absolute inset-0 flex items-center justify-center"
+                    className="avatar-fallback placeholder bg-[var(--color-primary-focus)] text-primary-content rounded-full w-full h-full absolute inset-0 flex items-center justify-center"
                     style={{ display: memberAvatarUrl ? "none" : "flex" }}
                   >
                     <span className="text-lg">

--- a/src/components/teams/TeamRoleManager.jsx
+++ b/src/components/teams/TeamRoleManager.jsx
@@ -192,7 +192,7 @@ case "owner":
               <div className="flex items-center space-x-3">
                 {/* Avatar */}
                 <div className="avatar placeholder">
-                  <div className="bg-primary text-primary-content rounded-full w-10 h-10">
+                  <div className="bg-[var(--color-primary-focus)] text-primary-content rounded-full w-10 h-10">
                     {member.avatar_url ? (
                       <img
                         src={member.avatar_url}

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -713,7 +713,7 @@ const VacantRoleCard = ({
     ? "bg-green-50 hover:bg-green-100"
     : "bg-amber-50 hover:bg-amber-100/70";
   const initialsAvatarClass = isFilled
-    ? "bg-success text-white"
+    ? "bg-[var(--color-primary-focus)] text-white"
     : "bg-amber-500 text-white";
   const isMiniView = viewMode === "mini";
   const avatarSizeClass = isMiniView ? "w-10 h-10" : "w-12 h-12";
@@ -1245,7 +1245,7 @@ const VacantRoleCard = ({
                   />
                 ) : null}
                 <div
-                  className="avatar-fallback bg-success text-white flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                  className="avatar-fallback bg-[var(--color-primary-focus)] text-white flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                   style={{ display: filledUserAvatarUrl ? "none" : "flex" }}
                 >
                   <span className={`${avatarTextClass} font-medium`}>
@@ -1293,7 +1293,7 @@ const VacantRoleCard = ({
                 wrapperClassName="block w-full min-w-0 overflow-hidden"
               >
                 <div
-                  className={`block w-full min-w-0 truncate ${roleNameClass} ${titleLeadingClass} text-base-content hover:text-primary transition-colors`}
+                  className={`block w-full min-w-0 truncate ${roleNameClass} ${titleLeadingClass} text-[var(--color-primary-focus)] transition-colors`}
                 >
                   {role_name || "Vacant Role"}
                 </div>

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -1770,7 +1770,7 @@ const VacantRoleDetailsModal = ({
                   />
                 ) : null}
                 <div
-                  className="avatar-fallback bg-success text-white rounded-full w-full h-full flex items-center justify-center absolute inset-0"
+                  className="avatar-fallback bg-[var(--color-primary-focus)] text-white rounded-full w-full h-full flex items-center justify-center absolute inset-0"
                   style={{ display: filledRoleAvatarUrl ? "none" : "flex" }}
                 >
                   <span className="text-2xl font-semibold">
@@ -2451,7 +2451,7 @@ const VacantRoleDetailsModal = ({
                               />
                             ) : null}
                             <div
-                              className="avatar-fallback bg-primary text-primary-content rounded-full w-full h-full flex items-center justify-center absolute inset-0"
+                              className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content rounded-full w-full h-full flex items-center justify-center absolute inset-0"
                               style={{ display: avatarUrl ? "none" : "flex" }}
                             >
                               <span className="text-lg">{initials}</span>
@@ -2665,7 +2665,7 @@ const VacantRoleDetailsModal = ({
                               />
                             ) : null}
                             <div
-                              className="avatar-fallback bg-primary text-primary-content rounded-full w-full h-full flex items-center justify-center absolute inset-0"
+                              className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content rounded-full w-full h-full flex items-center justify-center absolute inset-0"
                               style={{ display: avatarUrl ? "none" : "flex" }}
                             >
                               <span className="text-lg">{initials}</span>
@@ -2835,7 +2835,7 @@ const VacantRoleDetailsModal = ({
                               />
                             ) : null}
                             <div
-                              className="avatar-fallback bg-primary text-primary-content rounded-full w-full h-full flex items-center justify-center absolute inset-0"
+                              className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content rounded-full w-full h-full flex items-center justify-center absolute inset-0"
                               style={{ display: avatarUrl ? "none" : "flex" }}
                             >
                               <span className="text-lg">{initials}</span>

--- a/src/components/users/UserAvatar.jsx
+++ b/src/components/users/UserAvatar.jsx
@@ -56,7 +56,7 @@ const UserAvatar = ({
           className={`avatar-fallback flex items-center justify-center w-full h-full rounded-full absolute inset-0 ${
             isFormerUser
               ? "bg-base-300 text-base-content/30"
-              : "bg-primary text-primary-content"
+              : "bg-[var(--color-primary-focus)] text-primary-content"
           }`}
           style={{ display: avatarUrl ? "none" : "flex" }}
         >

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -108,7 +108,7 @@ const UserProfileHeaderSection = ({
               onError={() => setImageError(true)}
             />
           ) : (
-            <div className="bg-primary text-primary-content flex items-center justify-center w-full h-full rounded-full">
+            <div className="bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full">
               <span className="text-2xl">{getUserInitials(user)}</span>
             </div>
           )}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -951,7 +951,7 @@ const Profile = () => {
               {/* Avatar */}
               <div className="mb-4 md:mb-0 md:mr-8 flex-shrink-0">
                 <div className="avatar placeholder">
-                  <div className="bg-primary text-primary-content rounded-full w-32 h-32 relative overflow-hidden">
+                  <div className="bg-[var(--color-primary-focus)] text-primary-content rounded-full w-32 h-32 relative overflow-hidden">
                     {(user.avatarUrl || user.avatar_url) && !imageError ? (
                       <img
                         src={user.avatarUrl || user.avatar_url}

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -596,14 +596,7 @@ const SearchPage = () => {
       : sortedUsers.slice(0, Math.max(0, resultsPerPage - displayedTeams.length));
   const visibleMapItems =
     searchType === "all"
-      ? [
-          ...filteredResults.teams.map((team) => ({ ...team, _resultType: "team" })),
-          ...filteredResults.users.map((matchedUser) => ({
-            ...matchedUser,
-            _resultType: "user",
-          })),
-          ...filteredResults.roles.map((role) => ({ ...role, _resultType: "role" })),
-        ]
+      ? mergedDisplayItems
       : searchType === "roles"
         ? filteredResults.roles.map((role) => ({ ...role, _resultType: "role" }))
         : [


### PR DESCRIPTION
## Summary

- Refines the search map legend with larger colored entity swatches and centered white icons for teams, people, and open roles.
- Aligns map pin popups and Remote or unmapped result cards with the app’s card styling, including avatar/name layout, lighter typography, dark green entity names, and consistent hover behavior.
- Improves Remote or unmapped handling for remote entities, missing locations, country-only locations, and city-only role locations.
- Adds richer map bubble metadata for teams, users, and roles, including team member/open-role info, current user team role, visibility status, demo indicators, and role/team context.
- Uses the dark green avatar fallback color consistently across cards, map popups, and unmapped map items.
- Keeps all-search map ordering consistent with card, mini card, and list views.

## Testing

- `npx eslint src/components/search/SearchMapView.jsx`
- `git diff --check -- src/components/search/SearchMapView.jsx`
