### PR TITLE
UI/chat notifications

### DIFF
--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -26,7 +26,6 @@ const ConversationList = ({
   activeConversationId,
   onSelectConversation,
   loading,
-  onlineUsers = [],
   teamMembersRefreshSignal = null,
 }) => {
   // State for team details modal
@@ -249,9 +248,6 @@ const ConversationList = ({
           const isFormerPartner = !isTeam && !directDisplayName;
           const isUserClickable =
             !isTeam && !isFormerPartner && Boolean(conversationData?.id);
-          const isOnline =
-            isUserClickable && onlineUsers.includes(conversationData?.id);
-
           // Get display name
           const displayName = isTeam
             ? conversationData?.name
@@ -358,7 +354,15 @@ const ConversationList = ({
                   <div className="flex justify-between items-center min-w-0">
                     {/* Name - Clickable for both team and direct conversations */}
                     <Tooltip
-                      content={displayName?.length > 22 ? displayName : undefined}
+                      content={
+                        isUserClickable
+                          ? `Click to view ${displayName}'s details`
+                          : isTeam
+                            ? `Click to view ${displayName} details`
+                            : displayName?.length > 22
+                              ? displayName
+                              : undefined
+                      }
                       wrapperClassName="block min-w-0 flex-1 overflow-hidden"
                     >
                       <h3

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -1,13 +1,31 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import socketService from '../../services/socketService';
 import { messageService } from '../../services/messageService';
 import { useAuth } from '../../contexts/AuthContext';
+import {
+  getMessageConversationTarget,
+  getMessagePreviewText,
+  isMessageForCurrentChatPath,
+  isOwnMessage,
+} from '../../utils/messageNotificationUtils';
 
 const MessageNotifications = () => {
   const [notifications, setNotifications] = useState([]);
   const navigate = useNavigate();
-  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+  const locationRef = useRef({
+    pathname: location.pathname,
+    search: location.search,
+  });
+  const { isAuthenticated, user } = useAuth();
+
+  useEffect(() => {
+    locationRef.current = {
+      pathname: location.pathname,
+      search: location.search,
+    };
+  }, [location.pathname, location.search]);
   
   useEffect(() => {
     if (!isAuthenticated) return;
@@ -16,10 +34,11 @@ const MessageNotifications = () => {
     const fetchUnreadCount = async () => {
       try {
         const response = await messageService.getUnreadCount();
-        if (response.data.count > 0) {
+        const count = response.data?.count ?? response.count ?? 0;
+        if (count > 0) {
           setNotifications([{ 
             id: 'initial', 
-            text: `You have ${response.data.count} unread messages` 
+            text: `You have ${count} unread messages` 
           }]);
         }
       } catch (error) {
@@ -29,24 +48,36 @@ const MessageNotifications = () => {
     
     fetchUnreadCount();
     
-    // Set up socket listener for new messages
-    const socket = socketService.getSocket();
-    
-    if (socket) {
+    let detachMessageListener = null;
+
+    const attachMessageListener = (socket) => {
+      if (!socket) return;
+
+      if (detachMessageListener) {
+        detachMessageListener();
+      }
+
       const handleNewMessage = (message) => {
-        // Only add notification if we're not already in that conversation
-        const currentPath = window.location.pathname;
-        const isInConversation = currentPath === `/chat/${message.conversationId}`;
+        if (isOwnMessage(message, user?.id)) return;
+
+        const isInConversation = isMessageForCurrentChatPath(
+          message,
+          locationRef.current.pathname,
+          locationRef.current.search,
+          user?.id,
+        );
         
         if (!isInConversation) {
+          const target = getMessageConversationTarget(message, user?.id);
           setNotifications(prev => [
             ...prev, 
             {
-              id: message.id,
-              conversationId: message.conversationId,
-              senderId: message.senderId,
+              id: message.id || `${target.type}-${target.conversationId}-${Date.now()}`,
+              conversationId: target.conversationId,
+              conversationType: target.type,
+              senderId: message.senderId || message.sender_id,
               senderName: message.senderUsername,
-              text: message.content,
+              text: getMessagePreviewText(message),
               time: new Date()
             }
           ]);
@@ -54,12 +85,21 @@ const MessageNotifications = () => {
       };
       
       socket.on('message:received', handleNewMessage);
-      
-      return () => {
+
+      detachMessageListener = () => {
         socket.off('message:received', handleNewMessage);
       };
-    }
-  }, [isAuthenticated]);
+    };
+
+    const unsubscribeSocketReady = socketService.onSocketReady(attachMessageListener);
+    
+    return () => {
+      unsubscribeSocketReady();
+      if (detachMessageListener) {
+        detachMessageListener();
+      }
+    };
+  }, [isAuthenticated, user?.id]);
   
   // Remove notification when clicked and navigate to conversation
   const handleNotificationClick = (notification) => {
@@ -68,7 +108,7 @@ const MessageNotifications = () => {
     );
     
     if (notification.conversationId) {
-      navigate(`/chat/${notification.conversationId}`);
+      navigate(`/chat/${notification.conversationId}?type=${notification.conversationType || 'direct'}`);
     } else {
       navigate('/chat');
     }

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -10,6 +10,11 @@ import { messageService } from "../../services/messageService";
 import { notificationService } from "../../services/notificationService";
 import socketService from "../../services/socketService";
 import NotificationBadge from "../common/NotificationBadge";
+import {
+  getMessageConversationTarget,
+  isMessageForCurrentChatPath,
+  isOwnMessage,
+} from "../../utils/messageNotificationUtils";
 
 const Navbar = () => {
   const { isAuthenticated, user, logout } = useAuth();
@@ -26,6 +31,7 @@ const Navbar = () => {
   const lastMessageFetchRef = useRef(0);
   const lastNotificationFetchRef = useRef(0);
   const locationPathRef = useRef(location.pathname);
+  const locationSearchRef = useRef(location.search);
 
   // Define Tailwind class strings using CSS variables for consistent colors
   const iconClasses =
@@ -39,8 +45,8 @@ const Navbar = () => {
 
     try {
       const response = await messageService.getUnreadCount();
-      setUnreadMessageCount(response.data?.count || 0);
-      setFirstUnreadMessage(response.data?.firstUnread || null);
+      setUnreadMessageCount(response.data?.count ?? response.count ?? 0);
+      setFirstUnreadMessage(response.data?.firstUnread ?? response.firstUnread ?? null);
     } catch (error) {
       console.error("Error fetching unread message count:", error);
     }
@@ -77,7 +83,8 @@ const Navbar = () => {
 
   useEffect(() => {
     locationPathRef.current = location.pathname;
-  }, [location.pathname]);
+    locationSearchRef.current = location.search;
+  }, [location.pathname, location.search]);
 
   // Initial fetch and socket setup for messages
   useEffect(() => {
@@ -90,36 +97,28 @@ const Navbar = () => {
     lastMessageFetchRef.current = Date.now();
     fetchUnreadMessageCount();
 
-    // Set up socket listener for new messages
-    const socket = socketService.getSocket();
+    let detachSocketListeners = null;
 
-    if (socket) {
+    const attachSocketListeners = (socket) => {
+      if (!socket) return;
+
+      if (detachSocketListeners) {
+        detachSocketListeners();
+      }
+
       const handleNewMessage = (message) => {
-        // Only increment if we're not currently in that conversation
-        const currentPath = locationPathRef.current;
-        const currentConversationId = currentPath.startsWith("/chat/")
-          ? currentPath.split("/chat/")[1]?.split("?")[0]
-          : null;
+        if (isOwnMessage(message, user?.id)) return;
 
-        const messageConversationId =
-          message.teamId ||
-          message.team_id ||
-          message.conversationId ||
-          message.senderId;
-        const isInThisConversation =
-          currentConversationId &&
-          String(currentConversationId) === String(messageConversationId);
+        const isInThisConversation = isMessageForCurrentChatPath(
+          message,
+          locationPathRef.current,
+          locationSearchRef.current,
+          user?.id,
+        );
 
         if (!isInThisConversation) {
           setUnreadMessageCount((prev) => prev + 1);
-          // Set this as the first unread conversation
-          const isTeamMessage = !!(message.teamId || message.team_id);
-          setFirstUnreadMessage({
-            conversationId: isTeamMessage
-              ? message.teamId || message.team_id
-              : message.conversationId || message.senderId,
-            type: isTeamMessage ? "team" : "direct",
-          });
+          setFirstUnreadMessage(getMessageConversationTarget(message, user?.id));
         }
       };
 
@@ -131,12 +130,21 @@ const Navbar = () => {
       socket.on("message:received", handleNewMessage);
       socket.on("messages:read", handleMessagesRead);
 
-      return () => {
+      detachSocketListeners = () => {
         socket.off("message:received", handleNewMessage);
         socket.off("messages:read", handleMessagesRead);
       };
-    }
-  }, [isAuthenticated, fetchUnreadMessageCount]);
+    };
+
+    const unsubscribeSocketReady = socketService.onSocketReady(attachSocketListeners);
+
+    return () => {
+      unsubscribeSocketReady();
+      if (detachSocketListeners) {
+        detachSocketListeners();
+      }
+    };
+  }, [isAuthenticated, fetchUnreadMessageCount, user?.id]);
 
   // Initial fetch and socket setup for notifications
   useEffect(() => {
@@ -149,10 +157,15 @@ const Navbar = () => {
     lastNotificationFetchRef.current = Date.now();
     fetchUnreadNotificationCount();
 
-    // Set up socket listener for new notifications
-    const socket = socketService.getSocket();
+    let detachNotificationListener = null;
 
-    if (socket) {
+    const attachNotificationListener = (socket) => {
+      if (!socket) return;
+
+      if (detachNotificationListener) {
+        detachNotificationListener();
+      }
+
       const handleNewNotification = () => {
         // Refetch to get the latest count and firstUnread
         fetchUnreadNotificationCount();
@@ -160,10 +173,19 @@ const Navbar = () => {
 
       socket.on("notification:new", handleNewNotification);
 
-      return () => {
+      detachNotificationListener = () => {
         socket.off("notification:new", handleNewNotification);
       };
-    }
+    };
+
+    const unsubscribeSocketReady = socketService.onSocketReady(attachNotificationListener);
+
+    return () => {
+      unsubscribeSocketReady();
+      if (detachNotificationListener) {
+        detachNotificationListener();
+      }
+    };
   }, [isAuthenticated, fetchUnreadNotificationCount]);
 
   // Refetch message count when path changes

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -676,16 +676,6 @@ const Chat = () => {
       return;
     }
 
-    // Remove any existing listeners first to prevent duplicates
-    socket.off("users:online");
-    socket.off("message:received");
-    socket.off("message:deleted");
-    socket.off("typing:update");
-    socket.off("message:status");
-    socket.off("conversation:updated");
-    socket.off("team:member_left");
-    socket.off("conversation:deleted");
-
     // Handle online users
     const handleOnlineUsers = (users) => {
       setOnlineUsers(users);

--- a/src/services/socketService.js
+++ b/src/services/socketService.js
@@ -1,11 +1,20 @@
 import { io } from "socket.io-client";
 
 let socket = null;
+const SOCKET_READY_EVENT = "lomir:socket-ready";
+
+const notifySocketReady = (socketInstance) => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(SOCKET_READY_EVENT, { detail: { socket: socketInstance } }),
+  );
+};
 
 const socketService = {
   // Connect to the socket server
   connect: (token) => {
     if (socket && socket.connected) {
+      notifySocketReady(socket);
       return socket;
     }
 
@@ -28,9 +37,11 @@ const socketService = {
 
     // Assign to global variable
     socket = newSocket;
+    notifySocketReady(newSocket);
 
     // Use newSocket in callbacks to avoid race conditions
     newSocket.on("connect", () => {
+      notifySocketReady(newSocket);
     });
 
     newSocket.on("connect_error", (error) => {
@@ -56,6 +67,24 @@ const socketService = {
 
   // Get the socket instance
   getSocket: () => socket,
+
+  onSocketReady: (callback) => {
+    if (typeof window === "undefined") return () => {};
+
+    const handleSocketReady = (event) => {
+      callback(event.detail?.socket || socket);
+    };
+
+    window.addEventListener(SOCKET_READY_EVENT, handleSocketReady);
+
+    if (socket) {
+      callback(socket);
+    }
+
+    return () => {
+      window.removeEventListener(SOCKET_READY_EVENT, handleSocketReady);
+    };
+  },
 
   // Join a conversation room
   joinConversation: (conversationId, type = "direct") => {

--- a/src/utils/messageNotificationUtils.js
+++ b/src/utils/messageNotificationUtils.js
@@ -1,0 +1,105 @@
+const asIdString = (value) =>
+  value === null || value === undefined ? null : String(value);
+
+export const getMessageSenderId = (message) =>
+  message?.senderId ?? message?.sender_id ?? message?.sender?.id ?? null;
+
+export const getMessageType = (message) => {
+  if (message?.type) return message.type;
+  return message?.teamId || message?.team_id ? "team" : "direct";
+};
+
+export const getMessageConversationTarget = (message, viewerId = null) => {
+  const type = getMessageType(message);
+  const viewerIdString = asIdString(viewerId);
+
+  if (type === "team") {
+    return {
+      conversationId:
+        message?.teamId ??
+        message?.team_id ??
+        message?.conversationId ??
+        message?.conversation_id ??
+        null,
+      type: "team",
+    };
+  }
+
+  const senderId = getMessageSenderId(message);
+  const conversationId = message?.conversationId ?? message?.conversation_id;
+  const receiverId =
+    message?.receiverId ??
+    message?.receiver_id ??
+    message?.recipientId ??
+    message?.recipient_id;
+
+  const candidates = [senderId, conversationId, receiverId].filter(
+    (id) => id !== null && id !== undefined,
+  );
+  const partnerId =
+    candidates.find((id) => viewerIdString && asIdString(id) !== viewerIdString) ??
+    conversationId ??
+    senderId ??
+    receiverId ??
+    null;
+
+  return {
+    conversationId: partnerId,
+    type: "direct",
+  };
+};
+
+export const isOwnMessage = (message, viewerId) => {
+  const senderId = getMessageSenderId(message);
+  return (
+    senderId !== null &&
+    senderId !== undefined &&
+    viewerId !== null &&
+    viewerId !== undefined &&
+    asIdString(senderId) === asIdString(viewerId)
+  );
+};
+
+export const isMessageForCurrentChatPath = (
+  message,
+  pathname,
+  search = "",
+  viewerId = null,
+) => {
+  if (!pathname?.startsWith("/chat/")) return false;
+
+  const currentConversationId = pathname.split("/chat/")[1]?.split("/")[0];
+  if (!currentConversationId) return false;
+
+  const target = getMessageConversationTarget(message, viewerId);
+  const currentType = new URLSearchParams(search).get("type") || "direct";
+
+  if (target.type !== currentType) return false;
+
+  if (target.type === "team") {
+    return asIdString(target.conversationId) === currentConversationId;
+  }
+
+  const possibleDirectIds = [
+    target.conversationId,
+    message?.conversationId,
+    message?.conversation_id,
+    getMessageSenderId(message),
+    message?.receiverId,
+    message?.receiver_id,
+    message?.recipientId,
+    message?.recipient_id,
+  ]
+    .map(asIdString)
+    .filter(Boolean);
+
+  return possibleDirectIds.includes(currentConversationId);
+};
+
+export const getMessagePreviewText = (message) => {
+  const content = message?.content?.trim();
+  if (content) return content;
+  if (message?.imageUrl || message?.image_url) return "Sent an image";
+  if (message?.fileUrl || message?.file_url) return "Sent a file";
+  return "New message";
+};


### PR DESCRIPTION
## Summary

- Fix real-time message notifications so receivers see new message alerts instantly without refreshing or being on the chat page.
- Make navbar unread message state and toast notifications attach reliably after socket connect/reconnect.
- Prevent the chat page from removing global socket listeners used by notifications.
- Add shared message notification helpers for resolving direct/team conversation targets and preview text.
- Improve conversation-list name hover text to show “Click to view [Name]’s details”.

## Testing

- Verified incoming chat notifications appear instantly for the receiver outside the active chat page.
- `npx eslint src/components/chat/MessageNotifications.jsx src/components/layout/Navbar.jsx src/services/socketService.js src/utils/messageNotificationUtils.js`
- `npx eslint src/components/chat/ConversationList.jsx`
- `npm run build`

## Notes

Full `npm run lint` still reports existing unrelated unused-variable errors elsewhere in the repo.
