### PR TITLE
UI/lowscoringitems

### DIFF
--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -470,7 +470,7 @@ const BooleanSearchInput = ({
             {showDropdown && hasSuggestions && (
               <div
                 ref={dropdownRef}
-                className="absolute left-0 top-full z-50 mt-1 w-full overflow-y-auto rounded-lg border border-base-300 bg-white shadow-lg"
+                className="absolute left-0 top-full z-[10000] mt-1 w-full overflow-y-auto rounded-lg border border-base-300 bg-white shadow-lg"
                 style={{ maxHeight: "16rem" }}
               >
                 {suggestions.tags.length > 0 && (

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -152,6 +152,8 @@ const DEMO_PROFILE_LOCATION_FALLBACKS = {
 };
 
 const toNumber = (value) => {
+  if (value === null || value === undefined || value === "") return null;
+
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 };
@@ -656,8 +658,19 @@ const getDistanceLabel = (item) => {
   );
 
   if (distance === null || distance >= 999999) return null;
+  if (distance === 0) return "0 km away";
   if (distance < 1) return `${distance.toFixed(1)} km away`;
   return `${Math.round(distance)} km away`;
+};
+
+const getDistanceValue = (item) => {
+  const matchDetails = item?.matchDetails ?? item?.match_details ?? null;
+  return toNumber(
+    item?.distanceKm ??
+      item?.distance_km ??
+      matchDetails?.distanceKm ??
+      matchDetails?.distance_km,
+  );
 };
 
 const INACTIVE_APPLICATION_STATUSES = new Set(["withdrawn", "rejected", "declined", "cancelled", "canceled"]);
@@ -1101,6 +1114,7 @@ const normalizeMapPoint = (
     locationLabel,
     countryCode,
     maxDistanceKm: getItemMaxDistanceKm(item),
+    distanceKm: shouldUseCityCoordinateFallback ? null : getDistanceValue(item),
     distanceLabel: shouldUseCityCoordinateFallback ? null : getDistanceLabel(item),
     teamName: item.teamName ?? item.team_name ?? item.team?.name ?? null,
     memberCount: type === "team" ? getTeamMemberCount(item) : null,
@@ -2646,7 +2660,14 @@ const SearchMapView = ({
 
   const openPoint = (point) => {
     if (point.type === "team") {
-      teamModal?.openTeamModal(point.rawId, point.name);
+      teamModal?.openTeamModal(point.rawId, point.name, {
+        initialTeamData: point.item,
+        isFromSearch: true,
+        showMatchHighlights,
+        matchScore: showMatchScore ? getResultMatchScore(point.item) : null,
+        matchType: point.item.matchType ?? point.item.match_type ?? null,
+        matchDetails: point.item.matchDetails ?? point.item.match_details ?? null,
+      });
       return;
     }
 
@@ -2656,11 +2677,12 @@ const SearchMapView = ({
         roleMatchBadgeNames,
         roleMatchName,
         roleMatchMaxDistanceKm,
+        isFromSearch: true,
         showMatchHighlights,
         matchScore: showMatchScore ? getResultMatchScore(point.item) : null,
         matchType: point.item.matchType ?? point.item.match_type ?? null,
         matchDetails: point.item.matchDetails ?? point.item.match_details ?? null,
-        distanceKm: point.item.distance_km ?? point.item.distanceKm ?? null,
+        distanceKm: point.distanceKm,
         invitationPrefillTeamId,
         invitationPrefillRoleId,
         invitationPrefillTeamName,

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2690,9 +2690,13 @@ const SearchMapView = ({
       });
       return;
     }
-
     setSelectedRolePoint(point);
   };
+
+  const selectedRolePointForModal = selectedRolePoint
+    ? normalizedPoints.find((point) => point.id === selectedRolePoint.id) ??
+      selectedRolePoint
+    : null;
 
   return (
     <div className="space-y-4">
@@ -3014,29 +3018,31 @@ const SearchMapView = ({
         />
       )}
 
-      {selectedRolePoint && (
+      {selectedRolePointForModal && (
         <VacantRoleDetailsModal
           isOpen={true}
           onClose={() => setSelectedRolePoint(null)}
-          role={selectedRolePoint.item}
+          role={selectedRolePointForModal.item}
           team={{
-            id: selectedRolePoint.item.teamId ?? selectedRolePoint.item.team_id,
-            name: selectedRolePoint.teamName,
+            id:
+              selectedRolePointForModal.item.teamId ??
+              selectedRolePointForModal.item.team_id,
+            name: selectedRolePointForModal.teamName,
             teamavatar_url:
-              selectedRolePoint.item.teamAvatarUrl ??
-              selectedRolePoint.item.team_avatar_url,
+              selectedRolePointForModal.item.teamAvatarUrl ??
+              selectedRolePointForModal.item.team_avatar_url,
           }}
           matchScore={
-            selectedRolePoint.item.bestMatchScore ??
-            selectedRolePoint.item.best_match_score ??
+            selectedRolePointForModal.item.bestMatchScore ??
+            selectedRolePointForModal.item.best_match_score ??
             null
           }
           matchDetails={
-            selectedRolePoint.item.matchDetails ??
-            selectedRolePoint.item.match_details ??
+            selectedRolePointForModal.item.matchDetails ??
+            selectedRolePointForModal.item.match_details ??
             null
           }
-          hideActions
+          isTeamMember={selectedRolePointForModal.isViewerTeamMember}
         />
       )}
     </div>

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -1814,10 +1814,7 @@ const TeamCard = ({
           : getResultMatchScore(normalizedData.team)
       )
     : null;
-  const showScore =
-    showMatchScore &&
-    rawScore != null &&
-    (isRoleVariant || rawScore > 0);
+  const showScore = showMatchScore && rawScore != null;
 
   let matchTier = null;
   let matchOverlay = null;

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -59,7 +59,10 @@ import {
   enrichTeamMatchData,
 } from "../../utils/teamMatchUtils";
 import { getMatchTier } from "../../utils/matchScoreUtils";
-import { calculateDistanceKm } from "../../utils/locationUtils";
+import {
+  calculateDistanceKm,
+  locationsHaveDifferentKnownParts,
+} from "../../utils/locationUtils";
 import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
 
 const normalizeTeamTagIds = (team) => {
@@ -1302,18 +1305,28 @@ const TeamDetailsModal = ({
 
   const effectiveTeamDistanceKm = useMemo(() => {
     const rawDistance = team?.distance_km ?? team?.distanceKm;
-    const numericDistance = Number(rawDistance);
+    const numericDistance =
+      rawDistance != null ? Number(rawDistance) : null;
     const viewerForDistance = distanceViewerUser ?? user;
     const computedDistance = viewerForDistance
       ? calculateDistanceKm(viewerForDistance, team)
       : null;
+    const rawZeroLooksWrong =
+      Number.isFinite(numericDistance) &&
+      numericDistance <= 0.5 &&
+      viewerForDistance &&
+      locationsHaveDifferentKnownParts(viewerForDistance, team);
+
+    if (Number.isFinite(numericDistance) && numericDistance < 999999) {
+      if (rawZeroLooksWrong) {
+        return computedDistance;
+      }
+
+      return numericDistance;
+    }
 
     if (computedDistance != null) {
       return computedDistance;
-    }
-
-    if (Number.isFinite(numericDistance) && numericDistance < 999999) {
-      return numericDistance;
     }
 
     return null;

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -121,11 +121,12 @@ const UserCard = ({
       roleMatchBadgeNames,
       roleMatchName,
       roleMatchMaxDistanceKm,
+      isFromSearch: true,
       showMatchHighlights,
       matchScore: rawScore,
       matchType: user.matchType ?? user.match_type ?? null,
       matchDetails: user.matchDetails ?? user.match_details ?? null,
-      distanceKm: user.distance_km ?? user.distanceKm ?? null,
+      distanceKm: user.distanceKm ?? user.distance_km ?? null,
       invitationPrefillTeamId,
       invitationPrefillRoleId,
       invitationPrefillTeamName,
@@ -230,7 +231,7 @@ const UserCard = ({
       user.is_remote || user.isRemote
         ? "Remote"
         : [user.city, user.country].filter(Boolean).join(", ");
-    const distance = user.distance_km ?? user.distanceKm;
+    const distance = user.distanceKm ?? user.distance_km;
     const showDistance = distance != null && distance < 999999 && !(user.is_remote || user.isRemote);
 
     const tagNames = (user.tags || [])
@@ -444,7 +445,7 @@ const UserCard = ({
       <LocationDistanceTagsRow
         entity={user}
         entityType="user"
-        distance={user.distance_km ?? user.distanceKm}
+        distance={user.distanceKm ?? user.distance_km}
         tags={viewMode === "mini" && !activeFilters.showTags ? null : user.tags}
         badges={
           viewMode === "mini" && !activeFilters.showBadges ? null : user.badges

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -25,7 +25,10 @@ import {
   enrichUserMatchData,
   enrichUserRoleMatchData,
 } from "../../utils/teamMatchUtils";
-import { calculateDistanceKm } from "../../utils/locationUtils";
+import {
+  calculateDistanceKm,
+  locationsHaveDifferentKnownParts,
+} from "../../utils/locationUtils";
 
 const normalizeNumericSet = (values) => {
   if (values == null) return null;
@@ -73,6 +76,7 @@ const UserDetailsModal = ({
   roleMatchBadgeNames, // Set<string> | null — role's required badge names (lowercase)
   roleMatchName = null,
   roleMatchMaxDistanceKm = null,
+  isFromSearch = false,
   showMatchHighlights = false,
   matchScore = null,
   matchType = null,
@@ -162,10 +166,10 @@ const UserDetailsModal = ({
 
       const preservedDistanceKm =
         distanceKm ??
-        user?.distance_km ??
         user?.distanceKm ??
-        userData?.distance_km ??
+        user?.distance_km ??
         userData?.distanceKm ??
+        userData?.distance_km ??
         null;
 
       setUser({
@@ -363,6 +367,11 @@ const UserDetailsModal = ({
   };
 
   const effectiveUserMatch = useMemo(() => {
+    const isRoleMatchContext =
+      matchType === "role_match" ||
+      hasRoleMatchTagIds ||
+      hasRoleMatchBadgeNames;
+
     const shouldResolveMatchData =
       showMatchHighlights ||
       matchScore > 0 ||
@@ -373,10 +382,9 @@ const UserDetailsModal = ({
       return { matchScore, matchType, matchDetails };
     }
 
-    const isRoleMatchContext =
-      matchType === "role_match" ||
-      hasRoleMatchTagIds ||
-      hasRoleMatchBadgeNames;
+    if (isFromSearch && matchScore != null && isRoleMatchContext) {
+      return { matchScore, matchType, matchDetails };
+    }
 
     if (isRoleMatchContext) {
       const enrichedUser = enrichUserRoleMatchData({
@@ -429,6 +437,7 @@ const UserDetailsModal = ({
     currentUser,
     currentUserBadgeNames,
     currentUserTagIds,
+    isFromSearch,
     matchDetails,
     matchScore,
     matchType,
@@ -442,31 +451,43 @@ const UserDetailsModal = ({
   ]);
 
   const effectiveDistanceKm = useMemo(() => {
-    const roleDistance = Number(
+    const rawRoleDistance =
       effectiveUserMatch.matchType === "role_match"
         ? effectiveUserMatch.matchDetails?.distanceKm ??
-            effectiveUserMatch.matchDetails?.distance_km ??
-            matchDetails?.distanceKm ??
-            matchDetails?.distance_km
-        : null,
-    );
-    const rawDistance = distanceKm ?? user?.distance_km ?? user?.distanceKm;
-    const numericDistance = Number(rawDistance);
+          effectiveUserMatch.matchDetails?.distance_km ??
+          matchDetails?.distanceKm ??
+          matchDetails?.distance_km ??
+          null
+        : null;
+    const roleDistance =
+      rawRoleDistance != null ? Number(rawRoleDistance) : null;
+    const rawDistance = distanceKm ?? user?.distanceKm ?? user?.distance_km;
+    const numericDistance =
+      rawDistance != null ? Number(rawDistance) : null;
     const viewerForDistance = distanceViewerUser ?? currentUser;
     const computedDistance = viewerForDistance
       ? calculateDistanceKm(viewerForDistance, user)
       : null;
+    const rawZeroLooksWrong =
+      Number.isFinite(numericDistance) &&
+      numericDistance <= 0.5 &&
+      viewerForDistance &&
+      locationsHaveDifferentKnownParts(viewerForDistance, user);
 
-    if (Number.isFinite(roleDistance) && roleDistance < 999999) {
+    if (roleDistance != null && Number.isFinite(roleDistance) && roleDistance < 999999) {
       return roleDistance;
+    }
+
+    if (Number.isFinite(numericDistance) && numericDistance < 999999) {
+      if (rawZeroLooksWrong) {
+        return computedDistance;
+      }
+
+      return numericDistance;
     }
 
     if (computedDistance != null) {
       return computedDistance;
-    }
-
-    if (Number.isFinite(numericDistance) && numericDistance < 999999) {
-      return numericDistance;
     }
 
     return null;

--- a/src/contexts/TeamModalContext.jsx
+++ b/src/contexts/TeamModalContext.jsx
@@ -33,7 +33,18 @@ export const TeamModalProvider = ({ children }) => {
       ? Math.max(BASE_Z_INDEX, requestedZIndex)
       : BASE_Z_INDEX;
 
-    setSelectedTeam({ id: teamId, name: teamName, zIndex: modalZIndex });
+    setSelectedTeam({
+      id: teamId,
+      name: teamName,
+      zIndex: modalZIndex,
+      initialTeamData: options?.initialTeamData ?? null,
+      isFromSearch: Boolean(options?.isFromSearch),
+      showMatchHighlights: Boolean(options?.showMatchHighlights),
+      roleMatchBadgeNames: options?.roleMatchBadgeNames ?? null,
+      matchScore: options?.matchScore ?? null,
+      matchType: options?.matchType ?? null,
+      matchDetails: options?.matchDetails ?? null,
+    });
     setIsOpen(true);
   }, []);
 
@@ -66,10 +77,17 @@ export const TeamModalProvider = ({ children }) => {
               isOpen={true}
               teamId={selectedTeam.id}
               initialTeamData={{
-                id: selectedTeam.id,
-                name: selectedTeam.name,
+                ...(selectedTeam.initialTeamData ?? {}),
+                id: selectedTeam.initialTeamData?.id ?? selectedTeam.id,
+                name: selectedTeam.initialTeamData?.name ?? selectedTeam.name,
               }}
               onClose={closeTeamModal}
+              isFromSearch={selectedTeam.isFromSearch}
+              showMatchHighlights={selectedTeam.showMatchHighlights}
+              roleMatchBadgeNames={selectedTeam.roleMatchBadgeNames}
+              matchScore={selectedTeam.matchScore}
+              matchType={selectedTeam.matchType}
+              matchDetails={selectedTeam.matchDetails}
               zIndexStyle={{ zIndex: modalZIndex }}
               boxZIndexStyle={{ zIndex: modalZIndex + 1 }}
             />

--- a/src/contexts/UserModalContext.jsx
+++ b/src/contexts/UserModalContext.jsx
@@ -124,7 +124,25 @@ export const UserModalProvider = ({ children }) => {
 const UserModalStack = ({ stack, onClose, onOpenUser }) => {
   return (
     <>
-      {stack.map(({ userId, roleMatchTagIds, roleMatchBadgeNames, roleMatchName, roleMatchMaxDistanceKm, showMatchHighlights, matchScore, matchType, matchDetails, distanceKm, filledRoleName, teamName, invitationPrefillTeamId, invitationPrefillRoleId, invitationPrefillTeamName, invitationPrefillRoleName }, idx) => {
+      {stack.map(({
+        userId,
+        roleMatchTagIds,
+        roleMatchBadgeNames,
+        roleMatchName,
+        roleMatchMaxDistanceKm,
+        isFromSearch,
+        showMatchHighlights,
+        matchScore,
+        matchType,
+        matchDetails,
+        distanceKm,
+        filledRoleName,
+        teamName,
+        invitationPrefillTeamId,
+        invitationPrefillRoleId,
+        invitationPrefillTeamName,
+        invitationPrefillRoleName,
+      }, idx) => {
         const zIndex = BASE_Z_INDEX + idx * MODAL_Z_STEP;
         const isTop = idx === stack.length - 1;
 
@@ -151,6 +169,7 @@ const UserModalStack = ({ stack, onClose, onOpenUser }) => {
               roleMatchBadgeNames={roleMatchBadgeNames}
               roleMatchName={roleMatchName}
               roleMatchMaxDistanceKm={roleMatchMaxDistanceKm}
+              isFromSearch={isFromSearch}
               showMatchHighlights={showMatchHighlights}
               matchScore={matchScore}
               matchType={matchType}

--- a/src/index.css
+++ b/src/index.css
@@ -49,7 +49,6 @@
     border: 1.5px solid #ffffff;
     border-radius: 9999px 9999px 9999px 0;
     background: var(--marker-color);
-    box-shadow: 0 8px 18px rgba(3, 63, 5, 0.18);
     transform: rotate(-45deg);
   }
 
@@ -155,7 +154,6 @@
     border: 1.5px solid #ffffff;
     border-radius: 9999px;
     color: #ffffff;
-    box-shadow: 0 1px 4px rgba(3, 63, 5, 0.2);
     pointer-events: none;
   }
 

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -57,7 +57,10 @@ import {
   RESULTS_PER_PAGE_OPTIONS,
   DEFAULT_RESULTS_PER_PAGE,
 } from "../constants/pagination";
-import { calculateDistanceKm } from "../utils/locationUtils";
+import {
+  calculateDistanceKm,
+  locationsHaveDifferentKnownParts,
+} from "../utils/locationUtils";
 
 const SearchPage = () => {
   const location = useLocation();
@@ -206,13 +209,21 @@ const SearchPage = () => {
 
     const matchType = item.matchType ?? item.match_type ?? null;
     const matchDetails = item.matchDetails ?? item.match_details ?? null;
-    const roleDistance = Number(
-      matchDetails?.distanceKm ?? matchDetails?.distance_km,
-    );
-    const rawDistance = Number(item.distance_km ?? item.distanceKm);
+    const rawRoleDistance =
+      matchDetails?.distanceKm ?? matchDetails?.distance_km;
+    const roleDistance =
+      rawRoleDistance != null ? Number(rawRoleDistance) : null;
+    const rawDistanceValue = item.distanceKm ?? item.distance_km;
+    const rawDistance =
+      rawDistanceValue != null ? Number(rawDistanceValue) : null;
     const computedDistance = viewerEntity
       ? calculateDistanceKm(viewerEntity, item)
       : null;
+    const rawZeroLooksWrong =
+      Number.isFinite(rawDistance) &&
+      rawDistance <= 0.5 &&
+      viewerEntity &&
+      locationsHaveDifferentKnownParts(viewerEntity, item);
 
     let resolvedDistance = null;
 
@@ -222,10 +233,23 @@ const SearchPage = () => {
       roleDistance < 999999
     ) {
       resolvedDistance = roleDistance;
+    } else if (Number.isFinite(rawDistance) && rawDistance < 999999) {
+      resolvedDistance =
+        rawZeroLooksWrong && computedDistance != null
+          ? computedDistance
+          : rawZeroLooksWrong
+            ? null
+            : rawDistance;
     } else if (computedDistance != null) {
       resolvedDistance = computedDistance;
-    } else if (Number.isFinite(rawDistance) && rawDistance < 999999) {
-      resolvedDistance = rawDistance;
+    }
+
+    if (resolvedDistance == null && rawZeroLooksWrong) {
+      return {
+        ...item,
+        distance_km: null,
+        distanceKm: null,
+      };
     }
 
     if (resolvedDistance == null) {
@@ -349,40 +373,42 @@ const SearchPage = () => {
       ...searchResults,
       users: Array.isArray(searchResults.users)
         ? searchResults.users.map((matchedUser) => {
+            const distanceResolvedUser = withResolvedDistance(
+              matchedUser,
+              viewerDistanceSource,
+            );
             const enrichedUser =
               sortBy === "match"
                 ? matchRoleId
                   ? enrichUserRoleMatchData({
-                      user: matchedUser,
+                      user: distanceResolvedUser,
                       requiredTagIds: roleMatchTagIds,
                       requiredBadgeNames: roleMatchBadgeNames,
                     })
                   : enrichUserMatchData({
-                      user: matchedUser,
+                      user: distanceResolvedUser,
                       viewerProfile: viewerTeamMatchProfile,
                     })
-                : matchedUser;
+                : distanceResolvedUser;
 
-            return withResolvedDistance(
-              enrichedUser,
-              viewerDistanceSource,
-            );
+            return enrichedUser;
           })
         : searchResults.users,
       teams: Array.isArray(searchResults.teams)
         ? searchResults.teams.map((team) => {
+            const distanceResolvedTeam = withResolvedDistance(
+              team,
+              viewerDistanceSource,
+            );
             const enrichedTeam =
               sortBy === "match"
                 ? enrichTeamMatchData({
-                    team,
+                    team: distanceResolvedTeam,
                     viewerProfile: viewerTeamMatchProfile,
                   })
-                : team;
+                : distanceResolvedTeam;
 
-            return withResolvedDistance(
-              enrichedTeam,
-              viewerDistanceSource,
-            );
+            return enrichedTeam;
           })
         : searchResults.teams,
       roles: Array.isArray(searchResults.roles)

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -190,6 +190,9 @@ export const getCountryCode = (countryName) => {
  * @param {Object} entity - User or team object
  * @returns {Object} Normalized location data
  */
+const firstPresent = (...values) =>
+  values.find((value) => value !== null && value !== undefined && value !== "");
+
 export const normalizeLocationData = (entity) => {
   if (!entity) {
     return {
@@ -205,12 +208,29 @@ export const normalizeLocationData = (entity) => {
     };
   }
 
-  const postalCode = entity.postal_code || entity.postalCode || null;
-  const city = entity.city || null;
-  const state = entity.state || null;
-  const country = entity.country || null;
-  const latitude = entity.latitude || null;
-  const longitude = entity.longitude || null;
+  const postalCode = firstPresent(
+    entity.postal_code,
+    entity.postalCode,
+    entity.location?.postal_code,
+    entity.location?.postalCode,
+  ) ?? null;
+  const city = firstPresent(entity.city, entity.location?.city) ?? null;
+  const state = firstPresent(entity.state, entity.location?.state) ?? null;
+  const country = firstPresent(entity.country, entity.location?.country) ?? null;
+  const latitude = firstPresent(
+    entity.latitude,
+    entity.lat,
+    entity.location?.latitude,
+    entity.location?.lat,
+  ) ?? null;
+  const longitude = firstPresent(
+    entity.longitude,
+    entity.lng,
+    entity.lon,
+    entity.location?.longitude,
+    entity.location?.lng,
+    entity.location?.lon,
+  ) ?? null;
   const isRemote = entity.is_remote === true || entity.isRemote === true;
 
   // Determine if we have any location data
@@ -227,6 +247,41 @@ export const normalizeLocationData = (entity) => {
     isRemote,
     hasLocation,
   };
+};
+
+const normalizeComparableLocationValue = (value) =>
+  value == null ? "" : String(value).trim().toLowerCase();
+
+const normalizeComparableCountry = (value) =>
+  getCountryCode(value == null ? null : String(value)) ??
+  normalizeComparableLocationValue(value);
+
+export const locationsHaveDifferentKnownParts = (source, target) => {
+  const from = normalizeLocationData(source);
+  const to = normalizeLocationData(target);
+  const postalCodeFrom = normalizeComparableLocationValue(from.postalCode);
+  const postalCodeTo = normalizeComparableLocationValue(to.postalCode);
+  const cityFrom = normalizeComparableLocationValue(from.city);
+  const cityTo = normalizeComparableLocationValue(to.city);
+  const stateFrom = normalizeComparableLocationValue(from.state);
+  const stateTo = normalizeComparableLocationValue(to.state);
+  const countryFrom = normalizeComparableCountry(from.country);
+  const countryTo = normalizeComparableCountry(to.country);
+
+  const differs = (left, right) => left && right && left !== right;
+
+  if (differs(countryFrom, countryTo) || differs(cityFrom, cityTo)) {
+    return true;
+  }
+
+  if (cityFrom && cityFrom === cityTo) {
+    return false;
+  }
+
+  return (
+    differs(stateFrom, stateTo) ||
+    differs(postalCodeFrom, postalCodeTo)
+  );
 };
 
 /**
@@ -318,6 +373,10 @@ export const hasLocationChanged = (newData, oldData) => {
 };
 
 const toCoordinate = (value) => {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+
   const num = Number(value);
   return Number.isFinite(num) ? num : null;
 };
@@ -354,7 +413,13 @@ export const calculateDistanceKm = (source, target) => {
       Math.sin(dLon / 2) ** 2;
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
-  return earthRadiusKm * c;
+  const distanceKm = earthRadiusKm * c;
+
+  if (distanceKm <= 0.5 && locationsHaveDifferentKnownParts(source, target)) {
+    return null;
+  }
+
+  return distanceKm;
 };
 
 export default {
@@ -366,4 +431,5 @@ export default {
   formatLocation,
   hasLocationChanged,
   calculateDistanceKm,
+  locationsHaveDifferentKnownParts,
 };

--- a/src/utils/teamMatchUtils.js
+++ b/src/utils/teamMatchUtils.js
@@ -6,6 +6,8 @@ const normalizeText = (value) =>
   typeof value === "string" ? value.trim().toLowerCase() : "";
 
 const toFiniteNumber = (value) => {
+  if (value === null || value === undefined || value === "") return null;
+
   const num = Number(value);
   return Number.isFinite(num) ? num : null;
 };
@@ -224,6 +226,39 @@ const mergeMatchDetails = (computedMatchDetails, existingMatchDetails) => {
   };
 };
 
+const mergeMatchDetailsPreservingExistingScores = (
+  computedMatchDetails,
+  existingMatchDetails,
+) => {
+  const existing = existingMatchDetails ?? {};
+  const computed = computedMatchDetails ?? {};
+
+  return {
+    ...computed,
+    ...existing,
+    tagScore:
+      getDetailValue(existing, "tagScore", "tag_score") ?? computed.tagScore,
+    badgeScore:
+      getDetailValue(existing, "badgeScore", "badge_score") ??
+      computed.badgeScore,
+    distanceScore:
+      getDetailValue(existing, "distanceScore", "distance_score") ??
+      computed.distanceScore,
+    sharedTagCount:
+      getDetailValue(existing, "sharedTagCount", "shared_tag_count") ??
+      computed.sharedTagCount,
+    sharedBadgeCount:
+      getDetailValue(existing, "sharedBadgeCount", "shared_badge_count") ??
+      computed.sharedBadgeCount,
+    totalTagCount:
+      getDetailValue(existing, "totalTagCount", "total_tag_count") ??
+      computed.totalTagCount,
+    totalBadgeCount:
+      getDetailValue(existing, "totalBadgeCount", "total_badge_count") ??
+      computed.totalBadgeCount,
+  };
+};
+
 const calculateWeightedOverallScore = ({
   tagScore = null,
   badgeScore = null,
@@ -251,17 +286,20 @@ const getOverallScoreFromMatchDetails = (matchDetails) =>
     ),
   });
 
-export const getResultMatchScore = (item) => {
+const getExplicitMatchScore = (item) => {
   const raw =
     item?.bestMatchScore ??
     item?.best_match_score ??
     item?.matchScore ??
-    item?.match_score ??
-    0;
+    item?.match_score;
+
+  if (raw == null || raw === "") return null;
 
   const score = Number(raw);
-  return Number.isFinite(score) ? score : 0;
+  return Number.isFinite(score) ? score : null;
 };
+
+export const getResultMatchScore = (item) => getExplicitMatchScore(item) ?? 0;
 
 export const buildViewerTeamMatchProfile = ({
   user = null,
@@ -452,7 +490,7 @@ export const enrichTeamMatchData = ({
   const computed = calculateTeamMatchData({ team, viewerProfile, teamBadges });
   if (!computed) return team;
 
-  const existingScore = getResultMatchScore(team);
+  const existingScore = getExplicitMatchScore(team);
   const existingMatchType = team.matchType ?? team.match_type ?? null;
   const existingMatchDetails = team.matchDetails ?? team.match_details ?? null;
   const mergedMatchDetails = mergeMatchDetails(
@@ -464,7 +502,8 @@ export const enrichTeamMatchData = ({
   const finalScore =
     computedOverallScore ??
     computed.bestMatchScore ??
-    (existingScore > 0 ? existingScore : null);
+    existingScore ??
+    null;
   const finalMatchType = existingMatchType ?? computed.matchType;
   const finalMatchDetails = mergedMatchDetails;
   const finalSharedTagCount =
@@ -495,7 +534,7 @@ export const enrichUserMatchData = ({
   });
   if (!computed) return user;
 
-  const existingScore = getResultMatchScore(user);
+  const existingScore = getExplicitMatchScore(user);
   const existingMatchType = user.matchType ?? user.match_type ?? null;
   const existingMatchDetails = user.matchDetails ?? user.match_details ?? null;
   const mergedMatchDetails = mergeMatchDetails(
@@ -506,7 +545,8 @@ export const enrichUserMatchData = ({
   const finalScore =
     computedOverallScore ??
     computed.bestMatchScore ??
-    (existingScore > 0 ? existingScore : null);
+    existingScore ??
+    null;
   const finalMatchType = existingMatchType ?? computed.matchType;
   const finalSharedTagCount =
     user.sharedTagCount ??
@@ -537,7 +577,7 @@ export const enrichUserRoleMatchData = ({
 } = {}) => {
   if (!user) return user;
 
-  const existingScore = getResultMatchScore(user);
+  const existingScore = getExplicitMatchScore(user);
   const existingMatchDetails = user.matchDetails ?? user.match_details ?? null;
   const computed = calculateUserRoleMatchData({
     matchedUser: user,
@@ -548,15 +588,19 @@ export const enrichUserRoleMatchData = ({
 
   if (!computed) return user;
 
-  const mergedMatchDetails = mergeMatchDetails(
-    computed.matchDetails,
-    existingMatchDetails,
-  );
+  const mergedMatchDetails =
+    existingScore != null && existingMatchDetails
+      ? mergeMatchDetailsPreservingExistingScores(
+          computed.matchDetails,
+          existingMatchDetails,
+        )
+      : mergeMatchDetails(computed.matchDetails, existingMatchDetails);
   const computedOverallScore = getOverallScoreFromMatchDetails(mergedMatchDetails);
   const finalScore =
-    existingScore > 0
-      ? existingScore
-      : computedOverallScore ?? computed.bestMatchScore ?? existingScore;
+    existingScore ??
+    computedOverallScore ??
+    computed.bestMatchScore ??
+    0;
   const finalSharedTagCount =
     user.sharedTagCount ??
     user.shared_tag_count ??


### PR DESCRIPTION
Fixes several search map/detail-view inconsistencies around Best Match scores, distance display, role actions, and dropdown layering.

Changes
Keeps Best Match scores consistent between map popups/tooltips and details modals.
Preserves backend match scores and match breakdowns when opening user/team details from search results.
Fixes distance display so valid 0 km away results still render, while bogus zero-distance values are avoided.
Passes search/map distance and match context through user/team modal contexts.
Enables open role apply actions from the map role details modal.
Removes map pin shadows.
Raises search suggestion dropdowns above Leaflet map layers so focus area/badge suggestions are not clipped.
Verification
npm run build passes.
git diff --check passes.
Focused ESLint checks pass for the changed search/map/user/distance files.
Note: Vite still shows the existing large chunk warning.