### PR TITLE
UI/notifications1

### DIFF
--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { MessageCircle } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import socketService from '../../services/socketService';
 import { messageService } from '../../services/messageService';
 import { useAuth } from '../../contexts/AuthContext';
 import {
+  getMessageSenderDisplayName,
   getMessageConversationTarget,
   getMessagePreviewText,
   isMessageForCurrentChatPath,
@@ -76,7 +78,7 @@ const MessageNotifications = () => {
               conversationId: target.conversationId,
               conversationType: target.type,
               senderId: message.senderId || message.sender_id,
-              senderName: message.senderUsername,
+              senderName: getMessageSenderDisplayName(message),
               text: getMessagePreviewText(message),
               time: new Date()
             }
@@ -146,13 +148,18 @@ const MessageNotifications = () => {
       {notifications.map(notification => (
         <div 
           key={notification.id}
-          className="bg-primary text-primary-content rounded-lg shadow-lg p-4 max-w-xs animate-slide-in cursor-pointer"
+          className="bg-white text-black rounded-lg rounded-br-none shadow-lg p-4 max-w-xs animate-slide-in cursor-pointer"
           onClick={() => handleNotificationClick(notification)}
         >
-          <h4 className="font-medium">New Message</h4>
-          <p className="text-sm truncate">{notification.text}</p>
+          <h4 className="text-xs font-medium text-primary-focus flex items-center gap-1.5 mb-2">
+            <MessageCircle size={12} strokeWidth={2.2} aria-hidden="true" />
+            <span>New Message</span>
+          </h4>
+          <p className="text-sm">{notification.text}</p>
           {notification.senderName && (
-            <p className="text-xs mt-1">From: {notification.senderName}</p>
+            <p className="text-[11px] mt-0.5 text-primary-focus truncate">
+              from {notification.senderName}
+            </p>
           )}
         </div>
       ))}

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -84,10 +84,18 @@ const MessageNotifications = () => {
         }
       };
       
+      const handleMessageDeleted = (payload) => {
+        setNotifications((prev) =>
+          prev.filter((n) => String(n.id) !== String(payload.messageId)),
+        );
+      };
+
       socket.on('message:received', handleNewMessage);
+      socket.on('message:deleted', handleMessageDeleted);
 
       detachMessageListener = () => {
         socket.off('message:received', handleNewMessage);
+        socket.off('message:deleted', handleMessageDeleted);
       };
     };
 

