### PR TITLE
Fix map popup privacy flags

### DIFF
--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -109,6 +109,12 @@ const normalizeRoleValue = (value) => {
 const isTruthyValue = (value) =>
   value === true || value === 1 || value === "true" || value === "1";
 
+const normalizeBooleanFlag = (value) => {
+  if (value === true || value === 1 || value === "true" || value === "1") return true;
+  if (value === false || value === 0 || value === "false" || value === "0") return false;
+  return false;
+};
+
 const escapeHtml = (value) =>
   String(value ?? "")
     .replaceAll("&", "&amp;")
@@ -307,8 +313,10 @@ const getTeamViewerRole = (item, viewerUser = null) => {
   return null;
 };
 
-const getTeamIsPublic = (item) =>
-  isTruthyValue(firstPresent(item?.is_public, item?.isPublic));
+const getTeamIsPublic = (item) => {
+  const raw = firstPresent(item?.is_public, item?.isPublic);
+  return normalizeBooleanFlag(raw);
+};
 
 const coordinatesMatchCountry = (lat, lng, countryCode) => {
   if (!countryCode) return true;
@@ -743,7 +751,9 @@ const normalizeMapPoint = (
     initials: avatarData.initials,
     isDemo: isDemoPoint(item, type),
     username: type === "user" ? (item.username ?? null) : null,
-    isPublicProfile: type === "user" ? isTruthyValue(firstPresent(item?.is_public, item?.isPublic)) : null,
+    isPublicProfile: type === "user"
+      ? normalizeBooleanFlag(firstPresent(item?.is_public, item?.isPublic))
+      : null,
     isOwnProfile: type === "user" && rawId != null && viewerUser?.id != null
       ? String(rawId) === String(viewerUser.id)
       : false,

--- a/src/services/searchService.js
+++ b/src/services/searchService.js
@@ -17,6 +17,16 @@ export const getApiErrorMessage = (error) => {
   return "Something went wrong";
 };
 
+const normalizePublicFlag = (item) =>
+  item?.is_public === true ||
+  item?.is_public === 1 ||
+  item?.is_public === "true" ||
+  item?.is_public === "1" ||
+  item?.isPublic === true ||
+  item?.isPublic === 1 ||
+  item?.isPublic === "true" ||
+  item?.isPublic === "1";
+
 /**
  * Normalize team data to ensure consistent property names
  */
@@ -32,9 +42,19 @@ const normalizeTeamData = (team) => {
     normalizedTeam.teamavatar_url = team.teamavatarUrl;
   }
 
-  normalizedTeam.is_public = team.is_public === true;
+  normalizedTeam.is_public = normalizePublicFlag(team);
+  normalizedTeam.isPublic = normalizedTeam.is_public;
 
   return normalizedTeam;
+};
+
+const normalizeUserData = (user) => {
+  if (!user) return user;
+
+  const normalizedUser = { ...user };
+  normalizedUser.is_public = normalizePublicFlag(user);
+  normalizedUser.isPublic = normalizedUser.is_public;
+  return normalizedUser;
 };
 
 const VALID_SEARCH_TYPES = new Set(["all", "teams", "users", "roles"]);
@@ -53,7 +73,9 @@ const normalizeSearchResponse = (payload = {}) => {
       teams: Array.isArray(data.teams)
         ? data.teams.map(normalizeTeamData)
         : [],
-      users: data.users ?? [],
+      users: Array.isArray(data.users)
+        ? data.users.map(normalizeUserData)
+        : [],
       roles: data.roles ?? [],
     },
     pagination: {


### PR DESCRIPTION
# Fix: Privacy eye icon shows wrong state in Map view popups

## Summary

In the Search page Map view, the privacy eye icon (open eye = public, closed eye = private) was rendering closed for entities that are actually public. The bug affected popup info bubbles for member-teams and the viewer's own profile. Details modals were unaffected.

Root cause was a snake_case ↔ camelCase collision in the search service layer, not a missing field on the backend.

## Root cause

The Axios response interceptor converts `is_public` → `isPublic` on every response. `normalizeTeamData` in `searchService.js` was unaware of this and wrote `is_public: team.is_public === true` onto the already-converted object — where `team.is_public` was now `undefined`. Result: a public team arrived with `isPublic: true` from the API, then got `is_public: false` stamped on it by the normalizer.

Downstream, `SearchMapView.jsx`'s `getTeamIsPublic` used `firstPresent(item?.is_public, item?.isPublic)`, which returns the first non-null value — so the bogus `false` won over the real `true`, and the closed-eye icon rendered.

Users had no equivalent normalizer in the service layer at all, so their `is_public` was at the mercy of whatever the backend returned.

## Changes

### `src/services/searchService.js`
- Fixed `normalizeTeamData` so it no longer overwrites `isPublic: true` with a stale `is_public: false`. Both keys are now coerced from the same source of truth.
- Added `normalizeUserData` mirroring the team normalizer, so user `is_public` gets the same boolean coercion.
- Routed both `globalSearch` and `getAllUsersAndTeams` through a shared `normalizeSearchResponse` so teams and users are normalized consistently.

### `src/components/search/SearchMapView.jsx`
- Added a shared `normalizeBooleanFlag` helper that handles every variant the API might emit (`true`, `false`, `"true"`, `"false"`, `1`, `0`, `"1"`, `"0"`, `null`, `undefined`).
- Used it for both `getTeamIsPublic` (team popups) and the `isPublicProfile` field in `normalizeMapPoint` (user popups).
- Defaults to private only when the value is genuinely unknown.

### Unchanged on purpose
- Popup visibility conditions: the eye icon still only shows for member-teams (`point.currentUserRole`) and the viewer's own profile (`point.isOwnProfile`). Extending this to all entities is a separate UX decision.
- Backend (`searchController.js`): all the SQL already selects `is_public` correctly, and the frontend now insulates the map view from any string/boolean drift. Backend hardening is deferred — see "Follow-ups" below.

## Why

The map view is the discovery surface where "is this team open to me?" matters most before someone commits to clicking through. Showing a closed eye on a public team actively misled users about whether they could join.

The fix is also defensive against future drift: any endpoint returning `is_public` as a string, number, or under either casing will now render correctly without further changes.

## Verification

- `npx eslint src/components/search/SearchMapView.jsx src/services/searchService.js` — passes
- `npm run build` — passes
- No debug `console.log` lines left behind
- Live verification in an authenticated session: popup eye icon matches actual visibility for own-teams and own-profile; toggling visibility in Settings flips the icon after refresh; details modals unchanged

## Follow-ups (deferred)

- Backend belt-and-suspenders: apply the same `is_public` boolean coercion to user rows in `searchController.getAllUsersAndTeams` and other map-feeding endpoints, matching what teams already get. Not needed for this fix to work, but worth doing during the next backend pass for consistency.
- Open question for product: should the eye icon be visible on **all** team/user popups (so non-members can see public/private status before joining), not just own ones? Current behavior matches `TeamCard` / `UserCard`, so changing it is a coordinated UX change across cards and map.