### PR TITLE
Chat Page UI Improvements

### DIFF
--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -219,7 +219,7 @@ const ConversationList = ({
 
   return (
     <>
-      <div className="divide-y divide-base-200">
+      <div className="divide-y divide-base-200 w-full min-w-0">
         {conversations.map((conversation) => {
           // Handle both direct messages and team conversations
           const isTeam = conversation.type === "team";
@@ -355,20 +355,14 @@ const ConversationList = ({
                 </Tooltip>
 
                 <div className="flex-grow min-w-0 flex flex-col justify-center">
-                  <div className="flex justify-between items-center">
+                  <div className="flex justify-between items-center min-w-0">
                     {/* Name - Clickable for both team and direct conversations */}
                     <Tooltip
-                      content={
-                        isTeam
-                          ? `View ${conversationData?.name} details`
-                          : isUserClickable
-                            ? `View ${displayName} details`
-                            : undefined
-                      }
-                      wrapperClassName="min-w-0 flex-1"
+                      content={displayName?.length > 22 ? displayName : undefined}
+                      wrapperClassName="block min-w-0 flex-1 overflow-hidden"
                     >
                       <h3
-                        className={`font-medium truncate ${
+                        className={`font-medium truncate text-sm ${
                           isTeam || isUserClickable
                             ? "cursor-pointer hover:text-primary transition-colors"
                             : ""
@@ -386,17 +380,27 @@ const ConversationList = ({
                       </h3>
                     </Tooltip>
                   </div>
-                  <p className="text-sm text-base-content/70 truncate">
-                    {conversation.lastMessage || "No messages yet"}
-                  </p>
-                  <div className="flex justify-between items-center">
+                  <Tooltip
+                    content={
+                      (conversation.lastMessage?.length ?? 0) > 60
+                        ? conversation.lastMessage
+                        : undefined
+                    }
+                    position="bottom"
+                    wrapperClassName="block min-w-0 overflow-hidden"
+                  >
+                    <p className="text-sm text-base-content/70 truncate">
+                      {conversation.lastMessage || "No messages yet"}
+                    </p>
+                  </Tooltip>
+                  <div className="flex items-center min-w-0">
                     <p
-                      className="text-xs"
+                      className="text-xs truncate flex-1 min-w-0"
                       style={{ color: "#036b0c" }}
                     >
                       {isTeam ? "Team Chat" : "Direct Message"}
                     </p>
-                    <span className="whitespace-nowrap ml-2 text-xs" style={{ color: "#036b0c" }}>
+                    <span className="flex-shrink-0 ml-2 text-xs whitespace-nowrap" style={{ color: "#036b0c" }}>
                       {conversation.updatedAt
                         ? formatDistanceToNow(
                             new Date(conversation.updatedAt),
@@ -410,13 +414,14 @@ const ConversationList = ({
                 </div>
 
                 {/* Chevron button - visible on mobile, hover on desktop */}
-                <button
-                  onClick={() => onSelectConversation(conversation.id)}
-                  className="flex items-center justify-center p-2 ml-2 flex-shrink-0 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
-                  title="Open conversation"
-                >
-                  <ChevronRight size={20} className="text-base-content/70" />
-                </button>
+                <Tooltip content="Open conversation" position="top" wrapperClassName="inline-flex items-center flex-shrink-0 ml-1 -mr-4">
+                  <button
+                    onClick={() => onSelectConversation(conversation.id)}
+                    className="flex items-center justify-center p-2 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+                  >
+                    <ChevronRight size={16} className="text-base-content/70" />
+                  </button>
+                </Tooltip>
               </div>
             </div>
           );

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -1,4 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
+import { Users, User } from "lucide-react";
+import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
+import Tooltip from "../common/Tooltip";
 import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
 import { formatDistanceToNow } from "date-fns";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
@@ -264,7 +267,7 @@ const ConversationList = ({
                 p-4 cursor-pointer transition-colors duration-200
                 ${
                   isActive
-                    ? "bg-green-100 border-l-4 border-green-500"
+                    ? "bg-green-100"
                     : "hover:bg-base-200/50"
                 }
               `}
@@ -272,8 +275,18 @@ const ConversationList = ({
             >
               <div className="flex items-center">
                 {/* Avatar - Clickable for both team and direct conversations */}
+                <Tooltip
+                  content={
+                    isTeam
+                      ? `View ${conversationData?.name} details`
+                      : isUserClickable
+                        ? `View ${displayName} details`
+                        : undefined
+                  }
+                  wrapperClassName="inline-flex items-center mr-3"
+                >
                 <div
-                  className={`avatar indicator mr-3 ${
+                  className={`avatar indicator relative ${
                     isTeam || isUserClickable
                       ? "cursor-pointer hover:opacity-80 transition-opacity"
                       : ""
@@ -285,16 +298,13 @@ const ConversationList = ({
                         ? (e) => handleUserClick(e, conversationData)
                         : undefined
                   }
-                  title={
-                    isTeam
-                      ? `View ${conversationData?.name} details`
-                      : isUserClickable
-                        ? `View ${displayName} details`
-                        : undefined
-                  }
                 >
+                  <SearchResultTypeOverlay
+                    icon={isTeam ? Users : User}
+                    bgClassName={isTeam ? "bg-pink-500" : "bg-success"}
+                  />
                   {isTeam ? (
-                    <div className="w-12 h-12 rounded-full relative overflow-hidden">
+                    <div className="w-14 h-14 rounded-full relative overflow-hidden">
                       {getTeamAvatarUrl(conversationData) ? (
                         <img
                           src={getTeamAvatarUrl(conversationData)}
@@ -318,23 +328,23 @@ const ConversationList = ({
                             : "flex",
                         }}
                       >
-                        <span className="text-lg font-medium">
+                        <span className="text-xl font-medium">
                           {getTeamInitials(conversationData)}
                         </span>
                       </div>
                       {isSyntheticTeam(conversationData) && (
-                        <DemoAvatarOverlay textClassName="text-[7px]" />
+                        <DemoAvatarOverlay textClassName="text-[8px]" />
                       )}
                     </div>
                   ) : (
                     <UserAvatar
                       user={isFormerPartner ? null : conversationData}
                       deleted={isFormerPartner}
-                      sizeClass="w-12 h-12"
-                      iconSize={24}
-                      initialsClassName="text-lg font-medium"
+                      sizeClass="w-14 h-14"
+                      iconSize={28}
+                      initialsClassName="text-xl font-medium"
                       showDemoOverlay
-                      demoOverlayTextClassName="text-[7px]"
+                      demoOverlayTextClassName="text-[8px]"
                       demoOverlayTextTranslateClassName="-translate-y-[2px]"
                     />
                   )}
@@ -342,50 +352,61 @@ const ConversationList = ({
                     <span className="indicator-item badge badge-success badge-xs"></span>
                   )}
                 </div>
+                </Tooltip>
 
-                <div className="flex-grow min-w-0">
+                <div className="flex-grow min-w-0 flex flex-col justify-center">
                   <div className="flex justify-between items-center">
                     {/* Name - Clickable for both team and direct conversations */}
-                    <h3
-                      className={`font-medium truncate ${
-                        isTeam || isUserClickable
-                          ? "cursor-pointer hover:text-primary transition-colors"
-                          : ""
-                      }`}
-                      onClick={
-                        isTeam
-                          ? (e) => handleTeamClick(e, conversationData)
-                          : isUserClickable
-                            ? (e) => handleUserClick(e, conversationData)
-                            : undefined
-                      }
-                      title={
+                    <Tooltip
+                      content={
                         isTeam
                           ? `View ${conversationData?.name} details`
                           : isUserClickable
                             ? `View ${displayName} details`
                             : undefined
                       }
+                      wrapperClassName="min-w-0 flex-1"
                     >
-                      {displayName || "Unknown"}
-                    </h3>
-                    <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
+                      <h3
+                        className={`font-medium truncate ${
+                          isTeam || isUserClickable
+                            ? "cursor-pointer hover:text-primary transition-colors"
+                            : ""
+                        }`}
+                        style={{ color: "#036b0c" }}
+                        onClick={
+                          isTeam
+                            ? (e) => handleTeamClick(e, conversationData)
+                            : isUserClickable
+                              ? (e) => handleUserClick(e, conversationData)
+                              : undefined
+                        }
+                      >
+                        {displayName || "Unknown"}
+                      </h3>
+                    </Tooltip>
+                  </div>
+                  <p className="text-sm text-base-content/70 truncate">
+                    {conversation.lastMessage || "No messages yet"}
+                  </p>
+                  <div className="flex justify-between items-center">
+                    <p
+                      className="text-xs"
+                      style={{ color: "#036b0c" }}
+                    >
+                      {isTeam ? "Team Chat" : "Direct Message"}
+                    </p>
+                    <span className="whitespace-nowrap ml-2 text-xs" style={{ color: "#036b0c" }}>
                       {conversation.updatedAt
                         ? formatDistanceToNow(
                             new Date(conversation.updatedAt),
                             {
                               addSuffix: true,
                             },
-                          )
+                          ).replace("about ", "")
                         : ""}
                     </span>
                   </div>
-                  <p className="text-sm text-base-content/70 truncate">
-                    {conversation.lastMessage || "No messages yet"}
-                  </p>
-                  <p className="text-xs" style={{ color: "#036b0c" }}>
-                    {isTeam ? "Team Chat" : "Direct Message"}
-                  </p>
                 </div>
               </div>
             </div>

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Users, User } from "lucide-react";
+import { Users, User, ChevronRight } from "lucide-react";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import Tooltip from "../common/Tooltip";
 import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
@@ -264,7 +264,7 @@ const ConversationList = ({
               key={`${conversation.type}-${conversation.id}`}
               ref={isActive ? activeConversationRef : null}
               className={`
-                p-4 cursor-pointer transition-colors duration-200
+                p-4 cursor-pointer transition-colors duration-200 group
                 ${
                   isActive
                     ? "bg-green-100"
@@ -408,6 +408,15 @@ const ConversationList = ({
                     </span>
                   </div>
                 </div>
+
+                {/* Chevron button - visible on mobile, hover on desktop */}
+                <button
+                  onClick={() => onSelectConversation(conversation.id)}
+                  className="flex items-center justify-center p-2 ml-2 flex-shrink-0 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+                  title="Open conversation"
+                >
+                  <ChevronRight size={20} className="text-base-content/70" />
+                </button>
               </div>
             </div>
           );

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -30,6 +30,7 @@ import {
   formatFileSize,
 } from "../../utils/fileExpiration";
 import MessageText from "./MessageText";
+import Tooltip from "../common/Tooltip";
 import {
   DELETED_USER_DISPLAY_NAME,
   getDisplayName as getDeletedUserDisplayName,
@@ -719,15 +720,16 @@ const MessageDisplay = ({
     }
 
     return (
-      <button
-        type="button"
-        className="font-medium underline underline-offset-2 hover:no-underline hover:text-primary transition-colors"
-        onClick={() => handleMentionClick(safe)}
-        disabled={resolvingName}
-        title={`Open ${safe}`}
-      >
-        {safe}
-      </button>
+      <Tooltip content={`Open ${safe}`} position="top">
+        <button
+          type="button"
+          className="font-medium underline underline-offset-2 hover:no-underline hover:text-primary transition-colors"
+          onClick={() => handleMentionClick(safe)}
+          disabled={resolvingName}
+        >
+          {safe}
+        </button>
+      </Tooltip>
     );
   };
 
@@ -742,14 +744,15 @@ const MessageDisplay = ({
     }
 
     return (
-      <button
-        type="button"
-        className="font-medium underline underline-offset-2 hover:no-underline hover:text-primary transition-colors"
-        onClick={() => handleUserClick(userId, safeName)}
-        title={`Open ${safeName}`}
-      >
-        {safeName}
-      </button>
+      <Tooltip content={`Open ${safeName}`} position="top">
+        <button
+          type="button"
+          className="font-medium underline underline-offset-2 hover:no-underline hover:text-primary transition-colors"
+          onClick={() => handleUserClick(userId, safeName)}
+        >
+          {safeName}
+        </button>
+      </Tooltip>
     );
   };
 
@@ -774,14 +777,15 @@ const MessageDisplay = ({
     if (!teamId) return <span className="font-medium">"{safeName}"</span>;
 
     return (
-      <button
-        type="button"
-        className="font-medium underline underline-offset-2 hover:no-underline hover:text-primary transition-colors"
-        onClick={() => openTeamModal(teamId)}
-        title={`Open ${safeName}`}
-      >
-        "{safeName}"
-      </button>
+      <Tooltip content={`Open ${safeName}`} position="top">
+        <button
+          type="button"
+          className="font-medium underline underline-offset-2 hover:no-underline hover:text-primary transition-colors"
+          onClick={() => openTeamModal(teamId)}
+        >
+          "{safeName}"
+        </button>
+      </Tooltip>
     );
   };
 
@@ -898,52 +902,51 @@ const MessageDisplay = ({
 
     if (isDeletedSender) {
       return (
-        <UserAvatar
-          user={senderInfo}
-          deleted
-          sizeClass="w-8 h-8"
-          className="mr-2 flex-shrink-0"
-          iconSize={16}
-          title={DELETED_USER_DISPLAY_NAME}
-        />
+        <Tooltip content={DELETED_USER_DISPLAY_NAME} wrapperClassName="inline-flex flex-shrink-0 mr-2">
+          <UserAvatar
+            user={senderInfo}
+            deleted
+            sizeClass="w-8 h-8"
+            iconSize={16}
+          />
+        </Tooltip>
       );
     }
 
     if (!isFormerMember) {
       return (
-        <UserAvatar
-          user={senderInfo}
-          sizeClass="w-8 h-8"
-          className="mr-2 flex-shrink-0"
-          clickable={Boolean(isClickable)}
-          onClick={handleClick}
-          title={
-            isClickable
-              ? `View ${getSenderDisplayName(senderInfo, false)} details`
-              : undefined
-          }
-          iconSize={16}
-          initialsClassName="text-sm font-medium event-message-text"
-          showDemoOverlay
-          demoOverlayTextClassName="text-[5px]"
-          demoOverlayTextTranslateClassName="-translate-y-[1px]"
-        />
+        <Tooltip
+          content={isClickable ? `View ${getSenderDisplayName(senderInfo, false)} details` : undefined}
+          wrapperClassName="inline-flex flex-shrink-0 mr-2"
+        >
+          <UserAvatar
+            user={senderInfo}
+            sizeClass="w-8 h-8"
+            clickable={Boolean(isClickable)}
+            onClick={handleClick}
+            iconSize={16}
+            initialsClassName="text-sm font-medium event-message-text"
+            showDemoOverlay
+            demoOverlayTextClassName="text-[5px]"
+            demoOverlayTextTranslateClassName="-translate-y-[1px]"
+          />
+        </Tooltip>
       );
     }
 
+    const formerMemberTooltip = isClickable
+      ? `View ${getSenderDisplayName(senderInfo, false)} details`
+      : isFormerMember
+        ? "Former team member"
+        : undefined;
+
     return (
+      <Tooltip content={formerMemberTooltip} wrapperClassName="inline-flex flex-shrink-0 mr-2">
       <div
-        className={`avatar mr-2 flex-shrink-0 ${
+        className={`avatar ${
           isClickable ? "cursor-pointer hover:opacity-80 transition-opacity" : ""
         } ${isFormerMember ? "opacity-70" : ""}`}
         onClick={handleClick}
-        title={
-          isClickable
-            ? `View ${getSenderDisplayName(senderInfo, false)} details`
-            : isFormerMember
-              ? "Former team member"
-              : undefined
-        }
       >
         <div className="w-8 h-8 rounded-full relative">
           <div
@@ -955,6 +958,7 @@ const MessageDisplay = ({
           </div>
         </div>
       </div>
+      </Tooltip>
     );
   };
 
@@ -967,26 +971,28 @@ const MessageDisplay = ({
     const canClick = Boolean(!isDeletedSender && senderId);
 
     return (
-      <div
-        className={[
-          className,
-          canClick ? "cursor-pointer hover:text-primary transition-colors" : "",
-          isDeletedSender ? "text-base-content/50" : "",
-        ].join(" ")}
-        style={
-          isDeletedSender
-            ? undefined
-            : {
-                color: isFormerMember ? "#6b7280" : "#036b0c",
-              }
-        }
-        onClick={canClick ? () => handleUserClick(senderId, displayName) : undefined}
-        title={
-          canClick ? `View ${getSenderDisplayName(senderInfo, false)} details` : undefined
-        }
+      <Tooltip
+        content={canClick ? `View ${getSenderDisplayName(senderInfo, false)} details` : undefined}
+        position="top"
       >
-        {displayName}
-      </div>
+        <div
+          className={[
+            className,
+            canClick ? "cursor-pointer hover:text-primary transition-colors" : "",
+            isDeletedSender ? "text-base-content/50" : "",
+          ].join(" ")}
+          style={
+            isDeletedSender
+              ? undefined
+              : {
+                  color: isFormerMember ? "#6b7280" : "#036b0c",
+                }
+          }
+          onClick={canClick ? () => handleUserClick(senderId, displayName) : undefined}
+        >
+          {displayName}
+        </div>
+      </Tooltip>
     );
   };
 
@@ -994,22 +1000,22 @@ const MessageDisplay = ({
     if (!resolvedConversationPartner) return null;
 
     return (
-      <UserAvatar
-        user={resolvedConversationPartner}
-        sizeClass="w-16 h-16"
-        className="mb-2 mx-auto"
-        clickable
-        onClick={() => handleUserClick(resolvedConversationPartner.id)}
-        title={`View ${
-          resolvedConversationPartner.firstName ||
-          resolvedConversationPartner.username
-        } details`}
-        iconSize={24}
-        initialsClassName="text-xl font-medium"
-        showDemoOverlay
-        demoOverlayTextClassName="text-[9px]"
-        demoOverlayTextTranslateClassName="-translate-y-[4px]"
-      />
+      <Tooltip
+        content={`View ${resolvedConversationPartner.firstName || resolvedConversationPartner.username} details`}
+        wrapperClassName="inline-flex mb-2 mx-auto"
+      >
+        <UserAvatar
+          user={resolvedConversationPartner}
+          sizeClass="w-16 h-16"
+          clickable
+          onClick={() => handleUserClick(resolvedConversationPartner.id)}
+          iconSize={24}
+          initialsClassName="text-xl font-medium"
+          showDemoOverlay
+          demoOverlayTextClassName="text-[9px]"
+          demoOverlayTextTranslateClassName="-translate-y-[4px]"
+        />
+      </Tooltip>
     );
   };
 
@@ -1019,10 +1025,10 @@ const MessageDisplay = ({
     const teamAvatarUrl = getTeamAvatarUrl(resolvedTeamData);
 
     return (
+      <Tooltip content={`View ${resolvedTeamData.name} details`} wrapperClassName="inline-flex mb-2">
       <div
-        className="avatar mb-2 cursor-pointer hover:opacity-80 transition-opacity"
+        className="avatar cursor-pointer hover:opacity-80 transition-opacity"
         onClick={handleTeamClick}
-        title={`View ${resolvedTeamData.name} details`}
       >
         <div className="w-16 h-16 rounded-full mx-auto relative overflow-hidden">
           {teamAvatarUrl ? (
@@ -1054,6 +1060,7 @@ const MessageDisplay = ({
           )}
         </div>
       </div>
+      </Tooltip>
     );
   };
 
@@ -2206,32 +2213,37 @@ const MessageDisplay = ({
           {resolvedConversationPartner && conversationType === "direct" && (
             <div className="text-center pb-4 mb-4 border-b border-base-200">
               {renderConversationPartnerAvatar()}
-              <h3
-                className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
-                onClick={() => handleUserClick(resolvedConversationPartner.id)}
-                title={`View ${
-                  resolvedConversationPartner.firstName ||
-                  resolvedConversationPartner.username
-                } details`}
+              <Tooltip
+                content={`View ${resolvedConversationPartner.firstName || resolvedConversationPartner.username} details`}
+                wrapperClassName="block"
               >
-                {resolvedConversationPartner.firstName &&
-                resolvedConversationPartner.lastName
-                  ? `${resolvedConversationPartner.firstName} ${resolvedConversationPartner.lastName}`
-                  : resolvedConversationPartner.username}
-              </h3>
+                <h3
+                  className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
+                  onClick={() => handleUserClick(resolvedConversationPartner.id)}
+                >
+                  {resolvedConversationPartner.firstName &&
+                  resolvedConversationPartner.lastName
+                    ? `${resolvedConversationPartner.firstName} ${resolvedConversationPartner.lastName}`
+                    : resolvedConversationPartner.username}
+                </h3>
+              </Tooltip>
             </div>
           )}
 
           {resolvedTeamData && conversationType === "team" && (
             <div className="text-center pb-4 mb-4 border-b border-base-200">
               {renderTeamConversationAvatar()}
-              <h3
-                className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
-                onClick={handleTeamClick}
-                title={`View ${resolvedTeamData.name} details`}
+              <Tooltip
+                content={`View ${resolvedTeamData.name} details`}
+                wrapperClassName="block"
               >
-                {resolvedTeamData.name}
-              </h3>
+                <h3
+                  className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
+                  onClick={handleTeamClick}
+                >
+                  {resolvedTeamData.name}
+                </h3>
+              </Tooltip>
             </div>
           )}
 
@@ -2312,19 +2324,20 @@ const MessageDisplay = ({
         {resolvedConversationPartner && conversationType === "direct" && (
           <div className="text-center pb-4 mb-4 border-b border-base-200">
             {renderConversationPartnerAvatar()}
-            <h3
-              className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
-              onClick={() => handleUserClick(resolvedConversationPartner.id)}
-              title={`View ${
-                resolvedConversationPartner.firstName ||
-                resolvedConversationPartner.username
-              } details`}
+            <Tooltip
+              content={`View ${resolvedConversationPartner.firstName || resolvedConversationPartner.username} details`}
+              wrapperClassName="block"
             >
-              {resolvedConversationPartner.firstName &&
-              resolvedConversationPartner.lastName
-                ? `${resolvedConversationPartner.firstName} ${resolvedConversationPartner.lastName}`
-                : resolvedConversationPartner.username}
-            </h3>
+              <h3
+                className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
+                onClick={() => handleUserClick(resolvedConversationPartner.id)}
+              >
+                {resolvedConversationPartner.firstName &&
+                resolvedConversationPartner.lastName
+                  ? `${resolvedConversationPartner.firstName} ${resolvedConversationPartner.lastName}`
+                  : resolvedConversationPartner.username}
+              </h3>
+            </Tooltip>
           </div>
         )}
 
@@ -2332,13 +2345,17 @@ const MessageDisplay = ({
         {resolvedTeamData && conversationType === "team" && (
           <div className="text-center pb-4 mb-4 border-b border-base-200">
             {renderTeamConversationAvatar()}
-            <h3
-              className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
-              onClick={handleTeamClick}
-              title={`View ${resolvedTeamData.name} details`}
+            <Tooltip
+              content={`View ${resolvedTeamData.name} details`}
+              wrapperClassName="block"
             >
-              {resolvedTeamData.name}
-            </h3>
+              <h3
+                className="text-lg font-medium leading-[120%] mb-[0.2em] cursor-pointer hover:text-primary transition-colors"
+                onClick={handleTeamClick}
+              >
+                {resolvedTeamData.name}
+              </h3>
+            </Tooltip>
           </div>
         )}
 
@@ -2680,22 +2697,22 @@ const MessageDisplay = ({
                               !isDeleted &&
                               !String(message.id).startsWith("temp-") &&
                               typeof onDeleteMessage === "function" && (
-                                <button
-                                  type="button"
-                                  onClick={() => onDeleteMessage(message.id)}
-                                  className="
-          absolute -top-2 -right-2
-          opacity-0 group-hover:opacity-100 transition-opacity
-          bg-base-100 border border-base-300 rounded-full p-1 shadow-sm
-          hover:shadow
-        "
-                                  title="Delete message"
+                                <Tooltip
+                                  content="Delete message"
+                                  position="top"
+                                  wrapperClassName="absolute -top-2 -right-2 opacity-0 group-hover:opacity-100 transition-opacity inline-flex"
                                 >
-                                  <Trash2
-                                    size={14}
-                                    className="text-base-content/50 hover:text-error"
-                                  />
-                                </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => onDeleteMessage(message.id)}
+                                    className="bg-base-100 border border-base-300 rounded-full p-1 shadow-sm hover:shadow"
+                                  >
+                                    <Trash2
+                                      size={14}
+                                      className="text-base-content/50 hover:text-error"
+                                    />
+                                  </button>
+                                </Tooltip>
                               )}
 
                             {/* Only render media/text when NOT deleted */}

--- a/src/components/chat/MessageText.jsx
+++ b/src/components/chat/MessageText.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Cloud, Link as LinkIcon, ExternalLink } from "lucide-react";
+import Tooltip from "../common/Tooltip";
 
 // --- helpers -------------------------------------------------
 
@@ -100,44 +101,46 @@ const LinkChip = ({ href }) => {
   const { label, Icon } = classifyUrl(href);
 
   return (
+    <Tooltip content={href} position="top">
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="
+          inline-flex items-center gap-2
+          px-2 py-1 rounded-lg
+          bg-base-100/60 hover:bg-base-100
+          border border-base-200
+          text-sm text-base-content
+          max-w-full align-middle
+        "
+      >
+        <Icon size={16} className="text-primary flex-shrink-0" />
+        <span className="font-medium whitespace-nowrap">{label}</span>
+        <span className="text-base-content/60 truncate max-w-[12rem]">
+          {shortenForDisplay(href)}
+        </span>
+        <ExternalLink size={14} className="text-base-content/40 flex-shrink-0" />
+      </a>
+    </Tooltip>
+  );
+};
+
+const PlainLink = ({ href }) => (
+  <Tooltip content={href} position="top">
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
       className="
-        inline-flex items-center gap-2 
-        px-2 py-1 rounded-lg 
-        bg-base-100/60 hover:bg-base-100
-        border border-base-200
-        text-sm text-base-content
-        max-w-full align-middle
+        underline underline-offset-2
+        text-primary hover:no-underline
+        break-words
       "
-      title={href}
     >
-      <Icon size={16} className="text-primary flex-shrink-0" />
-      <span className="font-medium whitespace-nowrap">{label}</span>
-      <span className="text-base-content/60 truncate max-w-[12rem]">
-        {shortenForDisplay(href)}
-      </span>
-      <ExternalLink size={14} className="text-base-content/40 flex-shrink-0" />
+      {shortenForDisplay(href)}
     </a>
-  );
-};
-
-const PlainLink = ({ href }) => (
-  <a
-    href={href}
-    target="_blank"
-    rel="noopener noreferrer"
-    className="
-      underline underline-offset-2
-      text-primary hover:no-underline
-      break-words
-    "
-    title={href}
-  >
-    {shortenForDisplay(href)}
-  </a>
+  </Tooltip>
 );
 
 export default function MessageText({ content }) {

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1222,7 +1222,7 @@ const Chat = () => {
       <div className="flex h-[calc(100vh-200px)] bg-base-100 rounded-xl overflow-hidden">
         {/* Conversation List - Left Sidebar */}
         <div className={`border-r border-base-200 overflow-y-auto transition-all duration-300 ${
-          showChatView ? "hidden md:flex md:w-1/3" : "w-full md:w-1/3"
+          showChatView ? "hidden md:block md:w-1/3" : "w-full md:w-1/3"
         }`}>
           <ConversationList
             conversations={conversations}

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { LogOut } from "lucide-react";
+import { LogOut, ChevronRight, ChevronLeft } from "lucide-react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import PageContainer from "../components/layout/PageContainer";
 import ConversationList from "../components/chat/ConversationList";
@@ -59,6 +59,7 @@ const Chat = () => {
   const [loadingMore, setLoadingMore] = useState(false);
   const [teamMembersRefreshSignal, setTeamMembersRefreshSignal] =
     useState(null);
+  const [showChatView, setShowChatView] = useState(true); // Toggle between list and chat on mobile
 
   const typingTimeoutRef = useRef(null);
   const messagesContainerRef = useRef(null);
@@ -1171,6 +1172,9 @@ const Chat = () => {
       prev.map((conv) => (conv.id === id ? { ...conv, unreadCount: 0 } : conv)),
     );
 
+    // Show chat view on mobile/tablet when conversation is selected
+    setShowChatView(true);
+
     // Navigate with type parameter
     navigate(`/chat/${id}?type=${type}`);
   };
@@ -1188,7 +1192,9 @@ const Chat = () => {
 
       <div className="flex h-[calc(100vh-200px)] bg-base-100 rounded-xl overflow-hidden">
         {/* Conversation List - Left Sidebar */}
-        <div className="w-1/3 border-r border-base-200 overflow-y-auto">
+        <div className={`border-r border-base-200 overflow-y-auto transition-all duration-300 ${
+          showChatView ? "hidden md:flex md:w-1/3" : "w-full md:w-1/3"
+        }`}>
           <ConversationList
             conversations={conversations}
             activeConversationId={conversationId}
@@ -1200,9 +1206,52 @@ const Chat = () => {
         </div>
 
         {/* Message Display - Right Side */}
-        <div className="w-2/3 flex flex-col">
+        <div className={`flex flex-col transition-all duration-300 ${
+          showChatView ? "w-full md:w-2/3" : "hidden md:flex md:w-2/3"
+        }`}>
           {conversationId ? (
             <>
+              {/* Header with back button and conversation info - hidden on md and up */}
+              <div className="flex items-center justify-between border-b border-base-200 p-3 md:p-4 bg-base-100 md:hidden">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  {/* Back/List toggle button - visible on small screens */}
+                  <button
+                    onClick={() => setShowChatView(false)}
+                    className="md:hidden flex items-center justify-center p-2 hover:bg-base-200 rounded-lg transition-colors"
+                    title="Back to conversation list"
+                  >
+                    <ChevronLeft size={20} />
+                  </button>
+                  
+                  {/* Conversation Header - Avatar and name */}
+                  <div className="flex items-center gap-3 min-w-0 flex-1">
+                    {conversationType === "team" && teamData ? (
+                      <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0">
+                        <span className="text-sm font-medium">
+                          {teamData.name?.substring(0, 2).toUpperCase() || "TM"}
+                        </span>
+                      </div>
+                    ) : conversationPartner ? (
+                      <div className="w-10 h-10 rounded-full bg-success/20 flex items-center justify-center flex-shrink-0">
+                        <span className="text-sm font-medium">
+                          {conversationPartner.firstName?.substring(0, 1).toUpperCase() || "U"}
+                        </span>
+                      </div>
+                    ) : null}
+                    <div className="min-w-0 flex-1">
+                      <h3 className="font-medium truncate text-sm">
+                        {conversationType === "team" ? teamData?.name : conversationPartner?.firstName}
+                      </h3>
+                      {conversationType === "team" && teamData?.members ? (
+                        <p className="text-xs text-base-content/60">
+                          {teamData.members.length} {teamData.members.length === 1 ? "member" : "members"}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               <div ref={messagesContainerRef} className="flex-grow overflow-y-auto p-4">
                 <MessageDisplay
                   messages={messages}
@@ -1275,10 +1324,17 @@ const Chat = () => {
               </div>
             </>
           ) : (
-            <div className="flex items-center justify-center h-full">
+            <div className="flex flex-col items-center justify-center h-full gap-4">
               <p className="text-base-content/70">
                 Select a conversation to start chatting
               </p>
+              <button
+                onClick={() => setShowChatView(false)}
+                className="md:hidden flex items-center gap-2 btn btn-sm btn-outline"
+              >
+                <ChevronLeft size={16} />
+                Back to conversations
+              </button>
             </div>
           )}
         </div>

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -12,6 +12,10 @@ import { userService } from "../services/userService";
 import { teamService } from "../services/teamService";
 import Alert from "../components/common/Alert";
 import { uploadToImageKit } from "../config/imagekit";
+import UserAvatar from "../components/users/UserAvatar";
+import DemoAvatarOverlay from "../components/users/DemoAvatarOverlay";
+import { getTeamInitials, isSyntheticTeam } from "../utils/userHelpers";
+import { getTeamAvatarUrl } from "../utils/chatEntityResolvers";
 
 const getConversationPartnerId = (conversation) =>
   conversation?.partner?.id ??
@@ -1226,17 +1230,40 @@ const Chat = () => {
                   {/* Conversation Header - Avatar and name */}
                   <div className="flex items-center gap-3 min-w-0 flex-1">
                     {conversationType === "team" && teamData ? (
-                      <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0">
-                        <span className="text-sm font-medium">
-                          {teamData.name?.substring(0, 2).toUpperCase() || "TM"}
-                        </span>
+                      <div className="w-10 h-10 rounded-full relative overflow-hidden flex-shrink-0">
+                        {getTeamAvatarUrl(teamData) ? (
+                          <img
+                            src={getTeamAvatarUrl(teamData)}
+                            alt={teamData.name}
+                            className="object-cover w-full h-full rounded-full"
+                            onError={(e) => {
+                              e.target.style.display = "none";
+                              const fallback = e.target.parentElement.querySelector(".avatar-fallback");
+                              if (fallback) fallback.style.display = "flex";
+                            }}
+                          />
+                        ) : null}
+                        <div
+                          className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                          style={{ display: getTeamAvatarUrl(teamData) ? "none" : "flex" }}
+                        >
+                          <span className="text-sm font-medium">{getTeamInitials(teamData)}</span>
+                        </div>
+                        {isSyntheticTeam(teamData) && (
+                          <DemoAvatarOverlay textClassName="text-[7px]" />
+                        )}
                       </div>
                     ) : conversationPartner ? (
-                      <div className="w-10 h-10 rounded-full bg-success/20 flex items-center justify-center flex-shrink-0">
-                        <span className="text-sm font-medium">
-                          {conversationPartner.firstName?.substring(0, 1).toUpperCase() || "U"}
-                        </span>
-                      </div>
+                      <UserAvatar
+                        user={conversationPartner}
+                        sizeClass="w-10 h-10"
+                        iconSize={20}
+                        initialsClassName="text-sm font-medium"
+                        showDemoOverlay
+                        demoOverlayTextClassName="text-[7px]"
+                        demoOverlayTextTranslateClassName="-translate-y-[2px]"
+                        className="flex-shrink-0"
+                      />
                     ) : null}
                     <div className="min-w-0 flex-1">
                       <h3 className="font-medium truncate text-sm">

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { LogOut, ChevronRight, ChevronLeft } from "lucide-react";
+import { LogOut, ChevronRight, ChevronLeft, Users, User } from "lucide-react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import PageContainer from "../components/layout/PageContainer";
 import ConversationList from "../components/chat/ConversationList";
@@ -11,9 +11,12 @@ import socketService from "../services/socketService";
 import { userService } from "../services/userService";
 import { teamService } from "../services/teamService";
 import Alert from "../components/common/Alert";
+import Tooltip from "../components/common/Tooltip";
 import { uploadToImageKit } from "../config/imagekit";
 import UserAvatar from "../components/users/UserAvatar";
 import DemoAvatarOverlay from "../components/users/DemoAvatarOverlay";
+import TeamDetailsModal from "../components/teams/TeamDetailsModal";
+import UserDetailsModal from "../components/users/UserDetailsModal";
 import { getTeamInitials, isSyntheticTeam } from "../utils/userHelpers";
 import { getTeamAvatarUrl } from "../utils/chatEntityResolvers";
 
@@ -64,6 +67,11 @@ const Chat = () => {
   const [teamMembersRefreshSignal, setTeamMembersRefreshSignal] =
     useState(null);
   const [showChatView, setShowChatView] = useState(true); // Toggle between list and chat on mobile
+  const [isTeamModalOpen, setIsTeamModalOpen] = useState(false);
+  const [selectedTeamId, setSelectedTeamId] = useState(null);
+  const [selectedTeamData, setSelectedTeamData] = useState(null);
+  const [isUserModalOpen, setIsUserModalOpen] = useState(false);
+  const [selectedUserId, setSelectedUserId] = useState(null);
 
   const typingTimeoutRef = useRef(null);
   const messagesContainerRef = useRef(null);
@@ -921,6 +929,23 @@ const Chat = () => {
     user?.username,
   ]);
 
+  const handleHeaderTeamClick = (e) => {
+    e.stopPropagation();
+    if (teamData?.id) {
+      setSelectedTeamId(teamData.id);
+      setSelectedTeamData(teamData);
+      setIsTeamModalOpen(true);
+    }
+  };
+
+  const handleHeaderUserClick = (e) => {
+    e.stopPropagation();
+    if (conversationPartner?.id) {
+      setSelectedUserId(conversationPartner.id);
+      setIsUserModalOpen(true);
+    }
+  };
+
   // Handle leaving a deleted team (removes from conversation list)
   const handleLeaveTeam = async () => {
     if (!activeConversation?.team?.id) {
@@ -1230,48 +1255,92 @@ const Chat = () => {
                   {/* Conversation Header - Avatar and name */}
                   <div className="flex items-center gap-3 min-w-0 flex-1">
                     {conversationType === "team" && teamData ? (
-                      <div className="w-10 h-10 rounded-full relative overflow-hidden flex-shrink-0">
-                        {getTeamAvatarUrl(teamData) ? (
-                          <img
-                            src={getTeamAvatarUrl(teamData)}
-                            alt={teamData.name}
-                            className="object-cover w-full h-full rounded-full"
-                            onError={(e) => {
-                              e.target.style.display = "none";
-                              const fallback = e.target.parentElement.querySelector(".avatar-fallback");
-                              if (fallback) fallback.style.display = "flex";
-                            }}
-                          />
-                        ) : null}
+                      <Tooltip
+                        content={`View ${teamData.name} details`}
+                        position="bottom"
+                        wrapperClassName="inline-flex items-center flex-shrink-0"
+                      >
                         <div
-                          className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                          style={{ display: getTeamAvatarUrl(teamData) ? "none" : "flex" }}
+                          className="w-10 h-10 rounded-full relative overflow-hidden cursor-pointer hover:opacity-80 transition-opacity"
+                          onClick={handleHeaderTeamClick}
                         >
-                          <span className="text-sm font-medium">{getTeamInitials(teamData)}</span>
+                          {getTeamAvatarUrl(teamData) ? (
+                            <img
+                              src={getTeamAvatarUrl(teamData)}
+                              alt={teamData.name}
+                              className="object-cover w-full h-full rounded-full"
+                              onError={(e) => {
+                                e.target.style.display = "none";
+                                const fallback = e.target.parentElement.querySelector(".avatar-fallback");
+                                if (fallback) fallback.style.display = "flex";
+                              }}
+                            />
+                          ) : null}
+                          <div
+                            className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                            style={{ display: getTeamAvatarUrl(teamData) ? "none" : "flex" }}
+                          >
+                            <span className="text-sm font-medium">{getTeamInitials(teamData)}</span>
+                          </div>
+                          {isSyntheticTeam(teamData) && (
+                            <DemoAvatarOverlay textClassName="text-[7px]" />
+                          )}
                         </div>
-                        {isSyntheticTeam(teamData) && (
-                          <DemoAvatarOverlay textClassName="text-[7px]" />
-                        )}
-                      </div>
+                      </Tooltip>
                     ) : conversationPartner ? (
-                      <UserAvatar
-                        user={conversationPartner}
-                        sizeClass="w-10 h-10"
-                        iconSize={20}
-                        initialsClassName="text-sm font-medium"
-                        showDemoOverlay
-                        demoOverlayTextClassName="text-[7px]"
-                        demoOverlayTextTranslateClassName="-translate-y-[2px]"
-                        className="flex-shrink-0"
-                      />
+                      <Tooltip
+                        content={`View ${[conversationPartner.firstName, conversationPartner.lastName].filter(Boolean).join(" ")} details`}
+                        position="bottom"
+                        wrapperClassName="inline-flex items-center flex-shrink-0"
+                      >
+                        <div
+                          className="cursor-pointer hover:opacity-80 transition-opacity"
+                          onClick={handleHeaderUserClick}
+                        >
+                          <UserAvatar
+                            user={conversationPartner}
+                            sizeClass="w-10 h-10"
+                            iconSize={20}
+                            initialsClassName="text-sm font-medium"
+                            showDemoOverlay
+                            demoOverlayTextClassName="text-[7px]"
+                            demoOverlayTextTranslateClassName="-translate-y-[2px]"
+                          />
+                        </div>
+                      </Tooltip>
                     ) : null}
                     <div className="min-w-0 flex-1">
-                      <h3 className="font-medium truncate text-sm">
-                        {conversationType === "team" ? teamData?.name : conversationPartner?.firstName}
-                      </h3>
-                      {conversationType === "team" && teamData?.members ? (
-                        <p className="text-xs text-base-content/60">
-                          {teamData.members.length} {teamData.members.length === 1 ? "member" : "members"}
+                      <Tooltip
+                        content={
+                          conversationType === "team"
+                            ? `View ${teamData?.name} details`
+                            : `View ${[conversationPartner?.firstName, conversationPartner?.lastName].filter(Boolean).join(" ")} details`
+                        }
+                        position="bottom"
+                        wrapperClassName="block min-w-0"
+                      >
+                        <h3
+                          className="font-medium truncate text-sm cursor-pointer hover:text-primary transition-colors"
+                          onClick={conversationType === "team" ? handleHeaderTeamClick : handleHeaderUserClick}
+                        >
+                          {conversationType === "team" ? teamData?.name : [conversationPartner?.firstName, conversationPartner?.lastName].filter(Boolean).join(" ")}
+                        </h3>
+                      </Tooltip>
+                      {conversationType === "team" ? (
+                        <p className="text-xs text-base-content/60 flex items-center gap-1.5">
+                          <Users size={12} className="flex-shrink-0" />
+                          <span>Team Chat</span>
+                          {teamData?.members && (
+                            <>
+                              <span>·</span>
+                              <span>{teamData.members.length} {teamData.members.length === 1 ? "member" : "members"}</span>
+                            </>
+                          )}
+                        </p>
+                      ) : conversationType === "direct" ? (
+                        <p className="text-xs text-base-content/60 flex items-center gap-1.5">
+                          <User size={12} className="flex-shrink-0" />
+                          <span>Direct Message Chat</span>
                         </p>
                       ) : null}
                     </div>
@@ -1366,6 +1435,18 @@ const Chat = () => {
           )}
         </div>
       </div>
+      <TeamDetailsModal
+        isOpen={isTeamModalOpen}
+        teamId={selectedTeamId}
+        initialTeamData={selectedTeamData}
+        onClose={() => { setIsTeamModalOpen(false); setSelectedTeamId(null); setSelectedTeamData(null); }}
+      />
+
+      <UserDetailsModal
+        isOpen={isUserModalOpen}
+        userId={selectedUserId}
+        onClose={() => { setIsUserModalOpen(false); setSelectedUserId(null); }}
+      />
     </PageContainer>
   );
 };


### PR DESCRIPTION
Conversation List
Fixed layout root cause: sidebar was using md:flex (flex row) instead of md:block, preventing proper width constraints — items overflowed horizontally, hiding the timestamp and breaking text truncation
Text truncation: names and last messages now properly clip with … via correctly scoped overflow-hidden wrappers
Timestamp always visible: bottom row now uses flex-shrink-0 on the timestamp and flex-1 truncate on the type label so the timestamp is never pushed out
Chevron shifted right: uses -mr-4 to sit flush with the card edge, reclaiming ~20 px of horizontal space for text content; icon reduced to 16 px
Lomir tooltips: native browser title tooltip on the chevron replaced with the custom Lomir Tooltip component; long names and messages show full content on hover
Mobile / Narrow Chat Header
Chat type label: team chats show Users icon · Team Chat · N members; direct messages show User icon · Direct Message Chat — all on one subtitle line
Full name in DM header: displays first + last name instead of first name only
Clickable avatars & names: tapping the avatar or name in the mobile header opens TeamDetailsModal (for team chats) or UserDetailsModal (for DMs), with Lomir-style tooltips — matching the behaviour already present in the conversation list
Test plan
 Open chat on a narrow browser window / mobile viewport — confirm avatar, name, and subtitle line all render correctly in the header
 Click avatar and name in the mobile header — confirm the correct modal opens for both team and DM conversations
 Scroll through the conversation list — confirm names and last messages truncate with …, timestamps are always visible, and the chevron sits at the card's right edge
 Hover over a long name, long message, or the chevron — confirm Lomir-style tooltip appears