### PR TITLE
Feature/distance filter

### DIFF
--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -30,6 +30,7 @@ import {
   SlidersHorizontal,
   UserPlus,
   UserMinus,
+  Ruler,
   MapPin,
   Globe,
   Target,
@@ -51,6 +52,7 @@ import {
   getActiveCriteriaPills,
   getSortOptionDisplay,
   getVisibleSortOptions,
+  shouldUseMergedResultPagination,
 } from "./searchPageHelpers";
 
 import {
@@ -63,6 +65,11 @@ import {
 } from "../utils/locationUtils";
 
 const DISTANCE_UNAVAILABLE_SENTINEL_KM = 999999;
+const RESULT_TYPE_TIE_BREAKER_ORDER = {
+  team: 0,
+  user: 1,
+  role: 2,
+};
 
 const getFilterableDistanceKm = (item) => {
   const matchDetails = item?.matchDetails ?? item?.match_details ?? null;
@@ -81,6 +88,122 @@ const getFilterableDistanceKm = (item) => {
     ? distance
     : null;
 };
+
+const getProximitySortValue = (item) =>
+  getFilterableDistanceKm(item) ?? DISTANCE_UNAVAILABLE_SENTINEL_KM;
+
+const getUserDisplayName = (u) =>
+  (
+    (u?.first_name || u?.firstName || "") +
+    " " +
+    (u?.last_name || u?.lastName || "")
+  ).trim().toLowerCase() || (u?.username || "").toLowerCase();
+
+const getSearchItemDisplayName = (item) => {
+  if (!item) return "";
+
+  if (item._resultType === "team") {
+    return (item.name || "").toLowerCase();
+  }
+
+  if (item._resultType === "role") {
+    return String(
+      item.roleName ??
+        item.role_name ??
+        item.name ??
+        item.teamName ??
+        item.team_name ??
+        "",
+    ).toLowerCase();
+  }
+
+  return getUserDisplayName(item);
+};
+
+const getSearchItemActivityTime = (item) => {
+  if (!item) return 0;
+
+  const value =
+    item._resultType === "role"
+      ? item.updatedAt ?? item.updated_at ?? item.createdAt ?? item.created_at
+      : item.last_active_at ??
+        item.lastActiveAt ??
+        item.last_active ??
+        item.lastActive ??
+        item.updated_at ??
+        item.updatedAt ??
+        item.created_at ??
+        item.createdAt;
+  const timestamp = value ? new Date(value).getTime() : 0;
+
+  return Number.isFinite(timestamp) ? timestamp : 0;
+};
+
+const compareSearchItemTieBreakers = (a, b) => {
+  const groupIndexCompare =
+    (a?._resultGroupIndex ?? Number.MAX_SAFE_INTEGER) -
+    (b?._resultGroupIndex ?? Number.MAX_SAFE_INTEGER);
+
+  if (groupIndexCompare !== 0) return groupIndexCompare;
+
+  const resultTypeCompare =
+    (RESULT_TYPE_TIE_BREAKER_ORDER[a?._resultType] ??
+      Number.MAX_SAFE_INTEGER) -
+    (RESULT_TYPE_TIE_BREAKER_ORDER[b?._resultType] ??
+      Number.MAX_SAFE_INTEGER);
+
+  if (resultTypeCompare !== 0) return resultTypeCompare;
+
+  const activityCompare =
+    getSearchItemActivityTime(b) - getSearchItemActivityTime(a);
+
+  if (activityCompare !== 0) return activityCompare;
+
+  const nameCompare = getSearchItemDisplayName(a).localeCompare(
+    getSearchItemDisplayName(b),
+  );
+
+  if (nameCompare !== 0) return nameCompare;
+
+  return `${a?._resultType ?? ""}-${a?.id ?? ""}`.localeCompare(
+    `${b?._resultType ?? ""}-${b?.id ?? ""}`,
+  );
+};
+
+const isTruthyRemoteFlag = (value) =>
+  value === true || value === 1 || value === "true" || value === "1";
+
+const isRemoteSearchItem = (item) =>
+  isTruthyRemoteFlag(item?.is_remote) ||
+  isTruthyRemoteFlag(item?.isRemote) ||
+  isTruthyRemoteFlag(item?.role?.is_remote) ||
+  isTruthyRemoteFlag(item?.role?.isRemote);
+
+const getNearestSortPriority = (item) => {
+  if (isRemoteSearchItem(item)) return 2;
+  return getFilterableDistanceKm(item) === null ? 1 : 0;
+};
+
+const compareProximityItems = (a, b, sortDir) => {
+  const remoteCompare =
+    sortDir === "remote"
+      ? Number(isRemoteSearchItem(b)) - Number(isRemoteSearchItem(a))
+      : getNearestSortPriority(a) - getNearestSortPriority(b);
+
+  if (remoteCompare !== 0) return remoteCompare;
+
+  const aDist = getProximitySortValue(a);
+  const bDist = getProximitySortValue(b);
+  const distanceCompare =
+    sortDir === "remote" ? bDist - aDist : aDist - bDist;
+
+  return distanceCompare !== 0
+    ? distanceCompare
+    : compareSearchItemTieBreakers(a, b);
+};
+
+const sortByProximity = (items, sortDir) =>
+  [...items].sort((a, b) => compareProximityItems(a, b, sortDir));
 
 const SearchPage = () => {
   const location = useLocation();
@@ -346,14 +469,25 @@ const SearchPage = () => {
     {
       value: "proximity",
       defaultDir: "asc",
-      labelAsc: "Nearest",
-      labelRemote: "Remote",
-      shortLabelAsc: "Near",
-      shortLabelRemote: "Remote",
-      tooltipAsc: "Show the nearest results first",
+      filterOnly: true,
+      labelAsc: "Distance",
+      shortLabelAsc: "Distance",
+      tooltipAsc: "Filter results by distance from your location",
+      iconAsc: Ruler,
+    },
+    {
+      value: "locationPriority",
+      sortValue: "proximity",
+      defaultDir: "asc",
+      labelAsc: "Nearest First",
+      labelRemote: "Remote First",
+      shortLabelAsc: "Near 1st",
+      shortLabelRemote: "Remote 1st",
+      tooltipAsc: "Keep nearby results ahead of remote-friendly results",
       tooltipRemote: "Show remote-friendly results first",
       iconAsc: MapPin,
       iconRemote: Globe,
+      requiresCoordinates: true,
     },
     {
       value: "capacity",
@@ -514,8 +648,32 @@ const SearchPage = () => {
         ? displaySearchResults.roles
         : [],
   };
-
+  const usesClientMergedPagination = shouldUseMergedResultPagination({
+    searchType,
+    sortBy,
+  });
   const effectivePagination = useMemo(() => {
+    if (usesClientMergedPagination) {
+      const totalItems =
+        (pagination.totalTeams || 0) +
+        (pagination.totalUsers || 0) +
+        (pagination.totalRoles || 0);
+      const totalPages = Math.max(
+        1,
+        Math.ceil(totalItems / Math.max(1, resultsPerPage)),
+      );
+
+      return {
+        ...pagination,
+        page: currentPage,
+        limit: resultsPerPage,
+        totalItems,
+        totalPages,
+        hasNextPage: currentPage < totalPages,
+        hasPrevPage: currentPage > 1,
+      };
+    }
+
     if (
       !shouldExcludeCurrentUserFromBestMatch ||
       searchType === "teams" ||
@@ -547,49 +705,37 @@ const SearchPage = () => {
     };
   }, [
     pagination,
+    currentPage,
     resultsPerPage,
     searchType,
     shouldExcludeCurrentUserFromBestMatch,
+    usesClientMergedPagination,
   ]);
-
-  const getUserDisplayName = (u) =>
-    (
-      (u.first_name || u.firstName || "") +
-      " " +
-      (u.last_name || u.lastName || "")
-    ).trim().toLowerCase() || (u.username || "").toLowerCase();
 
   const mergedDisplayItems = (() => {
     if (searchType !== "all") return null;
-    const teams = filteredResults.teams.map((t) => ({
+    const teams = filteredResults.teams.map((t, index) => ({
       ...t,
       _resultType: "team",
+      _resultGroupIndex: index,
     }));
-    const users = filteredResults.users.map((u) => ({
+    const users = filteredResults.users.map((u, index) => ({
       ...u,
       _resultType: "user",
+      _resultGroupIndex: index,
     }));
-    const roles = filteredResults.roles.map((r) => ({
+    const roles = filteredResults.roles.map((r, index) => ({
       ...r,
       _resultType: "role",
+      _resultGroupIndex: index,
     }));
     const combined = [...teams, ...users, ...roles];
     combined.sort((a, b) => {
-      const aIsTeam = a._resultType === "team";
-      const bIsTeam = b._resultType === "team";
       const aIsRole = a._resultType === "role";
       const bIsRole = b._resultType === "role";
       if (sortBy === "name") {
-        const aName = aIsTeam
-          ? (a.name || "").toLowerCase()
-          : aIsRole
-            ? (a.roleName ?? a.role_name ?? "").toLowerCase()
-            : getUserDisplayName(a);
-        const bName = bIsTeam
-          ? (b.name || "").toLowerCase()
-          : bIsRole
-            ? (b.roleName ?? b.role_name ?? "").toLowerCase()
-            : getUserDisplayName(b);
+        const aName = getSearchItemDisplayName(a);
+        const bName = getSearchItemDisplayName(b);
         const cmp = aName.localeCompare(bName);
         return sortDir === "asc" ? cmp : -cmp;
       }
@@ -621,9 +767,7 @@ const SearchPage = () => {
         return sortDir === "asc" ? getDate(a) - getDate(b) : getDate(b) - getDate(a);
       }
       if (sortBy === "proximity") {
-        const aDist = a.distance_km ?? a.distanceKm ?? Infinity;
-        const bDist = b.distance_km ?? b.distanceKm ?? Infinity;
-        return aDist - bDist;
+        return compareProximityItems(a, b, sortDir);
       }
       if (sortBy === "match") {
         const aScore = getResultMatchScore(a);
@@ -632,7 +776,12 @@ const SearchPage = () => {
       }
       return 0;
     });
-    return combined.slice(0, resultsPerPage);
+
+    const startIndex = usesClientMergedPagination
+      ? (currentPage - 1) * resultsPerPage
+      : 0;
+
+    return combined.slice(startIndex, startIndex + resultsPerPage);
   })();
 
   const sortedUsers = (() => {
@@ -641,6 +790,9 @@ const SearchPage = () => {
       return [...users].sort(
         (a, b) => getResultMatchScore(b) - getResultMatchScore(a),
       );
+    }
+    if (sortBy === "proximity") {
+      return sortByProximity(users, sortDir);
     }
     if (sortBy !== "name") return users;
     return [...users].sort((a, b) => {
@@ -656,8 +808,16 @@ const SearchPage = () => {
         (a, b) => getResultMatchScore(b) - getResultMatchScore(a),
       );
     }
+    if (sortBy === "proximity") {
+      return sortByProximity(teams, sortDir);
+    }
     return teams;
   })();
+
+  const sortedRoles =
+    sortBy === "proximity"
+      ? sortByProximity(filteredResults.roles, sortDir)
+      : filteredResults.roles;
 
   const displayedTeams = mergedDisplayItems
     ? []
@@ -673,7 +833,7 @@ const SearchPage = () => {
     searchType === "all"
       ? mergedDisplayItems
       : searchType === "roles"
-        ? filteredResults.roles.map((role) => ({ ...role, _resultType: "role" }))
+        ? sortedRoles.map((role) => ({ ...role, _resultType: "role" }))
         : [
             ...displayedTeams.map((team) => ({ ...team, _resultType: "team" })),
             ...displayedUsers.map((matchedUser) => ({
@@ -709,6 +869,8 @@ const SearchPage = () => {
     searchType === "teams" && sortBy === "capacity" && capacityMode === "spots";
   const isCapacityRolesSort =
     searchType === "teams" && sortBy === "capacity" && capacityMode === "roles";
+  const shouldShowLocationContext =
+    sortBy === "proximity" || maxDistance !== null || sortBy === "match";
 
   const activeSubmenuKey = showSortDropdown ? openSubmenuKey : null;
 
@@ -1120,7 +1282,7 @@ const SearchPage = () => {
 
     if (newSortBy === sortBy) {
       if (newSortBy === "proximity") {
-        newSortDir = sortDir === "remote" ? "asc" : "remote";
+        newSortDir = "asc";
       } else if (newSortBy === "capacity") {
         newSortDir = sortDir === "desc" ? "asc" : "desc";
       } else if (newSortBy === "match") {
@@ -1147,13 +1309,20 @@ const SearchPage = () => {
       }
     }
 
-    if (newSortBy === "proximity" && newSortDir === "remote") {
-      setSearchType("teams");
-      setMaxDistance(null);
-      setCustomDistanceInput("");
-    }
-
     setSortBy(newSortBy);
+    setSortDir(newSortDir);
+    setCurrentPage(1);
+  };
+
+  const handleLocationPriorityToggle = () => {
+    const newSortDir =
+      sortBy !== "proximity"
+        ? "asc"
+        : sortDir === "remote"
+          ? "asc"
+          : "remote";
+
+    setSortBy("proximity");
     setSortDir(newSortDir);
     setCurrentPage(1);
   };
@@ -1165,8 +1334,13 @@ const SearchPage = () => {
       return;
     }
 
+    if (optionValue === "locationPriority") {
+      handleLocationPriorityToggle();
+      setOpenSubmenuKey(null);
+      return;
+    }
+
     if (optionValue === "proximity") {
-      handleSortChange("proximity");
       setOpenSubmenuKey(DISTANCE_SUBMENU_TYPE);
       return;
     }
@@ -1246,9 +1420,6 @@ const SearchPage = () => {
       setSortDir("asc");
     }
 
-    if (type !== "teams" && sortBy === "proximity" && sortDir === "remote") {
-      setSortDir("asc");
-    }
   };
 
   const handleOpenRolesOnlyToggle = () => {
@@ -1436,9 +1607,6 @@ const SearchPage = () => {
 
   const renderSortSubmenuPortal = () => {
     if (!activeSubmenuKey || !submenuPosition) return null;
-    if (activeSubmenuKey === DISTANCE_SUBMENU_TYPE && sortDir === "remote") {
-      return null;
-    }
 
     const submenuContent = (
       <div ref={submenuRef}>
@@ -1744,6 +1912,7 @@ const SearchPage = () => {
                           sortBy,
                           sortDir,
                           isCapacitySpotsSort,
+                          maxDistance,
                         });
                       const optionButton = (
                         <button
@@ -1912,7 +2081,7 @@ const SearchPage = () => {
                   <span className="text-sm font-normal text-base-content/60 ml-2">
                     (
                     {searchType === "all"
-                      ? `${filteredResults.teams.length + filteredResults.users.length + filteredResults.roles.length} results`
+                      ? `${effectivePagination.totalItems} results`
                       : searchType === "teams"
                         ? `${effectivePagination.totalTeams} results`
                         : searchType === "users"
@@ -1984,11 +2153,7 @@ const SearchPage = () => {
                   showMatchHighlights={sortBy === "match"}
                   showMatchScore={sortBy === "match"}
                   viewerLocation={viewerDistanceSource}
-                  proximityRadiusKm={
-                    sortBy === "proximity" && sortDir !== "remote"
-                      ? maxDistance
-                      : null
-                  }
+                  proximityRadiusKm={maxDistance !== null ? maxDistance : null}
                 />
               )}
 
@@ -2009,9 +2174,7 @@ const SearchPage = () => {
                           showSearchResultTypeOverlay={searchType === "all"}
                           viewMode="list"
                           activeFilters={{
-                            showLocation:
-                              (sortBy === "proximity" && sortDir !== "remote") ||
-                              sortBy === "match",
+                            showLocation: shouldShowLocationContext,
                             showTags: sortBy === "match",
                             showBadges: sortBy === "match",
                           }}
@@ -2030,9 +2193,7 @@ const SearchPage = () => {
                           showSearchResultTypeOverlay={searchType === "all"}
                           viewMode={resultView === "list" ? "list" : resultView}
                           activeFilters={{
-                            showLocation:
-                              (sortBy === "proximity" && sortDir !== "remote") ||
-                              sortBy === "match",
+                            showLocation: shouldShowLocationContext,
                             showTags: sortBy === "match",
                             showBadges: sortBy === "match",
                           }}
@@ -2059,9 +2220,7 @@ const SearchPage = () => {
                           showSearchResultTypeOverlay={searchType === "all"}
                           viewMode="list"
                           activeFilters={{
-                            showLocation:
-                              (sortBy === "proximity" && sortDir !== "remote") ||
-                              sortBy === "match",
+                            showLocation: shouldShowLocationContext,
                             showTags: sortBy === "match",
                             showBadges: sortBy === "match",
                           }}
@@ -2085,9 +2244,7 @@ const SearchPage = () => {
                           showSearchResultTypeOverlay={searchType === "all"}
                           viewMode={resultView}
                           activeFilters={{
-                            showLocation:
-                              (sortBy === "proximity" && sortDir !== "remote") ||
-                              sortBy === "match",
+                            showLocation: shouldShowLocationContext,
                             showTags: sortBy === "match",
                             showBadges: sortBy === "match",
                           }}
@@ -2106,9 +2263,7 @@ const SearchPage = () => {
                           showSearchResultTypeOverlay={searchType === "all"}
                           viewMode={resultView === "list" ? "list" : resultView}
                           activeFilters={{
-                            showLocation:
-                              (sortBy === "proximity" && sortDir !== "remote") ||
-                              sortBy === "match",
+                            showLocation: shouldShowLocationContext,
                             showTags: sortBy === "match",
                             showBadges: sortBy === "match",
                           }}
@@ -2135,9 +2290,7 @@ const SearchPage = () => {
                           showSearchResultTypeOverlay={searchType === "all"}
                           viewMode={resultView}
                           activeFilters={{
-                            showLocation:
-                              (sortBy === "proximity" && sortDir !== "remote") ||
-                              sortBy === "match",
+                            showLocation: shouldShowLocationContext,
                             showTags: sortBy === "match",
                             showBadges: sortBy === "match",
                           }}
@@ -2149,7 +2302,7 @@ const SearchPage = () => {
 
               {searchType === "roles" && resultView === "list" && (
                 <div className="background-opacity bg-opacity-70 shadow-soft rounded-xl divide-y divide-base-200">
-                  {filteredResults.roles.map((role) => (
+                  {sortedRoles.map((role) => (
                     <VacantRoleCard
                       key={`role-${role.id}`}
                       role={role}
@@ -2158,9 +2311,7 @@ const SearchPage = () => {
                       hideActions
                       viewMode="list"
                       activeFilters={{
-                        showLocation:
-                          (sortBy === "proximity" && sortDir !== "remote") ||
-                          sortBy === "match",
+                        showLocation: shouldShowLocationContext,
                         showTags: sortBy === "match",
                         showBadges: sortBy === "match",
                       }}
@@ -2180,7 +2331,7 @@ const SearchPage = () => {
                   lg={resultView === "mini" ? 4 : 3}
                   gap={resultView === "mini" ? 2 : 6}
                 >
-                  {filteredResults.roles.map((role) => (
+                  {sortedRoles.map((role) => (
                     <VacantRoleCard
                       key={`role-${role.id}`}
                       role={role}
@@ -2189,9 +2340,7 @@ const SearchPage = () => {
                       hideActions
                       viewMode={resultView}
                       activeFilters={{
-                        showLocation:
-                          (sortBy === "proximity" && sortDir !== "remote") ||
-                          sortBy === "match",
+                        showLocation: shouldShowLocationContext,
                         showTags: sortBy === "match",
                         showBadges: sortBy === "match",
                       }}

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -62,6 +62,26 @@ import {
   locationsHaveDifferentKnownParts,
 } from "../utils/locationUtils";
 
+const DISTANCE_UNAVAILABLE_SENTINEL_KM = 999999;
+
+const getFilterableDistanceKm = (item) => {
+  const matchDetails = item?.matchDetails ?? item?.match_details ?? null;
+  const rawDistance =
+    item?.distanceKm ??
+    item?.distance_km ??
+    matchDetails?.distanceKm ??
+    matchDetails?.distance_km;
+  const distance =
+    rawDistance !== null && rawDistance !== undefined && rawDistance !== ""
+      ? Number(rawDistance)
+      : null;
+
+  return Number.isFinite(distance) &&
+    distance < DISTANCE_UNAVAILABLE_SENTINEL_KM
+    ? distance
+    : null;
+};
+
 const SearchPage = () => {
   const location = useLocation();
   const { user, isAuthenticated } = useAuth();
@@ -212,10 +232,18 @@ const SearchPage = () => {
     const rawRoleDistance =
       matchDetails?.distanceKm ?? matchDetails?.distance_km;
     const roleDistance =
-      rawRoleDistance != null ? Number(rawRoleDistance) : null;
+      rawRoleDistance !== null &&
+      rawRoleDistance !== undefined &&
+      rawRoleDistance !== ""
+        ? Number(rawRoleDistance)
+        : null;
     const rawDistanceValue = item.distanceKm ?? item.distance_km;
     const rawDistance =
-      rawDistanceValue != null ? Number(rawDistanceValue) : null;
+      rawDistanceValue !== null &&
+      rawDistanceValue !== undefined &&
+      rawDistanceValue !== ""
+        ? Number(rawDistanceValue)
+        : null;
     const computedDistance = viewerEntity
       ? calculateDistanceKm(viewerEntity, item)
       : null;
@@ -230,10 +258,13 @@ const SearchPage = () => {
     if (
       matchType === "role_match" &&
       Number.isFinite(roleDistance) &&
-      roleDistance < 999999
+      roleDistance < DISTANCE_UNAVAILABLE_SENTINEL_KM
     ) {
       resolvedDistance = roleDistance;
-    } else if (Number.isFinite(rawDistance) && rawDistance < 999999) {
+    } else if (
+      Number.isFinite(rawDistance) &&
+      rawDistance < DISTANCE_UNAVAILABLE_SENTINEL_KM
+    ) {
       resolvedDistance =
         rawZeroLooksWrong && computedDistance != null
           ? computedDistance
@@ -316,16 +347,12 @@ const SearchPage = () => {
       value: "proximity",
       defaultDir: "asc",
       labelAsc: "Nearest",
-      labelDesc: "Farthest",
       labelRemote: "Remote",
       shortLabelAsc: "Near",
-      shortLabelDesc: "Far",
       shortLabelRemote: "Remote",
       tooltipAsc: "Show the nearest results first",
-      tooltipDesc: "Show the farthest results first",
       tooltipRemote: "Show remote-friendly results first",
       iconAsc: MapPin,
-      iconDesc: MapPin,
       iconRemote: Globe,
     },
     {
@@ -365,20 +392,19 @@ const SearchPage = () => {
   );
 
   const effectiveSearchResults = useMemo(() => {
-    if (!viewerTeamMatchProfile?.user) {
-      return searchResults;
-    }
+    const shouldResolveDistance = Boolean(viewerDistanceSource);
+    const shouldEnrichMatches =
+      sortBy === "match" && Boolean(viewerTeamMatchProfile?.user);
 
     return {
       ...searchResults,
       users: Array.isArray(searchResults.users)
         ? searchResults.users.map((matchedUser) => {
-            const distanceResolvedUser = withResolvedDistance(
-              matchedUser,
-              viewerDistanceSource,
-            );
+            const distanceResolvedUser = shouldResolveDistance
+              ? withResolvedDistance(matchedUser, viewerDistanceSource)
+              : matchedUser;
             const enrichedUser =
-              sortBy === "match"
+              shouldEnrichMatches
                 ? matchRoleId
                   ? enrichUserRoleMatchData({
                       user: distanceResolvedUser,
@@ -396,12 +422,11 @@ const SearchPage = () => {
         : searchResults.users,
       teams: Array.isArray(searchResults.teams)
         ? searchResults.teams.map((team) => {
-            const distanceResolvedTeam = withResolvedDistance(
-              team,
-              viewerDistanceSource,
-            );
+            const distanceResolvedTeam = shouldResolveDistance
+              ? withResolvedDistance(team, viewerDistanceSource)
+              : team;
             const enrichedTeam =
-              sortBy === "match"
+              shouldEnrichMatches
                 ? enrichTeamMatchData({
                     team: distanceResolvedTeam,
                     viewerProfile: viewerTeamMatchProfile,
@@ -413,7 +438,9 @@ const SearchPage = () => {
         : searchResults.teams,
       roles: Array.isArray(searchResults.roles)
         ? searchResults.roles.map((role) =>
-            withResolvedDistance(role, viewerDistanceSource),
+            shouldResolveDistance
+              ? withResolvedDistance(role, viewerDistanceSource)
+              : role,
           )
         : searchResults.roles,
     };
@@ -431,22 +458,44 @@ const SearchPage = () => {
   const shouldExcludeCurrentUserFromBestMatch =
     sortBy === "match" && isAuthenticated && !!user?.id;
 
-  const displaySearchResults = useMemo(() => {
-    if (
-      !shouldExcludeCurrentUserFromBestMatch ||
-      !Array.isArray(effectiveSearchResults.users)
-    ) {
+  const distanceFilteredSearchResults = useMemo(() => {
+    const distanceLimit = Number(maxDistance);
+
+    if (!Number.isFinite(distanceLimit) || distanceLimit <= 0) {
       return effectiveSearchResults;
     }
 
+    const isWithinDistanceLimit = (item) => {
+      const distance = getFilterableDistanceKm(item);
+      return distance !== null && distance <= distanceLimit;
+    };
+    const filterItems = (items) =>
+      Array.isArray(items) ? items.filter(isWithinDistanceLimit) : items;
+
     return {
       ...effectiveSearchResults,
-      users: effectiveSearchResults.users.filter(
+      users: filterItems(effectiveSearchResults.users),
+      teams: filterItems(effectiveSearchResults.teams),
+      roles: filterItems(effectiveSearchResults.roles),
+    };
+  }, [effectiveSearchResults, maxDistance]);
+
+  const displaySearchResults = useMemo(() => {
+    if (
+      !shouldExcludeCurrentUserFromBestMatch ||
+      !Array.isArray(distanceFilteredSearchResults.users)
+    ) {
+      return distanceFilteredSearchResults;
+    }
+
+    return {
+      ...distanceFilteredSearchResults,
+      users: distanceFilteredSearchResults.users.filter(
         (matchedUser) => String(matchedUser?.id) !== String(user.id),
       ),
     };
   }, [
-    effectiveSearchResults,
+    distanceFilteredSearchResults,
     shouldExcludeCurrentUserFromBestMatch,
     user?.id,
   ]);
@@ -574,7 +623,7 @@ const SearchPage = () => {
       if (sortBy === "proximity") {
         const aDist = a.distance_km ?? a.distanceKm ?? Infinity;
         const bDist = b.distance_km ?? b.distanceKm ?? Infinity;
-        return sortDir === "asc" ? aDist - bDist : bDist - aDist;
+        return aDist - bDist;
       }
       if (sortBy === "match") {
         const aScore = getResultMatchScore(a);
@@ -634,7 +683,10 @@ const SearchPage = () => {
           ];
 
   const hasActiveFilters =
-    filterTagIds.length > 0 || filterBadgeIds.length > 0 || !!matchRoleId;
+    filterTagIds.length > 0 ||
+    filterBadgeIds.length > 0 ||
+    maxDistance !== null ||
+    !!matchRoleId;
 
   const noResultsFound =
     (hasSearched || hasActiveFilters) &&
@@ -898,6 +950,13 @@ const SearchPage = () => {
     }
   }, [showSortDropdown, openSubmenuKey, searchType, userHasCoordinates]);
 
+  useEffect(() => {
+    if (sortBy === "proximity" && sortDir === "desc") {
+      setSortDir("asc");
+      setCurrentPage(1);
+    }
+  }, [sortBy, sortDir]);
+
   useLayoutEffect(() => {
     if (!activeSubmenuKey || !showSortDropdown) {
       setSubmenuPosition(null);
@@ -1061,13 +1120,7 @@ const SearchPage = () => {
 
     if (newSortBy === sortBy) {
       if (newSortBy === "proximity") {
-        if (sortDir === "asc") {
-          newSortDir = "desc";
-        } else if (sortDir === "desc") {
-          newSortDir = "remote";
-        } else {
-          newSortDir = "asc";
-        }
+        newSortDir = sortDir === "remote" ? "asc" : "remote";
       } else if (newSortBy === "capacity") {
         newSortDir = sortDir === "desc" ? "asc" : "desc";
       } else if (newSortBy === "match") {

--- a/src/pages/searchPageHelpers.js
+++ b/src/pages/searchPageHelpers.js
@@ -1,5 +1,11 @@
 export const DISTANCE_SUBMENU_TYPE = "distance";
 
+const getRequestSortDir = ({ sortBy, sortDir }) =>
+  sortBy === "proximity" && sortDir === "remote" ? "remote" : sortDir;
+
+export const shouldUseMergedResultPagination = ({ searchType, sortBy }) =>
+  searchType === "all" && sortBy === "proximity";
+
 export const getVisibleSortOptions = ({
   sortOptions,
   searchType,
@@ -10,6 +16,7 @@ export const getVisibleSortOptions = ({
     if (option.teamsOnly && searchType !== "teams") return false;
     if (option.usersOnly && searchType === "teams") return false;
     if (option.value === "proximity" && !userHasCoordinates) return false;
+    if (option.requiresCoordinates && !userHasCoordinates) return false;
     if (option.authOnly && !isAuthenticated) return false;
     return true;
   });
@@ -19,18 +26,38 @@ export const getSortOptionDisplay = ({
   sortBy,
   sortDir,
   isCapacitySpotsSort,
+  maxDistance,
 }) => {
+  if (option.filterOnly) {
+    return {
+      isActive: maxDistance !== null,
+      currentDir: option.defaultDir || "asc",
+      IconComponent: option.iconAsc,
+      label: option.labelAsc,
+      shortLabel: option.shortLabelAsc,
+      tooltip: option.tooltipAsc,
+    };
+  }
+
+  const optionSortValue = option.sortValue ?? option.value;
+  const matchesSort = sortBy === optionSortValue;
   const isActive =
-    option.value === "capacity" ? isCapacitySpotsSort : sortBy === option.value;
+    option.value === "capacity"
+      ? isCapacitySpotsSort
+      : matchesSort && (!option.activeDir || sortDir === option.activeDir);
   const currentDir = isActive
     ? option.value === "capacity"
       ? sortDir
-      : sortBy === option.value
+      : matchesSort
         ? sortDir
         : option.defaultDir || "desc"
     : option.defaultDir || "desc";
-  const displayDir =
+  const normalizedDir =
     option.value === "proximity" && currentDir === "desc" ? "asc" : currentDir;
+  const displayDir =
+    normalizedDir === "remote" && !option.labelRemote
+      ? option.defaultDir || "asc"
+      : normalizedDir;
 
   if (displayDir === "asc") {
     return {
@@ -108,7 +135,7 @@ export const getActiveCriteriaPills = ({
   } else if (sortBy === "proximity") {
     pills.push({
       key: "sort",
-      label: sortDir === "remote" ? "Remote" : "Nearest",
+      label: sortDir === "remote" ? "Remote First" : "Nearest First",
       shortLabel: sortDir === "remote" ? "Remote" : "Near",
     });
   }
@@ -174,21 +201,32 @@ export const buildSearchRequestCriteria = ({
   filterBadgeIds,
   matchRoleId,
   excludeTeamId,
-}) => ({
-  mode: hasSearched && searchQuery.trim() ? "search" : "all",
-  query: searchQuery.trim(),
-  searchType,
-  page: currentPage,
-  limit: resultsPerPage,
-  sortBy,
-  sortDir,
-  maxDistance,
-  openRolesOnly: effectiveOpenRolesOnly,
-  excludeOwnTeams: !effectiveIncludeOwnTeams,
-  includeDemoData,
-  capacityMode,
-  tagIds: filterTagIds,
-  badgeIds: filterBadgeIds,
-  roleId: matchRoleId,
-  excludeTeamId,
-});
+}) => {
+  const usesMergedPaginationWindow = shouldUseMergedResultPagination({
+    searchType,
+    sortBy,
+  });
+  const normalizedPage = Math.max(1, Number(currentPage) || 1);
+  const normalizedLimit = Math.max(1, Number(resultsPerPage) || 1);
+
+  return {
+    mode: hasSearched && searchQuery.trim() ? "search" : "all",
+    query: searchQuery.trim(),
+    searchType,
+    page: usesMergedPaginationWindow ? 1 : normalizedPage,
+    limit: usesMergedPaginationWindow
+      ? normalizedPage * normalizedLimit
+      : normalizedLimit,
+    sortBy,
+    sortDir: getRequestSortDir({ sortBy, sortDir }),
+    maxDistance,
+    openRolesOnly: effectiveOpenRolesOnly,
+    excludeOwnTeams: !effectiveIncludeOwnTeams,
+    includeDemoData,
+    capacityMode,
+    tagIds: filterTagIds,
+    badgeIds: filterBadgeIds,
+    roleId: matchRoleId,
+    excludeTeamId,
+  };
+};

--- a/src/pages/searchPageHelpers.js
+++ b/src/pages/searchPageHelpers.js
@@ -29,11 +29,13 @@ export const getSortOptionDisplay = ({
         ? sortDir
         : option.defaultDir || "desc"
     : option.defaultDir || "desc";
+  const displayDir =
+    option.value === "proximity" && currentDir === "desc" ? "asc" : currentDir;
 
-  if (currentDir === "asc") {
+  if (displayDir === "asc") {
     return {
       isActive,
-      currentDir,
+      currentDir: displayDir,
       IconComponent: option.iconAsc,
       label: option.labelAsc,
       shortLabel: option.shortLabelAsc,
@@ -41,10 +43,10 @@ export const getSortOptionDisplay = ({
     };
   }
 
-  if (currentDir === "remote") {
+  if (displayDir === "remote") {
     return {
       isActive,
-      currentDir,
+      currentDir: displayDir,
       IconComponent: option.iconRemote,
       label: option.labelRemote,
       shortLabel: option.shortLabelRemote,
@@ -106,14 +108,8 @@ export const getActiveCriteriaPills = ({
   } else if (sortBy === "proximity") {
     pills.push({
       key: "sort",
-      label:
-        sortDir === "remote"
-          ? "Remote"
-          : sortDir === "desc"
-            ? "Farthest"
-            : "Nearest",
-      shortLabel:
-        sortDir === "remote" ? "Remote" : sortDir === "desc" ? "Far" : "Near",
+      label: sortDir === "remote" ? "Remote" : "Nearest",
+      shortLabel: sortDir === "remote" ? "Remote" : "Near",
     });
   }
 

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -213,15 +213,38 @@ export const normalizeLocationData = (entity) => {
     entity.postalCode,
     entity.location?.postal_code,
     entity.location?.postalCode,
+    entity.role_location?.postal_code,
+    entity.role_location?.postalCode,
+    entity.roleLocation?.postal_code,
+    entity.roleLocation?.postalCode,
   ) ?? null;
-  const city = firstPresent(entity.city, entity.location?.city) ?? null;
-  const state = firstPresent(entity.state, entity.location?.state) ?? null;
-  const country = firstPresent(entity.country, entity.location?.country) ?? null;
+  const city = firstPresent(
+    entity.city,
+    entity.location?.city,
+    entity.role_location?.city,
+    entity.roleLocation?.city,
+  ) ?? null;
+  const state = firstPresent(
+    entity.state,
+    entity.location?.state,
+    entity.role_location?.state,
+    entity.roleLocation?.state,
+  ) ?? null;
+  const country = firstPresent(
+    entity.country,
+    entity.location?.country,
+    entity.role_location?.country,
+    entity.roleLocation?.country,
+  ) ?? null;
   const latitude = firstPresent(
     entity.latitude,
     entity.lat,
     entity.location?.latitude,
     entity.location?.lat,
+    entity.role_location?.latitude,
+    entity.role_location?.lat,
+    entity.roleLocation?.latitude,
+    entity.roleLocation?.lat,
   ) ?? null;
   const longitude = firstPresent(
     entity.longitude,
@@ -230,6 +253,12 @@ export const normalizeLocationData = (entity) => {
     entity.location?.longitude,
     entity.location?.lng,
     entity.location?.lon,
+    entity.role_location?.longitude,
+    entity.role_location?.lng,
+    entity.role_location?.lon,
+    entity.roleLocation?.longitude,
+    entity.roleLocation?.lng,
+    entity.roleLocation?.lon,
   ) ?? null;
   const isRemote = entity.is_remote === true || entity.isRemote === true;
 


### PR DESCRIPTION
## Summary

This PR improves the search page distance controls and mixed-result distance sorting.

## Changes

- Renames the previous `Nearest` distance filter control to `Distance`.
- Uses the ruler icon for the distance filter.
- Adds a separate `Nearest First / Remote First` sorting toggle next to the distance filter.
- Keeps `Remote First` as a sorting option across mixed result types instead of forcing team-only results.
- Improves proximity sorting for mixed `All` results:
  - Teams, people, and open roles are merged before display sorting.
  - `Nearest First` sorts by distance globally across result types.
  - Remote items remain visible and are placed after mapped and unmapped local results.
  - Pagination now slices after the combined proximity sort, so closer items are not stranded on later pages.
- Updates the visible total count for mixed proximity pagination.

## Validation

- Ran frontend ESLint for the changed search page files.
- Ran `npm run build`.
- Build passes with the existing large chunk warning.
