### PR TITLE
UI/sorting filtering menu

### DIFF
--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -42,6 +42,7 @@ const BooleanSearchInput = ({
   onRemoveBadgePill,
   onSelectTagSuggestion,
   onSelectBadgeSuggestion,
+  leftAdornment = null,
 }) => {
   const [query, setQuery] = useState(initialQuery);
   const [hasBooleanOperators, setHasBooleanOperators] = useState(false);
@@ -66,13 +67,15 @@ const BooleanSearchInput = ({
   });
 
   const showMinQueryHint = query.trim().length > 0 && query.trim().length < 2;
+  const hasLeftAdornment = Boolean(leftAdornment);
+  const leftAdornmentWidthPx = hasLeftAdornment ? 24 : 0;
   const minimumInputWidthPx = query.trim().length > 0 ? 132 : 180;
   const inputTextWidthPx = Math.max(
     minimumInputWidthPx,
     query.trim().length > 0
       ? measuredTextWidths.query + 8
       : measuredTextWidths.placeholder + 12,
-  );
+  ) + leftAdornmentWidthPx;
 
   // Combined pill width calculations across all three groups
   const allPills = [...badgePills, ...focusAreaPills, ...activePills];
@@ -414,21 +417,27 @@ const BooleanSearchInput = ({
                 </div>
               )}
 
-              <input
-                ref={inputRef}
-                type="text"
-                value={query}
-                onChange={handleChange}
-                onKeyDown={handleKeyDown}
-                placeholder={placeholder}
-                className="w-full min-w-0 bg-transparent text-sm focus:outline-none"
-                style={{
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-                minLength={2}
-              />
+              <div className="flex min-w-0 items-center gap-2">
+                {hasLeftAdornment && (
+                  <div className="shrink-0">{leftAdornment}</div>
+                )}
+
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={query}
+                  onChange={handleChange}
+                  onKeyDown={handleKeyDown}
+                  placeholder={placeholder}
+                  className="min-w-0 flex-1 bg-transparent text-sm focus:outline-none"
+                  style={{
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                  minLength={2}
+                />
+              </div>
             </div>
 
             <div className={helperControlsClassName}>

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -27,6 +27,7 @@ import {
   Sparkles,
   ArrowDownAZ,
   ArrowUpZA,
+  RotateCcw,
   SlidersHorizontal,
   UserPlus,
   UserMinus,
@@ -1277,6 +1278,19 @@ const SearchPage = () => {
     setOpenSubmenuKey(null);
   };
 
+  const handleResetSortFilters = () => {
+    setSortBy("name");
+    setSortDir("asc");
+    setMaxDistance(null);
+    setCustomDistanceInput("");
+    setCapacityMode("spots");
+    setOpenRolesOnly(false);
+    setIncludeOwnTeams(true);
+    setIncludeDemoData(true);
+    setOpenSubmenuKey(null);
+    setCurrentPage(1);
+  };
+
   const handleSortChange = (newSortBy) => {
     let newSortDir = sortDir;
 
@@ -1891,6 +1905,25 @@ const SearchPage = () => {
                   onSelectTagSuggestion={handleAddTagFilter}
                   onSelectBadgeSuggestion={handleAddBadgeFilter}
                   onSearchSuggestions={handleSearchSuggestions}
+                  leftAdornment={
+                    isSortModified ? (
+                      <div className="transition-all duration-200 opacity-100 scale-100">
+                        <Tooltip content="Reset sorting and filters">
+                          <button
+                            type="button"
+                            onClick={handleResetSortFilters}
+                            className="shrink-0 rounded-lg p-0.5 transition-colors"
+                            aria-label="Reset sorting and filters"
+                          >
+                            <RotateCcw
+                              className="w-3.5 h-3.5"
+                              color="var(--color-primary-focus)"
+                            />
+                          </button>
+                        </Tooltip>
+                      </div>
+                    ) : null
+                  }
                   className="min-w-0 w-full sm:w-auto sm:max-w-full"
                 />
               </div>

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -467,15 +467,6 @@ const SearchPage = () => {
       authOnly: true,
     },
     {
-      value: "proximity",
-      defaultDir: "asc",
-      filterOnly: true,
-      labelAsc: "Distance",
-      shortLabelAsc: "Distance",
-      tooltipAsc: "Filter results by distance from your location",
-      iconAsc: Ruler,
-    },
-    {
       value: "locationPriority",
       sortValue: "proximity",
       defaultDir: "asc",
@@ -488,6 +479,15 @@ const SearchPage = () => {
       iconAsc: MapPin,
       iconRemote: Globe,
       requiresCoordinates: true,
+    },
+    {
+      value: "proximity",
+      defaultDir: "asc",
+      filterOnly: true,
+      labelAsc: "Distance",
+      shortLabelAsc: "Distance",
+      tooltipAsc: "Filter results by distance from your location",
+      iconAsc: Ruler,
     },
     {
       value: "capacity",

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1857,14 +1857,19 @@ const SearchPage = () => {
         >
           <div className="mx-auto w-full max-w-full sm:w-fit">
             <div className="flex w-full max-w-full items-center gap-2">
-              <button
-                type="button"
-                onClick={handleSortDropdownToggle}
-                className="shrink-0 rounded-lg p-2 transition-colors"
-                title="Sort options"
-              >
-                <SlidersHorizontal className="w-5 h-5" color={sortIconColor} />
-              </button>
+              <Tooltip content="Sorting & Filtering">
+                <button
+                  type="button"
+                  onClick={handleSortDropdownToggle}
+                  className="shrink-0 rounded-lg p-2 transition-colors"
+                  aria-label="Sorting & Filtering"
+                >
+                  <SlidersHorizontal
+                    className="w-5 h-5"
+                    color={sortIconColor}
+                  />
+                </button>
+              </Tooltip>
 
               <div className="min-w-0 flex-1 sm:w-auto sm:flex-none sm:max-w-full">
                 <BooleanSearchInput


### PR DESCRIPTION
## Summary

- Reordered the search sort/filter options so `Distance` appears after `Nearest First / Remote First`.
- Updated the sliders tooltip to use the Lomir tooltip styling and renamed it to `Sorting & Filtering`.
- Added a reset sorting/filter control inside the search input, shown only when sort/display filters are modified.
- Added a `leftAdornment` slot to `BooleanSearchInput` so the reset control can sit before the placeholder/search text.

## Testing

- `npx eslint src/pages/SearchPage.jsx`
- `npx eslint src/pages/SearchPage.jsx src/components/BooleanSearchInput.jsx`

Note: full `npm run lint` still fails due to existing unrelated lint errors across the repo.