--- a/src/components/common/Alert.jsx
+++ b/src/components/common/Alert.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 const Alert = ({
   type = "info",
@@ -7,6 +7,19 @@ const Alert = ({
   onClose,
   className = "",
 }) => {
+  const [fading, setFading] = useState(false);
+
+  useEffect(() => {
+    if (!onClose) return;
+    setFading(false);
+    const fadeTimer = setTimeout(() => setFading(true), 2000);
+    const closeTimer = setTimeout(onClose, 3000);
+    return () => {
+      clearTimeout(fadeTimer);
+      clearTimeout(closeTimer);
+    };
+  }, [type, message, onClose]);
+
   const alertClasses = {
     info: "alert-info",
     success: "alert-success",
@@ -17,8 +30,7 @@ const Alert = ({
 
   return (
     <div
-      className={`alert ${alertClasses[type]} !text-white shadow-sm w-fit ${className}`}
-
+      className={`alert ${alertClasses[type]} !text-white shadow-sm w-fit transition-opacity duration-1000 ${fading ? "opacity-0" : "opacity-100"} ${className}`}
     >
       <div className="flex items-center gap-2">
         {type === "info" && (

--- a/src/components/common/ConfirmModal.jsx
+++ b/src/components/common/ConfirmModal.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Loader2 } from "lucide-react";
+import Modal from "./Modal";
+import Button from "./Button";
+
+const ConfirmModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  children,
+  loading = false,
+  confirmLabel = "Confirm",
+  loadingLabel,
+  confirmVariant = "primary",
+  confirmIcon = null,
+  cancelLabel = "Cancel",
+}) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onClose}
+    title={title}
+    position="center"
+    size="small"
+    bodyClassName="p-4"
+    closeOnBackdrop={!loading}
+    closeOnEscape={!loading}
+    showCloseButton={!loading}
+    footer={
+      <div className="flex justify-end gap-3">
+        <Button variant="ghost" onClick={onClose} disabled={loading}>
+          {cancelLabel}
+        </Button>
+        <Button
+          variant={confirmVariant}
+          onClick={onConfirm}
+          disabled={loading}
+          icon={
+            loading
+              ? <Loader2 className="w-4 h-4 animate-spin" />
+              : confirmIcon
+          }
+        >
+          {loading ? (loadingLabel ?? `${confirmLabel}...`) : confirmLabel}
+        </Button>
+      </div>
+    }
+  >
+    {children}
+  </Modal>
+);
+
+export default ConfirmModal;

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -28,6 +28,7 @@ import {
  * @param {string} size - "small", "default", "large", or "lg"
  * @param {string} maxHeight - Max height class (default: "max-h-[90vh]")
  * @param {string} minHeight - Min height class
+ * @param {string} bodyClassName - Classes for the modal body wrapper
  * @param {boolean} closeOnBackdrop - Close when clicking backdrop
  * @param {boolean} closeOnEscape - Close when pressing ESC
  * @param {boolean} showCloseButton - Show X button in header
@@ -46,6 +47,7 @@ const Modal = ({
   size = "default",
   maxHeight = "max-h-[90vh]",
   minHeight = "",
+  bodyClassName = "p-6",
   closeOnBackdrop = true,
   closeOnEscape = true,
   showCloseButton = true,
@@ -160,7 +162,7 @@ const Modal = ({
         )}
 
         {/* Body - wrapped in ModalLayerProvider for child modals */}
-        <div className="p-6">
+        <div className={bodyClassName}>
           <ModalLayerProvider zIndex={childLayerZIndex}>
             {children}
           </ModalLayerProvider>

--- a/src/components/common/RequestListModal.jsx
+++ b/src/components/common/RequestListModal.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { User } from "lucide-react";
 import Modal from "./Modal";
-import Alert from "./Alert";
+import ScreenAlert from "./ScreenAlert";
 
 /**
  * RequestListModal Component
@@ -108,26 +108,6 @@ const RequestListModal = ({
         closeOnEscape={true}
         showCloseButton={true}
       >
-        {/* Error Alert */}
-        {error && (
-          <Alert
-            type="error"
-            message={error}
-            onClose={onErrorClose}
-            className="mb-4"
-          />
-        )}
-
-        {/* Success Alert */}
-        {success && (
-          <Alert
-            type="success"
-            message={success}
-            onClose={onSuccessClose}
-            className="mb-4"
-          />
-        )}
-
         {/* Content: Empty State or List */}
         {itemCount === 0 ? (
           <div className="text-center py-12">
@@ -146,6 +126,21 @@ const RequestListModal = ({
           <div className="space-y-4">{children}</div>
         )}
       </Modal>
+
+      <ScreenAlert
+        alerts={[
+          error && {
+            type: "error",
+            message: error,
+            onClose: onErrorClose,
+          },
+          success && {
+            type: "success",
+            message: success,
+            onClose: onSuccessClose,
+          },
+        ]}
+      />
 
       {/* Extra modals (e.g., UserDetailsModal) rendered outside */}
       {extraModals}

--- a/src/components/common/ScreenAlert.jsx
+++ b/src/components/common/ScreenAlert.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import Alert from "./Alert";
+
+const ScreenAlert = ({ alerts, type, message, onClose }) => {
+  const alertItems = (
+    alerts ?? (message ? [{ type, message, onClose }] : [])
+  ).filter((alert) => alert?.type && alert?.message);
+
+  if (alertItems.length === 0 || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div className="pointer-events-none fixed inset-0 z-[9999] flex items-center justify-center px-4">
+      <div className="flex max-w-[min(calc(100vw-2rem),32rem)] flex-col items-center gap-3">
+        {alertItems.map((alert, index) => (
+          <Alert
+            key={`${alert.type}-${index}`}
+            type={alert.type}
+            message={alert.message}
+            onClose={alert.onClose}
+            className="pointer-events-auto max-w-full shadow-[0_24px_70px_rgba(31,41,55,0.26),0_8px_24px_rgba(31,41,55,0.16)] ring-1 ring-white/25"
+          />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default ScreenAlert;

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -16,16 +16,50 @@ import {
   isOwnMessage,
 } from "../../utils/messageNotificationUtils";
 
+const buildMessageTooltip = (count, teamCount, senderCount) => {
+  if (!count) return undefined;
+  const msg = `${count} unread message${count !== 1 ? "s" : ""}`;
+  const parts = [];
+  if (teamCount > 0) parts.push(`in ${teamCount} team${teamCount !== 1 ? "s" : ""}`);
+  if (senderCount > 0) parts.push(`from ${senderCount} person${senderCount !== 1 ? "s" : ""}`);
+  return parts.length ? `${msg}\n${parts.join(" and ")}` : msg;
+};
+
+const buildNotificationTooltip = (count, types) => {
+  if (!count || !types) return undefined;
+  const p = (n, s) => `${n} ${s}${n !== 1 ? "s" : ""}`;
+  const lines = [
+    types.invitationReceived && `${p(types.invitationReceived, "team invitation")} for you`,
+    types.applicationReceived && `${p(types.applicationReceived, "team application")} to review`,
+    types.applicationApproved && `${p(types.applicationApproved, "team")} joined successfully`,
+    types.applicationRejected && `${p(types.applicationRejected, "team application")} rejected`,
+    types.badgeAwarded && `${p(types.badgeAwarded, "new badge award")} for you`,
+    types.memberJoined && `${p(types.memberJoined, "new member")} joined your team${types.memberJoined !== 1 ? "s" : ""}`,
+    types.memberLeft && `${p(types.memberLeft, "member")} left your team${types.memberLeft !== 1 ? "s" : ""}`,
+    types.memberRemoved && `Removed from ${p(types.memberRemoved, "team")}`,
+    types.roleChanged && `${p(types.roleChanged, "role change")} in your team${types.roleChanged !== 1 ? "s" : ""}`,
+    types.ownershipTransferred && `${p(types.ownershipTransferred, "ownership transfer")}`,
+    types.teamDeleted && `${p(types.teamDeleted, "team")} deleted`,
+    types.invitationDeclined && `${p(types.invitationDeclined, "invitation")} declined`,
+    types.invitationCancelled && `${p(types.invitationCancelled, "invitation")} cancelled`,
+    types.applicationCancelled && `${p(types.applicationCancelled, "application")} cancelled`,
+  ].filter(Boolean);
+  return lines.length ? lines.join("\n") : `${p(count, "notification")}`;
+};
+
 const Navbar = () => {
   const { isAuthenticated, user, logout } = useAuth();
   const [imageError, setImageError] = useState(false);
   // Message notification state
   const [unreadMessageCount, setUnreadMessageCount] = useState(0);
   const [firstUnreadMessage, setFirstUnreadMessage] = useState(null);
+  const [messageTeamCount, setMessageTeamCount] = useState(0);
+  const [messageSenderCount, setMessageSenderCount] = useState(0);
 
   // General notification state (invitations, applications, etc.)
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
   const [firstUnreadNotification, setFirstUnreadNotification] = useState(null);
+  const [notificationTypeCounts, setNotificationTypeCounts] = useState({});
   const location = useLocation();
   const navigate = useNavigate();
   const lastMessageFetchRef = useRef(0);
@@ -47,6 +81,8 @@ const Navbar = () => {
       const response = await messageService.getUnreadCount();
       setUnreadMessageCount(response.data?.count ?? response.count ?? 0);
       setFirstUnreadMessage(response.data?.firstUnread ?? response.firstUnread ?? null);
+      setMessageTeamCount(response.data?.teamCount ?? 0);
+      setMessageSenderCount(response.data?.senderCount ?? 0);
     } catch (error) {
       console.error("Error fetching unread message count:", error);
     }
@@ -60,6 +96,7 @@ const Navbar = () => {
       const response = await notificationService.getUnreadCount();
       setUnreadNotificationCount(response.data?.count || 0);
       setFirstUnreadNotification(response.data?.firstUnread || null);
+      setNotificationTypeCounts(response.data?.typeCounts || {});
     } catch (error) {
       console.error("Error fetching unread notification count:", error);
     }
@@ -91,6 +128,8 @@ const Navbar = () => {
     if (!isAuthenticated) {
       setUnreadMessageCount(0);
       setFirstUnreadMessage(null);
+      setMessageTeamCount(0);
+      setMessageSenderCount(0);
       return;
     }
 
@@ -123,16 +162,21 @@ const Navbar = () => {
       };
 
       const handleMessagesRead = () => {
-        // Refetch count when messages are marked as read
+        fetchUnreadMessageCount();
+      };
+
+      const handleMessageDeleted = () => {
         fetchUnreadMessageCount();
       };
 
       socket.on("message:received", handleNewMessage);
       socket.on("messages:read", handleMessagesRead);
+      socket.on("message:deleted", handleMessageDeleted);
 
       detachSocketListeners = () => {
         socket.off("message:received", handleNewMessage);
         socket.off("messages:read", handleMessagesRead);
+        socket.off("message:deleted", handleMessageDeleted);
       };
     };
 
@@ -151,6 +195,7 @@ const Navbar = () => {
     if (!isAuthenticated) {
       setUnreadNotificationCount(0);
       setFirstUnreadNotification(null);
+      setNotificationTypeCounts({});
       return;
     }
 
@@ -172,9 +217,11 @@ const Navbar = () => {
       };
 
       socket.on("notification:new", handleNewNotification);
+      socket.on("notification:updated", handleNewNotification);
 
       detachNotificationListener = () => {
         socket.off("notification:new", handleNewNotification);
+        socket.off("notification:updated", handleNewNotification);
       };
     };
 
@@ -278,6 +325,7 @@ const Navbar = () => {
                 <NotificationBadge
                   variant="alert"
                   count={unreadNotificationCount}
+                  title={buildNotificationTooltip(unreadNotificationCount, notificationTypeCounts)}
                 >
                   <Bell size={22} strokeWidth={2.2} />
                 </NotificationBadge>
@@ -293,6 +341,7 @@ const Navbar = () => {
                 <NotificationBadge
                   variant="message"
                   count={unreadMessageCount}
+                  title={buildMessageTooltip(unreadMessageCount, messageTeamCount, messageSenderCount)}
                 >
                   <MessageCircle size={22} strokeWidth={2.2} />
                 </NotificationBadge>

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -218,10 +218,12 @@ const Navbar = () => {
 
       socket.on("notification:new", handleNewNotification);
       socket.on("notification:updated", handleNewNotification);
+      socket.on("notification:deleted", handleNewNotification);
 
       detachNotificationListener = () => {
         socket.off("notification:new", handleNewNotification);
         socket.off("notification:updated", handleNewNotification);
+        socket.off("notification:deleted", handleNewNotification);
       };
     };
 
@@ -261,29 +263,42 @@ const Navbar = () => {
 
   // Handle notification badge click
   const handleNotificationClick = async () => {
-    if (unreadNotificationCount > 0 && firstUnreadNotification) {
-      // Mark this notification as read
+    // Always fetch fresh data before navigating so we never land on a deleted entity
+    let freshFirst = null;
+    try {
+      const response = await notificationService.getUnreadCount();
+      const fresh = response.data;
+      setUnreadNotificationCount(fresh?.count || 0);
+      setFirstUnreadNotification(fresh?.firstUnread || null);
+      setNotificationTypeCounts(fresh?.typeCounts || {});
+      freshFirst = fresh?.firstUnread || null;
+    } catch (error) {
+      console.error("Error fetching notifications:", error);
+      // Fall back to cached state on error
+      freshFirst = firstUnreadNotification;
+    }
+
+    if (freshFirst) {
       try {
-        await notificationService.markAsRead(firstUnreadNotification.id);
+        await notificationService.markAsRead(freshFirst.id);
       } catch (error) {
         console.error("Error marking notification as read:", error);
       }
 
-      const canNavigateToNotification =
-        firstUnreadNotification.referenceId != null &&
-        Boolean(firstUnreadNotification.navigateTo);
+      const canNavigate =
+        freshFirst.referenceId != null && Boolean(freshFirst.navigateTo);
 
-      if (canNavigateToNotification) {
-        // Navigate to the notification target
-        navigate(firstUnreadNotification.navigateTo);
+      if (canNavigate) {
+        navigate(freshFirst.navigateTo);
+      } else {
+        navigate("/teams/my-teams");
       }
 
-      // Refetch after a delay to get the NEXT unread notification
+      // Refetch after navigation to update the badge to the next unread
       setTimeout(() => {
         fetchUnreadNotificationCount();
       }, 1000);
     } else {
-      // No unread notifications, go to my-teams page
       navigate("/teams/my-teams");
     }
   };

--- a/src/components/teams/RoleBadgeDropdown.jsx
+++ b/src/components/teams/RoleBadgeDropdown.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Crown, Shield, User, UserX } from "lucide-react";
 import Dropdown, { DropdownItem } from "../common/Dropdown";
 import RoleBadgePill from "../common/RoleBadgePill";
+import ConfirmModal from "../common/ConfirmModal";
 
 const RoleBadgeDropdown = ({
   member,
@@ -12,6 +13,7 @@ const RoleBadgeDropdown = ({
   isTeamArchived = false,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
+  const [pendingAction, setPendingAction] = useState(null);
 
   // Get role display information
   const getRoleInfo = (role) => {
@@ -46,47 +48,93 @@ const RoleBadgeDropdown = ({
   const roleInfo = getRoleInfo(member.role);
   const RoleIcon = roleInfo.icon;
 
-  const handleRoleChange = async (newRole) => {
-    const memberName = member.username || member.first_name || "this member";
+  const getMemberName = () => {
+    const first = member.first_name || member.firstName;
+    const last = member.last_name || member.lastName;
+    if (first && last) return `${first} ${last}`;
+    return first || member.username || "this member";
+  };
 
-    let confirmMessage;
+  const handleRoleChange = (newRole) => {
+    const memberName = getMemberName();
+
+    let message;
+    let title;
+    let confirmLabel;
+    let variant = "primary";
+    let icon = null;
+
     if (newRole === "owner") {
-      confirmMessage = `Are you sure you want to transfer ownership to ${memberName}? You will become an Admin.`;
+      title = "Transfer Ownership";
+      message = `Transfer ownership to ${memberName}? You will become an Admin.`;
+      confirmLabel = "Transfer";
+      variant = "warning";
+      icon = <Crown size={16} />;
     } else if (newRole === "admin") {
-      confirmMessage = `Are you sure you want to promote ${memberName} to Admin?`;
+      title = "Promote Member";
+      message = `Promote ${memberName} to Admin?`;
+      confirmLabel = "Promote";
+      icon = <Shield size={16} />;
     } else {
-      confirmMessage = `Are you sure you want to demote ${memberName} to Member?`;
+      title = "Demote Admin";
+      message = `Demote ${memberName} to Member?`;
+      confirmLabel = "Demote";
+      icon = <User size={16} />;
     }
 
-    if (window.confirm(confirmMessage)) {
-      setIsLoading(true);
-      try {
-        await onRoleChange(newRole);
-      } catch (error) {
-        console.error("Role change error:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    }
+    setPendingAction({
+      type: "role",
+      newRole,
+      title,
+      message,
+      confirmLabel,
+      loadingLabel: "Updating...",
+      variant,
+      icon,
+    });
   };
 
   // Handle member removal
-  const handleRemoveMember = async () => {
-    const memberName = member.username || member.first_name || "this member";
+  const handleRemoveMember = () => {
+    const memberName = getMemberName();
 
-    if (
-      window.confirm(
-        `Are you sure you want to remove ${memberName} from the team? This action cannot be undone.`,
-      )
-    ) {
-      setIsLoading(true);
-      try {
+    setPendingAction({
+      type: "remove",
+      title: "Remove Team Member",
+      message: `Remove ${memberName} from the team? This action cannot be undone.`,
+      confirmLabel: "Remove",
+      loadingLabel: "Removing...",
+      variant: "error",
+      icon: <UserX size={16} />,
+    });
+  };
+
+  const closePendingAction = () => {
+    if (isLoading) return;
+    setPendingAction(null);
+  };
+
+  const confirmPendingAction = async () => {
+    if (!pendingAction) return;
+
+    setIsLoading(true);
+    try {
+      if (pendingAction.type === "role") {
+        await onRoleChange(pendingAction.newRole);
+      } else if (pendingAction.type === "remove") {
         await onRemoveMember(member.user_id || member.userId);
-      } catch (error) {
-        console.error("Remove member error:", error);
-      } finally {
-        setIsLoading(false);
       }
+
+      setPendingAction(null);
+    } catch (error) {
+      console.error(
+        pendingAction.type === "remove"
+          ? "Remove member error:"
+          : "Role change error:",
+        error,
+      );
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -102,7 +150,7 @@ const RoleBadgeDropdown = ({
   );
 
   // If user can't manage this member, show static badge
-  if (!canManage || isLoading) {
+  if (!canManage || (isLoading && !pendingAction)) {
     return triggerBadge;
   }
 
@@ -118,64 +166,82 @@ const RoleBadgeDropdown = ({
   }
 
   return (
-    <Dropdown
-      trigger={triggerBadge}
-      position="bottom-right"
-      openOnHover={true}
-      hoverDelay={150}
-      dropdownClassName="min-w-48"
-    >
-      {/* Promote to Admin - shown for members (NOT for archived teams) */}
-      {member.role === "member" && !isTeamArchived && (
-        <DropdownItem
-          icon={<Shield className="w-4 h-4" />}
-          onClick={() => handleRoleChange("admin")}
-          variant="default"
-        >
-          Promote to Admin
-        </DropdownItem>
-      )}
-
-      {/* Demote to Member - shown for admins (NOT for archived teams) */}
-      {member.role === "admin" && !isTeamArchived && (
-        <DropdownItem
-          icon={<User className="w-4 h-4" />}
-          onClick={() => handleRoleChange("member")}
-          variant="default"
-        >
-          Demote to Member
-        </DropdownItem>
-      )}
-
-      {/* Transfer Ownership - only shown to current owner (NOT for archived teams) */}
-      {isOwner && member.role !== "owner" && !isTeamArchived && (
-        <>
-          <div className="border-t border-base-300 my-1" />
+    <>
+      <Dropdown
+        trigger={triggerBadge}
+        position="bottom-right"
+        openOnHover={true}
+        hoverDelay={150}
+        dropdownClassName="min-w-48"
+      >
+        {/* Promote to Admin - shown for members (NOT for archived teams) */}
+        {member.role === "member" && !isTeamArchived && (
           <DropdownItem
-            icon={<Crown className="w-4 h-4 text-warning" />}
-            onClick={() => handleRoleChange("owner")}
-            variant="warning"
+            icon={<Shield className="w-4 h-4" />}
+            onClick={() => handleRoleChange("admin")}
+            variant="default"
           >
-            Transfer Ownership
+            Promote to Admin
           </DropdownItem>
-        </>
-      )}
+        )}
 
-      {/* Remove from Team - shown for non-owners (KEEP for archived teams) */}
-      {member.role !== "owner" && onRemoveMember && (
-        <>
-          {/* Only show divider if there were items above */}
-          {!isTeamArchived && <div className="border-t border-base-300 my-1" />}
+        {/* Demote to Member - shown for admins (NOT for archived teams) */}
+        {member.role === "admin" && !isTeamArchived && (
           <DropdownItem
-            icon={<UserX className="w-4 h-4 text-error" />}
-            onClick={handleRemoveMember}
-            variant="error"
+            icon={<User className="w-4 h-4" />}
+            onClick={() => handleRoleChange("member")}
+            variant="default"
           >
-            Remove from Team
+            Demote to Member
           </DropdownItem>
-        </>
-      )}
-    </Dropdown>
+        )}
+
+        {/* Transfer Ownership - only shown to current owner (NOT for archived teams) */}
+        {isOwner && member.role !== "owner" && !isTeamArchived && (
+          <>
+            <div className="border-t border-base-300 my-1" />
+            <DropdownItem
+              icon={<Crown className="w-4 h-4 text-warning" />}
+              onClick={() => handleRoleChange("owner")}
+              variant="warning"
+            >
+              Transfer Ownership
+            </DropdownItem>
+          </>
+        )}
+
+        {/* Remove from Team - shown for non-owners (KEEP for archived teams) */}
+        {member.role !== "owner" && onRemoveMember && (
+          <>
+            {/* Only show divider if there were items above */}
+            {!isTeamArchived && <div className="border-t border-base-300 my-1" />}
+            <DropdownItem
+              icon={<UserX className="w-4 h-4 text-error" />}
+              onClick={handleRemoveMember}
+              variant="error"
+            >
+              Remove from Team
+            </DropdownItem>
+          </>
+        )}
+      </Dropdown>
+
+      <ConfirmModal
+        isOpen={Boolean(pendingAction)}
+        onClose={closePendingAction}
+        onConfirm={confirmPendingAction}
+        title={pendingAction?.title}
+        loading={isLoading}
+        confirmLabel={pendingAction?.confirmLabel}
+        loadingLabel={pendingAction?.loadingLabel}
+        confirmVariant={pendingAction?.variant || "primary"}
+        confirmIcon={pendingAction?.icon}
+      >
+        <p className="text-sm text-base-content/80">
+          {pendingAction?.message}
+        </p>
+      </ConfirmModal>
+    </>
   );
 };
 

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -5,9 +5,11 @@ import {
   X,
   SendHorizontal,
   FlaskConical,
+  Trash2,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
+import ConfirmModal from "../common/ConfirmModal";
 import Tooltip from "../common/Tooltip";
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
@@ -55,6 +57,7 @@ const TeamApplicationDetailsModal = ({
   const [error, setError] = useState(null);
   const [isTeamDetailsOpen, setIsTeamDetailsOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
+  const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
 
   // ============ Helpers ============
 
@@ -173,19 +176,21 @@ const TeamApplicationDetailsModal = ({
 
   // ============ Handlers ============
 
-  const handleCancelApplication = async () => {
-    if (
-      !window.confirm(
-        "Are you sure you want to cancel your application to this team?"
-      )
-    ) {
-      return;
-    }
+  const handleCancelApplication = () => {
+    setIsCancelDialogOpen(true);
+  };
 
+  const closeCancelApplicationDialog = () => {
+    if (actionLoading === "cancel") return;
+    setIsCancelDialogOpen(false);
+  };
+
+  const confirmCancelApplication = async () => {
     try {
       setActionLoading("cancel");
       setError(null);
       await onCancel(application.id);
+      setIsCancelDialogOpen(false);
       onClose();
     } catch (err) {
       setError(err.message || "Failed to cancel application");
@@ -457,6 +462,24 @@ const TeamApplicationDetailsModal = ({
           </div>
         )}
       </Modal>
+
+      <ConfirmModal
+        isOpen={isCancelDialogOpen}
+        onClose={closeCancelApplicationDialog}
+        onConfirm={confirmCancelApplication}
+        title="Cancel Application"
+        loading={actionLoading === "cancel"}
+        confirmLabel="Cancel Application"
+        loadingLabel="Canceling..."
+        confirmVariant="error"
+        confirmIcon={<Trash2 size={16} />}
+        cancelLabel="Keep"
+      >
+        <p className="text-sm text-base-content/80">
+          Cancel your application to {team.name || "this team"}? The team will
+          no longer be able to review it.
+        </p>
+      </ConfirmModal>
 
       {/* Team Details Modal */}
       <TeamDetailsModal

--- a/src/components/teams/TeamApplicationModal.jsx
+++ b/src/components/teams/TeamApplicationModal.jsx
@@ -3,7 +3,7 @@ import { Send, Save, Users, SendHorizontal, UserSearch, MapPin, Globe, Check, Ci
 import { vacantRoleService } from "../../services/vacantRoleService";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
-import Alert from "../common/Alert";
+import ScreenAlert from "../common/ScreenAlert";
 import TeamDetailsModal from "./TeamDetailsModal";
 
 /**
@@ -248,23 +248,22 @@ const TeamApplicationModal = ({
         closeOnEscape={!loading}
         showCloseButton={true}
       >
+        <ScreenAlert
+          alerts={[
+            error && {
+              type: "error",
+              message: error,
+              onClose: () => setError(null),
+            },
+            success && {
+              type: "success",
+              message: success,
+              onClose: () => setSuccess(null),
+            },
+          ]}
+        />
+
         <div className="space-y-5 bg-transparent">
-          {error && (
-            <Alert
-              type="error"
-              message={error}
-              onClose={() => setError(null)}
-            />
-          )}
-
-          {success && (
-            <Alert
-              type="success"
-              message={success}
-              onClose={() => setSuccess(null)}
-            />
-          )}
-
           {/* Team info (click + hover like TeamInvitationDetailsModal) */}
           <div className="flex items-start justify-between gap-4 mb-5">
             <div

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -455,6 +455,7 @@ const TeamApplicationsModal = ({
             isOpen={showCloseGuard}
             onClose={() => setShowCloseGuard(false)}
             size="small"
+            bodyClassName="p-4"
             showCloseButton={false}
             closeOnBackdrop={false}
             title={

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -19,6 +19,7 @@ import {
   Ruler,
   Calendar,
   FlaskConical,
+  Trash2,
 } from "lucide-react";
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
@@ -31,6 +32,7 @@ import { vacantRoleService } from "../../services/vacantRoleService";
 import { userService } from "../../services/userService";
 import { useAuth } from "../../contexts/AuthContext";
 import Alert from "../common/Alert";
+import ConfirmModal from "../common/ConfirmModal";
 import NotificationBadge from "../common/NotificationBadge";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import TeamApplicationsModal from "./TeamApplicationsModal";
@@ -619,6 +621,9 @@ const TeamCard = ({
   const [isRoleDetailsModalOpen, setIsRoleDetailsModalOpen] = useState(false);
   const [roleMatchData, setRoleMatchData] = useState(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isCancelApplicationDialogOpen, setIsCancelApplicationDialogOpen] =
+    useState(false);
   const [actionLoading, setActionLoading] = useState(null);
   const [reminderNotice, setReminderNotice] = useState(null);
   const [error, setError] = useState(null);
@@ -1530,16 +1535,19 @@ const TeamCard = ({
   // Member variant handlers
   const handleDeleteClick = async (e) => {
     e.stopPropagation();
-    if (
-      !window.confirm(
-        "Are you sure you want to delete this team? This action cannot be undone.",
-      )
-    ) {
-      return;
-    }
+    setIsDeleteDialogOpen(true);
+  };
+
+  const closeDeleteTeamDialog = () => {
+    if (isDeleting) return;
+    setIsDeleteDialogOpen(false);
+  };
+
+  const confirmDeleteTeam = async () => {
     try {
       setIsDeleting(true);
       await teamService.deleteTeam(teamData.id);
+      setIsDeleteDialogOpen(false);
       if (onDelete) onDelete(teamData.id);
     } catch (err) {
       console.error("Error deleting team:", err);
@@ -1555,21 +1563,24 @@ const TeamCard = ({
   };
 
   // Application variant handlers
-  const handleCancelApplication = async (e) => {
-    e.stopPropagation();
-    if (
-      !window.confirm(
-        "Are you sure you want to cancel your application to this team?",
-      )
-    ) {
-      return;
-    }
+  const handleCancelApplication = (e) => {
+    e?.stopPropagation();
+    setIsCancelApplicationDialogOpen(true);
+  };
+
+  const closeCancelApplicationDialog = () => {
+    if (actionLoading === "cancel") return;
+    setIsCancelApplicationDialogOpen(false);
+  };
+
+  const confirmCancelApplication = async () => {
     setActionLoading("cancel");
     try {
       const cancelHandler = onCancel || onCancelApplication;
       if (cancelHandler) {
         await cancelHandler(normalizedData.id);
       }
+      setIsCancelApplicationDialogOpen(false);
     } catch (err) {
       console.error("Error canceling application:", err);
       setError("Failed to cancel application. Please try again.");
@@ -2864,6 +2875,40 @@ const TeamCard = ({
         {/* Action buttons */}
         {renderActionButtons()}
       </Card>
+
+      <ConfirmModal
+        isOpen={isDeleteDialogOpen}
+        onClose={closeDeleteTeamDialog}
+        onConfirm={confirmDeleteTeam}
+        title="Delete Team"
+        loading={isDeleting}
+        confirmLabel="Delete Team"
+        loadingLabel="Deleting..."
+        confirmVariant="error"
+        confirmIcon={<Trash2 size={16} />}
+      >
+        <p className="text-sm text-base-content/80">
+          Delete this team? This action cannot be undone.
+        </p>
+      </ConfirmModal>
+
+      <ConfirmModal
+        isOpen={isCancelApplicationDialogOpen}
+        onClose={closeCancelApplicationDialog}
+        onConfirm={confirmCancelApplication}
+        title="Cancel Application"
+        loading={actionLoading === "cancel"}
+        confirmLabel="Cancel Application"
+        loadingLabel="Canceling..."
+        confirmVariant="error"
+        confirmIcon={<Trash2 size={16} />}
+        cancelLabel="Keep"
+      >
+        <p className="text-sm text-base-content/80">
+          Cancel your application to {teamData.name || "this team"}? The team
+          will no longer be able to review it.
+        </p>
+      </ConfirmModal>
 
       <TeamDetailsModal
         isOpen={isModalOpen}

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -13,7 +13,7 @@ import { teamService } from "../../services/teamService";
 import { userService } from "../../services/userService";
 import Button from "../common/Button";
 import SendMessageButton from "../common/SendMessageButton";
-import Alert from "../common/Alert";
+import ScreenAlert from "../common/ScreenAlert";
 import Tooltip from "../common/Tooltip";
 import TagDisplay from "../common/TagDisplay";
 import LocationDisplay from "../common/LocationDisplay";
@@ -47,6 +47,7 @@ import TeamFocusAreaSection from "./TeamFocusAreaSection";
 import VacantRolesSection from "./VacantRolesSection";
 import axios from "axios";
 import Modal from "../common/Modal";
+import ConfirmModal from "../common/ConfirmModal";
 import LocationSection from "../common/LocationSection";
 import TagAwardsModal from "../badges/TagAwardsModal";
 import SupercategoryAwardsModal from "../badges/SupercategoryAwardsModal";
@@ -175,6 +176,7 @@ const TeamDetailsModal = ({
   const userHasEditedTagsRef = useRef(false);
   const [isLeaveDialogOpen, setIsLeaveDialogOpen] = useState(false);
   const [leaveLoading, setLeaveLoading] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isInvitationModalOpen, setIsInvitationModalOpen] = useState(false);
 
   const [teamImageError, setTeamImageError] = useState(false);
@@ -1090,38 +1092,42 @@ const TeamDetailsModal = ({
     }
   };
 
-  const handleDeleteTeam = async () => {
-    if (
-      window.confirm(
-        "Are you sure you want to delete this team? This action cannot be undone.",
-      )
-    ) {
-      try {
-        setLoading(true);
+  const handleDeleteTeam = () => {
+    setIsDeleteDialogOpen(true);
+  };
 
-        let success = false;
-        if (onDelete) {
-          success = await onDelete(effectiveTeamId);
-        } else {
-          await teamService.deleteTeam(effectiveTeamId);
-          success = true;
-        }
+  const closeDeleteTeamDialog = () => {
+    if (loading) return;
+    setIsDeleteDialogOpen(false);
+  };
 
-        if (success) {
-          handleClose();
-          // If we're on a team-specific route, navigate away
-          if (urlTeamId) {
-            navigate("/teams/my-teams");
-          }
-        }
-      } catch (err) {
-        console.error("Error deleting team:", err);
-        setNotification({
-          type: "error",
-          message: "Failed to delete team. Please try again.",
-        });
-        setLoading(false);
+  const confirmDeleteTeam = async () => {
+    try {
+      setLoading(true);
+
+      let success = false;
+      if (onDelete) {
+        success = await onDelete(effectiveTeamId);
+      } else {
+        await teamService.deleteTeam(effectiveTeamId);
+        success = true;
       }
+
+      if (success) {
+        setIsDeleteDialogOpen(false);
+        handleClose();
+        // If we're on a team-specific route, navigate away
+        if (urlTeamId) {
+          navigate("/teams/my-teams");
+        }
+      }
+    } catch (err) {
+      console.error("Error deleting team:", err);
+      setNotification({
+        type: "error",
+        message: "Failed to delete team. Please try again.",
+      });
+      setLoading(false);
     }
   };
 
@@ -1234,11 +1240,10 @@ const TeamDetailsModal = ({
     if (!notification.type || !notification.message) return null;
 
     return (
-      <Alert
+      <ScreenAlert
         type={notification.type}
         message={notification.message}
         onClose={() => setNotification({ type: null, message: null })}
-        className="mb-4"
       />
     );
   };
@@ -1690,50 +1695,43 @@ const TeamDetailsModal = ({
         />
       )}
 
+      <ConfirmModal
+        isOpen={isDeleteDialogOpen}
+        onClose={closeDeleteTeamDialog}
+        onConfirm={confirmDeleteTeam}
+        title="Delete Team"
+        loading={loading}
+        confirmLabel="Delete Team"
+        loadingLabel="Deleting..."
+        confirmVariant="error"
+        confirmIcon={<Trash2 size={16} />}
+      >
+        <p className="text-sm text-base-content/80">
+          Delete this team? This action cannot be undone.
+        </p>
+      </ConfirmModal>
+
       {/* Leave Team Confirmation Dialog */}
-      {isLeaveDialogOpen && (
-        <Modal
-          isOpen={isLeaveDialogOpen}
-          onClose={() => setIsLeaveDialogOpen(false)}
-          title="Leave Team"
-          position="center"
-          size="small"
-          closeOnBackdrop={!leaveLoading}
-          closeOnEscape={!leaveLoading}
-          showCloseButton={!leaveLoading}
-        >
-          <div className="py-4">
-            <p className="text-base-content">Really want to leave this team?</p>
-            {isOwner && (
-              <p className="text-warning text-sm mt-2">
-                Note: As an owner, you can only leave if there's another owner
-                to manage the team. Pass ownership before leaving.
-              </p>
-            )}
-          </div>
-          <div className="flex justify-end gap-3 mt-4">
-            <Button
-              variant="ghost"
-              onClick={() => setIsLeaveDialogOpen(false)}
-              disabled={leaveLoading}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="error"
-              onClick={handleLeaveTeam}
-              disabled={leaveLoading}
-              className="bg-red-500 hover:bg-red-600 text-white"
-            >
-              {leaveLoading ? (
-                <span className="loading loading-spinner loading-sm"></span>
-              ) : (
-                "Leave Team"
-              )}
-            </Button>
-          </div>
-        </Modal>
-      )}
+      <ConfirmModal
+        isOpen={isLeaveDialogOpen}
+        onClose={() => setIsLeaveDialogOpen(false)}
+        onConfirm={handleLeaveTeam}
+        title="Leave Team"
+        loading={leaveLoading}
+        confirmLabel="Leave Team"
+        loadingLabel="Leaving..."
+        confirmVariant="error"
+      >
+        <p className="text-sm text-base-content/80">
+          Really want to leave this team?
+        </p>
+        {isOwner && (
+          <p className="text-warning text-sm mt-2">
+            Note: As an owner, you can only leave if there&apos;s another owner
+            to manage the team. Pass ownership before leaving.
+          </p>
+        )}
+      </ConfirmModal>
       <TagAwardsModal {...tagAwardsModalProps} />
       <SupercategoryAwardsModal {...supercategoryModalProps} />
 

--- a/src/components/teams/TeamEditForm.jsx
+++ b/src/components/teams/TeamEditForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo } from "react";
 import Button from "../common/Button";
+import ConfirmModal from "../common/ConfirmModal";
 import VisibilityToggle from "../common/VisibilityToggle";
 import LocationModeToggle from "../common/LocationModeToggle";
 import FormSectionDivider from "../common/FormSectionDivider";
@@ -10,7 +11,7 @@ import LocationInput from "../common/LocationInput";
 import TagInput from "../tags/TagInput";
 import { UI_TEXT } from "../../constants/uiText";
 import { useLocationAutoFill } from "../../hooks/useLocationAutoFill";
-import { Camera, Users, Settings, Tag } from "lucide-react";
+import { Camera, Users, Settings, Tag, Trash2 } from "lucide-react";
 
 const PRESET_OPTIONS = [2, 3, 4, 5, 6, 8, 10, 12, 15, 20];
 const UNLIMITED_VALUE = null;
@@ -47,6 +48,8 @@ const TeamEditForm = ({
 }) => {
   const [uploadingImage, setUploadingImage] = useState(false);
   const [avatarDeleteLoading, setAvatarDeleteLoading] = useState(false);
+  const [isAvatarDeleteDialogOpen, setIsAvatarDeleteDialogOpen] =
+    useState(false);
 
   // Location auto-fill hook
   const { getSuggestedUpdates } = useLocationAutoFill({
@@ -172,13 +175,18 @@ const TeamEditForm = ({
   };
 
   // Handle avatar deletion
-  const handleAvatarDelete = async () => {
+  const handleAvatarDelete = () => {
     if (!team?.id) return;
+    setIsAvatarDeleteDialogOpen(true);
+  };
 
-    if (!window.confirm("Are you sure you want to remove the team picture?")) {
-      return;
-    }
+  const closeAvatarDeleteDialog = () => {
+    if (avatarDeleteLoading) return;
+    setIsAvatarDeleteDialogOpen(false);
+  };
 
+  const confirmAvatarDelete = async () => {
+    if (!team?.id) return;
     try {
       setAvatarDeleteLoading(true);
       const response = await teamService.deleteTeamAvatar(team.id);
@@ -191,6 +199,7 @@ const TeamEditForm = ({
         }));
 
         onAvatarDeleted?.();
+        setIsAvatarDeleteDialogOpen(false);
       }
     } catch (error) {
       console.error("Error deleting team avatar:", error);
@@ -239,7 +248,8 @@ const TeamEditForm = ({
   }, [formData.selectedTags, team?.tags]);
 
   return (
-    <form onSubmit={handleFormSubmit} className="space-y-4">
+    <>
+      <form onSubmit={handleFormSubmit} className="space-y-4">
       {/* Team Avatar Section */}
       <section className="space-y-4">
         <FormSectionDivider text="Team Avatar" icon={Camera} />
@@ -576,7 +586,24 @@ const TeamEditForm = ({
           {loading ? "Saving..." : "Save Changes"}
         </Button>
       </div>
-    </form>
+      </form>
+
+      <ConfirmModal
+        isOpen={isAvatarDeleteDialogOpen}
+        onClose={closeAvatarDeleteDialog}
+        onConfirm={confirmAvatarDelete}
+        title="Remove Team Picture"
+        loading={avatarDeleteLoading}
+        confirmLabel="Remove"
+        loadingLabel="Removing..."
+        confirmVariant="error"
+        confirmIcon={<Trash2 size={16} />}
+      >
+        <p className="text-sm text-base-content/80">
+          Remove the team picture? The team will show its initials instead.
+        </p>
+      </ConfirmModal>
+    </>
   );
 };
 

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
-import Alert from "../common/Alert";
+import ScreenAlert from "../common/ScreenAlert";
 import UserDetailsModal from "../users/UserDetailsModal";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import TeamInvitesModal from "../teams/TeamInvitesModal";
@@ -943,19 +943,22 @@ const TeamInviteModal = ({
         closeOnEscape={!sending}
         showCloseButton={true}
       >
+        <ScreenAlert
+          alerts={[
+            success && {
+              type: "success",
+              message: success,
+              onClose: () => setSuccess(null),
+            },
+            error && {
+              type: "error",
+              message: error,
+              onClose: () => setError(null),
+            },
+          ]}
+        />
+
         <div className="space-y-5">
-          {/* Success message */}
-          {success && <Alert type="success" message={success} />}
-
-          {/* Error message */}
-          {error && (
-            <Alert
-              type="error"
-              message={error}
-              onClose={() => setError(null)}
-            />
-          )}
-
           {/* Invitee info */}
           <div className="flex items-start space-x-3 mb-3">
             <div

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -5,9 +5,11 @@ import {
   Calendar,
   SendHorizontal,
   FlaskConical,
+  Trash2,
 } from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
 import Button from "../common/Button";
+import Modal from "../common/Modal";
 import Tooltip from "../common/Tooltip";
 import InlineUserLink, { InvitedByLink } from "../users/InlineUserLink";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
@@ -214,6 +216,8 @@ const TeamInvitesModal = ({
   const [roleCandidateMatchMap, setRoleCandidateMatchMap] = useState({});
   const [selfRoleMatchMap, setSelfRoleMatchMap] = useState({});
   const [localInviteeRoleMatchMap, setLocalInviteeRoleMatchMap] = useState({});
+  const [pendingCancelInvitationId, setPendingCancelInvitationId] =
+    useState(null);
 
   // ============ Refs ============
   const highlightedRef = useRef(null);
@@ -531,18 +535,27 @@ const TeamInvitesModal = ({
 
   // ============ Handlers ============
 
-  const handleCancelInvitation = async (invitationId) => {
-    if (!window.confirm("Are you sure you want to cancel this invitation?")) {
-      return;
-    }
+  const handleCancelInvitation = (invitationId) => {
+    if (!invitationId) return;
+    setPendingCancelInvitationId(invitationId);
+  };
+
+  const closeCancelInvitationModal = () => {
+    if (loading) return;
+    setPendingCancelInvitationId(null);
+  };
+
+  const confirmCancelInvitation = async () => {
+    if (!pendingCancelInvitationId) return;
 
     try {
       setLoading(true);
       setError(null);
 
-      await onCancelInvitation(invitationId);
+      await onCancelInvitation(pendingCancelInvitationId);
 
       setSuccess("Invitation canceled successfully!");
+      setPendingCancelInvitationId(null);
 
       // Clear success after 3 seconds
       setTimeout(() => setSuccess(null), 3000);
@@ -586,6 +599,14 @@ const TeamInvitesModal = ({
   };
 
   // ============ Render ============
+  const pendingCancelInvitation = invitations.find(
+    (invitation) => String(invitation.id) === String(pendingCancelInvitationId),
+  );
+  const pendingInviteeName =
+    pendingCancelInvitation?.invitee
+      ? getDisplayName(pendingCancelInvitation.invitee)
+      : "this user";
+
   return (
     <RequestListModal
       isOpen={isOpen}
@@ -602,7 +623,43 @@ const TeamInvitesModal = ({
       emptyIcon={User}
       emptyTitle="No pending invitations"
       emptyMessage="Invitations you send to users will appear here."
-      // No extraModals needed - UserModalContext handles it globally
+      extraModals={
+        <Modal
+          isOpen={Boolean(pendingCancelInvitationId)}
+          onClose={closeCancelInvitationModal}
+          title="Cancel Invitation"
+          position="center"
+          size="small"
+          bodyClassName="p-4"
+          closeOnBackdrop={!loading}
+          closeOnEscape={!loading}
+          showCloseButton={!loading}
+          footer={
+            <div className="flex justify-end gap-3">
+              <Button
+                variant="ghost"
+                onClick={closeCancelInvitationModal}
+                disabled={loading}
+              >
+                Keep
+              </Button>
+              <Button
+                variant="error"
+                onClick={confirmCancelInvitation}
+                disabled={loading}
+                icon={<Trash2 size={16} />}
+              >
+                {loading ? "Canceling..." : "Cancel Invitation"}
+              </Button>
+            </div>
+          }
+        >
+          <p className="text-sm text-base-content/80">
+            Cancel the invitation for {pendingInviteeName}? They will no longer
+            be able to respond to it.
+          </p>
+        </Modal>
+      }
     >
       {invitations.map((invitation) => {
         // Get invitee ID for highlighting comparison

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -9,7 +9,7 @@ import {
   FlaskConical,
 } from "lucide-react";
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
-import Alert from "../common/Alert";
+import ScreenAlert from "../common/ScreenAlert";
 import { teamService } from "../../services/teamService";
 import { userService } from "../../services/userService";
 import { formatDisplayName } from "../../utils/nameFormatters";
@@ -180,15 +180,11 @@ const TeamMembersSection = ({
         </h3>
       </div>
 
-      {/* Notification Alert */}
-      {notification.type && (
-        <Alert
-          type={notification.type}
-          message={notification.message}
-          onClose={() => setNotification({ type: null, message: null })}
-          className="mb-4"
-        />
-      )}
+      <ScreenAlert
+        type={notification.type}
+        message={notification.message}
+        onClose={() => setNotification({ type: null, message: null })}
+      />
 
       {/* Members Grid - using key to force re-render when roles change */}
       <div
@@ -319,7 +315,7 @@ const TeamMembersSection = ({
                           );
                           setNotification({
                             type: "success",
-                            message: `${member.username || "Member"} has been ${
+                            message: `${formatDisplayName(member)} has been ${
                               newRole === "admin"
                                 ? "promoted to Admin"
                                 : "demoted to Member"
@@ -343,9 +339,7 @@ const TeamMembersSection = ({
                           await teamService.removeTeamMember(team.id, memberId);
                           setNotification({
                             type: "success",
-                            message: `${
-                              member.username || "Member"
-                            } has been removed from the team.`,
+                            message: `${formatDisplayName(member)} has been removed from the team.`,
                           });
                           if (onMemberRemoved) {
                             await onMemberRemoved();

--- a/src/components/teams/TeamRoleManager.jsx
+++ b/src/components/teams/TeamRoleManager.jsx
@@ -2,7 +2,8 @@ import React, { useState, useEffect } from "react";
 import { useAuth } from "../../contexts/AuthContext";
 import { teamService } from "../../services/teamService";
 import Button from "../common/Button";
-import Alert from "../common/Alert";
+import ConfirmModal from "../common/ConfirmModal";
+import ScreenAlert from "../common/ScreenAlert";
 import {
   Crown,
   Shield,
@@ -10,7 +11,6 @@ import {
   ChevronUp,
   ChevronDown,
   Loader2,
-  AlertTriangle,
 } from "lucide-react";
 
 const TeamRoleManager = ({ team, onRoleUpdate, className = "" }) => {
@@ -101,9 +101,13 @@ case "owner":
     try {
       await teamService.updateMemberRole(team.id, member.user_id, newRole);
 
+      const memberName =
+        member.first_name && member.last_name
+          ? `${member.first_name} ${member.last_name}`
+          : member.first_name || member.username;
       setNotification({
         type: "success",
-        message: `${member.first_name || member.username} has been ${
+        message: `${memberName} has been ${
           newRole === "admin" ? "promoted to admin" : "demoted to member"
         } successfully!`,
       });
@@ -164,15 +168,11 @@ case "owner":
         </div>
       </div>
 
-      {/* Notification */}
-      {notification.type && (
-        <Alert
-          type={notification.type}
-          message={notification.message}
-          onClose={() => setNotification({ type: null, message: null })}
-          className="mb-4"
-        />
-      )}
+      <ScreenAlert
+        type={notification.type}
+        message={notification.message}
+        onClose={() => setNotification({ type: null, message: null })}
+      />
 
       {/* Members List */}
       <div className="space-y-3">
@@ -296,52 +296,25 @@ case "owner":
       </div>
 
       {/* Confirmation Dialog */}
-      {confirmDialog.isOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          {/* Backdrop */}
-          <div
-            className="absolute inset-0 bg-black bg-opacity-50"
-            onClick={closeConfirmDialog}
-          />
-
-          {/* Dialog */}
-          <div className="relative bg-base-100 rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
-            <div className="flex items-center space-x-3 mb-4">
-              <AlertTriangle className="w-6 h-6 text-warning" />
-              <h3 className="text-lg font-semibold">Confirm Role Change</h3>
-            </div>
-
-            <p className="text-base-content/80 mb-6">
-              Are you sure you want to {confirmDialog.action}{" "}
-              <strong>
-                {confirmDialog.member?.first_name ||
-                  confirmDialog.member?.username}
-              </strong>{" "}
-              to {confirmDialog.newRole}?
-            </p>
-
-            <div className="flex justify-end space-x-3">
-              <Button
-                variant="ghost"
-                onClick={closeConfirmDialog}
-                disabled={loading}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="primary"
-                onClick={executeRoleChange}
-                disabled={loading}
-                icon={
-                  loading ? <Loader2 className="w-4 h-4 animate-spin" /> : null
-                }
-              >
-                {loading ? "Updating..." : "Confirm"}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      <ConfirmModal
+        isOpen={confirmDialog.isOpen}
+        onClose={closeConfirmDialog}
+        onConfirm={executeRoleChange}
+        title="Confirm Role Change"
+        loading={loading}
+        confirmLabel="Confirm"
+        loadingLabel="Updating..."
+      >
+        <p className="text-sm text-base-content/80">
+          Are you sure you want to {confirmDialog.action}{" "}
+          <strong>
+            {confirmDialog.member?.first_name && confirmDialog.member?.last_name
+              ? `${confirmDialog.member.first_name} ${confirmDialog.member.last_name}`
+              : confirmDialog.member?.first_name || confirmDialog.member?.username}
+          </strong>{" "}
+          to {confirmDialog.newRole}?
+        </p>
+      </ConfirmModal>
     </div>
   );
 };

--- a/src/components/teams/VacantRolesSection.jsx
+++ b/src/components/teams/VacantRolesSection.jsx
@@ -1,9 +1,17 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { UserSearch, Plus, AlertCircle, ChevronRight, ChevronUp } from "lucide-react";
+import {
+  UserSearch,
+  Plus,
+  AlertCircle,
+  ChevronRight,
+  ChevronUp,
+  Trash2,
+} from "lucide-react";
 import VacantRoleCard from "./VacantRoleCard";
 import CreateVacantRoleModal from "./CreateVacantRoleModal";
 import Button from "../common/Button";
-import Alert from "../common/Alert";
+import ConfirmModal from "../common/ConfirmModal";
+import ScreenAlert from "../common/ScreenAlert";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { matchingService } from "../../services/matchingService";
 import { useAuth } from "../../contexts/AuthContext";
@@ -63,6 +71,11 @@ const VacantRolesSection = ({
   // Modal state
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingRole, setEditingRole] = useState(null);
+  const [pendingDeleteRoleId, setPendingDeleteRoleId] = useState(null);
+  const [deleteRoleLoading, setDeleteRoleLoading] = useState(false);
+  const pendingDeleteRole = roles.find(
+    (role) => String(role.id) === String(pendingDeleteRoleId),
+  );
 
   // Fetch vacant roles
   const fetchRoles = useCallback(async () => {
@@ -143,17 +156,26 @@ const VacantRolesSection = ({
   };
 
   // Handle delete
-  const handleDelete = async (roleId) => {
-    if (!window.confirm("Are you sure you want to delete this vacant role?")) {
-      return;
-    }
+  const handleDelete = (roleId) => {
+    if (!roleId) return;
+    setPendingDeleteRoleId(roleId);
+  };
 
+  const closeDeleteRoleDialog = () => {
+    if (deleteRoleLoading) return;
+    setPendingDeleteRoleId(null);
+  };
+
+  const confirmDeleteRole = async () => {
+    if (!pendingDeleteRoleId) return;
     try {
-      await vacantRoleService.deleteVacantRole(teamId, roleId);
+      setDeleteRoleLoading(true);
+      await vacantRoleService.deleteVacantRole(teamId, pendingDeleteRoleId);
       setNotification({
         type: "success",
         message: "Vacant role deleted successfully",
       });
+      setPendingDeleteRoleId(null);
       await fetchRoles();
     } catch (err) {
       console.error("Error deleting vacant role:", err);
@@ -161,6 +183,8 @@ const VacantRolesSection = ({
         type: "error",
         message: err.response?.data?.message || "Failed to delete role",
       });
+    } finally {
+      setDeleteRoleLoading(false);
     }
   };
 
@@ -241,15 +265,11 @@ const VacantRolesSection = ({
         )}
       </div>
 
-      {/* Notification */}
-      {notification.type && (
-        <Alert
-          type={notification.type}
-          message={notification.message}
-          onClose={() => setNotification({ type: null, message: null })}
-          className="mb-4"
-        />
-      )}
+      <ScreenAlert
+        type={notification.type}
+        message={notification.message}
+        onClose={() => setNotification({ type: null, message: null })}
+      />
 
       {/* Error state */}
       {error && (
@@ -322,6 +342,26 @@ const VacantRolesSection = ({
         existingRole={editingRole}
         onSuccess={handleModalSuccess}
       />
+
+      <ConfirmModal
+        isOpen={Boolean(pendingDeleteRoleId)}
+        onClose={closeDeleteRoleDialog}
+        onConfirm={confirmDeleteRole}
+        title="Delete Vacant Role"
+        loading={deleteRoleLoading}
+        confirmLabel="Delete Role"
+        loadingLabel="Deleting..."
+        confirmVariant="error"
+        confirmIcon={<Trash2 size={16} />}
+      >
+        <p className="text-sm text-base-content/80">
+          Delete{" "}
+          {pendingDeleteRole?.roleName ||
+            pendingDeleteRole?.role_name ||
+            "this vacant role"}
+          ? This removes the role from your team.
+        </p>
+      </ConfirmModal>
     </div>
   );
 };

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1,5 +1,12 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { LogOut, ChevronRight, ChevronLeft, Users, User } from "lucide-react";
+import {
+  LogOut,
+  ChevronRight,
+  ChevronLeft,
+  Users,
+  User,
+  Trash2,
+} from "lucide-react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import PageContainer from "../components/layout/PageContainer";
 import ConversationList from "../components/chat/ConversationList";
@@ -10,7 +17,9 @@ import { messageService } from "../services/messageService";
 import socketService from "../services/socketService";
 import { userService } from "../services/userService";
 import { teamService } from "../services/teamService";
-import Alert from "../components/common/Alert";
+import ScreenAlert from "../components/common/ScreenAlert";
+import Button from "../components/common/Button";
+import Modal from "../components/common/Modal";
 import Tooltip from "../components/common/Tooltip";
 import { CountBadge } from "../components/common/NotificationBadge";
 import { uploadToImageKit } from "../config/imagekit";
@@ -148,6 +157,9 @@ const Chat = () => {
   const [selectedTeamData, setSelectedTeamData] = useState(null);
   const [isUserModalOpen, setIsUserModalOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
+  const [pendingChatAction, setPendingChatAction] = useState(null);
+  const [pendingChatActionLoading, setPendingChatActionLoading] =
+    useState(false);
   const [isActiveConversationVisible, setIsActiveConversationVisible] =
     useState(true);
   const [
@@ -1198,6 +1210,11 @@ const Chat = () => {
     }
   };
 
+  const closePendingChatAction = () => {
+    if (pendingChatActionLoading) return;
+    setPendingChatAction(null);
+  };
+
   // Handle leaving a deleted team (removes from conversation list)
   const handleLeaveTeam = async () => {
     if (!activeConversation?.team?.id) {
@@ -1207,12 +1224,10 @@ const Chat = () => {
     const teamId = activeConversation.team.id;
     const teamName = activeConversation.team.name || "this team";
 
-    const confirmLeave = window.confirm(
-      `Are you sure you want to leave "${teamName}"? This will remove the chat from your conversation list.`,
-    );
+    setPendingChatAction({ type: "leave-team", teamId, teamName });
+  };
 
-    if (!confirmLeave) return;
-
+  const executeLeaveTeam = async ({ teamId }) => {
     try {
       // Call the existing leave team API
       await teamService.removeTeamMember(teamId, user.id);
@@ -1225,9 +1240,11 @@ const Chat = () => {
 
       setActiveConversation(null);
       setMessages([]);
+      return true;
     } catch (error) {
       console.error("Error leaving team:", error);
       setError("Failed to leave team. Please try again.");
+      return false;
     }
   };
 
@@ -1237,15 +1254,15 @@ const Chat = () => {
       return;
     }
 
-    const confirmDelete = window.confirm(
-      "Are you sure you want to remove this chat from your conversation list?",
-    );
+    setPendingChatAction({
+      type: "delete-conversation",
+      conversationId: activeConversation.id,
+    });
+  };
 
-    if (!confirmDelete) return;
-
+  const executeDeleteConversation = async ({ conversationId }) => {
     try {
-      const convId = activeConversation.id;
-      const type = activeConversation.type || conversationType;
+      const convId = conversationId;
 
       // Remove from local state
       setConversations((prev) => prev.filter((c) => c.id !== convId));
@@ -1255,9 +1272,11 @@ const Chat = () => {
 
       setActiveConversation(null);
       setMessages([]);
+      return true;
     } catch (error) {
       console.error("Error deleting conversation:", error);
       setError("Failed to delete conversation. Please try again.");
+      return false;
     }
   };
 
@@ -1364,9 +1383,10 @@ const Chat = () => {
   const handleDeleteMessage = async (messageId) => {
     if (!messageId) return;
 
-    const ok = window.confirm("Delete this message?");
-    if (!ok) return;
+    setPendingChatAction({ type: "delete-message", messageId });
+  };
 
+  const executeDeleteMessage = async ({ messageId }) => {
     try {
       // Optimistic UI update
       setMessages((prev) =>
@@ -1387,12 +1407,38 @@ const Chat = () => {
       );
 
       await messageService.deleteMessage(messageId);
+      return true;
     } catch (err) {
       console.error("Failed to delete message:", err);
       setError("Failed to delete message. Please try again.");
 
       // Optional: re-fetch messages for correctness after failure
       // (you can leave this out if you don’t want)
+      return false;
+    }
+  };
+
+  const confirmPendingChatAction = async () => {
+    if (!pendingChatAction) return;
+
+    try {
+      setPendingChatActionLoading(true);
+
+      let actionSucceeded = false;
+
+      if (pendingChatAction.type === "leave-team") {
+        actionSucceeded = await executeLeaveTeam(pendingChatAction);
+      } else if (pendingChatAction.type === "delete-conversation") {
+        actionSucceeded = await executeDeleteConversation(pendingChatAction);
+      } else if (pendingChatAction.type === "delete-message") {
+        actionSucceeded = await executeDeleteMessage(pendingChatAction);
+      }
+
+      if (actionSucceeded) {
+        setPendingChatAction(null);
+      }
+    } finally {
+      setPendingChatActionLoading(false);
     }
   };
 
@@ -1569,15 +1615,80 @@ const Chat = () => {
     .filter(([userId, username]) => userId !== user?.id && username)
     .map(([_, username]) => username);
 
+  const pendingChatActionType = pendingChatAction?.type;
+  const pendingChatActionConfig = {
+    "delete-message": {
+      title: "Delete Message",
+      message:
+        "Delete this message? It will be replaced with a deleted-message marker in this chat.",
+      confirmLabel: "Delete",
+      loadingLabel: "Deleting...",
+      variant: "error",
+      icon: <Trash2 size={16} />,
+    },
+    "delete-conversation": {
+      title: "Remove Chat",
+      message:
+        "Remove this chat from your conversation list? Your message history with this conversation will no longer be shown here.",
+      confirmLabel: "Remove",
+      loadingLabel: "Removing...",
+      variant: "error",
+      icon: <Trash2 size={16} />,
+    },
+    "leave-team": {
+      title: "Leave Team Chat",
+      message: `Leave "${pendingChatAction?.teamName || "this team"}"? This removes the chat from your conversation list.`,
+      confirmLabel: "Leave",
+      loadingLabel: "Leaving...",
+      variant: "error",
+      icon: <LogOut size={16} />,
+    },
+  }[pendingChatActionType];
+
   return (
     <PageContainer
       title="Messages"
       className="p-0 overflow-hidden"
       variant="muted"
     >
-      {error && (
-        <Alert type="error" message={error} onClose={() => setError(null)} />
-      )}
+      <ScreenAlert type="error" message={error} onClose={() => setError(null)} />
+
+      <Modal
+        isOpen={Boolean(pendingChatAction)}
+        onClose={closePendingChatAction}
+        title={pendingChatActionConfig?.title}
+        position="center"
+        size="small"
+        bodyClassName="p-4"
+        closeOnBackdrop={!pendingChatActionLoading}
+        closeOnEscape={!pendingChatActionLoading}
+        showCloseButton={!pendingChatActionLoading}
+        footer={
+          <div className="flex justify-end gap-3">
+            <Button
+              variant="ghost"
+              onClick={closePendingChatAction}
+              disabled={pendingChatActionLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant={pendingChatActionConfig?.variant || "primary"}
+              onClick={confirmPendingChatAction}
+              disabled={pendingChatActionLoading}
+              icon={pendingChatActionConfig?.icon}
+            >
+              {pendingChatActionLoading
+                ? pendingChatActionConfig?.loadingLabel
+                : pendingChatActionConfig?.confirmLabel}
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-sm text-base-content/80">
+          {pendingChatActionConfig?.message}
+        </p>
+      </Modal>
 
       <div className="bg-white shadow-soft flex h-[calc(100vh-200px)] rounded-xl overflow-hidden">
         {/* Conversation List - Left Sidebar */}

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1065,6 +1065,7 @@ const Chat = () => {
             : m,
         ),
       );
+      refreshConversationList();
     };
 
     const handleMessageEdited = (payload) => {

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -25,6 +25,7 @@ import {
   normalizeTimestampToDate,
 } from "../utils/dateHelpers";
 import { getTeamAvatarUrl } from "../utils/chatEntityResolvers";
+import { getMessageConversationTarget } from "../utils/messageNotificationUtils";
 
 const getConversationPartnerId = (conversation) =>
   conversation?.partner?.id ??
@@ -697,7 +698,10 @@ const Chat = () => {
 
     // Handle new messages
     const handleNewMessage = (message) => {
-      const messageConvId = String(message.conversationId);
+      const messageTarget = getMessageConversationTarget(message, user?.id);
+      const messageConvId = String(
+        messageTarget.conversationId ?? message.conversationId,
+      );
       const currentConvId = String(conversationId);
 
       // Get current conversation type from URL
@@ -798,22 +802,52 @@ const Chat = () => {
 
       // Update conversation list
       setConversations((prev) => {
+        const isUnreadIncoming =
+          messageConvId !== currentConvId && message.senderId !== user.id;
+        let conversationUpdated = false;
         const updatedList = prev.map((conv) => {
           if (String(conv.id) === messageConvId) {
+            conversationUpdated = true;
+            const currentUnreadCount = conv.unreadCount ?? conv.unread_count ?? 0;
+            const unreadCount = isUnreadIncoming
+              ? currentUnreadCount + 1
+              : currentUnreadCount;
+
             return {
               ...conv,
               lastMessage: message.content,
               updatedAt: message.createdAt,
               isVirtual: false,
-              // Increment unread count if not current conversation
-              unreadCount:
-                messageConvId !== currentConvId && message.senderId !== user.id
-                  ? (conv.unreadCount || 0) + 1
-                  : conv.unreadCount,
+              unreadCount,
+              unread_count: unreadCount,
             };
           }
           return conv;
         });
+
+        if (!conversationUpdated) {
+          if (messageTarget.type === "direct" && message.senderId !== user.id) {
+            updatedList.unshift({
+              id: Number.isNaN(Number(messageConvId))
+                ? messageConvId
+                : Number(messageConvId),
+              type: "direct",
+              partner: {
+                id: message.senderId,
+                username: message.senderUsername,
+                firstName: message.senderFirstName,
+                lastName: message.senderLastName,
+                avatarUrl: message.senderAvatarUrl,
+              },
+              lastMessage: message.content,
+              updatedAt: message.createdAt,
+              unreadCount: isUnreadIncoming ? 1 : 0,
+              unread_count: isUnreadIncoming ? 1 : 0,
+            });
+          }
+
+          refreshConversationList();
+        }
 
         const deduplicatedList = dedupeConversations(updatedList);
 

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -8,7 +8,7 @@ import Grid from "../components/layout/Grid";
 import Card from "../components/common/Card";
 import Button from "../components/common/Button";
 import DataDisplay from "../components/common/DataDisplay";
-import Alert from "../components/common/Alert";
+import ScreenAlert from "../components/common/ScreenAlert";
 import Tooltip from "../components/common/Tooltip";
 import { uploadToImageKit } from "../config/imagekit";
 import {
@@ -46,7 +46,7 @@ import {
   isSyntheticUser,
 } from "../utils/userHelpers";
 import DemoAvatarOverlay from "../components/users/DemoAvatarOverlay";
-import Modal from "../components/common/Modal";
+import ConfirmModal from "../components/common/ConfirmModal";
 import LocationInput from "../components/common/LocationInput";
 import { format } from "date-fns";
 
@@ -82,6 +82,8 @@ const Profile = () => {
   } = useAwardModals(profileUserId);
 
   const [avatarDeleteLoading, setAvatarDeleteLoading] = useState(false);
+  const [isAvatarDeleteDialogOpen, setIsAvatarDeleteDialogOpen] =
+    useState(false);
   const [badgeActionLoadingKey, setBadgeActionLoadingKey] = useState(null);
   const [pendingBadgeAction, setPendingBadgeAction] = useState(null);
   const [selectedUserId, setSelectedUserId] = useState(null);
@@ -435,16 +437,18 @@ const Profile = () => {
   };
 
   // Handle avatar deletion
-  const handleAvatarDelete = async () => {
+  const handleAvatarDelete = () => {
     if (!user) return;
+    setIsAvatarDeleteDialogOpen(true);
+  };
 
-    // Confirm deletion
-    if (
-      !window.confirm("Are you sure you want to remove your profile picture?")
-    ) {
-      return;
-    }
+  const closeAvatarDeleteDialog = () => {
+    if (avatarDeleteLoading) return;
+    setIsAvatarDeleteDialogOpen(false);
+  };
 
+  const confirmAvatarDelete = async () => {
+    if (!user) return;
     try {
       setAvatarDeleteLoading(true);
       setError(null);
@@ -471,6 +475,7 @@ const Profile = () => {
         }));
 
         setSuccess("Profile picture removed successfully");
+        setIsAvatarDeleteDialogOpen(false);
       } else {
         setError(response.message || "Failed to remove profile picture");
       }
@@ -1008,37 +1013,25 @@ const Profile = () => {
 
   return (
     <div className="space-y-6">
-      {registrationMessage && (
-        <Alert
-          type="success"
-          message={registrationMessage}
-          onClose={() => setRegistrationMessage("")}
-        />
-      )}
-
-      {(success || error) && (
-        <div className="pointer-events-none fixed inset-0 z-[9999] flex items-center justify-center px-4">
-          <div className="flex max-w-[min(calc(100vw-2rem),32rem)] flex-col items-center gap-3">
-            {success && (
-              <Alert
-                type="success"
-                message={success}
-                onClose={() => setSuccess(null)}
-                className="pointer-events-auto max-w-full shadow-2xl"
-              />
-            )}
-
-            {error && (
-              <Alert
-                type="error"
-                message={error}
-                onClose={() => setError(null)}
-                className="pointer-events-auto max-w-full shadow-2xl"
-              />
-            )}
-          </div>
-        </div>
-      )}
+      <ScreenAlert
+        alerts={[
+          registrationMessage && {
+            type: "success",
+            message: registrationMessage,
+            onClose: () => setRegistrationMessage(""),
+          },
+          success && {
+            type: "success",
+            message: success,
+            onClose: () => setSuccess(null),
+          },
+          error && {
+            type: "error",
+            message: error,
+            onClose: () => setError(null),
+          },
+        ]}
+      />
 
       <Card className="overflow-visible">
         {isEditing ? (
@@ -1510,59 +1503,40 @@ const Profile = () => {
         badgeActionLoadingKey={badgeActionLoadingKey}
       />
 
-      <Modal
+      <ConfirmModal
+        isOpen={isAvatarDeleteDialogOpen}
+        onClose={closeAvatarDeleteDialog}
+        onConfirm={confirmAvatarDelete}
+        title="Remove Profile Picture"
+        loading={avatarDeleteLoading}
+        confirmLabel="Remove"
+        loadingLabel="Removing..."
+        confirmVariant="error"
+        confirmIcon={<Trash2 size={16} />}
+      >
+        <p className="text-sm text-base-content/80">
+          Remove your profile picture? Your profile will show your initials
+          instead.
+        </p>
+      </ConfirmModal>
+
+      <ConfirmModal
         isOpen={Boolean(pendingBadgeAction)}
         onClose={closePendingBadgeAction}
-        title={
-          pendingBadgeActionType === "delete"
-            ? "Delete Badge Award"
-            : "Hide Badge Award"
-        }
-        position="center"
-        size="small"
-        closeOnBackdrop={!pendingBadgeActionLoading}
-        closeOnEscape={!pendingBadgeActionLoading}
-        showCloseButton={!pendingBadgeActionLoading}
-        footer={
-          <div className="flex justify-end gap-3">
-            <Button
-              variant="ghost"
-              onClick={closePendingBadgeAction}
-              disabled={pendingBadgeActionLoading}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant={
-                pendingBadgeActionType === "delete" ? "error" : "primary"
-              }
-              onClick={confirmPendingBadgeAction}
-              disabled={pendingBadgeActionLoading}
-              icon={
-                pendingBadgeActionType === "delete" ? (
-                  <Trash2 size={16} />
-                ) : (
-                  <EyeClosed size={16} />
-                )
-              }
-            >
-              {pendingBadgeActionLoading
-                ? pendingBadgeActionType === "delete"
-                  ? "Deleting..."
-                  : "Hiding..."
-                : pendingBadgeActionType === "delete"
-                  ? "Delete"
-                  : "Hide"}
-            </Button>
-          </div>
-        }
+        onConfirm={confirmPendingBadgeAction}
+        title={pendingBadgeActionType === "delete" ? "Delete Badge Award" : "Hide Badge Award"}
+        loading={pendingBadgeActionLoading}
+        confirmLabel={pendingBadgeActionType === "delete" ? "Delete" : "Hide"}
+        loadingLabel={pendingBadgeActionType === "delete" ? "Deleting..." : "Hiding..."}
+        confirmVariant={pendingBadgeActionType === "delete" ? "error" : "primary"}
+        confirmIcon={pendingBadgeActionType === "delete" ? <Trash2 size={16} /> : <EyeClosed size={16} />}
       >
         <p className="text-sm text-base-content/80">
           {pendingBadgeActionType === "delete"
             ? `Delete ${pendingBadgeAwardDescription} permanently? This removes only this awarded instance, not other awards for the same badge.`
             : `Hide ${pendingBadgeAwardDescription} from others? You will still see it on your profile with a closed-eye marker.`}
         </p>
-      </Modal>
+      </ConfirmModal>
 
       <TagAwardsModal
         {...tagAwardsModalProps}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../contexts/AuthContext";
 import Card from "../components/common/Card";
 import Button from "../components/common/Button";
 import Alert from "../components/common/Alert";
+import ScreenAlert from "../components/common/ScreenAlert";
 import FormSectionDivider from "../components/common/FormSectionDivider";
 import VisibilityToggle from "../components/common/VisibilityToggle";
 import Modal from "../components/common/Modal";
@@ -630,16 +631,20 @@ const Settings = () => {
 
   return (
     <div className="space-y-6">
-      {success && (
-        <Alert
-          type="success"
-          message={success}
-          onClose={() => setSuccess(null)}
-        />
-      )}
-      {error && (
-        <Alert type="error" message={error} onClose={() => setError(null)} />
-      )}
+      <ScreenAlert
+        alerts={[
+          success && {
+            type: "success",
+            message: success,
+            onClose: () => setSuccess(null),
+          },
+          error && {
+            type: "error",
+            message: error,
+            onClose: () => setError(null),
+          },
+        ]}
+      />
 
       <Card className="overflow-visible">
         {/* Page Header — sits directly in Card, no extra wrapper */}

--- a/src/utils/messageNotificationUtils.js
+++ b/src/utils/messageNotificationUtils.js
@@ -1,3 +1,5 @@
+import { formatDisplayName } from "./nameFormatters";
+
 const asIdString = (value) =>
   value === null || value === undefined ? null : String(value);
 
@@ -94,6 +96,17 @@ export const isMessageForCurrentChatPath = (
     .filter(Boolean);
 
   return possibleDirectIds.includes(currentConversationId);
+};
+
+export const getMessageSenderDisplayName = (message) => {
+  const firstName =
+    message?.senderFirstName ?? message?.sender_first_name ?? message?.sender?.firstName;
+  const lastName =
+    message?.senderLastName ?? message?.sender_last_name ?? message?.sender?.lastName;
+
+  const displayName = formatDisplayName({ firstName, lastName });
+
+  return displayName === "Unknown" ? "" : displayName;
 };
 
 export const getMessagePreviewText = (message) => {


### PR DESCRIPTION
Summary
Consistent confirmation modals — replaced all window.confirm dialogs across the app with a shared ConfirmModal component. All destructive actions (delete team, leave team, remove member, cancel application, remove profile/team picture, delete vacant role, role changes) now use the same Lomir-styled modal with aligned body text, correct button variants, loading states, and a spinner.
New ConfirmModal component — encodes all defaults (size="small", position="center", loading-aware backdrop/escape/close-button behaviour, Cancel + Confirm footer) so future confirmation dialogs are consistent by construction and require no boilerplate.
Full names in UI copy — confirmation modals, success messages, and error messages now show a member's first + last name (via the existing formatDisplayName utility) instead of their username.
Auto-dismissing alerts — Alert/ScreenAlert notifications now fade out and dismiss automatically after 3 seconds (2 s visible, 1 s CSS fade), while keeping the manual × close button.
Live notification badge — the bell badge now decreases instantly when invitations or applications are cancelled, by listening to the notification:deleted socket event alongside the existing notification:new and notification:updated listeners.
Stale-free badge navigation — clicking the notification badge now fetches a fresh count from the backend before navigating, so users are never directed to a deleted invitation, application, or badge award.
Message notification polish — improved toast behaviour and conversation resolution handling in the chat flow.
Test plan
 Trigger each confirmation dialog (delete team, leave team, remove member, cancel application, remove profile picture, remove team picture, delete vacant role, promote/demote/transfer role) — verify consistent modal design, correct button labels, loading state, and that Cancel closes without acting
 Verify member names in confirmation modals and success toasts show "First Last" not "username"
 Trigger a success or error notification — verify it fades and disappears after ~3 seconds; verify the × button still dismisses it immediately
 Have another user cancel a sent invitation or application — verify the recipient's badge count decreases without a page refresh
 Click the notification badge after an invitation has been cancelled — verify navigation goes to a valid destination, not the deleted entity
 Verify message notifications and chat conversation resolution still work correctly
