### PR TITLE
UI/chat page polish

### DIFF
--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -25,6 +25,7 @@ const ConversationList = ({
   activeConversationId,
   onSelectConversation,
   loading,
+  onActiveConversationVisibilityChange,
   teamMembersRefreshSignal = null,
 }) => {
   // State for team details modal
@@ -55,6 +56,38 @@ const ConversationList = ({
       return () => clearTimeout(timer);
     }
   }, [activeConversationId]);
+
+  useEffect(() => {
+    if (!onActiveConversationVisibilityChange) return undefined;
+
+    const activeItem = activeConversationRef.current;
+    if (!activeItem) {
+      onActiveConversationVisibilityChange(true);
+      return undefined;
+    }
+
+    const scrollRoot = activeItem.closest(
+      "[data-conversation-list-viewport='true']",
+    );
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        onActiveConversationVisibilityChange(
+          entry.isIntersecting && entry.intersectionRatio > 0,
+        );
+      },
+      {
+        root: scrollRoot,
+        threshold: [0, 0.01, 1],
+      },
+    );
+
+    observer.observe(activeItem);
+    return () => observer.disconnect();
+  }, [
+    activeConversationId,
+    conversations,
+    onActiveConversationVisibilityChange,
+  ]);
 
   useEffect(() => {
     const userIdsToFetch = [];

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -3,8 +3,7 @@ import { Users, User, ChevronRight } from "lucide-react";
 import Tooltip from "../common/Tooltip";
 import { CountBadge } from "../common/NotificationBadge";
 import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
-import { formatDistanceToNow } from "date-fns";
-import { normalizeTimestampToDate } from "../../utils/dateHelpers";
+import { formatRelativeChatTimestamp } from "../../utils/dateHelpers";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import UserAvatar from "../users/UserAvatar";
@@ -399,30 +398,23 @@ const ConversationList = ({
                   </Tooltip>
                   <div className="flex items-center min-w-0 gap-2">
                     <p
-                      className="text-xs truncate flex-1 min-w-0 flex items-center gap-1"
+                      className="lomir-conversation-kind text-xs truncate flex-1 min-w-0 flex items-center gap-1"
                       style={{ color: "#036b0c" }}
                     >
                       {isTeam ? (
                         <>
                           <Users size={12} className="flex-shrink-0" />
-                          <span>Team chat</span>
+                          <span className="lomir-conversation-kind-label">Team Chat</span>
                         </>
                       ) : (
                         <>
                           <User size={12} className="flex-shrink-0" />
-                          <span>DM Chat</span>
+                          <span className="lomir-conversation-kind-label">DM Chat</span>
                         </>
                       )}
                     </p>
                     <span className="flex-shrink-0 ml-2 text-xs whitespace-nowrap" style={{ color: "#036b0c" }}>
-                      {conversation.updatedAt
-                        ? formatDistanceToNow(
-                            normalizeTimestampToDate(conversation.updatedAt) || new Date(),
-                            {
-                              addSuffix: true,
-                            },
-                          ).replace("about ", "")
-                        : ""}
+                      {formatRelativeChatTimestamp(conversation.updatedAt)}
                     </span>
                   </div>
                 </div>

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from "react";
+import React, { useRef, useEffect, useState, useCallback } from "react";
 import { format, isToday, isYesterday } from "date-fns";
 import {
   normalizeTimestampToDate,
@@ -417,9 +417,12 @@ const MessageDisplay = ({
   onDeleteMessage,
   onEditMessage,
   onLeaveTeam,
+  onConversationHeaderVisibilityChange,
 }) => {
   const messagesEndRef = useRef(null);
   const highlightedMessageRef = useRef(null);
+  const [conversationHeaderElement, setConversationHeaderElement] =
+    useState(null);
   const previousMessageSnapshotRef = useRef({
     firstMessageId: null,
     lastMessageId: null,
@@ -447,6 +450,33 @@ const MessageDisplay = ({
   const [editingContent, setEditingContent] = useState("");
   const [editingError, setEditingError] = useState(null);
   const [savingEditMessageId, setSavingEditMessageId] = useState(null);
+
+  const setConversationHeaderRef = useCallback((node) => {
+    setConversationHeaderElement(node);
+  }, []);
+
+  useEffect(() => {
+    if (!onConversationHeaderVisibilityChange) return undefined;
+
+    if (!conversationHeaderElement) {
+      onConversationHeaderVisibilityChange(true);
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        onConversationHeaderVisibilityChange(
+          entry.isIntersecting && entry.intersectionRatio > 0,
+        );
+      },
+      {
+        threshold: [0, 0.01, 1],
+      },
+    );
+
+    observer.observe(conversationHeaderElement);
+    return () => observer.disconnect();
+  }, [conversationHeaderElement, onConversationHeaderVisibilityChange]);
 
   const startEditingMessage = (message) => {
     setEditingMessageId(message.id);
@@ -1276,7 +1306,7 @@ const MessageDisplay = ({
           href={fileUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-3 p-3 bg-base-100/50 rounded-lg hover:bg-base-100 transition-colors group"
+          className="flex items-center gap-3 p-3 bg-base-100/50 rounded-lg hover:bg-base-100 hover:shadow-soft transition-all duration-200 group"
           download={fileName || undefined}
         >
           {React.createElement(FileIcon, {
@@ -2359,7 +2389,10 @@ const MessageDisplay = ({
           )}
 
           {resolvedConversationPartner && conversationType === "direct" && (
-            <div className="text-center pb-4 mb-4 border-b border-base-200">
+            <div
+              ref={setConversationHeaderRef}
+              className="text-center pb-4 mb-4 border-b border-base-200"
+            >
               {renderConversationPartnerAvatar()}
               <Tooltip
                 content={`View ${resolvedConversationPartner.firstName || resolvedConversationPartner.username} details`}
@@ -2379,7 +2412,10 @@ const MessageDisplay = ({
           )}
 
           {resolvedTeamData && conversationType === "team" && (
-            <div className="text-center pb-4 mb-4 border-b border-base-200">
+            <div
+              ref={setConversationHeaderRef}
+              className="text-center pb-4 mb-4 border-b border-base-200"
+            >
               {renderTeamConversationAvatar()}
               <Tooltip
                 content={`View ${resolvedTeamData.name} details`}
@@ -2471,7 +2507,10 @@ const MessageDisplay = ({
 
         {/* Show conversation partner header for direct messages - CLICKABLE */}
         {resolvedConversationPartner && conversationType === "direct" && (
-          <div className="text-center pb-4 mb-4 border-b border-base-200">
+          <div
+            ref={setConversationHeaderRef}
+            className="text-center pb-4 mb-4 border-b border-base-200"
+          >
             {renderConversationPartnerAvatar()}
             <Tooltip
               content={`View ${resolvedConversationPartner.firstName || resolvedConversationPartner.username} details`}
@@ -2492,7 +2531,10 @@ const MessageDisplay = ({
 
         {/* Show team header for team conversations - CLICKABLE */}
         {resolvedTeamData && conversationType === "team" && (
-          <div className="text-center pb-4 mb-4 border-b border-base-200">
+          <div
+            ref={setConversationHeaderRef}
+            className="text-center pb-4 mb-4 border-b border-base-200"
+          >
             {renderTeamConversationAvatar()}
             <Tooltip
               content={`View ${resolvedTeamData.name} details`}

--- a/src/components/chat/MessageInput.jsx
+++ b/src/components/chat/MessageInput.jsx
@@ -81,7 +81,7 @@ const MessageInput = ({
 
   return (
     <div className="relative">
-      <form onSubmit={handleSubmit} className="flex items-center gap-1">
+      <form onSubmit={handleSubmit} className="flex items-center gap-3">
         {/* Attachment Menu */}
         <ChatAttachmentMenu
           onEmojiSelect={handleEmojiSelect}

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,24 @@
     margin-top: 4rem; /* generous separation from fields */
     margin-bottom: 1.5rem;
   }
+
+  .lomir-conversation-kind {
+    container: lomir-conversation-kind / inline-size;
+  }
+
+  .lomir-conversation-kind-label {
+    display: inline-block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @container lomir-conversation-kind (max-width: 4.75rem) {
+    .lomir-conversation-kind-label {
+      display: none;
+    }
+  }
 }
 
 @layer components {

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -147,6 +147,12 @@ const Chat = () => {
   const [selectedTeamData, setSelectedTeamData] = useState(null);
   const [isUserModalOpen, setIsUserModalOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
+  const [isActiveConversationVisible, setIsActiveConversationVisible] =
+    useState(true);
+  const [
+    isRegularConversationHeaderVisible,
+    setIsRegularConversationHeaderVisible,
+  ] = useState(true);
 
   const typingTimeoutRef = useRef(null);
   const messagesContainerRef = useRef(null);
@@ -231,6 +237,10 @@ const Chat = () => {
   const conversationUpdatedAt =
     getConversationUpdatedAt(activeConversation) ||
     getConversationUpdatedAt(messages?.[messages.length - 1] || messages?.[0] || null);
+  const showCompactConversationHeader =
+    Boolean(conversationId) &&
+    !isActiveConversationVisible &&
+    !isRegularConversationHeaderVisible;
 
   useEffect(() => {
     conversationsRef.current = conversations;
@@ -239,6 +249,26 @@ const Chat = () => {
   useEffect(() => {
     activeConversationRef.current = activeConversation;
   }, [activeConversation]);
+
+  useEffect(() => {
+    setIsActiveConversationVisible(true);
+    setIsRegularConversationHeaderVisible(true);
+  }, [conversationId]);
+
+  const handleActiveConversationVisibilityChange = useCallback((isVisible) => {
+    setIsActiveConversationVisible((current) =>
+      current === isVisible ? current : isVisible,
+    );
+  }, []);
+
+  const handleRegularConversationHeaderVisibilityChange = useCallback(
+    (isVisible) => {
+      setIsRegularConversationHeaderVisible((current) =>
+        current === isVisible ? current : isVisible,
+      );
+    },
+    [],
+  );
 
   const refreshConversationList = useCallback(async () => {
     try {
@@ -1505,22 +1535,32 @@ const Chat = () => {
     .map(([_, username]) => username);
 
   return (
-    <PageContainer title="Messages" className="p-0 overflow-hidden">
+    <PageContainer
+      title="Messages"
+      className="p-0 overflow-hidden"
+      variant="muted"
+    >
       {error && (
         <Alert type="error" message={error} onClose={() => setError(null)} />
       )}
 
-      <div className="flex h-[calc(100vh-200px)] bg-base-100 rounded-xl overflow-hidden">
+      <div className="bg-white shadow-soft flex h-[calc(100vh-200px)] rounded-xl overflow-hidden">
         {/* Conversation List - Left Sidebar */}
-        <div className={`border-r border-base-200 overflow-y-auto transition-all duration-300 ${
-          showChatView ? "hidden md:block md:w-1/3" : "w-full md:w-1/3"
-        }`}>
+        <div
+          data-conversation-list-viewport="true"
+          className={`border-r border-base-200 overflow-y-auto transition-all duration-300 ${
+            showChatView ? "hidden md:block md:w-1/3" : "w-full md:w-1/3"
+          }`}
+        >
           <ConversationList
             conversations={conversations}
             activeConversationId={conversationId}
             onSelectConversation={selectConversation}
             loading={loading}
             onlineUsers={onlineUsers}
+            onActiveConversationVisibilityChange={
+              handleActiveConversationVisibilityChange
+            }
             teamMembersRefreshSignal={teamMembersRefreshSignal}
           />
         </div>
@@ -1531,17 +1571,27 @@ const Chat = () => {
         }`}>
           {conversationId ? (
             <>
-              {/* Header with back button and conversation info - hidden on md and up */}
-              <div className="flex items-center justify-between border-b border-base-200 p-3 md:p-4 bg-base-100 md:hidden">
+              {/* Compact header, also shown on desktop when both regular headers are out of view */}
+              <div
+                className={`flex items-center justify-between border-b border-base-200 p-3 md:p-4 bg-base-100 ${
+                  showCompactConversationHeader ? "md:flex" : "md:hidden"
+                }`}
+              >
                 <div className="flex items-center gap-2 min-w-0 flex-1">
                   {/* Back/List toggle button - visible on small screens */}
-                  <button
-                    onClick={() => setShowChatView(false)}
-                    className="md:hidden flex items-center justify-center p-2 hover:bg-base-200 rounded-lg transition-colors"
-                    title="Back to conversation list"
+                  <Tooltip
+                    content="Back to conversation list"
+                    position="bottom"
+                    wrapperClassName="md:hidden inline-flex items-center flex-shrink-0"
                   >
-                    <ChevronLeft size={20} />
-                  </button>
+                    <button
+                      onClick={() => setShowChatView(false)}
+                      className="flex items-center justify-center p-2 hover:bg-base-200 rounded-lg transition-colors"
+                      aria-label="Back to conversation list"
+                    >
+                      <ChevronLeft size={20} />
+                    </button>
+                  </Tooltip>
                   
                   {/* Conversation Header - Avatar and name */}
                   <div className="flex items-center gap-3 min-w-0 flex-1">
@@ -1682,6 +1732,9 @@ const Chat = () => {
                   onDeleteMessage={handleDeleteMessage}
                   onEditMessage={handleEditMessage}
                   onLeaveTeam={handleLeaveTeam}
+                  onConversationHeaderVisibilityChange={
+                    handleRegularConversationHeaderVisibilityChange
+                  }
                 />
               </div>
 

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -20,8 +20,10 @@ import TeamDetailsModal from "../components/teams/TeamDetailsModal";
 import UserDetailsModal from "../components/users/UserDetailsModal";
 import { getTeamInitials, isSyntheticTeam } from "../utils/userHelpers";
 import { formatDisplayName } from "../utils/nameFormatters";
-import { formatDistanceToNowStrict } from "date-fns";
-import { normalizeTimestampToDate } from "../utils/dateHelpers";
+import {
+  formatRelativeChatTimestamp,
+  normalizeTimestampToDate,
+} from "../utils/dateHelpers";
 import { getTeamAvatarUrl } from "../utils/chatEntityResolvers";
 
 const getConversationPartnerId = (conversation) =>
@@ -97,24 +99,6 @@ const getConversationUpdatedAt = (conversation) => {
   if (!timestamp) return null;
   const parsedDate = normalizeTimestampToDate(timestamp);
   return parsedDate;
-};
-
-const formatChatTimestamp = (timestamp) => {
-  if (!timestamp) return "";
-  const now = new Date();
-  const date = normalizeTimestampToDate(timestamp);
-  if (!date) return "";
-  const minutes = Math.round((now - date) / 60000);
-  if (minutes < 60) {
-    return formatDistanceToNowStrict(date, {
-      addSuffix: true,
-      unit: "minute",
-    });
-  }
-  return formatDistanceToNowStrict(date, {
-    addSuffix: true,
-    unit: "hour",
-  });
 };
 
 const isDirectConversationForPartner = (conversation, partnerId) =>
@@ -1649,17 +1633,15 @@ const Chat = () => {
                         <div className="text-xs text-base-content/60 flex items-center justify-between gap-1.5 flex-nowrap">
                           <div className="flex items-center gap-1.5 min-w-0">
                             <Users size={12} className="flex-shrink-0" />
-                            <span className="truncate">Team chat</span>
-                            {teamData?.members && (
-                              <>
-                                <span>·</span>
-                                <span className="truncate">{teamData.members.length} {teamData.members.length === 1 ? "member" : "members"}</span>
-                              </>
-                            )}
+                            <span className="truncate">
+                              {teamData?.members
+                                ? `Team Chat with ${teamData.members.length} ${teamData.members.length === 1 ? "Member" : "Members"}`
+                                : "Team Chat"}
+                            </span>
                           </div>
                           {conversationUpdatedAt && (
                             <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
-                              {formatChatTimestamp(conversationUpdatedAt)}
+                              {formatRelativeChatTimestamp(conversationUpdatedAt)}
                             </span>
                           )}
                         </div>
@@ -1671,7 +1653,7 @@ const Chat = () => {
                           </div>
                           {conversationUpdatedAt && (
                             <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
-                              {formatChatTimestamp(conversationUpdatedAt)}
+                              {formatRelativeChatTimestamp(conversationUpdatedAt)}
                             </span>
                           )}
                         </div>

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -1,4 +1,4 @@
-import { parseISO } from "date-fns";
+import { formatDistanceToNow, parseISO } from "date-fns";
 
 // Maps country names (Nominatim) and ISO-2 codes to IANA timezone identifiers.
 // Country names come from the geocoding service (OpenStreetMap/Nominatim).
@@ -169,6 +169,13 @@ const normalizeServerTimestamp = (value) => {
 export const normalizeTimestampToDate = (value) => {
   const date = normalizeServerTimestamp(value);
   return date && !Number.isNaN(date.getTime()) ? date : null;
+};
+
+export const formatRelativeChatTimestamp = (value) => {
+  const date = normalizeTimestampToDate(value);
+  if (!date) return "";
+
+  return formatDistanceToNow(date, { addSuffix: true }).replace("about ", "");
 };
 
 export const formatLocalTime = (value) => {


### PR DESCRIPTION
## Summary

This PR polishes the chat page UI and conversation list behavior.

- Aligns chat timestamp formatting between the conversation list and compact chat header
- Updates the mobile/compact chat header copy and layout for team conversations
- Improves conversation list metadata behavior by hiding “Team Chat” / “DM Chat” labels when space is tight, leaving the icons visible
- Applies the muted/transparent page container treatment used elsewhere in the app while keeping the main chat panel on a white surface
- Adds the compact conversation header on larger screens when both the selected conversation row and regular in-message header are out of view
- Replaces the native back-button tooltip with the Lomir tooltip design
- Adds more spacing around the message input controls
- Adds a hover shadow to file attachment cards

## Testing

- Ran `npm run build`