### PR TITLE
Responsiveness polish for My Teams and Home pages

### DIFF
--- a/src/components/common/InfoCard.jsx
+++ b/src/components/common/InfoCard.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const InfoCard = ({ title, children, icon }) => {
+const InfoCard = ({ title, children, icon, className = "" }) => {
   return (
-    <div className="w-1/3 rounded-xl shadow-soft overflow-hidden bg-opacity-70 mb-6 mr-4 p-6 sm:p-7 border border-base-200 hover:shadow-md transition-shadow duration-300 bg-base-100">
+    <div className={`rounded-xl shadow-soft overflow-hidden bg-opacity-70 p-6 sm:p-7 border border-base-200 hover:shadow-md transition-shadow duration-300 bg-base-100 ${className}`}>
       <div className="flex flex-col items-center">
         {icon && <div className="mb-4">{icon}</div>}
         {title && <h3 className="text-lg font-medium text-primary text-center mb-2">{title}</h3>}

--- a/src/components/layout/Section.jsx
+++ b/src/components/layout/Section.jsx
@@ -51,7 +51,7 @@ const Section = ({
             )}
             {subtitle && (
               <div
-                className={`flex items-center justify-between mt-1 ${
+                className={`flex items-center justify-between gap-2 mt-1 ${
                   collapsible ? "cursor-pointer select-none group" : ""
                 }`}
                 onClick={
@@ -60,18 +60,20 @@ const Section = ({
                     : undefined
                 }
               >
-                <p className="text-base-content/70 text-sm">{subtitle}</p>
-                <div className="flex items-center gap-2 mr-4">
-                  <div onClick={(e) => e.stopPropagation()}>
-                    {subtitleAction}
-                  </div>
-                  {collapsible && (
-                    <ChevronIcon
-                      size={22}
-                      className="text-success group-hover:text-success/70 transition-colors flex-shrink-0"
-                    />
+                <div className="flex flex-wrap items-center justify-between flex-1 min-w-0 gap-y-0.5">
+                  <p className="text-base-content/70 text-sm">{subtitle}</p>
+                  {subtitleAction && (
+                    <div onClick={(e) => e.stopPropagation()}>
+                      {subtitleAction}
+                    </div>
                   )}
                 </div>
+                {collapsible && (
+                  <ChevronIcon
+                    size={22}
+                    className="text-success group-hover:text-success/70 transition-colors flex-shrink-0"
+                  />
+                )}
               </div>
             )}
           </div>

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -358,6 +358,7 @@ const TeamCard = ({
   viewerDistanceSource = null,
   listLocationInsetClassName = "",
   listLocationWidthClassName = "",
+  listLocationVisibilityClassName = "flex",
   listTagsWidthClassName = "",
   listBadgesWidthClassName = "",
   hideDistanceInfo = false,
@@ -2221,7 +2222,7 @@ const TeamCard = ({
           listEdgeRounding={!disableListEdgeRounding}
       >
           <div
-            className={`box-border flex w-24 flex-shrink-0 items-center gap-3 overflow-hidden sm:w-56 ${listLocationWidthClassName} ${listLocationInsetClassName}`}
+            className={`box-border ${listLocationVisibilityClassName} w-24 flex-shrink-0 items-center gap-3 overflow-hidden sm:w-56 ${listLocationWidthClassName} ${listLocationInsetClassName}`}
           >
             {showDistance && (
               <div className="hidden w-16 flex-shrink-0 overflow-hidden md:block">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -70,8 +70,8 @@ const Home = () => {
           </p>
         </div>
 
-        <div className="flex justify-between gap-x-4">
-          <InfoCard className="w-1/3" title="Find Your People" hoverable={true}>
+        <div className="flex flex-col items-center sm:flex-row sm:items-stretch justify-between gap-4">
+          <InfoCard className="w-full sm:w-1/3" title="Find Your People" hoverable={true}>
             <div className="flex justify-center mb-4">
               <Users className="w-8 h-8 text-primary" />
             </div>
@@ -80,7 +80,7 @@ const Home = () => {
               skills.
             </p>
           </InfoCard>
-          <InfoCard className="w-1/3" title="Build Together" hoverable={true}>
+          <InfoCard className="w-full sm:w-1/3" title="Build Together" hoverable={true}>
             <div className="flex justify-center mb-4">
               <Handshake className="w-8 h-8 text-primary" />
             </div>
@@ -89,7 +89,7 @@ const Home = () => {
               skills on meaningful projects.
             </p>
           </InfoCard>
-          <InfoCard className="w-1/3" title="Stay in Touch" hoverable={true}>
+          <InfoCard className="w-full sm:w-1/3" title="Stay in Touch" hoverable={true}>
             <div className="flex justify-center mb-4">
               <MessageCircle className="w-8 h-8 text-primary" />
             </div>

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -33,6 +33,7 @@ import {
 
 const MY_TEAMS_LIST_LOCATION_WIDTH_CLASSNAME = "sm:w-40";
 const MY_TEAMS_LIST_LOCATION_INSET_CLASSNAME = "sm:pl-[24px]";
+const MY_TEAMS_LIST_LOCATION_VISIBILITY_CLASSNAME = "hidden sm:flex";
 const MY_TEAMS_LIST_TAGS_WIDTH_CLASSNAME = "sm:w-36";
 const MY_TEAMS_LIST_BADGES_WIDTH_CLASSNAME = "sm:w-32";
 
@@ -504,7 +505,7 @@ const MyTeams = () => {
 
   return (
     <PageContainer title="My Teams" action={CreateTeamAction} variant="muted">
-      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-y-0.5 mb-6">
         <div className="flex flex-wrap items-center gap-1 -ml-2">
           <button
             type="button"
@@ -643,6 +644,7 @@ const MyTeams = () => {
                             }`}
                             listLocationWidthClassName={MY_TEAMS_LIST_LOCATION_WIDTH_CLASSNAME}
                             listLocationInsetClassName={MY_TEAMS_LIST_LOCATION_INSET_CLASSNAME}
+                            listLocationVisibilityClassName={MY_TEAMS_LIST_LOCATION_VISIBILITY_CLASSNAME}
                             listTagsWidthClassName={MY_TEAMS_LIST_TAGS_WIDTH_CLASSNAME}
                             listBadgesWidthClassName={MY_TEAMS_LIST_BADGES_WIDTH_CLASSNAME}
                             viewMode="list"
@@ -759,6 +761,7 @@ const MyTeams = () => {
                           hideDistanceInfo={true}
                           listLocationWidthClassName={MY_TEAMS_LIST_LOCATION_WIDTH_CLASSNAME}
                           listLocationInsetClassName={MY_TEAMS_LIST_LOCATION_INSET_CLASSNAME}
+                          listLocationVisibilityClassName={MY_TEAMS_LIST_LOCATION_VISIBILITY_CLASSNAME}
                           listTagsWidthClassName={MY_TEAMS_LIST_TAGS_WIDTH_CLASSNAME}
                           listBadgesWidthClassName={MY_TEAMS_LIST_BADGES_WIDTH_CLASSNAME}
                           viewMode="list"
@@ -833,16 +836,18 @@ const MyTeams = () => {
           <button
             type="button"
             onClick={() => handleSortChange("requests")}
-            className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
+            className={`flex items-center gap-1 pr-1 text-xs rounded transition-colors shrink-0 ${
               sortBy === "requests"
                 ? "text-[var(--color-primary)] font-bold"
                 : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
             }`}
           >
             <Inbox className="w-3.5 h-3.5 shrink-0" />
-            {sortBy === "requests" && sortDir === "asc"
-              ? "Least Requests"
-              : "Most Requests"}
+            {sortBy === "requests"
+              ? sortDir === "asc"
+                ? "Sorted by least requests"
+                : "Sorted by most requests"
+              : "Sort by most requests"}
           </button>
         }
         collapsible
@@ -896,6 +901,7 @@ const MyTeams = () => {
                       }`}
                       listLocationWidthClassName={MY_TEAMS_LIST_LOCATION_WIDTH_CLASSNAME}
                       listLocationInsetClassName={MY_TEAMS_LIST_LOCATION_INSET_CLASSNAME}
+                      listLocationVisibilityClassName={MY_TEAMS_LIST_LOCATION_VISIBILITY_CLASSNAME}
                       listTagsWidthClassName={MY_TEAMS_LIST_TAGS_WIDTH_CLASSNAME}
                       listBadgesWidthClassName={MY_TEAMS_LIST_BADGES_WIDTH_CLASSNAME}
                       autoOpenApplications={


### PR DESCRIPTION
Responsiveness polish for My Teams and Home pages

My Teams (list view): Location column is hidden on the narrowest viewports to save space. Sort and view mode controls wrap naturally — view mode stays right when there's room, falls left underneath when not.
My Teams (Teams You're A Part Of section): "Sort by most requests" button wraps independently of the collapse chevron, which stays pinned to the right. Label now reflects active state ("Sorted by most requests" / "Sort by most requests").
Home page: The three feature cards (Find Your People, Build Together, Stay in Touch) stack vertically on narrow viewports instead of cramming into a single row.