### PR TITLE
Feature/confirm awards

### DIFF
--- a/src/components/badges/AwardCard.jsx
+++ b/src/components/badges/AwardCard.jsx
@@ -277,7 +277,7 @@ const AwardCard = ({
 
   return (
     <div
-      className={`group relative rounded-lg p-3 flex flex-col border ${highlighted ? "animate-badge-highlight" : ""}`}
+      className={`group relative rounded-lg p-3 flex flex-col border ${showBadgeActions ? "hover:shadow-md transition-shadow" : ""} ${highlighted ? "animate-badge-highlight" : ""}`}
       style={{
         backgroundColor: cardBackgroundColor,
         borderColor: cardBorderColor,

--- a/src/components/badges/BadgeAwardModal.jsx
+++ b/src/components/badges/BadgeAwardModal.jsx
@@ -370,7 +370,7 @@ const BadgeAwardModal = ({
       });
 
       setSuccess(
-        `${selectedBadge.name} badge awarded to ${getDisplayName()} (+${credits} ct.)!`,
+        `${selectedBadge.name} badge awarded to ${getDisplayName()} (+${credits} ct.). It will stay private until they make it visible.`,
       );
 
       // Notify parent to refresh badge data

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1016,16 +1016,28 @@ const Profile = () => {
         />
       )}
 
-      {success && (
-        <Alert
-          type="success"
-          message={success}
-          onClose={() => setSuccess(null)}
-        />
-      )}
+      {(success || error) && (
+        <div className="pointer-events-none fixed inset-0 z-[9999] flex items-center justify-center px-4">
+          <div className="flex max-w-[min(calc(100vw-2rem),32rem)] flex-col items-center gap-3">
+            {success && (
+              <Alert
+                type="success"
+                message={success}
+                onClose={() => setSuccess(null)}
+                className="pointer-events-auto max-w-full shadow-2xl"
+              />
+            )}
 
-      {error && (
-        <Alert type="error" message={error} onClose={() => setError(null)} />
+            {error && (
+              <Alert
+                type="error"
+                message={error}
+                onClose={() => setError(null)}
+                className="pointer-events-auto max-w-full shadow-2xl"
+              />
+            )}
+          </div>
+        </div>
       )}
 
       <Card className="overflow-visible">

--- a/src/services/badgeService.js
+++ b/src/services/badgeService.js
@@ -31,7 +31,7 @@ export const badgeService = {
    * @param {number} [awardData.contextId] - Optional context ID
    * @param {number} [awardData.teamId] - Optional team ID (required when contextType is "team")
    * @param {number} [awardData.tagId] - Optional tag ID (links award to a focus area)
-   * @returns {Promise<object>} { success: true, data: {...award} }
+   * @returns {Promise<object>} { success: true, data: {...award, hidden: true} }
    */
   awardBadge: async (awardData) => {
     try {


### PR DESCRIPTION
## Summary

- Updates the badge award success copy to explain that newly awarded badges stay private until the receiver makes them visible.
- Moves profile success/error feedback into centered heads-up messages instead of rendering them at the top of the page.
- Adds a larger soft shadow to centered profile feedback messages so they feel elevated above the page.
- Adds hover shadow feedback to award cards only when the current user can act on them, keeping read-only award cards on other users’ detail modals visually flat.

## Testing

- `npm run build`
