### PR TITLE
UI/map view fine tune

### DIFF
--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2777,7 +2777,7 @@ const SearchMapView = ({
             </MapContainer>
           </div>
 
-          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:max-h-[520px] lg:w-[260px] lg:overflow-y-auto lg:rounded-xl lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm">
+          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:max-h-[520px] lg:w-[260px] lg:overflow-y-auto lg:rounded-bl-xl lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm">
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-sm font-bold text-base-content">Mapped results</h3>
               <span className="text-xs text-base-content/60">

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2701,7 +2701,7 @@ const SearchMapView = ({
   return (
     <div className="space-y-4">
       <div className="overflow-hidden rounded-xl border border-base-200 bg-base-100/80 shadow-soft">
-        <div className="grid min-h-[520px] grid-cols-1 lg:grid-cols-[minmax(0,1fr)_260px]">
+        <div className="relative min-h-[360px] lg:min-h-[520px]">
           <div className="relative min-h-[360px]">
             {markerPoints.length === 0 && (
               <div className="pointer-events-none absolute left-1/2 top-4 z-[500] w-[min(calc(100%-2rem),26rem)] -translate-x-1/2 rounded-lg border border-base-200 bg-white/90 px-4 py-2 text-center text-sm text-base-content/70 shadow-soft backdrop-blur-sm">
@@ -2774,7 +2774,7 @@ const SearchMapView = ({
             </MapContainer>
           </div>
 
-          <aside className="flex min-h-[260px] flex-col border-t border-base-200 bg-base-100/75 p-4 lg:h-[520px] lg:border-l lg:border-t-0">
+          <aside className="flex flex-col border-t border-base-200 bg-white/85 p-4 backdrop-blur-sm lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0">
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-sm font-bold text-base-content">Mapped results</h3>
               <span className="text-xs text-base-content/60">

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2777,7 +2777,7 @@ const SearchMapView = ({
             </MapContainer>
           </div>
 
-          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0 lg:bg-white/85 lg:backdrop-blur-sm">
+          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm">
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-sm font-bold text-base-content">Mapped results</h3>
               <span className="text-xs text-base-content/60">

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
+  AttributionControl,
   Circle,
   MapContainer,
   Marker,
@@ -2715,7 +2716,9 @@ const SearchMapView = ({
               maxBounds={[[-90, -180], [90, 180]]}
               maxBoundsViscosity={1}
               className="h-[360px] w-full lg:h-[520px]"
+              attributionControl={false}
             >
+              <AttributionControl position="bottomleft" />
               <MapInstanceCapture onReady={setMapInstance} />
               <TileLayer
                 attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2704,10 +2704,14 @@ const SearchMapView = ({
   useEffect(() => {
     const el = asideRef.current;
     if (!el) return;
-    const observer = new ResizeObserver(() => {
-      setAsideAtFullHeight(el.scrollHeight > el.clientHeight);
-    });
+    const parent = el.parentElement;
+    const check = () => {
+      if (!parent) return;
+      setAsideAtFullHeight(el.offsetHeight >= parent.clientHeight - 2);
+    };
+    const observer = new ResizeObserver(check);
     observer.observe(el);
+    if (parent) observer.observe(parent);
     return () => observer.disconnect();
   }, []);
 

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2777,7 +2777,7 @@ const SearchMapView = ({
             </MapContainer>
           </div>
 
-          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:max-h-[520px] lg:w-[260px] lg:overflow-y-auto lg:rounded-bl-xl lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm">
+          <aside className={`flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:max-h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm${fallbackPoints.length === 0 ? " lg:rounded-bl-xl" : ""}`}>
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-sm font-bold text-base-content">Mapped results</h3>
               <span className="text-xs text-base-content/60">

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2777,7 +2777,7 @@ const SearchMapView = ({
             </MapContainer>
           </div>
 
-          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm">
+          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:max-h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm">
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-sm font-bold text-base-content">Mapped results</h3>
               <span className="text-xs text-base-content/60">

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2777,7 +2777,7 @@ const SearchMapView = ({
             </MapContainer>
           </div>
 
-          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:max-h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm">
+          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:max-h-[520px] lg:w-[260px] lg:overflow-y-auto lg:rounded-xl lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm">
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-sm font-bold text-base-content">Mapped results</h3>
               <span className="text-xs text-base-content/60">

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2774,7 +2774,7 @@ const SearchMapView = ({
             </MapContainer>
           </div>
 
-          <aside className="flex flex-col border-t border-base-200 bg-white/85 p-4 backdrop-blur-sm lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0">
+          <aside className="flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0 lg:bg-white/85 lg:backdrop-blur-sm">
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-sm font-bold text-base-content">Mapped results</h3>
               <span className="text-xs text-base-content/60">

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2699,6 +2699,18 @@ const SearchMapView = ({
       selectedRolePoint
     : null;
 
+  const asideRef = useRef(null);
+  const [asideAtFullHeight, setAsideAtFullHeight] = useState(false);
+  useEffect(() => {
+    const el = asideRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      setAsideAtFullHeight(el.scrollHeight > el.clientHeight);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div className="space-y-4">
       <div className="overflow-hidden rounded-xl border border-base-200 bg-base-100/80 shadow-soft">
@@ -2777,7 +2789,7 @@ const SearchMapView = ({
             </MapContainer>
           </div>
 
-          <aside className={`flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:max-h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm${fallbackPoints.length === 0 ? " lg:rounded-bl-xl" : ""}`}>
+          <aside ref={asideRef} className={`flex flex-col border-t border-base-200 bg-base-100/75 p-4 lg:absolute lg:right-0 lg:top-0 lg:z-[500] lg:max-h-[520px] lg:w-[260px] lg:overflow-y-auto lg:border-l lg:border-t-0 lg:bg-white/70 lg:backdrop-blur-sm${!asideAtFullHeight ? " lg:rounded-bl-xl" : ""}`}>
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-sm font-bold text-base-content">Mapped results</h3>
               <span className="text-xs text-base-content/60">

--- a/src/index.css
+++ b/src/index.css
@@ -206,6 +206,41 @@
     border-bottom: 6px solid #ffffff;
     border-left: 6px solid transparent;
   }
+
+  /* --- Lomir: Leaflet zoom controls --- */
+  .leaflet-control-zoom.leaflet-bar {
+    border: none;
+    border-radius: 0.625rem;
+    box-shadow: var(--shadow-soft);
+    overflow: hidden;
+  }
+
+  .leaflet-control-zoom.leaflet-bar a {
+    width: 32px;
+    height: 32px;
+    line-height: 32px;
+    background-color: rgba(255, 255, 255, 0.82);
+    backdrop-filter: blur(var(--blur-amount));
+    -webkit-backdrop-filter: blur(var(--blur-amount));
+    border-bottom: 1px solid var(--color-border);
+    color: var(--color-primary-focus);
+    font-size: 1.1rem;
+    font-weight: 400;
+    transition: background-color 150ms ease;
+  }
+
+  .leaflet-control-zoom.leaflet-bar a:last-child {
+    border-bottom: none;
+  }
+
+  .leaflet-control-zoom.leaflet-bar a:hover {
+    background-color: rgba(255, 255, 255, 0.96);
+  }
+
+  .leaflet-control-zoom.leaflet-bar a.leaflet-disabled {
+    color: var(--color-border);
+    background-color: rgba(255, 255, 255, 0.6);
+  }
 }
 
 :root {

--- a/src/index.css
+++ b/src/index.css
@@ -211,7 +211,7 @@
   .leaflet-control-zoom.leaflet-bar {
     border: none;
     border-radius: 0.625rem;
-    box-shadow: var(--shadow-soft);
+    box-shadow: none;
     overflow: hidden;
   }
 

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1920,7 +1920,7 @@ const SearchPage = () => {
   };
   return (
     <PageContainer
-      title="Search teams or users"
+      title="Search teams, people or open roles"
       titleAlignment="center"
       variant="muted"
     >

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -286,7 +286,7 @@ const SearchPage = () => {
   const [capacityMode, setCapacityMode] = useState("spots");
 
   // ===== RESULT VIEW STATE =====
-  const [resultView, setResultView] = useState("card");
+  const [resultView, setResultView] = useState("map");
 
   // ===== ROLE MATCH CONTEXT STATE =====
   const [matchRoleId, setMatchRoleId] = useState(() => {


### PR DESCRIPTION
A series of UI refinements to the search page map view, improving layout, visual consistency, and usability.

Changes
Map overlay panel

Converted the results sidebar from a fixed grid column into a floating overlay panel on desktop — the map now uses the full horizontal width
Overlay uses a frosted-glass background (bg-white/70 + backdrop-blur) on desktop, restoring the original solid background on mobile/narrow screens
Panel height adapts to its content: shrinks to fit when only the mapped results legend is visible, capped at full map height when the unmapped results list is long
Bottom-left border radius is applied only when the panel doesn't cover the full map height (detected via ResizeObserver), keeping corners clean when the panel spans edge to edge
Map controls

Moved the Leaflet attribution text from the bottom-right to the bottom-left corner
Restyled the zoom buttons to match Lomir's design language: frosted-glass background, --color-border divider, primary-focus icon color, no drop shadow
Search page

Map view is now the default view mode on page load
Page headline updated to "Search teams, people or open roles"