### PR TITLE
Improve chat read receipts

### DIFF
--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -4,6 +4,7 @@ import Tooltip from "../common/Tooltip";
 import { CountBadge } from "../common/NotificationBadge";
 import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
 import { formatDistanceToNow } from "date-fns";
+import { normalizeTimestampToDate } from "../../utils/dateHelpers";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import UserAvatar from "../users/UserAvatar";
@@ -405,14 +406,14 @@ const ConversationList = ({
                       ) : (
                         <>
                           <User size={12} className="flex-shrink-0" />
-                          <span>Direct message</span>
+                          <span>DM Chat</span>
                         </>
                       )}
                     </p>
                     <span className="flex-shrink-0 ml-2 text-xs whitespace-nowrap" style={{ color: "#036b0c" }}>
                       {conversation.updatedAt
                         ? formatDistanceToNow(
-                            new Date(conversation.updatedAt),
+                            normalizeTimestampToDate(conversation.updatedAt) || new Date(),
                             {
                               addSuffix: true,
                             },

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -25,6 +25,8 @@ import {
   AlertTriangle,
   Clock,
   Trash2,
+  Check,
+  CheckCheck,
 } from "lucide-react";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
@@ -438,6 +440,95 @@ const MessageDisplay = ({
   const [nameToIdCache, setNameToIdCache] = useState({});
   const [resolvedChatUsers, setResolvedChatUsers] = useState({});
   const [resolvedChatTeams, setResolvedChatTeams] = useState({});
+
+  const getDisplayName = (userData) => {
+    if (!userData) return "";
+    const first = userData.firstName ?? userData.first_name;
+    const last = userData.lastName ?? userData.last_name;
+    if (first && last) return `${first} ${last}`;
+    if (first) return first;
+    return userData.username ?? "";
+  };
+
+  const formatReadByTooltip = (names) => {
+    const uniqueNames = [...new Set((names || []).filter(Boolean))];
+    if (uniqueNames.length === 0) return "Read.";
+    if (uniqueNames.length === 1) return `Read by ${uniqueNames[0]}.`;
+    if (uniqueNames.length === 2) {
+      return `Read by ${uniqueNames[0]} and ${uniqueNames[1]}.`;
+    }
+
+    const lastName = uniqueNames[uniqueNames.length - 1];
+    const leadingNames = uniqueNames.slice(0, -1).join(", ");
+    return `Read by ${leadingNames} and ${lastName}.`;
+  };
+
+  const getReadByTooltip = (message) => {
+    if (conversationType === "team") {
+      const readByUsers = message.readByUsers ?? message.read_by_users ?? [];
+      return formatReadByTooltip(readByUsers.map(getDisplayName));
+    }
+
+    return formatReadByTooltip([getDisplayName(resolvedConversationPartner)]);
+  };
+
+  const renderReadReceipt = (message, isCurrentUser) => {
+    if (!isCurrentUser) return null;
+
+    const parsedReadCount = Number(message.readCount ?? message.read_count);
+    const readCount = Number.isFinite(parsedReadCount) ? parsedReadCount : 0;
+    const fallbackRecipientCount =
+      conversationType === "team"
+        ? (teamMembers || []).filter((member) => {
+            const memberId = member?.user_id ?? member?.userId ?? member?.id;
+            return String(memberId) !== String(currentUserId);
+          }).length
+        : 1;
+    const parsedRecipientCount = Number(
+      message.recipientCount ??
+        message.recipient_count ??
+        fallbackRecipientCount,
+    );
+    const recipientCount = Number.isFinite(parsedRecipientCount)
+      ? parsedRecipientCount
+      : fallbackRecipientCount;
+
+    if (conversationType === "team") {
+      if (readCount <= 0 && !message.readAt) return null;
+
+      const isReadByAll = recipientCount > 0 && readCount >= recipientCount;
+      const ReceiptIcon = isReadByAll ? CheckCheck : Check;
+
+      return (
+        <Tooltip
+          content={isReadByAll ? "Read by all" : getReadByTooltip(message)}
+          position="top"
+        >
+          <span className="ml-2 inline-flex shrink-0">
+            <ReceiptIcon
+              size={14}
+              strokeWidth={2.25}
+              aria-label={isReadByAll ? "Read by all" : "Read by someone"}
+            />
+          </span>
+        </Tooltip>
+      );
+    }
+
+    if (!message.readAt) return null;
+
+    return (
+      <Tooltip content={getReadByTooltip(message)} position="top">
+        <span className="ml-2 inline-flex shrink-0">
+          <CheckCheck
+            size={14}
+            strokeWidth={2.25}
+            aria-label="Read"
+          />
+        </span>
+      </Tooltip>
+    );
+  };
 
   useEffect(() => {
     const previousSnapshot = previousMessageSnapshotRef.current;
@@ -1485,9 +1576,7 @@ const MessageDisplay = ({
                   `}
                 >
                   <span>{formatLocalTime(message.createdAt)}</span>
-                  {isCurrentUser && message.readAt && (
-                    <span className="ml-2">✓</span>
-                  )}
+                  {renderReadReceipt(message, isCurrentUser)}
                 </div>
               </div>
             </div>
@@ -1708,9 +1797,7 @@ const MessageDisplay = ({
                   `}
                 >
                   <span>{formatLocalTime(message.createdAt)}</span>
-                  {isCurrentUser && message.readAt && (
-                    <span className="ml-2">✓</span>
-                  )}
+                  {renderReadReceipt(message, isCurrentUser)}
                 </div>
               </div>
             </div>
@@ -1857,9 +1944,7 @@ const MessageDisplay = ({
                   `}
                 >
                   <span>{formatLocalTime(message.createdAt)}</span>
-                  {isCurrentUser && message.readAt && (
-                    <span className="ml-2">✓</span>
-                  )}
+                  {renderReadReceipt(message, isCurrentUser)}
                 </div>
               </div>
             </div>
@@ -2842,9 +2927,7 @@ const MessageDisplay = ({
                                 <span>
                                   {formatLocalTime(message.createdAt)}
                                 </span>
-                                {isCurrentUser && message.readAt && (
-                                  <span className="ml-2">✓</span>
-                                )}
+                                {renderReadReceipt(message, isCurrentUser)}
                               </div>
                             )}
                           </div>

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -1,6 +1,12 @@
 import React, { useRef, useEffect, useState } from "react";
 import { format, isToday, isYesterday } from "date-fns";
 import {
+  normalizeTimestampToDate,
+  formatLocalTime,
+  formatDateHeading as formatMessageDateHeading,
+  getDateGroupKey,
+} from "../../utils/dateHelpers";
+import {
   getTeamInitials,
   isSyntheticTeam,
 } from "../../utils/userHelpers";
@@ -791,7 +797,7 @@ const MessageDisplay = ({
 
   // Group messages by date
   const messagesByDate = messages.reduce((groups, message) => {
-    const date = format(new Date(message.createdAt), "yyyy-MM-dd");
+    const date = getDateGroupKey(message.createdAt);
     if (!groups[date]) {
       groups[date] = [];
     }
@@ -800,12 +806,7 @@ const MessageDisplay = ({
   }, {});
 
   // Format date heading
-  const formatDateHeading = (dateString) => {
-    const date = new Date(dateString);
-    if (isToday(date)) return "Today";
-    if (isYesterday(date)) return "Yesterday";
-    return format(date, "MMMM d, yyyy");
-  };
+  const formatDateHeading = (dateString) => formatMessageDateHeading(dateString);
 
   // Get sender info from team members or message data
   const getSenderInfo = (senderId, message = null) => {
@@ -1247,7 +1248,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -1289,7 +1290,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -1321,7 +1322,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -1362,7 +1363,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -1408,7 +1409,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -1483,7 +1484,7 @@ const MessageDisplay = ({
                     }
                   `}
                 >
-                  <span>{format(new Date(message.createdAt), "p")}</span>
+                  <span>{formatLocalTime(message.createdAt)}</span>
                   {isCurrentUser && message.readAt && (
                     <span className="ml-2">✓</span>
                   )}
@@ -1495,7 +1496,7 @@ const MessageDisplay = ({
 
         {!parsedMessage.personalMessage && (
           <div className="text-xs text-base-content/50">
-            {format(new Date(message.createdAt), "p")}
+            {formatLocalTime(message.createdAt)}
           </div>
         )}
       </div>
@@ -1556,7 +1557,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -1641,7 +1642,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -1706,7 +1707,7 @@ const MessageDisplay = ({
                     }
                   `}
                 >
-                  <span>{format(new Date(message.createdAt), "p")}</span>
+                  <span>{formatLocalTime(message.createdAt)}</span>
                   {isCurrentUser && message.readAt && (
                     <span className="ml-2">✓</span>
                   )}
@@ -1798,7 +1799,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -1855,7 +1856,7 @@ const MessageDisplay = ({
                     }
                   `}
                 >
-                  <span>{format(new Date(message.createdAt), "p")}</span>
+                  <span>{formatLocalTime(message.createdAt)}</span>
                   {isCurrentUser && message.readAt && (
                     <span className="ml-2">✓</span>
                   )}
@@ -1909,7 +1910,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -2022,7 +2023,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -2047,7 +2048,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -2096,7 +2097,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -2149,7 +2150,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -2193,7 +2194,7 @@ const MessageDisplay = ({
         </div>
 
         <div className="text-xs text-base-content/50">
-          {format(new Date(message.createdAt), "p")}
+          {formatLocalTime(message.createdAt)}
         </div>
       </div>
     );
@@ -2839,7 +2840,7 @@ const MessageDisplay = ({
                         `}
                               >
                                 <span>
-                                  {format(new Date(message.createdAt), "p")}
+                                  {formatLocalTime(message.createdAt)}
                                 </span>
                                 {isCurrentUser && message.readAt && (
                                   <span className="ml-2">✓</span>

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useState, useEffect, useContext } from "react";
 import api from "../services/api";
 import socketService from "../services/socketService";
+import { setUserTimezone } from "../utils/dateHelpers";
 
 const AuthContext = createContext(null);
 
@@ -49,6 +50,7 @@ export const AuthProvider = ({ children }) => {
                 : true,
           };
           setUser(enhancedUserData);
+          setUserTimezone(enhancedUserData);
           setError(null);
 
           // Connect socket AFTER user is loaded
@@ -126,6 +128,7 @@ export const AuthProvider = ({ children }) => {
       localStorage.setItem("token", token);
       setToken(token);
       setUser(enhancedUser);
+      setUserTimezone(enhancedUser);
       setError(null);
 
       try {
@@ -189,6 +192,7 @@ export const AuthProvider = ({ children }) => {
       localStorage.setItem("token", token);
       setToken(token);
       setUser(enhancedUser);
+      setUserTimezone(enhancedUser);
       setError(null);
 
       // Initialize socket connection AFTER user is set
@@ -287,6 +291,7 @@ export const AuthProvider = ({ children }) => {
         newUser.avatarUrl = userData.avatarUrl;
         newUser.avatar_url = userData.avatarUrl;
       }
+      setUserTimezone(newUser);
       return newUser;
     });
   };
@@ -296,6 +301,7 @@ export const AuthProvider = ({ children }) => {
     localStorage.removeItem("token");
     setToken(null);
     setUser(null);
+    setUserTimezone(null);
     setError(null); // Clear error when logging out
     // Disconnect socket
     socketService.disconnect();

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -744,6 +744,9 @@ const Chat = () => {
               fileSize: message.fileSize,
               fileExpiresAt: message.fileExpiresAt,
               fileDeletedAt: message.fileDeletedAt,
+              readCount: message.readCount,
+              recipientCount: message.recipientCount,
+              readByUsers: message.readByUsers,
             };
 
             return dedupeMessages([...withoutOptimistic, newMessage]);
@@ -766,6 +769,9 @@ const Chat = () => {
               fileSize: message.fileSize,
               fileExpiresAt: message.fileExpiresAt,
               fileDeletedAt: message.fileDeletedAt,
+              readCount: message.readCount,
+              recipientCount: message.recipientCount,
+              readByUsers: message.readByUsers,
             };
 
             return dedupeMessages([...prev, newMessage]);
@@ -857,12 +863,42 @@ const Chat = () => {
     // Handle message status updates
     const handleMessageStatus = (data) => {
       if (String(data.conversationId) === String(conversationId)) {
+        const readCountByMessageId = new Map(
+          (data.messageReadCounts || []).map((status) => [
+            String(status.messageId),
+            status,
+          ]),
+        );
+
         setMessages((prev) =>
-          prev.map((msg) => ({
-            ...msg,
-            readAt:
-              msg.readAt || (msg.senderId !== user.id ? data.readAt : null),
-          })),
+          prev.map((msg) => {
+            if (data.type === "team") {
+              const status = readCountByMessageId.get(String(msg.id));
+
+              if (!status) {
+                return msg;
+              }
+
+              return {
+                ...msg,
+                readAt: msg.readAt || status.firstReadAt || data.readAt,
+                readCount: status.readCount,
+                recipientCount: status.recipientCount,
+                readByUsers: status.readByUsers || msg.readByUsers,
+              };
+            }
+
+            if (msg.senderId !== user.id) {
+              return msg;
+            }
+
+            return {
+              ...msg,
+              readAt: msg.readAt || data.readAt,
+              readCount: 1,
+              recipientCount: 1,
+            };
+          }),
         );
       }
     };

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -20,7 +20,8 @@ import TeamDetailsModal from "../components/teams/TeamDetailsModal";
 import UserDetailsModal from "../components/users/UserDetailsModal";
 import { getTeamInitials, isSyntheticTeam } from "../utils/userHelpers";
 import { formatDisplayName } from "../utils/nameFormatters";
-import { formatDistanceToNow } from "date-fns";
+import { formatDistanceToNowStrict } from "date-fns";
+import { normalizeTimestampToDate } from "../utils/dateHelpers";
 import { getTeamAvatarUrl } from "../utils/chatEntityResolvers";
 
 const getConversationPartnerId = (conversation) =>
@@ -81,6 +82,41 @@ const resolveConversationUser = (conversation, userId) => {
   return null;
 };
 
+const getConversationUpdatedAt = (conversation) => {
+  const timestamp =
+    conversation?.updatedAt ??
+    conversation?.updated_at ??
+    conversation?.createdAt ??
+    conversation?.created_at ??
+    conversation?.lastMessage?.createdAt ??
+    conversation?.lastMessage?.created_at ??
+    conversation?.team?.updatedAt ??
+    conversation?.team?.updated_at ??
+    null;
+
+  if (!timestamp) return null;
+  const parsedDate = normalizeTimestampToDate(timestamp);
+  return parsedDate;
+};
+
+const formatChatTimestamp = (timestamp) => {
+  if (!timestamp) return "";
+  const now = new Date();
+  const date = normalizeTimestampToDate(timestamp);
+  if (!date) return "";
+  const minutes = Math.round((now - date) / 60000);
+  if (minutes < 60) {
+    return formatDistanceToNowStrict(date, {
+      addSuffix: true,
+      unit: "minute",
+    });
+  }
+  return formatDistanceToNowStrict(date, {
+    addSuffix: true,
+    unit: "hour",
+  });
+};
+
 const isDirectConversationForPartner = (conversation, partnerId) =>
   conversation?.type === "direct" &&
   String(getConversationPartnerId(conversation)) === String(partnerId);
@@ -138,7 +174,7 @@ const Chat = () => {
   // ---- Message de-duplication (focus: ownership/system duplicates) ----
   const toMinuteBucket = (isoOrDate) => {
     try {
-      const d = isoOrDate ? new Date(isoOrDate) : null;
+      const d = isoOrDate ? normalizeTimestampToDate(isoOrDate) : null;
       if (!d || Number.isNaN(d.getTime())) return "";
       return d.toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM
     } catch {
@@ -207,6 +243,10 @@ const Chat = () => {
 
   const teamMembers =
     conversationType === "team" ? activeConversation?.team?.members || [] : [];
+
+  const conversationUpdatedAt =
+    getConversationUpdatedAt(activeConversation) ||
+    getConversationUpdatedAt(messages?.[messages.length - 1] || messages?.[0] || null);
 
   useEffect(() => {
     conversationsRef.current = conversations;
@@ -761,9 +801,11 @@ const Chat = () => {
 
         const deduplicatedList = dedupeConversations(updatedList);
 
-        return deduplicatedList.sort(
-          (a, b) => new Date(b.updatedAt) - new Date(a.updatedAt),
-        );
+        return deduplicatedList.sort((a, b) => {
+          const aDate = normalizeTimestampToDate(a.updatedAt)?.getTime() ?? 0;
+          const bDate = normalizeTimestampToDate(b.updatedAt)?.getTime() ?? 0;
+          return bDate - aDate;
+        });
       });
     };
 
@@ -846,9 +888,11 @@ const Chat = () => {
 
         const deduplicatedList = dedupeConversations(updatedList);
 
-        return deduplicatedList.sort(
-          (a, b) => new Date(b.updatedAt) - new Date(a.updatedAt),
-        );
+        return deduplicatedList.sort((a, b) => {
+          const aDate = normalizeTimestampToDate(a.updatedAt)?.getTime() ?? 0;
+          const bDate = normalizeTimestampToDate(b.updatedAt)?.getTime() ?? 0;
+          return bDate - aDate;
+        });
       });
     };
 
@@ -1427,32 +1471,32 @@ const Chat = () => {
                         </h3>
                       </Tooltip>
                       {conversationType === "team" ? (
-                        <div className="text-xs text-base-content/60 flex items-center justify-between gap-1.5">
-                          <div className="flex items-center gap-1.5">
+                        <div className="text-xs text-base-content/60 flex items-center justify-between gap-1.5 flex-nowrap">
+                          <div className="flex items-center gap-1.5 min-w-0">
                             <Users size={12} className="flex-shrink-0" />
-                            <span>Team chat</span>
+                            <span className="truncate">Team chat</span>
                             {teamData?.members && (
                               <>
                                 <span>·</span>
-                                <span>{teamData.members.length} {teamData.members.length === 1 ? "member" : "members"}</span>
+                                <span className="truncate">{teamData.members.length} {teamData.members.length === 1 ? "member" : "members"}</span>
                               </>
                             )}
                           </div>
-                          {activeConversation?.updatedAt && (
+                          {conversationUpdatedAt && (
                             <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
-                              {formatDistanceToNow(new Date(activeConversation.updatedAt), { addSuffix: true })}
+                              {formatChatTimestamp(conversationUpdatedAt)}
                             </span>
                           )}
                         </div>
                       ) : conversationType === "direct" ? (
-                        <div className="text-xs text-base-content/60 flex items-center justify-between gap-1.5">
-                          <div className="flex items-center gap-1.5">
+                        <div className="text-xs text-base-content/60 flex items-center justify-between gap-1.5 flex-nowrap">
+                          <div className="flex items-center gap-1.5 min-w-0">
                             <User size={12} className="flex-shrink-0" />
-                            <span>Direct message</span>
+                            <span className="truncate">DM Chat</span>
                           </div>
-                          {activeConversation?.updatedAt && (
+                          {conversationUpdatedAt && (
                             <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
-                              {formatDistanceToNow(new Date(activeConversation.updatedAt), { addSuffix: true })}
+                              {formatChatTimestamp(conversationUpdatedAt)}
                             </span>
                           )}
                         </div>

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -1,0 +1,157 @@
+import { parseISO } from "date-fns";
+
+// Maps country names (Nominatim) and ISO-2 codes to IANA timezone identifiers.
+// Country names come from the geocoding service (OpenStreetMap/Nominatim).
+// Nominatim may return names in English OR in the local language of the country,
+// so both variants are included here.
+const COUNTRY_TIMEZONES = {
+  // ISO-2 codes
+  DE: "Europe/Berlin",   AT: "Europe/Vienna",   CH: "Europe/Zurich",
+  NL: "Europe/Amsterdam", BE: "Europe/Brussels", FR: "Europe/Paris",
+  ES: "Europe/Madrid",   IT: "Europe/Rome",     PT: "Europe/Lisbon",
+  GB: "Europe/London",   IE: "Europe/Dublin",   PL: "Europe/Warsaw",
+  CZ: "Europe/Prague",   SK: "Europe/Bratislava", HU: "Europe/Budapest",
+  SE: "Europe/Stockholm", NO: "Europe/Oslo",    DK: "Europe/Copenhagen",
+  FI: "Europe/Helsinki", EE: "Europe/Tallinn",  LV: "Europe/Riga",
+  LT: "Europe/Vilnius",  RO: "Europe/Bucharest", BG: "Europe/Sofia",
+  HR: "Europe/Zagreb",   SI: "Europe/Ljubljana", GR: "Europe/Athens",
+  ZA: "Africa/Johannesburg", CO: "America/Bogota",
+  // English names
+  Germany: "Europe/Berlin",       Austria: "Europe/Vienna",
+  Switzerland: "Europe/Zurich",   Netherlands: "Europe/Amsterdam",
+  Belgium: "Europe/Brussels",     France: "Europe/Paris",
+  Spain: "Europe/Madrid",         Italy: "Europe/Rome",
+  Portugal: "Europe/Lisbon",      "United Kingdom": "Europe/London",
+  Ireland: "Europe/Dublin",       Poland: "Europe/Warsaw",
+  "Czech Republic": "Europe/Prague", Czechia: "Europe/Prague",
+  Slovakia: "Europe/Bratislava",  Hungary: "Europe/Budapest",
+  Sweden: "Europe/Stockholm",     Norway: "Europe/Oslo",
+  Denmark: "Europe/Copenhagen",   Finland: "Europe/Helsinki",
+  Estonia: "Europe/Tallinn",      Latvia: "Europe/Riga",
+  Lithuania: "Europe/Vilnius",    Romania: "Europe/Bucharest",
+  Bulgaria: "Europe/Sofia",       Croatia: "Europe/Zagreb",
+  Slovenia: "Europe/Ljubljana",   Greece: "Europe/Athens",
+  "South Africa": "Africa/Johannesburg", Colombia: "America/Bogota",
+  // Local language names (Nominatim returns these when no language is specified)
+  Deutschland: "Europe/Berlin",   Österreich: "Europe/Vienna",
+  Schweiz: "Europe/Zurich",       Suisse: "Europe/Zurich",
+  Svizzera: "Europe/Zurich",      Nederland: "Europe/Amsterdam",
+  Frankreich: "Europe/Paris",     Spanien: "Europe/Madrid",
+  Italien: "Europe/Rome",         Polen: "Europe/Warsaw",
+  Tschechien: "Europe/Prague",    Slowakei: "Europe/Bratislava",
+  Ungarn: "Europe/Budapest",      Schweden: "Europe/Stockholm",
+  Norwegen: "Europe/Oslo",        Dänemark: "Europe/Copenhagen",
+  Finnland: "Europe/Helsinki",    Estland: "Europe/Tallinn",
+  Lettland: "Europe/Riga",        Litauen: "Europe/Vilnius",
+  Rumänien: "Europe/Bucharest",   Bulgarien: "Europe/Sofia",
+  Kroatien: "Europe/Zagreb",      Slowenien: "Europe/Ljubljana",
+  Griechenland: "Europe/Athens",
+};
+
+// Set by AuthContext after the user profile is loaded.
+let _userTimezone = null;
+
+// Call this from AuthContext whenever user data changes.
+export const setUserTimezone = (user) => {
+  if (!user) { _userTimezone = null; return; }
+
+  const country = (user.country || user.country_code || "").trim();
+
+  // Direct match
+  if (COUNTRY_TIMEZONES[country]) {
+    _userTimezone = COUNTRY_TIMEZONES[country];
+    return;
+  }
+
+  // Case-insensitive match (handles lowercase country codes etc.)
+  const lower = country.toLowerCase();
+  const match = Object.keys(COUNTRY_TIMEZONES).find(k => k.toLowerCase() === lower);
+  if (match) {
+    _userTimezone = COUNTRY_TIMEZONES[match];
+    return;
+  }
+
+  // Postal code fallback: 5-digit German postal codes are unambiguous
+  const postal = (user.postalCode || user.postal_code || "").trim();
+  if (/^\d{5}$/.test(postal)) {
+    _userTimezone = "Europe/Berlin";
+    return;
+  }
+
+  _userTimezone = null;
+  console.warn("[dateHelpers] Could not resolve timezone from user profile. country =", JSON.stringify(country), "| postal =", JSON.stringify(postal));
+};
+
+// Returns the best available timezone: profile-derived > browser > UTC.
+const resolveTimezone = () =>
+  _userTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+
+const hasTimezoneOffset = (value) => /[zZ]$|[+-]\d{2}(?::?\d{2})?$/.test(value);
+
+const normalizeServerTimestamp = (value) => {
+  if (value instanceof Date) return value;
+  if (value === null || value === undefined) return null;
+
+  const raw = String(value).trim();
+  if (!raw) return null;
+
+  if (/^\d+$/.test(raw)) {
+    return new Date(Number(raw));
+  }
+
+  const normalized = raw.replace(" ", "T");
+  if (!hasTimezoneOffset(normalized)) {
+    // Server stores timestamps in UTC without a timezone marker — treat as UTC.
+    return parseISO(normalized + "Z");
+  }
+
+  return parseISO(normalized);
+};
+
+export const normalizeTimestampToDate = (value) => {
+  const date = normalizeServerTimestamp(value);
+  return date && !Number.isNaN(date.getTime()) ? date : null;
+};
+
+export const formatLocalTime = (value) => {
+  const date = normalizeTimestampToDate(value);
+  if (!date) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: resolveTimezone(),
+  }).format(date);
+};
+
+// Returns "YYYY-MM-DD" in the user's local timezone — used to group messages by day.
+const toLocalDateString = (date, tz) =>
+  new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+
+export const formatDateHeading = (value) => {
+  const date = normalizeTimestampToDate(value);
+  if (!date) return "";
+  const tz = resolveTimezone();
+  const dateStr = toLocalDateString(date, tz);
+  const todayStr = toLocalDateString(new Date(), tz);
+  const yesterday = new Date(Date.now() - 86_400_000);
+  const yesterdayStr = toLocalDateString(yesterday, tz);
+  if (dateStr === todayStr) return "Today";
+  if (dateStr === yesterdayStr) return "Yesterday";
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+};
+
+export const getDateGroupKey = (value) => {
+  const date = normalizeTimestampToDate(value);
+  if (!date) return "";
+  return toLocalDateString(date, resolveTimezone());
+};

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -15,7 +15,7 @@ const COUNTRY_TIMEZONES = {
   FI: "Europe/Helsinki", EE: "Europe/Tallinn",  LV: "Europe/Riga",
   LT: "Europe/Vilnius",  RO: "Europe/Bucharest", BG: "Europe/Sofia",
   HR: "Europe/Zagreb",   SI: "Europe/Ljubljana", GR: "Europe/Athens",
-  ZA: "Africa/Johannesburg", CO: "America/Bogota",
+  ZA: "Africa/Johannesburg", CO: "America/Bogota", AU: "Australia/Sydney",
   // English names
   Germany: "Europe/Berlin",       Austria: "Europe/Vienna",
   Switzerland: "Europe/Zurich",   Netherlands: "Europe/Amsterdam",
@@ -32,6 +32,7 @@ const COUNTRY_TIMEZONES = {
   Bulgaria: "Europe/Sofia",       Croatia: "Europe/Zagreb",
   Slovenia: "Europe/Ljubljana",   Greece: "Europe/Athens",
   "South Africa": "Africa/Johannesburg", Colombia: "America/Bogota",
+  Australia: "Australia/Sydney",
   // Local language names (Nominatim returns these when no language is specified)
   Deutschland: "Europe/Berlin",   Österreich: "Europe/Vienna",
   Schweiz: "Europe/Zurich",       Suisse: "Europe/Zurich",
@@ -45,17 +46,68 @@ const COUNTRY_TIMEZONES = {
   Lettland: "Europe/Riga",        Litauen: "Europe/Vilnius",
   Rumänien: "Europe/Bucharest",   Bulgarien: "Europe/Sofia",
   Kroatien: "Europe/Zagreb",      Slowenien: "Europe/Ljubljana",
-  Griechenland: "Europe/Athens",
+  Griechenland: "Europe/Athens",  Australien: "Australia/Sydney",
 };
+
+const CITY_TIMEZONES = {
+  Adelaide: "Australia/Adelaide",
+  Sydney: "Australia/Sydney",
+  Melbourne: "Australia/Melbourne",
+  Brisbane: "Australia/Brisbane",
+  Perth: "Australia/Perth",
+  Darwin: "Australia/Darwin",
+  Hobart: "Australia/Hobart",
+  Canberra: "Australia/Sydney",
+};
+
+// ISO-2 codes and names for German-speaking countries.
+const GERMAN_LOCALE_COUNTRIES = new Set([
+  "DE", "AT", "CH", "LI",
+  "Germany", "Austria", "Switzerland", "Liechtenstein",
+  "Deutschland", "Österreich", "Schweiz", "Suisse", "Svizzera",
+]);
+
+// ISO-2 codes and names for English-speaking countries (AM/PM convention).
+const ENGLISH_LOCALE_COUNTRIES = new Set([
+  "US", "CA", "AU", "NZ", "IE", "GB", "ZA", "BS", "PH", "SG", "MY",
+  "United States", "Canada", "Australia", "New Zealand", "Ireland",
+  "United Kingdom", "South Africa", "Bahamas", "Philippines",
+  "Singapore", "Malaysia", "Australien",
+]);
+
+const ENGLISH_LOCALE_CITIES = new Set([
+  "Adelaide", "Sydney", "Melbourne", "Brisbane", "Perth", "Darwin",
+  "Hobart", "Canberra",
+]);
 
 // Set by AuthContext after the user profile is loaded.
 let _userTimezone = null;
+let _userLocale = null;
 
 // Call this from AuthContext whenever user data changes.
 export const setUserTimezone = (user) => {
-  if (!user) { _userTimezone = null; return; }
+  if (!user) { _userTimezone = null; _userLocale = null; return; }
 
   const country = (user.country || user.country_code || "").trim();
+  const city = (user.city || "").trim();
+
+  // Derive locale from profile country.
+  const countryLower = country.toLowerCase();
+  const cityLower = city.toLowerCase();
+  const isGerman = GERMAN_LOCALE_COUNTRIES.has(country) ||
+    [...GERMAN_LOCALE_COUNTRIES].some(k => k.toLowerCase() === countryLower);
+  const isEnglish = !isGerman && (
+    ENGLISH_LOCALE_COUNTRIES.has(country) ||
+    [...ENGLISH_LOCALE_COUNTRIES].some(k => k.toLowerCase() === countryLower) ||
+    [...ENGLISH_LOCALE_CITIES].some(k => k.toLowerCase() === cityLower)
+  );
+  _userLocale = isGerman ? "de-DE" : isEnglish ? "en-US" : null;
+
+  const cityMatch = Object.keys(CITY_TIMEZONES).find(k => k.toLowerCase() === cityLower);
+  if (cityMatch) {
+    _userTimezone = CITY_TIMEZONES[cityMatch];
+    return;
+  }
 
   // Direct match
   if (COUNTRY_TIMEZONES[country]) {
@@ -75,6 +127,7 @@ export const setUserTimezone = (user) => {
   const postal = (user.postalCode || user.postal_code || "").trim();
   if (/^\d{5}$/.test(postal)) {
     _userTimezone = "Europe/Berlin";
+    _userLocale = "de-DE";
     return;
   }
 
@@ -82,9 +135,14 @@ export const setUserTimezone = (user) => {
   console.warn("[dateHelpers] Could not resolve timezone from user profile. country =", JSON.stringify(country), "| postal =", JSON.stringify(postal));
 };
 
-// Returns the best available timezone: profile-derived > browser > UTC.
+// Display chat timestamps in the viewer's device timezone. Profile location only
+// decides locale style (12-hour vs 24-hour), not the actual clock conversion.
 const resolveTimezone = () =>
-  _userTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  Intl.DateTimeFormat().resolvedOptions().timeZone || _userTimezone || "UTC";
+
+// Returns the best available locale: profile-derived > browser default.
+const resolveLocale = () =>
+  _userLocale || navigator.language || undefined;
 
 const hasTimezoneOffset = (value) => /[zZ]$|[+-]\d{2}(?::?\d{2})?$/.test(value);
 
@@ -116,11 +174,16 @@ export const normalizeTimestampToDate = (value) => {
 export const formatLocalTime = (value) => {
   const date = normalizeTimestampToDate(value);
   if (!date) return "";
-  return new Intl.DateTimeFormat(undefined, {
+  const locale = resolveLocale();
+  const isGerman = _userLocale != null && _userLocale.startsWith("de");
+  const isEnglish = _userLocale != null && _userLocale.startsWith("en");
+  const formatted = new Intl.DateTimeFormat(locale, {
     hour: "numeric",
     minute: "2-digit",
+    hour12: isGerman ? false : isEnglish ? true : undefined,
     timeZone: resolveTimezone(),
   }).format(date);
+  return isGerman ? `${formatted} Uhr` : formatted;
 };
 
 // Returns "YYYY-MM-DD" in the user's local timezone — used to group messages by day.


### PR DESCRIPTION
This PR refines chat message read receipts and timestamp formatting on the chat page.

Changes

Replaces plain text checkmarks with Lucide Check and CheckCheck icons.
Shows Check for team messages read by at least one recipient.
Shows CheckCheck for team messages read by all recipients.
Adds hover tooltips for read receipts:
Single team check: Read by X, Y and Z.
Team double check: Read by all
Direct messages: Read by [conversation partner].
Preserves reader metadata from incoming socket updates and fetched messages.
Updates chat timestamp formatting so English-profile users see 2:00 PM style times, while German-profile users keep 14:00 Uhr.

Validation

Ran npm run build successfully.
Notes

Full team read-receipt data depends on the backend read-receipt changes being deployed as well.