### PR TITLE
Feature/hide awards

### DIFF
--- a/src/components/badges/AwardCard.jsx
+++ b/src/components/badges/AwardCard.jsx
@@ -9,6 +9,9 @@ import {
   Tag,
   Award,
   FlaskConical,
+  EyeOff,
+  Loader2,
+  Trash2,
 } from "lucide-react";
 import Tooltip from "../common/Tooltip";
 import InlineUserLink from "../users/InlineUserLink";
@@ -48,6 +51,9 @@ import {
  * - onOpenTeam: optional function(teamId, teamName)
  * - hideTag: boolean
  * - highlighted: boolean
+ * - onHideBadge: optional function(award)
+ * - onDeleteAward: optional function(award)
+ * - badgeActionLoadingKey: optional string used to show per-action loading
  */
 const AwardCard = ({
   award,
@@ -59,13 +65,24 @@ const AwardCard = ({
   hideTag = false,
   highlighted = false,
   showBadgeTitle = true,
+  onHideBadge = null,
+  onDeleteAward = null,
+  badgeActionLoadingKey = null,
 }) => {
   const catColor = categoryColor;
   const childTeamModalZIndex = useChildModalZIndex();
 
   // --- Normalize fields (camelCase + snake_case) ---
+  const awardId = award?.awardId || award?.award_id || award?.id || null;
+  const badgeId = award?.badgeId || award?.badge_id || null;
   const badgeName = award?.badgeName || award?.badge_name || "Badge";
   const credits = Number(award?.credits ?? 0);
+  const hideActionKey = `hide-${badgeId ?? badgeName}`;
+  const deleteActionKey = `delete-${awardId}`;
+  const isAnyBadgeActionLoading = Boolean(badgeActionLoadingKey);
+  const isHideLoading = badgeActionLoadingKey === hideActionKey;
+  const isDeleteLoading = badgeActionLoadingKey === deleteActionKey;
+  const showBadgeActions = Boolean(onHideBadge || onDeleteAward);
 
   const awardedAt = award?.awardedAt || award?.awarded_at;
   const reason = award?.reason;
@@ -234,7 +251,7 @@ const AwardCard = ({
 
   return (
     <div
-      className={`rounded-lg p-3 flex flex-col border ${highlighted ? "animate-badge-highlight" : ""}`}
+      className={`group relative rounded-lg p-3 flex flex-col border ${highlighted ? "animate-badge-highlight" : ""}`}
       style={{
         backgroundColor: highlighted
           ? `${catColor}20`
@@ -249,6 +266,72 @@ const AwardCard = ({
       }}
       title={category}
     >
+      {showBadgeActions && (
+        <div className="absolute -top-2 -right-2 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto transition-opacity inline-flex items-center gap-1">
+          {onHideBadge && (
+            <Tooltip
+              content="Hide badge"
+              position="top"
+              wrapperClassName="inline-flex"
+            >
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onHideBadge(award);
+                }}
+                disabled={isAnyBadgeActionLoading || !badgeId}
+                className="bg-base-100 border border-base-300 rounded-full p-1 shadow-sm hover:shadow disabled:opacity-60 disabled:cursor-not-allowed"
+                aria-label="Hide badge"
+              >
+                {isHideLoading ? (
+                  <Loader2
+                    size={14}
+                    className="text-base-content/50 animate-spin"
+                  />
+                ) : (
+                  <EyeOff
+                    size={14}
+                    className="text-base-content/50 hover:text-primary"
+                  />
+                )}
+              </button>
+            </Tooltip>
+          )}
+
+          {onDeleteAward && (
+            <Tooltip
+              content="Delete badge award"
+              position="top"
+              wrapperClassName="inline-flex"
+            >
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDeleteAward(award);
+                }}
+                disabled={isAnyBadgeActionLoading || !awardId}
+                className="bg-base-100 border border-base-300 rounded-full p-1 shadow-sm hover:shadow disabled:opacity-60 disabled:cursor-not-allowed"
+                aria-label="Delete badge award"
+              >
+                {isDeleteLoading ? (
+                  <Loader2
+                    size={14}
+                    className="text-base-content/50 animate-spin"
+                  />
+                ) : (
+                  <Trash2
+                    size={14}
+                    className="text-base-content/50 hover:text-error"
+                  />
+                )}
+              </button>
+            </Tooltip>
+          )}
+        </div>
+      )}
+
       {/* ── Title row + credits pill ── */}
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">

--- a/src/components/badges/AwardCard.jsx
+++ b/src/components/badges/AwardCard.jsx
@@ -9,7 +9,8 @@ import {
   Tag,
   Award,
   FlaskConical,
-  EyeOff,
+  Eye,
+  EyeClosed,
   Loader2,
   Trash2,
 } from "lucide-react";
@@ -52,12 +53,13 @@ import {
  * - hideTag: boolean
  * - highlighted: boolean
  * - onHideBadge: optional function(award)
+ * - onShowBadge: optional function(award)
  * - onDeleteAward: optional function(award)
+ * - isBadgeHidden: boolean
  * - badgeActionLoadingKey: optional string used to show per-action loading
  */
 const AwardCard = ({
   award,
-  category = "Other",
   categoryColor = "#6B7280",
   categoryPastel,
   onOpenUser,
@@ -66,23 +68,47 @@ const AwardCard = ({
   highlighted = false,
   showBadgeTitle = true,
   onHideBadge = null,
+  onShowBadge = null,
   onDeleteAward = null,
+  isBadgeHidden = false,
   badgeActionLoadingKey = null,
 }) => {
-  const catColor = categoryColor;
+  const mutedBadgeColor = "#6B7280";
+  const mutedCardBackground = "#F3F4F6";
+  const mutedHighlightBackground = "#E5E7EB";
+  const mutedBorderColor = "#D1D5DB";
+  const catColor = isBadgeHidden ? mutedBadgeColor : categoryColor;
+  const cardBackgroundColor = isBadgeHidden
+    ? highlighted
+      ? mutedHighlightBackground
+      : mutedCardBackground
+    : highlighted
+      ? `${catColor}20`
+      : categoryPastel || "#F9FAFB";
+  const cardBorderColor = isBadgeHidden
+    ? mutedBorderColor
+    : highlighted
+      ? catColor
+      : `${catColor}33`;
+  const cardBoxShadow = highlighted
+    ? `0 0 12px ${isBadgeHidden ? "#9CA3AF66" : `${catColor}66`}`
+    : undefined;
   const childTeamModalZIndex = useChildModalZIndex();
 
   // --- Normalize fields (camelCase + snake_case) ---
   const awardId = award?.awardId || award?.award_id || award?.id || null;
-  const badgeId = award?.badgeId || award?.badge_id || null;
   const badgeName = award?.badgeName || award?.badge_name || "Badge";
   const credits = Number(award?.credits ?? 0);
-  const hideActionKey = `hide-${badgeId ?? badgeName}`;
+  const hideActionKey = `hide-${awardId}`;
+  const showActionKey = `show-${awardId}`;
   const deleteActionKey = `delete-${awardId}`;
   const isAnyBadgeActionLoading = Boolean(badgeActionLoadingKey);
   const isHideLoading = badgeActionLoadingKey === hideActionKey;
+  const isShowLoading = badgeActionLoadingKey === showActionKey;
   const isDeleteLoading = badgeActionLoadingKey === deleteActionKey;
-  const showBadgeActions = Boolean(onHideBadge || onDeleteAward);
+  const showBadgeActions = Boolean(
+    (onHideBadge && !isBadgeHidden) || onDeleteAward,
+  );
 
   const awardedAt = award?.awardedAt || award?.awarded_at;
   const reason = award?.reason;
@@ -253,24 +279,21 @@ const AwardCard = ({
     <div
       className={`group relative rounded-lg p-3 flex flex-col border ${highlighted ? "animate-badge-highlight" : ""}`}
       style={{
-        backgroundColor: highlighted
-          ? `${catColor}20`
-          : categoryPastel || "#F9FAFB",
-        borderColor: highlighted ? catColor : `${catColor}33`,
+        backgroundColor: cardBackgroundColor,
+        borderColor: cardBorderColor,
         ...(highlighted
           ? {
               borderWidth: "2px",
-              boxShadow: `0 0 12px ${catColor}66`,
+              boxShadow: cardBoxShadow,
             }
           : {}),
       }}
-      title={category}
     >
       {showBadgeActions && (
         <div className="absolute -top-2 -right-2 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto transition-opacity inline-flex items-center gap-1">
-          {onHideBadge && (
+          {onHideBadge && !isBadgeHidden && (
             <Tooltip
-              content="Hide badge"
+              content="Hide badge from others"
               position="top"
               wrapperClassName="inline-flex"
             >
@@ -280,9 +303,9 @@ const AwardCard = ({
                   event.stopPropagation();
                   onHideBadge(award);
                 }}
-                disabled={isAnyBadgeActionLoading || !badgeId}
+                disabled={isAnyBadgeActionLoading || !awardId}
                 className="bg-base-100 border border-base-300 rounded-full p-1 shadow-sm hover:shadow disabled:opacity-60 disabled:cursor-not-allowed"
-                aria-label="Hide badge"
+                aria-label="Hide badge from others"
               >
                 {isHideLoading ? (
                   <Loader2
@@ -290,7 +313,7 @@ const AwardCard = ({
                     className="text-base-content/50 animate-spin"
                   />
                 ) : (
-                  <EyeOff
+                  <EyeClosed
                     size={14}
                     className="text-base-content/50 hover:text-primary"
                   />
@@ -374,29 +397,33 @@ const AwardCard = ({
                   className="flex-shrink-0 text-base-content/70"
                 />
                 <span className="flex-shrink-0">awarded by</span>
-                <span
-                  className={[
-                    "truncate font-medium",
-                    isDeletedAwarder
-                      ? "text-base-content/50"
-                      : "text-base-content/70",
-                    awardedByUserId && canOpenUser && !isDeletedAwarder
-                      ? "cursor-pointer hover:text-primary transition-colors"
-                      : "",
-                  ].join(" ")}
-                  title={
+                <Tooltip
+                  content={
                     awardedByUserId && canOpenUser && !isDeletedAwarder
                       ? "View profile"
-                      : awarderName
+                      : null
                   }
-                  onClick={
-                    awardedByUserId && canOpenUser && !isDeletedAwarder
-                      ? () => openUser(awardedByUserId)
-                      : undefined
-                  }
+                  wrapperClassName="inline-flex min-w-0"
                 >
-                  {awarderName}
-                </span>
+                  <span
+                    className={[
+                      "truncate font-medium",
+                      isDeletedAwarder
+                        ? "text-base-content/50"
+                        : "text-base-content/70",
+                      awardedByUserId && canOpenUser && !isDeletedAwarder
+                        ? "cursor-pointer hover:text-primary transition-colors"
+                        : "",
+                    ].join(" ")}
+                    onClick={
+                      awardedByUserId && canOpenUser && !isDeletedAwarder
+                        ? () => openUser(awardedByUserId)
+                        : undefined
+                    }
+                  >
+                    {awarderName}
+                  </span>
+                </Tooltip>
               </span>
             )}
 
@@ -411,18 +438,22 @@ const AwardCard = ({
                   teamName ? (
                     <>
                       <span className="flex-shrink-0">Team:</span>
-                      <span
-                        className={[
-                          "truncate text-base-content/70",
-                          isTeamClickable
-                            ? "font-medium cursor-pointer hover:text-primary transition-colors"
-                            : "cursor-default",
-                        ].join(" ")}
-                        title={isTeamClickable ? "View team" : teamName}
-                        onClick={handleOpenTeam}
+                      <Tooltip
+                        content={isTeamClickable ? "View team" : teamName}
+                        wrapperClassName="inline-flex min-w-0"
                       >
-                        {teamName}
-                      </span>
+                        <span
+                          className={[
+                            "truncate text-base-content/70",
+                            isTeamClickable
+                              ? "font-medium cursor-pointer hover:text-primary transition-colors"
+                              : "cursor-default",
+                          ].join(" ")}
+                          onClick={handleOpenTeam}
+                        >
+                          {teamName}
+                        </span>
+                      </Tooltip>
                       {isTeamSynthetic && (
                         <Tooltip
                           content={DEMO_TEAM_TOOLTIP}
@@ -458,18 +489,22 @@ const AwardCard = ({
                   className="flex-shrink-0 text-base-content/70"
                 />
                 <span className="flex-shrink-0">Team:</span>
-                <span
-                  className={[
-                    "truncate text-base-content/70",
-                    isTeamClickable
-                      ? "font-medium cursor-pointer hover:text-primary transition-colors"
-                      : "cursor-default",
-                  ].join(" ")}
-                  title={isTeamClickable ? "View team" : teamName}
-                  onClick={handleOpenTeam}
+                <Tooltip
+                  content={isTeamClickable ? "View team" : teamName}
+                  wrapperClassName="inline-flex min-w-0"
                 >
-                  {teamName}
-                </span>
+                  <span
+                    className={[
+                      "truncate text-base-content/70",
+                      isTeamClickable
+                        ? "font-medium cursor-pointer hover:text-primary transition-colors"
+                        : "cursor-default",
+                    ].join(" ")}
+                    onClick={handleOpenTeam}
+                  >
+                    {teamName}
+                  </span>
+                </Tooltip>
                 {isTeamSynthetic && (
                   <Tooltip
                     content={DEMO_TEAM_TOOLTIP}
@@ -505,18 +540,64 @@ const AwardCard = ({
           </div>
         </div>
 
-        {/* Credits pill */}
-        <span
-          className="px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap text-white"
-          style={{ backgroundColor: catColor }}
-        >
-          +{credits} ct.
-        </span>
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {isBadgeHidden && (
+            <div className="group/visibility relative h-5 w-5">
+              <EyeClosed
+                size={14}
+                className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-base-content/40 group-hover/visibility:opacity-0"
+                aria-hidden="true"
+              />
+              {onShowBadge && (
+                <Tooltip
+                  content="Make badge visible for others"
+                  position="top"
+                  wrapperClassName="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+                >
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onShowBadge(award);
+                    }}
+                    disabled={isAnyBadgeActionLoading || !awardId}
+                    className="opacity-0 group-hover/visibility:opacity-100 bg-base-100 border border-base-300 rounded-full p-1 shadow-sm hover:shadow disabled:opacity-60 disabled:cursor-not-allowed transition-opacity"
+                    aria-label="Make badge visible for others"
+                  >
+                    {isShowLoading ? (
+                      <Loader2
+                        size={14}
+                        className="text-base-content/50 animate-spin"
+                      />
+                    ) : (
+                      <Eye
+                        size={14}
+                        className="text-base-content/50 hover:text-primary"
+                      />
+                    )}
+                  </button>
+                </Tooltip>
+              )}
+            </div>
+          )}
+
+          {/* Credits pill */}
+          <span
+            className="px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap text-white"
+            style={{ backgroundColor: catColor }}
+          >
+            +{credits} ct.
+          </span>
+        </div>
       </div>
 
       {/* Reason */}
       {reason && (
-        <p className="mt-2 text-sm text-base-content/80 italic">
+        <p
+          className={`mt-2 text-sm italic ${
+            isBadgeHidden ? "text-base-content/55" : "text-base-content/80"
+          }`}
+        >
           &ldquo;{reason}&rdquo;
         </p>
       )}
@@ -543,11 +624,15 @@ const AwardCard = ({
           />
         )}
 
-        <div className="flex items-center gap-1 text-xs text-base-content/60 leading-tight">
-          <Calendar size={12} className="flex-shrink-0" />
-          <span>
-            {awardedAt ? format(new Date(awardedAt), "MMM d, yyyy") : "Unknown"}
-          </span>
+        <div className="flex flex-col items-end gap-1">
+          <div className="flex items-center gap-1 text-xs text-base-content/60 leading-tight">
+            <Calendar size={12} className="flex-shrink-0" />
+            <span>
+              {awardedAt
+                ? format(new Date(awardedAt), "MMM d, yyyy")
+                : "Unknown"}
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/badges/BadgeCategoryModal.jsx
+++ b/src/components/badges/BadgeCategoryModal.jsx
@@ -31,6 +31,9 @@ const BadgeCategoryModal = ({
   onOpenUser,
   focusedBadgeName = null,
   highlightBadgeName = null,
+  onHideBadge = null,
+  onDeleteAward = null,
+  badgeActionLoadingKey = null,
 }) => {
   // Team details modal state (for AwardCard team clicks)
   const [selectedTeamForDetails, setSelectedTeamForDetails] = useState(null);
@@ -305,6 +308,9 @@ const BadgeCategoryModal = ({
                         onOpenUser={onOpenUser}
                         onOpenTeam={handleOpenTeam}
                         showBadgeTitle={false}
+                        onHideBadge={onHideBadge}
+                        onDeleteAward={onDeleteAward}
+                        badgeActionLoadingKey={badgeActionLoadingKey}
                         highlighted={
                           !!highlightBadgeName &&
                           (

--- a/src/components/badges/BadgeCategoryModal.jsx
+++ b/src/components/badges/BadgeCategoryModal.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { format } from "date-fns";
 import { Users, Lightbulb, Award } from "lucide-react";
 import {
   CATEGORY_SECTION_PASTELS,
@@ -24,7 +23,6 @@ const BadgeCategoryModal = ({
   onClose,
   category,
   color,
-  badges = [],
   detailedAwards = [],
   totalCredits = 0,
   loading = false,
@@ -32,8 +30,11 @@ const BadgeCategoryModal = ({
   focusedBadgeName = null,
   highlightBadgeName = null,
   onHideBadge = null,
+  onShowBadge = null,
   onDeleteAward = null,
   badgeActionLoadingKey = null,
+  hiddenAwardIds = [],
+  showHiddenBadgeAwards = false,
 }) => {
   // Team details modal state (for AwardCard team clicks)
   const [selectedTeamForDetails, setSelectedTeamForDetails] = useState(null);
@@ -50,8 +51,25 @@ const BadgeCategoryModal = ({
     setSelectedTeamForDetails(null);
   };
 
+  const hiddenAwardIdSet = new Set(
+    (Array.isArray(hiddenAwardIds) ? hiddenAwardIds : [])
+      .filter((value) => value !== undefined && value !== null)
+      .map((value) => String(value)),
+  );
+
+  const isAwardHidden = (award) => {
+    const awardId = award?.awardId ?? award?.award_id ?? award?.id;
+    return awardId !== undefined && awardId !== null
+      ? hiddenAwardIdSet.has(String(awardId))
+      : false;
+  };
+
+  const visibleDetailedAwards = showHiddenBadgeAwards
+    ? detailedAwards
+    : detailedAwards.filter((award) => !isAwardHidden(award));
+
   // Group detailed awards by badge name
-  const awardsByBadge = detailedAwards.reduce((acc, award) => {
+  const awardsByBadge = visibleDetailedAwards.reduce((acc, award) => {
     const badgeName = award.badgeName;
     if (!badgeName) return acc;
 
@@ -84,46 +102,23 @@ const BadgeCategoryModal = ({
   const pastelBg = CATEGORY_SECTION_PASTELS[category] || DEFAULT_SECTION_PASTEL;
   const cardPastel = CATEGORY_CARD_PASTELS[category] || DEFAULT_CARD_PASTEL;
 
-  // Unique badges in this category
-  const badgeCount = Object.keys(awardsByBadge).length;
-
   // Total awards in this category
-  const totalAwards = detailedAwards.length;
+  const totalAwards = visibleDetailedAwards.length;
 
   // Unique awarding users (people)
   const peopleCount = new Set(
-    detailedAwards.map((a) => a.awardedByUserId).filter(Boolean),
+    visibleDetailedAwards.map((a) => a.awardedByUserId).filter(Boolean),
   ).size;
 
   // Focus areas in this category = distinct tagName that received awards
   const creditedFocusAreaCount = new Set(
-    detailedAwards.map((a) => a.tagName).filter(Boolean),
+    visibleDetailedAwards.map((a) => a.tagName).filter(Boolean),
   ).size;
 
   // Unique teams with awards in this category
   const teamCount = new Set(
-    detailedAwards.map((a) => a.teamName).filter(Boolean),
+    visibleDetailedAwards.map((a) => a.teamName).filter(Boolean),
   ).size;
-
-  // Unique projects with awards in this category
-  const projectCount = new Set(
-    detailedAwards
-      .filter((a) => a.contextType === "project")
-      .map(
-        (a) =>
-          a.projectName ||
-          a.projectId ||
-          a.projectTitle ||
-          a.awardId ||
-          a.awardedAt,
-      )
-      .filter(Boolean),
-  ).size;
-
-  // Unique personal contributions in this category
-  const personalCount = detailedAwards.filter(
-    (a) => a.contextType === "personal",
-  ).length;
 
   const titleNode = (
     <div className="min-w-0">
@@ -309,7 +304,9 @@ const BadgeCategoryModal = ({
                         onOpenTeam={handleOpenTeam}
                         showBadgeTitle={false}
                         onHideBadge={onHideBadge}
+                        onShowBadge={onShowBadge}
                         onDeleteAward={onDeleteAward}
+                        isBadgeHidden={isAwardHidden(award)}
                         badgeActionLoadingKey={badgeActionLoadingKey}
                         highlighted={
                           !!highlightBadgeName &&

--- a/src/components/badges/SupercategoryAwardsModal.jsx
+++ b/src/components/badges/SupercategoryAwardsModal.jsx
@@ -1,73 +1,20 @@
 import React, { useState } from "react";
-import { format } from "date-fns";
-import { Tag, Award, Users, Info, Briefcase, User } from "lucide-react";
+import { Tag, Award, Users } from "lucide-react";
 import {
   CATEGORY_COLORS,
-  CATEGORY_SECTION_PASTELS,
   CATEGORY_CARD_PASTELS,
   DEFAULT_COLOR,
-  DEFAULT_SECTION_PASTEL,
   DEFAULT_CARD_PASTEL,
   FOCUS_GREEN,
   FOCUS_GREEN_DARK,
   TAG_SECTION_BG,
-  SUPERCATEGORY_ORDER,
 } from "../../constants/badgeConstants";
 import {
-  getCategoryIcon,
-  getBadgeIcon,
   getSupercategoryIcon,
-  SUPERCATEGORY_ICONS,
 } from "../../utils/badgeIconUtils";
 import Modal from "../common/Modal";
-import InlineUserLink from "../users/InlineUserLink";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import AwardCard from "./AwardCard";
-
-const getContextMeta = (contextType) => {
-  switch (contextType) {
-    case "team":
-      return { label: "Team contribution", Icon: Users };
-    case "project":
-      return { label: "Project contribution", Icon: Briefcase };
-    case "personal":
-    case "profile":
-    case "chat":
-      return { label: "Personal contribution", Icon: User };
-    default:
-      return { label: "Contribution", Icon: Info };
-  }
-};
-
-// Inline team link (mirrors the “Awarded by …” click affordance style)
-const InlineTeamLink = ({ teamId, teamName, onOpenTeam, contextLabel }) => {
-  const isClickable = Boolean(teamId && onOpenTeam);
-
-  return (
-    <span className="inline-flex items-center gap-1 min-w-0">
-      <Users size={12} className="flex-shrink-0" />
-      {/* label should NOT be bold */}
-      <span className="truncate">{contextLabel}:</span>
-
-      {/* team name bold + clickable */}
-      <span
-        className={[
-          "min-w-0 truncate font-medium text-base-content/80",
-          isClickable
-            ? "cursor-pointer hover:text-primary transition-colors"
-            : "cursor-default",
-        ].join(" ")}
-        title={isClickable ? "View team" : teamName}
-        onClick={() => {
-          if (!isClickable) return;
-          onOpenTeam(teamId);
-        }}
-      >
-        {teamName}
-      </span>
-    </span>
-  );
-};
 
 const SupercategoryAwardsModal = ({
   isOpen,
@@ -80,6 +27,12 @@ const SupercategoryAwardsModal = ({
   onOpenUser,
   entityType,
   highlightBadgeName = null,
+  onHideBadge = null,
+  onShowBadge = null,
+  onDeleteAward = null,
+  badgeActionLoadingKey = null,
+  hiddenAwardIds = [],
+  showHiddenBadgeAwards = false,
 }) => {
   // Internal TeamDetailsModal state (so the team click works even if parent doesn’t manage it)
   const [selectedTeamForDetails, setSelectedTeamForDetails] = useState(null);
@@ -96,8 +49,25 @@ const SupercategoryAwardsModal = ({
     setSelectedTeamForDetails(null);
   };
 
+  const hiddenAwardIdSet = new Set(
+    (Array.isArray(hiddenAwardIds) ? hiddenAwardIds : [])
+      .filter((value) => value !== undefined && value !== null)
+      .map((value) => String(value)),
+  );
+
+  const isAwardHidden = (award) => {
+    const awardId = award?.awardId ?? award?.award_id ?? award?.id;
+    return awardId !== undefined && awardId !== null
+      ? hiddenAwardIdSet.has(String(awardId))
+      : false;
+  };
+
+  const visibleAwards = showHiddenBadgeAwards
+    ? awards
+    : awards.filter((award) => !isAwardHidden(award));
+
   // Group awards by tag name
-  const awardsByTag = awards.reduce((acc, award) => {
+  const awardsByTag = visibleAwards.reduce((acc, award) => {
     const tagName = award.tagName ?? award.tag_name ?? "Unknown";
     if (!acc[tagName]) {
       acc[tagName] = { awards: [], totalCredits: 0 };
@@ -118,12 +88,12 @@ const SupercategoryAwardsModal = ({
   const personCount =
     entityType === "team"
       ? new Set(
-          awards
+          visibleAwards
             .map((a) => a.awardedToUserId || a.awarded_to_user_id)
             .filter(Boolean),
         ).size
       : new Set(
-          awards
+          visibleAwards
             .map((a) => a.awardedByUserId || a.awarded_by_user_id)
             .filter(Boolean),
         ).size;
@@ -173,9 +143,9 @@ const SupercategoryAwardsModal = ({
                 <div className="flex items-center flex-wrap gap-x-4 gap-y-2 text-sm text-base-content/60 min-w-0">
                   <span className="inline-flex items-center gap-1 whitespace-nowrap">
                     <Award size={14} />
-                    <span className="font-medium">{awards.length}</span>
+                    <span className="font-medium">{visibleAwards.length}</span>
                     <span className="hidden sm:inline">
-                      award{awards.length !== 1 ? "s" : ""}
+                      award{visibleAwards.length !== 1 ? "s" : ""}
                     </span>
                   </span>
 
@@ -273,9 +243,6 @@ const SupercategoryAwardsModal = ({
                           const category = award._category || "Other";
                           const catColor =
                             CATEGORY_COLORS[category] || DEFAULT_COLOR;
-                          const sectionPastel =
-                            CATEGORY_SECTION_PASTELS[category] ||
-                            DEFAULT_SECTION_PASTEL;
                           const cardPastel =
                             CATEGORY_CARD_PASTELS[category] ||
                             DEFAULT_CARD_PASTEL;
@@ -295,6 +262,11 @@ const SupercategoryAwardsModal = ({
                                 handleOpenTeam(teamId, teamName)
                               }
                               hideTag
+                              onHideBadge={onHideBadge}
+                              onShowBadge={onShowBadge}
+                              onDeleteAward={onDeleteAward}
+                              isBadgeHidden={isAwardHidden(award)}
+                              badgeActionLoadingKey={badgeActionLoadingKey}
                               highlighted={
                                 !!highlightBadgeName &&
                                 (

--- a/src/components/badges/TagAwardsModal.jsx
+++ b/src/components/badges/TagAwardsModal.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { format } from "date-fns";
-import { Tag, Award, Users, Calendar } from "lucide-react";
+import { Tag, Award, Users } from "lucide-react";
 import {
   CATEGORY_COLORS,
   CATEGORY_SECTION_PASTELS,
@@ -12,7 +11,6 @@ import {
 } from "../../constants/badgeConstants";
 import { getCategoryIcon } from "../../utils/badgeIconUtils";
 import Modal from "../common/Modal";
-import InlineUserLink from "../users/InlineUserLink";
 import AwardCard from "./AwardCard";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 
@@ -32,31 +30,22 @@ import TeamDetailsModal from "../teams/TeamDetailsModal";
  * @param {Function} onOpenUser - Callback to open a user's profile
  */
 
-// Get context label
-const getContextLabel = (contextType) => {
-  switch (contextType) {
-    case "team":
-      return "Teamwork";
-    case "project":
-      return "Project";
-    case "personal":
-      return "Personal";
-    default:
-      return "Contribution";
-  }
-};
-
 const TagAwardsModal = ({
   isOpen,
   onClose,
   tagName,
-  dominantBadgeCategory,
   totalCredits = 0,
   awards = [],
   loading = false,
   onOpenUser,
   entityType,
   highlightBadgeName = null,
+  onHideBadge = null,
+  onShowBadge = null,
+  onDeleteAward = null,
+  badgeActionLoadingKey = null,
+  hiddenAwardIds = [],
+  showHiddenBadgeAwards = false,
 }) => {
   // Internal TeamDetailsModal state (mirrors SupercategoryAwardsModal)
   const [selectedTeamForDetails, setSelectedTeamForDetails] = useState(null);
@@ -73,10 +62,25 @@ const TagAwardsModal = ({
     setSelectedTeamForDetails(null);
   };
 
-  // const dominantColor = CATEGORY_COLORS[dominantBadgeCategory] || DEFAULT_COLOR;
+  const hiddenAwardIdSet = new Set(
+    (Array.isArray(hiddenAwardIds) ? hiddenAwardIds : [])
+      .filter((value) => value !== undefined && value !== null)
+      .map((value) => String(value)),
+  );
+
+  const isAwardHidden = (award) => {
+    const awardId = award?.awardId ?? award?.award_id ?? award?.id;
+    return awardId !== undefined && awardId !== null
+      ? hiddenAwardIdSet.has(String(awardId))
+      : false;
+  };
+
+  const visibleAwards = showHiddenBadgeAwards
+    ? awards
+    : awards.filter((award) => !isAwardHidden(award));
 
   // Group awards by badge category
-  const awardsByCategory = awards.reduce((acc, award) => {
+  const awardsByCategory = visibleAwards.reduce((acc, award) => {
     const category = award.badgeCategory || award.badge_category || "Other";
     if (!acc[category]) {
       acc[category] = {
@@ -100,12 +104,12 @@ const TagAwardsModal = ({
   const personCount =
     entityType === "team"
       ? new Set(
-          awards
+          visibleAwards
             .map((a) => a.awardedToUserId || a.awarded_to_user_id)
             .filter(Boolean),
         ).size
       : new Set(
-          awards
+          visibleAwards
             .map((a) => a.awardedByUserId || a.awarded_by_user_id)
             .filter(Boolean),
         ).size;
@@ -156,9 +160,9 @@ const TagAwardsModal = ({
                 <div className="flex items-center flex-wrap gap-x-4 gap-y-2 text-sm text-base-content/60 min-w-0">
                   <span className="inline-flex items-center gap-1 whitespace-nowrap">
                     <Award size={14} />
-                    <span className="font-medium">{awards.length}</span>
+                    <span className="font-medium">{visibleAwards.length}</span>
                     <span className="hidden sm:inline">
-                      award{awards.length !== 1 ? "s" : ""}
+                      award{visibleAwards.length !== 1 ? "s" : ""}
                     </span>
                   </span>
 
@@ -268,7 +272,7 @@ const TagAwardsModal = ({
                                 (award.awardId || award.award_id || award.id) ??
                                 `${category}-${idx}`
                               }
-                              award={award}
+                              award={normalizedAward}
                               category={category}
                               categoryColor={catColor}
                               categoryPastel={cardPastel}
@@ -277,6 +281,11 @@ const TagAwardsModal = ({
                                 handleOpenTeam(teamId, teamName)
                               }
                               hideTag
+                              onHideBadge={onHideBadge}
+                              onShowBadge={onShowBadge}
+                              onDeleteAward={onDeleteAward}
+                              isBadgeHidden={isAwardHidden(normalizedAward)}
+                              badgeActionLoadingKey={badgeActionLoadingKey}
                               highlighted={
                                 !!highlightBadgeName &&
                                 (

--- a/src/components/users/InlineUserLink.jsx
+++ b/src/components/users/InlineUserLink.jsx
@@ -184,33 +184,40 @@ const InlineUserLink = ({
 
       {/* Avatar */}
       {showAvatar && (
-        <UserAvatar
-          user={inlineUser}
-          deleted={isFormerUser}
-          sizeClass={avatarSize}
-          className="mr-1"
-          clickable={Boolean(canClick)}
-          onClick={handleClick}
-          title={canClick ? "View profile" : undefined}
-          iconSize={avatarSize === "w-4 h-4" ? 10 : 12}
-          initialsClassName={
-            avatarSize === "w-4 h-4"
-              ? "text-[8px] font-medium"
-              : "text-[10px] font-medium"
-          }
-        />
+        <Tooltip
+          content={canClick ? "View profile" : null}
+          wrapperClassName="inline-flex mr-1"
+        >
+          <UserAvatar
+            user={inlineUser}
+            deleted={isFormerUser}
+            sizeClass={avatarSize}
+            clickable={Boolean(canClick)}
+            onClick={handleClick}
+            iconSize={avatarSize === "w-4 h-4" ? 10 : 12}
+            initialsClassName={
+              avatarSize === "w-4 h-4"
+                ? "text-[8px] font-medium"
+                : "text-[10px] font-medium"
+            }
+          />
+        </Tooltip>
       )}
 
       {/* Name */}
-      <span
-        className={`font-medium ${
-          isFormerUser ? "text-base-content/50" : "text-base-content/80"
-        } ${canClick ? "cursor-pointer hover:text-primary transition-colors" : ""}`}
-        onClick={canClick ? handleClick : undefined}
-        title={canClick ? "View profile" : undefined}
+      <Tooltip
+        content={canClick ? "View profile" : null}
+        wrapperClassName="inline-flex min-w-0"
       >
-        {name}
-      </span>
+        <span
+          className={`font-medium truncate ${
+            isFormerUser ? "text-base-content/50" : "text-base-content/80"
+          } ${canClick ? "cursor-pointer hover:text-primary transition-colors" : ""}`}
+          onClick={canClick ? handleClick : undefined}
+        >
+          {name}
+        </span>
+      </Tooltip>
       {showDemoIndicator && (
         <Tooltip
           content={DEMO_PROFILE_TOOLTIP}

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -148,6 +148,8 @@ const UserDetailsModal = ({
   const showEdit = !isEditing && isAuthenticated && ownProfile;
   const showChatInvite = !isEditing && isAuthenticated && !ownProfile;
   const isNumericUserId = /^\d+$/.test(String(userId ?? "").trim());
+  const visibleUserBadges = Array.isArray(user?.badges) ? user.badges : [];
+  const hiddenAwardIds = user?.hidden_award_ids ?? user?.hiddenAwardIds ?? [];
 
   const fetchUserDetails = useCallback(async () => {
     try {
@@ -745,7 +747,7 @@ const UserDetailsModal = ({
             {/* Badges */}
             <BadgesDisplaySection
               title="Badges"
-              badges={user?.badges}
+              badges={visibleUserBadges}
               emptyMessage="No badges earned yet"
               maxVisible={8}
               groupByCategory={true}
@@ -763,7 +765,7 @@ const UserDetailsModal = ({
                   ? normalizedRoleMatchBadgeNames
                   : currentUserBadgeNames;
                 if (!effectiveMatchNames || effectiveMatchNames.size === 0) return null;
-                const badgeList = user?.badges || [];
+                const badgeList = visibleUserBadges;
                 if (!Array.isArray(badgeList) || badgeList.length === 0) return null;
                 const userBadgeNames = new Set(
                   badgeList
@@ -845,15 +847,24 @@ const UserDetailsModal = ({
       <BadgeCategoryModal
         {...badgeCategoryModalProps}
         onOpenUser={onOpenUser}
+        hiddenAwardIds={hiddenAwardIds}
+        showHiddenBadgeAwards={ownProfile}
       />
 
       {/* Tag Awards Modal */}
-      <TagAwardsModal {...tagAwardsModalProps} onOpenUser={onOpenUser} />
+      <TagAwardsModal
+        {...tagAwardsModalProps}
+        onOpenUser={onOpenUser}
+        hiddenAwardIds={hiddenAwardIds}
+        showHiddenBadgeAwards={ownProfile}
+      />
 
       {/* Supercategory Awards Modal */}
       <SupercategoryAwardsModal
         {...supercategoryModalProps}
         onOpenUser={onOpenUser}
+        hiddenAwardIds={hiddenAwardIds}
+        showHiddenBadgeAwards={ownProfile}
       />
 
       {/* Badge Award Modal */}

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -37,6 +37,18 @@ export const AuthProvider = ({ children }) => {
                 : userData.isPublic !== undefined
                   ? userData.isPublic
                   : true,
+            hideBadges:
+              userData.hide_badges !== undefined
+                ? userData.hide_badges
+                : userData.hideBadges !== undefined
+                  ? userData.hideBadges
+                  : false,
+            hiddenBadgeIds:
+              Array.isArray(userData.hidden_badge_ids)
+                ? userData.hidden_badge_ids
+                : Array.isArray(userData.hiddenBadgeIds)
+                  ? userData.hiddenBadgeIds
+                  : [],
             // Add snake_case versions if missing
             first_name: userData.first_name || userData.firstName,
             last_name: userData.last_name || userData.lastName,
@@ -48,6 +60,18 @@ export const AuthProvider = ({ children }) => {
                 : userData.isPublic !== undefined
                 ? userData.isPublic
                 : true,
+            hide_badges:
+              userData.hide_badges !== undefined
+                ? userData.hide_badges
+                : userData.hideBadges !== undefined
+                  ? userData.hideBadges
+                  : false,
+            hidden_badge_ids:
+              Array.isArray(userData.hidden_badge_ids)
+                ? userData.hidden_badge_ids
+                : Array.isArray(userData.hiddenBadgeIds)
+                  ? userData.hiddenBadgeIds
+                  : [],
           };
           setUser(enhancedUserData);
           setUserTimezone(enhancedUserData);
@@ -113,6 +137,18 @@ export const AuthProvider = ({ children }) => {
             : user.isPublic !== undefined
               ? user.isPublic
               : false,
+        hideBadges:
+          user.hide_badges !== undefined
+            ? user.hide_badges
+            : user.hideBadges !== undefined
+              ? user.hideBadges
+              : false,
+        hiddenBadgeIds:
+          Array.isArray(user.hidden_badge_ids)
+            ? user.hidden_badge_ids
+            : Array.isArray(user.hiddenBadgeIds)
+              ? user.hiddenBadgeIds
+              : [],
         first_name: user.first_name || user.firstName,
         last_name: user.last_name || user.lastName,
         postal_code: user.postal_code || user.postalCode,
@@ -123,6 +159,18 @@ export const AuthProvider = ({ children }) => {
             : user.isPublic !== undefined
               ? user.isPublic
               : false,
+        hide_badges:
+          user.hide_badges !== undefined
+            ? user.hide_badges
+            : user.hideBadges !== undefined
+              ? user.hideBadges
+              : false,
+        hidden_badge_ids:
+          Array.isArray(user.hidden_badge_ids)
+            ? user.hidden_badge_ids
+            : Array.isArray(user.hiddenBadgeIds)
+              ? user.hiddenBadgeIds
+              : [],
       };
 
       localStorage.setItem("token", token);
@@ -176,6 +224,18 @@ export const AuthProvider = ({ children }) => {
             : user.isPublic !== undefined
               ? user.isPublic
               : false,
+        hideBadges:
+          user.hide_badges !== undefined
+            ? user.hide_badges
+            : user.hideBadges !== undefined
+              ? user.hideBadges
+              : false,
+        hiddenBadgeIds:
+          Array.isArray(user.hidden_badge_ids)
+            ? user.hidden_badge_ids
+            : Array.isArray(user.hiddenBadgeIds)
+              ? user.hiddenBadgeIds
+              : [],
         // Add snake_case versions
         first_name: user.first_name || user.firstName,
         last_name: user.last_name || user.lastName,
@@ -186,6 +246,12 @@ export const AuthProvider = ({ children }) => {
             ? user.is_public
             : user.isPublic !== undefined
               ? user.isPublic
+              : false,
+        hide_badges:
+          user.hide_badges !== undefined
+            ? user.hide_badges
+            : user.hideBadges !== undefined
+              ? user.hideBadges
               : false,
       };
 
@@ -242,6 +308,30 @@ export const AuthProvider = ({ children }) => {
       } else if (userData.isPublic !== undefined) {
         newUser.isPublic = userData.isPublic;
         newUser.is_public = userData.isPublic;
+      }
+
+      if (userData.hide_badges !== undefined) {
+        newUser.hide_badges = userData.hide_badges;
+        newUser.hideBadges = userData.hide_badges;
+      } else if (userData.hideBadges !== undefined) {
+        newUser.hideBadges = userData.hideBadges;
+        newUser.hide_badges = userData.hideBadges;
+      }
+
+      if (userData.hidden_badge_ids !== undefined) {
+        newUser.hidden_badge_ids = Array.isArray(userData.hidden_badge_ids)
+          ? userData.hidden_badge_ids
+          : [];
+        newUser.hiddenBadgeIds = Array.isArray(userData.hidden_badge_ids)
+          ? userData.hidden_badge_ids
+          : [];
+      } else if (userData.hiddenBadgeIds !== undefined) {
+        newUser.hiddenBadgeIds = Array.isArray(userData.hiddenBadgeIds)
+          ? userData.hiddenBadgeIds
+          : [];
+        newUser.hidden_badge_ids = Array.isArray(userData.hiddenBadgeIds)
+          ? userData.hiddenBadgeIds
+          : [];
       }
 
       if (userData.is_synthetic !== undefined) {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -5,6 +5,18 @@ import { setUserTimezone } from "../utils/dateHelpers";
 
 const AuthContext = createContext(null);
 
+const normalizeHiddenBadgeIds = (source = {}) => {
+  if (Array.isArray(source.hidden_badge_ids)) return source.hidden_badge_ids;
+  if (Array.isArray(source.hiddenBadgeIds)) return source.hiddenBadgeIds;
+  return [];
+};
+
+const normalizeHiddenAwardIds = (source = {}) => {
+  if (Array.isArray(source.hidden_award_ids)) return source.hidden_award_ids;
+  if (Array.isArray(source.hiddenAwardIds)) return source.hiddenAwardIds;
+  return [];
+};
+
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [token, setToken] = useState(localStorage.getItem("token"));
@@ -44,11 +56,9 @@ export const AuthProvider = ({ children }) => {
                   ? userData.hideBadges
                   : false,
             hiddenBadgeIds:
-              Array.isArray(userData.hidden_badge_ids)
-                ? userData.hidden_badge_ids
-                : Array.isArray(userData.hiddenBadgeIds)
-                  ? userData.hiddenBadgeIds
-                  : [],
+              normalizeHiddenBadgeIds(userData),
+            hiddenAwardIds:
+              normalizeHiddenAwardIds(userData),
             // Add snake_case versions if missing
             first_name: userData.first_name || userData.firstName,
             last_name: userData.last_name || userData.lastName,
@@ -67,11 +77,9 @@ export const AuthProvider = ({ children }) => {
                   ? userData.hideBadges
                   : false,
             hidden_badge_ids:
-              Array.isArray(userData.hidden_badge_ids)
-                ? userData.hidden_badge_ids
-                : Array.isArray(userData.hiddenBadgeIds)
-                  ? userData.hiddenBadgeIds
-                  : [],
+              normalizeHiddenBadgeIds(userData),
+            hidden_award_ids:
+              normalizeHiddenAwardIds(userData),
           };
           setUser(enhancedUserData);
           setUserTimezone(enhancedUserData);
@@ -144,11 +152,9 @@ export const AuthProvider = ({ children }) => {
               ? user.hideBadges
               : false,
         hiddenBadgeIds:
-          Array.isArray(user.hidden_badge_ids)
-            ? user.hidden_badge_ids
-            : Array.isArray(user.hiddenBadgeIds)
-              ? user.hiddenBadgeIds
-              : [],
+          normalizeHiddenBadgeIds(user),
+        hiddenAwardIds:
+          normalizeHiddenAwardIds(user),
         first_name: user.first_name || user.firstName,
         last_name: user.last_name || user.lastName,
         postal_code: user.postal_code || user.postalCode,
@@ -166,11 +172,9 @@ export const AuthProvider = ({ children }) => {
               ? user.hideBadges
               : false,
         hidden_badge_ids:
-          Array.isArray(user.hidden_badge_ids)
-            ? user.hidden_badge_ids
-            : Array.isArray(user.hiddenBadgeIds)
-              ? user.hiddenBadgeIds
-              : [],
+          normalizeHiddenBadgeIds(user),
+        hidden_award_ids:
+          normalizeHiddenAwardIds(user),
       };
 
       localStorage.setItem("token", token);
@@ -231,11 +235,9 @@ export const AuthProvider = ({ children }) => {
               ? user.hideBadges
               : false,
         hiddenBadgeIds:
-          Array.isArray(user.hidden_badge_ids)
-            ? user.hidden_badge_ids
-            : Array.isArray(user.hiddenBadgeIds)
-              ? user.hiddenBadgeIds
-              : [],
+          normalizeHiddenBadgeIds(user),
+        hiddenAwardIds:
+          normalizeHiddenAwardIds(user),
         // Add snake_case versions
         first_name: user.first_name || user.firstName,
         last_name: user.last_name || user.lastName,
@@ -253,6 +255,10 @@ export const AuthProvider = ({ children }) => {
             : user.hideBadges !== undefined
               ? user.hideBadges
               : false,
+        hidden_badge_ids:
+          normalizeHiddenBadgeIds(user),
+        hidden_award_ids:
+          normalizeHiddenAwardIds(user),
       };
 
       localStorage.setItem("token", token);
@@ -331,6 +337,22 @@ export const AuthProvider = ({ children }) => {
           : [];
         newUser.hidden_badge_ids = Array.isArray(userData.hiddenBadgeIds)
           ? userData.hiddenBadgeIds
+          : [];
+      }
+
+      if (userData.hidden_award_ids !== undefined) {
+        newUser.hidden_award_ids = Array.isArray(userData.hidden_award_ids)
+          ? userData.hidden_award_ids
+          : [];
+        newUser.hiddenAwardIds = Array.isArray(userData.hidden_award_ids)
+          ? userData.hidden_award_ids
+          : [];
+      } else if (userData.hiddenAwardIds !== undefined) {
+        newUser.hiddenAwardIds = Array.isArray(userData.hiddenAwardIds)
+          ? userData.hiddenAwardIds
+          : [];
+        newUser.hidden_award_ids = Array.isArray(userData.hiddenAwardIds)
+          ? userData.hiddenAwardIds
           : [];
       }
 

--- a/src/hooks/useAwardModals.js
+++ b/src/hooks/useAwardModals.js
@@ -34,6 +34,36 @@ const unwrapRows = (response) => {
   return rows;
 };
 
+const getAwardId = (award) => award?.awardId ?? award?.award_id ?? award?.id;
+
+const getBadgeId = (awardOrBadge) =>
+  awardOrBadge?.badgeId ?? awardOrBadge?.badge_id ?? awardOrBadge?.id;
+
+const getBadgeName = (awardOrBadge) =>
+  (awardOrBadge?.badgeName ?? awardOrBadge?.badge_name ?? awardOrBadge?.name ?? "")
+    .trim();
+
+const sameAward = (a, b) => {
+  const aId = getAwardId(a);
+  const bId = getAwardId(b);
+  if (aId === undefined || aId === null || bId === undefined || bId === null) {
+    return false;
+  }
+  return String(aId) === String(bId);
+};
+
+const sameBadge = (a, b) => {
+  const aId = getBadgeId(a);
+  const bId = getBadgeId(b);
+  if (aId !== undefined && aId !== null && bId !== undefined && bId !== null) {
+    return String(aId) === String(bId);
+  }
+
+  const aName = getBadgeName(a).toLowerCase();
+  const bName = getBadgeName(b).toLowerCase();
+  return Boolean(aName && bName && aName === bName);
+};
+
 const useAwardModals = (userId) => {
   // ========= Badge Category Modal state =========
   const [badgeCategoryModal, setBadgeCategoryModal] = useState({
@@ -248,6 +278,51 @@ const useAwardModals = (userId) => {
     setSupercategoryAwards([]);
   }, []);
 
+  const removeAwardFromBadgeModal = useCallback((removedAward) => {
+    setDetailedBadgeAwards((prevAwards) => {
+      let removedCredits = 0;
+      const nextAwards = prevAwards.filter((award) => {
+        if (!sameAward(award, removedAward)) return true;
+        removedCredits += Number(award.credits ?? 0);
+        return false;
+      });
+
+      if (removedCredits > 0) {
+        setBadgeCategoryModal((prevModal) => ({
+          ...prevModal,
+          totalCredits: Math.max(
+            0,
+            Number(prevModal.totalCredits ?? 0) - removedCredits,
+          ),
+        }));
+      }
+
+      return nextAwards;
+    });
+  }, []);
+
+  const removeBadgeFromBadgeModal = useCallback((hiddenBadge) => {
+    setDetailedBadgeAwards((prevAwards) => {
+      let removedCredits = 0;
+      const nextAwards = prevAwards.filter((award) => {
+        if (!sameBadge(award, hiddenBadge)) return true;
+        removedCredits += Number(award.credits ?? 0);
+        return false;
+      });
+
+      setBadgeCategoryModal((prevModal) => ({
+        ...prevModal,
+        badges: prevModal.badges.filter((badge) => !sameBadge(badge, hiddenBadge)),
+        totalCredits: Math.max(
+          0,
+          Number(prevModal.totalCredits ?? 0) - removedCredits,
+        ),
+      }));
+
+      return nextAwards;
+    });
+  }, []);
+
   // ========= Props-spreader objects (for cleaner JSX) =========
 
   /** Spread onto <BadgeCategoryModal ... /> */
@@ -296,6 +371,8 @@ const useAwardModals = (userId) => {
     closeBadgeCategoryModal,
     closeTagAwardsModal,
     closeSupercategoryModal,
+    removeAwardFromBadgeModal,
+    removeBadgeFromBadgeModal,
 
     // Props-spreader objects (for JSX)
     badgeCategoryModalProps,

--- a/src/hooks/useAwardModals.js
+++ b/src/hooks/useAwardModals.js
@@ -36,8 +36,16 @@ const unwrapRows = (response) => {
 
 const getAwardId = (award) => award?.awardId ?? award?.award_id ?? award?.id;
 
-const getBadgeId = (awardOrBadge) =>
-  awardOrBadge?.badgeId ?? awardOrBadge?.badge_id ?? awardOrBadge?.id;
+const getBadgeId = (awardOrBadge) => {
+  const explicitBadgeId = awardOrBadge?.badgeId ?? awardOrBadge?.badge_id;
+  if (explicitBadgeId !== undefined && explicitBadgeId !== null) {
+    return explicitBadgeId;
+  }
+
+  const hasAwardId =
+    awardOrBadge?.awardId !== undefined || awardOrBadge?.award_id !== undefined;
+  return hasAwardId ? undefined : awardOrBadge?.id;
+};
 
 const getBadgeName = (awardOrBadge) =>
   (awardOrBadge?.badgeName ?? awardOrBadge?.badge_name ?? awardOrBadge?.name ?? "")
@@ -279,6 +287,8 @@ const useAwardModals = (userId) => {
   }, []);
 
   const removeAwardFromBadgeModal = useCallback((removedAward) => {
+    const removedAwardCredits = Number(removedAward?.credits ?? 0);
+
     setDetailedBadgeAwards((prevAwards) => {
       let removedCredits = 0;
       const nextAwards = prevAwards.filter((award) => {
@@ -293,6 +303,48 @@ const useAwardModals = (userId) => {
           totalCredits: Math.max(
             0,
             Number(prevModal.totalCredits ?? 0) - removedCredits,
+          ),
+        }));
+      }
+
+      return nextAwards;
+    });
+
+    setTagAwards((prevAwards) => {
+      let removed = false;
+      const nextAwards = prevAwards.filter((award) => {
+        if (!sameAward(award, removedAward)) return true;
+        removed = true;
+        return false;
+      });
+
+      if (removed && removedAwardCredits > 0) {
+        setTagAwardsModal((prevModal) => ({
+          ...prevModal,
+          totalCredits: Math.max(
+            0,
+            Number(prevModal.totalCredits ?? 0) - removedAwardCredits,
+          ),
+        }));
+      }
+
+      return nextAwards;
+    });
+
+    setSupercategoryAwards((prevAwards) => {
+      let removed = false;
+      const nextAwards = prevAwards.filter((award) => {
+        if (!sameAward(award, removedAward)) return true;
+        removed = true;
+        return false;
+      });
+
+      if (removed && removedAwardCredits > 0) {
+        setSupercategoryModal((prevModal) => ({
+          ...prevModal,
+          totalCredits: Math.max(
+            0,
+            Number(prevModal.totalCredits ?? 0) - removedAwardCredits,
           ),
         }));
       }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -23,6 +23,7 @@ import {
   Tag,
   Calendar,
   FlaskConical,
+  Trash2,
 } from "lucide-react";
 import useAwardModals from "../hooks/useAwardModals";
 import { CATEGORY_COLORS } from "../constants/badgeConstants";
@@ -42,7 +43,6 @@ import ImageUploader from "../components/common/ImageUploader";
 import {
   DEMO_PROFILE_TOOLTIP,
   getUserInitials,
-  isBadgeHiddenForUser,
   isSyntheticUser,
 } from "../utils/userHelpers";
 import DemoAvatarOverlay from "../components/users/DemoAvatarOverlay";
@@ -79,11 +79,11 @@ const Profile = () => {
     tagAwardsModalProps,
     supercategoryModalProps,
     removeAwardFromBadgeModal,
-    removeBadgeFromBadgeModal,
   } = useAwardModals(profileUserId);
 
   const [avatarDeleteLoading, setAvatarDeleteLoading] = useState(false);
   const [badgeActionLoadingKey, setBadgeActionLoadingKey] = useState(null);
+  const [pendingBadgeAction, setPendingBadgeAction] = useState(null);
   const [selectedUserId, setSelectedUserId] = useState(null);
 
   // Add form errors state
@@ -116,10 +116,10 @@ const Profile = () => {
   // Prefer freshest API user (includes badges totals). Fall back to auth context.
   const displayUser = localUser || user;
   const displayBadges = Array.isArray(displayUser?.badges)
-    ? displayUser.badges.filter(
-        (badge) => !isBadgeHiddenForUser(badge, displayUser),
-      )
+    ? displayUser.badges
     : [];
+  const hiddenAwardIds =
+    displayUser?.hidden_award_ids ?? displayUser?.hiddenAwardIds ?? [];
 
   // Auto-fill city from postal code lookup
   const { getSuggestedUpdates } = useLocationAutoFill({
@@ -487,8 +487,16 @@ const Profile = () => {
   };
 
   const getAwardId = (award) => award?.awardId ?? award?.award_id ?? award?.id;
-  const getBadgeId = (awardOrBadge) =>
-    awardOrBadge?.badgeId ?? awardOrBadge?.badge_id ?? awardOrBadge?.id;
+  const getBadgeId = (awardOrBadge) => {
+    const explicitBadgeId = awardOrBadge?.badgeId ?? awardOrBadge?.badge_id;
+    if (explicitBadgeId !== undefined && explicitBadgeId !== null) {
+      return explicitBadgeId;
+    }
+
+    const hasAwardId =
+      awardOrBadge?.awardId !== undefined || awardOrBadge?.award_id !== undefined;
+    return hasAwardId ? undefined : awardOrBadge?.id;
+  };
   const getBadgeName = (awardOrBadge) =>
     (
       awardOrBadge?.badgeName ??
@@ -496,6 +504,37 @@ const Profile = () => {
       awardOrBadge?.name ??
       ""
     ).trim();
+  const getAwardContextLabel = (award) => {
+    const contextType = award?.contextType ?? award?.context_type;
+
+    switch (contextType) {
+      case "team":
+        return "Team Contribution";
+      case "project":
+        return "Project Contribution";
+      case "personal":
+      case "profile":
+      case "chat":
+        return "Personal Contribution";
+      default:
+        return "Contribution";
+    }
+  };
+  const getAwarderName = (award) => {
+    const firstName =
+      award?.awardedByFirstName ?? award?.awarded_by_first_name ?? "";
+    const lastName =
+      award?.awardedByLastName ?? award?.awarded_by_last_name ?? "";
+    const fullName = `${firstName} ${lastName}`.trim();
+
+    return (
+      fullName ||
+      award?.awardedByUsername ||
+      award?.awarded_by_username ||
+      "another user"
+    );
+  };
+  const getAwardTagName = (award) => award?.tagName ?? award?.tag_name ?? null;
 
   const sameBadge = (badge, awardOrBadge) => {
     const badgeId = getBadgeId(badge);
@@ -525,46 +564,53 @@ const Profile = () => {
     });
   };
 
-  const handleHideBadge = async (award) => {
+  const handleHideBadge = (award) => {
+    setPendingBadgeAction({ type: "hide", award });
+  };
+
+  const handleDeleteBadgeAward = (award) => {
+    setPendingBadgeAction({ type: "delete", award });
+  };
+
+  const closePendingBadgeAction = () => {
+    if (badgeActionLoadingKey) return;
+    setPendingBadgeAction(null);
+  };
+
+  const executeHideBadge = async (award) => {
     if (!user?.id) return;
 
-    const badgeId = getBadgeId(award);
-    if (!badgeId) {
-      setError("Could not hide this badge because it is missing a badge ID.");
+    const awardId = getAwardId(award);
+    if (!awardId) {
+      setError("Could not hide this badge award because it is missing an ID.");
       return;
     }
 
-    const ok = window.confirm("Hide this badge from your profile?");
-    if (!ok) return;
-
-    const loadingKey = `hide-${badgeId}`;
+    const loadingKey = `hide-${awardId}`;
 
     try {
       setError(null);
       setBadgeActionLoadingKey(loadingKey);
-      await userService.updateUserBadgeVisibility(user.id, badgeId, true);
+      await userService.updateUserBadgeVisibility(user.id, awardId, true);
 
-      removeBadgeFromBadgeModal(award);
       updateLocalUserBadges((currentUser) => {
         const hiddenIds =
-          currentUser.hidden_badge_ids ?? currentUser.hiddenBadgeIds ?? [];
+          currentUser.hidden_award_ids ?? currentUser.hiddenAwardIds ?? [];
         const nextHiddenIds = hiddenIds
           .map((value) => String(value))
-          .includes(String(badgeId))
+          .includes(String(awardId))
           ? hiddenIds
-          : [...hiddenIds, badgeId];
+          : [...hiddenIds, awardId];
 
         return {
           ...currentUser,
-          badges: Array.isArray(currentUser.badges)
-            ? currentUser.badges.filter((badge) => !sameBadge(badge, award))
-            : currentUser.badges,
-          hidden_badge_ids: nextHiddenIds,
-          hiddenBadgeIds: nextHiddenIds,
+          hidden_award_ids: nextHiddenIds,
+          hiddenAwardIds: nextHiddenIds,
         };
       });
 
-      setSuccess("Badge hidden from your profile.");
+      setSuccess("Badge hidden from others.");
+      setPendingBadgeAction(null);
     } catch (err) {
       console.error("Failed to hide badge:", err);
       setError(
@@ -577,7 +623,50 @@ const Profile = () => {
     }
   };
 
-  const handleDeleteBadgeAward = async (award) => {
+  const handleShowBadge = async (award) => {
+    if (!user?.id) return;
+
+    const awardId = getAwardId(award);
+    if (!awardId) {
+      setError("Could not show this badge award because it is missing an ID.");
+      return;
+    }
+
+    const loadingKey = `show-${awardId}`;
+
+    try {
+      setError(null);
+      setBadgeActionLoadingKey(loadingKey);
+      await userService.updateUserBadgeVisibility(user.id, awardId, false);
+
+      updateLocalUserBadges((currentUser) => {
+        const hiddenIds =
+          currentUser.hidden_award_ids ?? currentUser.hiddenAwardIds ?? [];
+        const nextHiddenIds = hiddenIds.filter(
+          (value) => String(value) !== String(awardId),
+        );
+
+        return {
+          ...currentUser,
+          hidden_award_ids: nextHiddenIds,
+          hiddenAwardIds: nextHiddenIds,
+        };
+      });
+
+      setSuccess("Badge visible for others.");
+    } catch (err) {
+      console.error("Failed to show badge:", err);
+      setError(
+        err.response?.data?.message ||
+          err.message ||
+          "Failed to make badge visible. Please try again.",
+      );
+    } finally {
+      setBadgeActionLoadingKey(null);
+    }
+  };
+
+  const executeDeleteBadgeAward = async (award) => {
     if (!user?.id) return;
 
     const awardId = getAwardId(award);
@@ -585,9 +674,6 @@ const Profile = () => {
       setError("Could not delete this badge award because it is missing an ID.");
       return;
     }
-
-    const ok = window.confirm("Delete this badge award?");
-    if (!ok) return;
 
     const loadingKey = `delete-${awardId}`;
     const removedCredits = Number(award?.credits ?? 0);
@@ -598,6 +684,28 @@ const Profile = () => {
       await userService.deleteUserBadgeAward(user.id, awardId);
 
       removeAwardFromBadgeModal(award);
+      setUserTagObjects((currentTags) => {
+        const awardTagName = getAwardTagName(award);
+        if (!awardTagName) return currentTags;
+
+        return currentTags
+          .map((tag) => {
+            const tagName = tag.name ?? tag.tag_name;
+            if (tagName !== awardTagName) return tag;
+
+            const currentCredits = Number(
+              tag.badgeCredits ?? tag.badge_credits ?? 0,
+            );
+            const nextCredits = Math.max(0, currentCredits - removedCredits);
+
+            return {
+              ...tag,
+              badgeCredits: nextCredits,
+              badge_credits: nextCredits,
+            };
+          })
+          .filter((tag) => Number(tag.badgeCredits ?? tag.badge_credits ?? 0) > 0);
+      });
       updateLocalUserBadges((currentUser) => ({
         ...currentUser,
         badges: Array.isArray(currentUser.badges)
@@ -629,6 +737,7 @@ const Profile = () => {
       }));
 
       setSuccess("Badge award deleted.");
+      setPendingBadgeAction(null);
     } catch (err) {
       console.error("Failed to delete badge award:", err);
       setError(
@@ -872,6 +981,30 @@ const Profile = () => {
       profileLocation.state ||
       profileLocation.country,
   );
+  const pendingBadgeAward = pendingBadgeAction?.award;
+  const pendingBadgeActionType = pendingBadgeAction?.type;
+  const pendingBadgeAwardDescription = pendingBadgeAward
+    ? `"${getAwardContextLabel(pendingBadgeAward)}" Award from ${getAwarderName(
+        pendingBadgeAward,
+      )}`
+    : "this badge award";
+  const pendingBadgeActionLoading = Boolean(
+    pendingBadgeAward &&
+      badgeActionLoadingKey ===
+        `${pendingBadgeActionType}-${getAwardId(pendingBadgeAward)}`,
+  );
+  const confirmPendingBadgeAction = () => {
+    if (!pendingBadgeAward) return;
+
+    if (pendingBadgeActionType === "hide") {
+      executeHideBadge(pendingBadgeAward);
+      return;
+    }
+
+    if (pendingBadgeActionType === "delete") {
+      executeDeleteBadgeAward(pendingBadgeAward);
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -1358,14 +1491,77 @@ const Profile = () => {
         onOpenUser={openUserModal}
         highlightBadgeName={highlightBadgeName}
         onHideBadge={handleHideBadge}
+        onShowBadge={handleShowBadge}
         onDeleteAward={handleDeleteBadgeAward}
+        hiddenAwardIds={hiddenAwardIds}
+        showHiddenBadgeAwards={true}
         badgeActionLoadingKey={badgeActionLoadingKey}
       />
+
+      <Modal
+        isOpen={Boolean(pendingBadgeAction)}
+        onClose={closePendingBadgeAction}
+        title={
+          pendingBadgeActionType === "delete"
+            ? "Delete Badge Award"
+            : "Hide Badge Award"
+        }
+        position="center"
+        size="small"
+        closeOnBackdrop={!pendingBadgeActionLoading}
+        closeOnEscape={!pendingBadgeActionLoading}
+        showCloseButton={!pendingBadgeActionLoading}
+        footer={
+          <div className="flex justify-end gap-3">
+            <Button
+              variant="ghost"
+              onClick={closePendingBadgeAction}
+              disabled={pendingBadgeActionLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant={
+                pendingBadgeActionType === "delete" ? "error" : "primary"
+              }
+              onClick={confirmPendingBadgeAction}
+              disabled={pendingBadgeActionLoading}
+              icon={
+                pendingBadgeActionType === "delete" ? (
+                  <Trash2 size={16} />
+                ) : (
+                  <EyeClosed size={16} />
+                )
+              }
+            >
+              {pendingBadgeActionLoading
+                ? pendingBadgeActionType === "delete"
+                  ? "Deleting..."
+                  : "Hiding..."
+                : pendingBadgeActionType === "delete"
+                  ? "Delete"
+                  : "Hide"}
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-sm text-base-content/80">
+          {pendingBadgeActionType === "delete"
+            ? `Delete ${pendingBadgeAwardDescription} permanently? This removes only this awarded instance, not other awards for the same badge.`
+            : `Hide ${pendingBadgeAwardDescription} from others? You will still see it on your profile with a closed-eye marker.`}
+        </p>
+      </Modal>
 
       <TagAwardsModal
         {...tagAwardsModalProps}
         onOpenUser={openUserModal}
         highlightBadgeName={highlightBadgeName}
+        onHideBadge={handleHideBadge}
+        onShowBadge={handleShowBadge}
+        onDeleteAward={handleDeleteBadgeAward}
+        hiddenAwardIds={hiddenAwardIds}
+        showHiddenBadgeAwards={true}
+        badgeActionLoadingKey={badgeActionLoadingKey}
       />
 
       {/* Supercategory Awards Modal */}
@@ -1373,6 +1569,12 @@ const Profile = () => {
         {...supercategoryModalProps}
         onOpenUser={openUserModal}
         highlightBadgeName={highlightBadgeName}
+        onHideBadge={handleHideBadge}
+        onShowBadge={handleShowBadge}
+        onDeleteAward={handleDeleteBadgeAward}
+        hiddenAwardIds={hiddenAwardIds}
+        showHiddenBadgeAwards={true}
+        badgeActionLoadingKey={badgeActionLoadingKey}
       />
     </div>
   );

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -42,6 +42,7 @@ import ImageUploader from "../components/common/ImageUploader";
 import {
   DEMO_PROFILE_TOOLTIP,
   getUserInitials,
+  isBadgeHiddenForUser,
   isSyntheticUser,
 } from "../utils/userHelpers";
 import DemoAvatarOverlay from "../components/users/DemoAvatarOverlay";
@@ -77,9 +78,12 @@ const Profile = () => {
     badgeCategoryModalProps,
     tagAwardsModalProps,
     supercategoryModalProps,
+    removeAwardFromBadgeModal,
+    removeBadgeFromBadgeModal,
   } = useAwardModals(profileUserId);
 
   const [avatarDeleteLoading, setAvatarDeleteLoading] = useState(false);
+  const [badgeActionLoadingKey, setBadgeActionLoadingKey] = useState(null);
   const [selectedUserId, setSelectedUserId] = useState(null);
 
   // Add form errors state
@@ -111,6 +115,11 @@ const Profile = () => {
 
   // Prefer freshest API user (includes badges totals). Fall back to auth context.
   const displayUser = localUser || user;
+  const displayBadges = Array.isArray(displayUser?.badges)
+    ? displayUser.badges.filter(
+        (badge) => !isBadgeHiddenForUser(badge, displayUser),
+      )
+    : [];
 
   // Auto-fill city from postal code lookup
   const { getSuggestedUpdates } = useLocationAutoFill({
@@ -474,6 +483,161 @@ const Profile = () => {
       );
     } finally {
       setAvatarDeleteLoading(false);
+    }
+  };
+
+  const getAwardId = (award) => award?.awardId ?? award?.award_id ?? award?.id;
+  const getBadgeId = (awardOrBadge) =>
+    awardOrBadge?.badgeId ?? awardOrBadge?.badge_id ?? awardOrBadge?.id;
+  const getBadgeName = (awardOrBadge) =>
+    (
+      awardOrBadge?.badgeName ??
+      awardOrBadge?.badge_name ??
+      awardOrBadge?.name ??
+      ""
+    ).trim();
+
+  const sameBadge = (badge, awardOrBadge) => {
+    const badgeId = getBadgeId(badge);
+    const targetBadgeId = getBadgeId(awardOrBadge);
+    if (
+      badgeId !== undefined &&
+      badgeId !== null &&
+      targetBadgeId !== undefined &&
+      targetBadgeId !== null
+    ) {
+      return String(badgeId) === String(targetBadgeId);
+    }
+
+    const badgeName = getBadgeName(badge).toLowerCase();
+    const targetBadgeName = getBadgeName(awardOrBadge).toLowerCase();
+    return Boolean(badgeName && targetBadgeName && badgeName === targetBadgeName);
+  };
+
+  const updateLocalUserBadges = (updater) => {
+    setLocalUser((prev) => {
+      const source = prev || user;
+      if (!source) return prev;
+
+      const nextUser = updater(source);
+      updateUser(nextUser);
+      return nextUser;
+    });
+  };
+
+  const handleHideBadge = async (award) => {
+    if (!user?.id) return;
+
+    const badgeId = getBadgeId(award);
+    if (!badgeId) {
+      setError("Could not hide this badge because it is missing a badge ID.");
+      return;
+    }
+
+    const ok = window.confirm("Hide this badge from your profile?");
+    if (!ok) return;
+
+    const loadingKey = `hide-${badgeId}`;
+
+    try {
+      setError(null);
+      setBadgeActionLoadingKey(loadingKey);
+      await userService.updateUserBadgeVisibility(user.id, badgeId, true);
+
+      removeBadgeFromBadgeModal(award);
+      updateLocalUserBadges((currentUser) => {
+        const hiddenIds =
+          currentUser.hidden_badge_ids ?? currentUser.hiddenBadgeIds ?? [];
+        const nextHiddenIds = hiddenIds
+          .map((value) => String(value))
+          .includes(String(badgeId))
+          ? hiddenIds
+          : [...hiddenIds, badgeId];
+
+        return {
+          ...currentUser,
+          badges: Array.isArray(currentUser.badges)
+            ? currentUser.badges.filter((badge) => !sameBadge(badge, award))
+            : currentUser.badges,
+          hidden_badge_ids: nextHiddenIds,
+          hiddenBadgeIds: nextHiddenIds,
+        };
+      });
+
+      setSuccess("Badge hidden from your profile.");
+    } catch (err) {
+      console.error("Failed to hide badge:", err);
+      setError(
+        err.response?.data?.message ||
+          err.message ||
+          "Failed to hide badge. Please try again.",
+      );
+    } finally {
+      setBadgeActionLoadingKey(null);
+    }
+  };
+
+  const handleDeleteBadgeAward = async (award) => {
+    if (!user?.id) return;
+
+    const awardId = getAwardId(award);
+    if (!awardId) {
+      setError("Could not delete this badge award because it is missing an ID.");
+      return;
+    }
+
+    const ok = window.confirm("Delete this badge award?");
+    if (!ok) return;
+
+    const loadingKey = `delete-${awardId}`;
+    const removedCredits = Number(award?.credits ?? 0);
+
+    try {
+      setError(null);
+      setBadgeActionLoadingKey(loadingKey);
+      await userService.deleteUserBadgeAward(user.id, awardId);
+
+      removeAwardFromBadgeModal(award);
+      updateLocalUserBadges((currentUser) => ({
+        ...currentUser,
+        badges: Array.isArray(currentUser.badges)
+          ? currentUser.badges
+              .map((badge) => {
+                if (!sameBadge(badge, award)) return badge;
+
+                const currentCredits = Number(
+                  badge.total_credits ?? badge.totalCredits ?? 0,
+                );
+                const currentAwardCount = Number(
+                  badge.award_count ?? badge.awardCount ?? 1,
+                );
+                const nextCredits = Math.max(0, currentCredits - removedCredits);
+                const nextAwardCount = Math.max(0, currentAwardCount - 1);
+
+                if (nextCredits <= 0 || nextAwardCount <= 0) return null;
+
+                return {
+                  ...badge,
+                  total_credits: nextCredits,
+                  totalCredits: nextCredits,
+                  award_count: nextAwardCount,
+                  awardCount: nextAwardCount,
+                };
+              })
+              .filter(Boolean)
+          : currentUser.badges,
+      }));
+
+      setSuccess("Badge award deleted.");
+    } catch (err) {
+      console.error("Failed to delete badge award:", err);
+      setError(
+        err.response?.data?.message ||
+          err.message ||
+          "Failed to delete badge award. Please try again.",
+      );
+    } finally {
+      setBadgeActionLoadingKey(null);
     }
   };
 
@@ -1033,8 +1197,7 @@ const Profile = () => {
                 userTagObjects.length > 0 ||
                 (selectedTags && selectedTags.length > 0);
               const hasBadges =
-                Array.isArray(displayUser?.badges) &&
-                displayUser.badges.length > 0;
+                displayBadges.length > 0;
               const bothEmpty = !hasTags && !hasBadges;
 
               return (
@@ -1169,7 +1332,7 @@ const Profile = () => {
                       <div ref={badgesSectionRef}>
                         <BadgesDisplaySection
                           title="My Badges"
-                          badges={displayUser?.badges}
+                          badges={displayBadges}
                           emptyMessage="No badges earned yet."
                           maxVisible={8}
                           groupByCategory={true}
@@ -1194,6 +1357,9 @@ const Profile = () => {
         {...badgeCategoryModalProps}
         onOpenUser={openUserModal}
         highlightBadgeName={highlightBadgeName}
+        onHideBadge={handleHideBadge}
+        onDeleteAward={handleDeleteBadgeAward}
+        badgeActionLoadingKey={badgeActionLoadingKey}
       />
 
       <TagAwardsModal

--- a/src/pages/PublicProfile.jsx
+++ b/src/pages/PublicProfile.jsx
@@ -8,7 +8,6 @@ import BadgesDisplaySection from "../components/badges/BadgesDisplaySection";
 import UserAvatar from "../components/users/UserAvatar";
 import DeletedUserProfilePlaceholder from "../components/users/DeletedUserProfilePlaceholder";
 import { userService } from "../services/userService";
-import { isBadgeHiddenForUser } from "../utils/userHelpers";
 
 const unwrapUserPayload = (response) => {
   const payload = response?.data ?? response;
@@ -99,7 +98,7 @@ const PublicProfile = () => {
   const badges = shouldHideBadges
     ? []
     : Array.isArray(user?.badges)
-      ? user.badges.filter((badge) => !isBadgeHiddenForUser(badge, user))
+      ? user.badges
       : [];
   const badgeEmptyMessage = shouldHideBadges
     ? "This user's badges are hidden."

--- a/src/pages/PublicProfile.jsx
+++ b/src/pages/PublicProfile.jsx
@@ -8,6 +8,7 @@ import BadgesDisplaySection from "../components/badges/BadgesDisplaySection";
 import UserAvatar from "../components/users/UserAvatar";
 import DeletedUserProfilePlaceholder from "../components/users/DeletedUserProfilePlaceholder";
 import { userService } from "../services/userService";
+import { isBadgeHiddenForUser } from "../utils/userHelpers";
 
 const unwrapUserPayload = (response) => {
   const payload = response?.data ?? response;
@@ -93,7 +94,16 @@ const PublicProfile = () => {
   const displayName = useMemo(() => getUserDisplayName(user), [user]);
   const username = user?.username ? `@${user.username}` : null;
   const bio = user?.bio || user?.biography || "";
-  const badges = Array.isArray(user?.badges) ? user.badges : [];
+  const shouldHideBadges =
+    user?.hide_badges === true || user?.hideBadges === true;
+  const badges = shouldHideBadges
+    ? []
+    : Array.isArray(user?.badges)
+      ? user.badges.filter((badge) => !isBadgeHiddenForUser(badge, user))
+      : [];
+  const badgeEmptyMessage = shouldHideBadges
+    ? "This user's badges are hidden."
+    : "No badges earned yet";
 
   if (loading) {
     return (
@@ -160,7 +170,7 @@ const PublicProfile = () => {
             <BadgesDisplaySection
               title="Badges"
               badges={badges}
-              emptyMessage="No badges earned yet"
+              emptyMessage={badgeEmptyMessage}
               groupByCategory={true}
               showCredits={true}
             />

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -92,22 +92,22 @@ export const userService = {
   },
 
   /**
-   * Hide or unhide one badge type on the current user's profile.
+   * Hide or unhide one awarded badge event on the current user's profile.
    * @param {string|number} userId - The profile owner.
-   * @param {string|number} badgeId - The badge catalog ID to update.
+   * @param {string|number} awardId - The awarded badge event ID to update.
    * @param {boolean} hidden - Whether the badge should be hidden.
    * @returns {Promise<object>} A promise resolving to the updated visibility payload.
    */
-  updateUserBadgeVisibility: async (userId, badgeId, hidden = true) => {
+  updateUserBadgeVisibility: async (userId, awardId, hidden = true) => {
     try {
       const response = await api.patch(
-        `/api/users/${userId}/badges/${badgeId}/visibility`,
+        `/api/users/${userId}/badges/awards/${awardId}/visibility`,
         { hidden },
       );
       return response.data;
     } catch (error) {
       console.error(
-        `Error updating badge ${badgeId} visibility for user ${userId}:`,
+        `Error updating badge award ${awardId} visibility for user ${userId}:`,
         error,
       );
       throw error;

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -92,6 +92,48 @@ export const userService = {
   },
 
   /**
+   * Hide or unhide one badge type on the current user's profile.
+   * @param {string|number} userId - The profile owner.
+   * @param {string|number} badgeId - The badge catalog ID to update.
+   * @param {boolean} hidden - Whether the badge should be hidden.
+   * @returns {Promise<object>} A promise resolving to the updated visibility payload.
+   */
+  updateUserBadgeVisibility: async (userId, badgeId, hidden = true) => {
+    try {
+      const response = await api.patch(
+        `/api/users/${userId}/badges/${badgeId}/visibility`,
+        { hidden },
+      );
+      return response.data;
+    } catch (error) {
+      console.error(
+        `Error updating badge ${badgeId} visibility for user ${userId}:`,
+        error,
+      );
+      throw error;
+    }
+  },
+
+  /**
+   * Delete one awarded badge event from the current user's profile.
+   * @param {string|number} userId - The profile owner.
+   * @param {string|number} awardId - The awarded badge event ID.
+   * @returns {Promise<object>} A promise resolving to the deletion result.
+   */
+  deleteUserBadgeAward: async (userId, awardId) => {
+    try {
+      const response = await api.delete(`/api/badges/awards/${awardId}`);
+      return response.data;
+    } catch (error) {
+      console.error(
+        `Error deleting badge award ${awardId} for user ${userId}:`,
+        error,
+      );
+      throw error;
+    }
+  },
+
+  /**
    * Fetches a preview of everything affected by deleting the current user's account.
    * @param {string|number} userId - The ID of the user to preview deletion for.
    * @param {string} password - The user's current password.

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -115,3 +115,33 @@ export const DEMO_TEAM_TOOLTIP =
 
 export const DEMO_ROLE_TOOLTIP =
   "Demo Role: for testing purposes, no real role";
+
+export const normalizeHiddenBadgeIds = (user) => {
+  if (!user) return [];
+
+  const rawIds = user.hidden_badge_ids ?? user.hiddenBadgeIds ?? [];
+  if (!Array.isArray(rawIds)) return [];
+
+  return rawIds
+    .filter((value) => value !== undefined && value !== null)
+    .map((value) => String(value));
+};
+
+export const isBadgeHiddenForUser = (badge, user) => {
+  const hiddenIds = normalizeHiddenBadgeIds(user);
+  if (!hiddenIds.length) return false;
+
+  const badgeId =
+    badge?.id ?? badge?.badgeId ?? badge?.badge_id ?? badge?.badge_id;
+  if (badgeId !== undefined && badgeId !== null) {
+    if (hiddenIds.includes(String(badgeId))) return true;
+  }
+
+  const badgeName = (badge?.name ?? badge?.badgeName ?? badge?.badge_name ?? "")
+    .trim();
+  if (badgeName) {
+    return hiddenIds.includes(badgeName);
+  }
+
+  return false;
+};


### PR DESCRIPTION
Summary
Adds award-level hide and delete controls for profile badge awards. Users can now manage individual awarded badge instances from the badge and focus-area modals without affecting other awards for the same badge.

Changes
Added hover actions to award cards for hiding and deleting specific badge awards.
Added restore visibility flow for hidden awards with the closed-eye/open-eye UI.
Muted hidden award cards visually while keeping them visible to the profile owner.
Added consistent Lomir-styled confirmation modals for hide/delete actions.
Updated badge and focus-area modals to support award-level hidden state.
Updated profile state handling so hidden_award_ids are tracked in both API and auth/user state.
Replaced native hover titles in award rows with the shared Lomir tooltip component.
Updated public profile display to rely on backend-filtered badge data.
Verification
npm run build passes.
Focused ESLint checks passed for the touched modal/card files during implementation.