### PR TITLE
Polish chat layout and empty states

### DIFF
--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Users, User, ChevronRight } from "lucide-react";
+import { Link } from "react-router-dom";
 import Tooltip from "../common/Tooltip";
 import { CountBadge } from "../common/NotificationBadge";
 import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
@@ -242,16 +243,32 @@ const ConversationList = ({
       <div className="flex flex-col items-center justify-center h-full p-4 text-center">
         <p className="text-base-content/70 mb-2">No conversations yet</p>
         <p className="text-sm text-base-content/50">
-          Start chatting with team members by visiting their profile and
-          clicking "Send Message"
+          Start chatting with other people or team members by visiting their
+          profile and clicking "Send Message"
         </p>
+        <div className="mt-5 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <Link
+            to="/search?type=users"
+            className="btn btn-sm btn-primary gap-2"
+          >
+            <User size={16} />
+            Find People
+          </Link>
+          <Link
+            to="/search?type=teams"
+            className="btn btn-sm btn-primary gap-2"
+          >
+            <Users size={16} />
+            Find Teams
+          </Link>
+        </div>
       </div>
     );
   }
 
   return (
     <>
-      <div className="divide-y divide-base-200 w-full min-w-0">
+      <div className="w-full min-w-0 space-y-3">
         {conversations.map((conversation) => {
           // Handle both direct messages and team conversations
           const isTeam = conversation.type === "team";
@@ -293,11 +310,11 @@ const ConversationList = ({
               key={`${conversation.type}-${conversation.id}`}
               ref={isActive ? activeConversationRef : null}
               className={`
-                p-4 cursor-pointer transition-colors duration-200 group
+                p-4 mr-4 cursor-pointer rounded-lg border shadow-soft transition-all duration-300 hover:shadow-md group
                 ${
                   isActive
-                    ? "bg-green-100"
-                    : "hover:bg-base-200/50"
+                    ? "lomir-active-conversation-card bg-green-100 border-transparent"
+                    : "bg-white/80 border-base-200"
                 }
               `}
               onClick={() => onSelectConversation(conversation.id)}
@@ -452,15 +469,16 @@ const ConversationList = ({
                   </div>
                 </div>
 
-                {/* Chevron button - visible on mobile, hover on desktop */}
-                <Tooltip content="Open conversation" position="top" wrapperClassName="inline-flex items-center flex-shrink-0 ml-1 -mr-4">
-                  <button
-                    onClick={() => onSelectConversation(conversation.id)}
-                    className="flex items-center justify-center p-2 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
-                  >
-                    <ChevronRight size={16} className="text-base-content/70" />
-                  </button>
-                </Tooltip>
+                {!isActive && (
+                  <Tooltip content="Open conversation" position="top" wrapperClassName="inline-flex items-center flex-shrink-0 ml-1 -mr-4">
+                    <button
+                      onClick={() => onSelectConversation(conversation.id)}
+                      className="flex items-center justify-center p-2 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+                    >
+                      <ChevronRight size={16} className="text-base-content/70" />
+                    </button>
+                  </Tooltip>
+                )}
               </div>
             </div>
           );

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,37 @@
       display: none;
     }
   }
+
+  .lomir-conversation-list-scrollbar {
+    scrollbar-width: thin;
+  }
+
+  .lomir-conversation-list-scrollbar::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .lomir-active-conversation-card {
+    position: relative;
+  }
+
+  .lomir-active-conversation-card::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: -1.5rem;
+    width: 36px;
+    height: 24px;
+    background-color: #dcfce7;
+    pointer-events: none;
+    transform: translateY(-50%) rotate(270deg);
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.500009 1C3.5 1 3.00001 7 6.00001 7C9 7 8.5 1 11.5 1C12 1 12 0.5 12 0H0C0 0.5 0 1 0.500009 1Z' fill='white'/%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.500009 1C3.5 1 3.00001 7 6.00001 7C9 7 8.5 1 11.5 1C12 1 12 0.5 12 0H0C0 0.5 0 1 0.500009 1Z' fill='white'/%3E%3C/svg%3E");
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    filter: drop-shadow(0 2px 6px rgba(4, 80, 20, 0.12));
+  }
 }
 
 @layer components {

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -162,11 +162,6 @@ const Chat = () => {
     useState(false);
   const [isActiveConversationVisible, setIsActiveConversationVisible] =
     useState(true);
-  const [
-    isRegularConversationHeaderVisible,
-    setIsRegularConversationHeaderVisible,
-  ] = useState(true);
-
   const typingTimeoutRef = useRef(null);
   const messagesContainerRef = useRef(null);
   const pendingScrollAdjustmentRef = useRef(null);
@@ -252,8 +247,9 @@ const Chat = () => {
     getConversationUpdatedAt(messages?.[messages.length - 1] || messages?.[0] || null);
   const showCompactConversationHeader =
     Boolean(conversationId) &&
-    !isActiveConversationVisible &&
-    !isRegularConversationHeaderVisible;
+    !isActiveConversationVisible;
+  const showEmptyConversationState =
+    !loading && conversations.length === 0 && !conversationId;
 
   useEffect(() => {
     conversationsRef.current = conversations;
@@ -265,7 +261,6 @@ const Chat = () => {
 
   useEffect(() => {
     setIsActiveConversationVisible(true);
-    setIsRegularConversationHeaderVisible(true);
   }, [conversationId]);
 
   const handleActiveConversationVisibilityChange = useCallback((isVisible) => {
@@ -273,15 +268,6 @@ const Chat = () => {
       current === isVisible ? current : isVisible,
     );
   }, []);
-
-  const handleRegularConversationHeaderVisibilityChange = useCallback(
-    (isVisible) => {
-      setIsRegularConversationHeaderVisible((current) =>
-        current === isVisible ? current : isVisible,
-      );
-    },
-    [],
-  );
 
   const refreshConversationList = useCallback(async () => {
     try {
@@ -1647,8 +1633,8 @@ const Chat = () => {
 
   return (
     <PageContainer
-      title="Messages"
-      className="p-0 overflow-hidden"
+      title="Chats"
+      className="p-0"
       variant="muted"
     >
       <ScreenAlert type="error" message={error} onClose={() => setError(null)} />
@@ -1690,29 +1676,37 @@ const Chat = () => {
         </p>
       </Modal>
 
-      <div className="bg-white shadow-soft flex h-[calc(100vh-200px)] rounded-xl overflow-hidden">
+      <div className="flex h-[calc(100vh-200px)] gap-2">
         {/* Conversation List - Left Sidebar */}
         <div
           data-conversation-list-viewport="true"
-          className={`border-r border-base-200 overflow-y-auto transition-all duration-300 ${
-            showChatView ? "hidden md:block md:w-1/3" : "w-full md:w-1/3"
+          className={`lomir-conversation-list-scrollbar overflow-y-auto transition-all duration-300 ${
+            showEmptyConversationState
+              ? "w-full"
+              : showChatView
+                ? "hidden md:block md:w-1/3"
+                : "w-full md:w-1/3"
           }`}
+          style={{ direction: "rtl" }}
         >
-          <ConversationList
-            conversations={conversations}
-            activeConversationId={conversationId}
-            onSelectConversation={selectConversation}
-            loading={loading}
-            onlineUsers={onlineUsers}
-            onActiveConversationVisibilityChange={
-              handleActiveConversationVisibilityChange
-            }
-            teamMembersRefreshSignal={teamMembersRefreshSignal}
-          />
+          <div className="h-full" style={{ direction: "ltr" }}>
+            <ConversationList
+              conversations={conversations}
+              activeConversationId={conversationId}
+              onSelectConversation={selectConversation}
+              loading={loading}
+              onlineUsers={onlineUsers}
+              onActiveConversationVisibilityChange={
+                handleActiveConversationVisibilityChange
+              }
+              teamMembersRefreshSignal={teamMembersRefreshSignal}
+            />
+          </div>
         </div>
 
         {/* Message Display - Right Side */}
-        <div className={`flex flex-col transition-all duration-300 ${
+        {!showEmptyConversationState && (
+        <div className={`bg-white shadow-soft rounded-xl overflow-hidden flex flex-col min-w-0 transition-all duration-300 ${
           showChatView ? "w-full md:w-2/3" : "hidden md:flex md:w-2/3"
         }`}>
           {conversationId ? (
@@ -1878,9 +1872,6 @@ const Chat = () => {
                   onDeleteMessage={handleDeleteMessage}
                   onEditMessage={handleEditMessage}
                   onLeaveTeam={handleLeaveTeam}
-                  onConversationHeaderVisibilityChange={
-                    handleRegularConversationHeaderVisibilityChange
-                  }
                 />
               </div>
 
@@ -1949,6 +1940,7 @@ const Chat = () => {
             </div>
           )}
         </div>
+        )}
       </div>
       <TeamDetailsModal
         isOpen={isTeamModalOpen}

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -861,12 +861,19 @@ const MyTeams = () => {
             <p className="text-base-content/70 mb-4">
               You haven't joined any teams yet.
             </p>
-            <Button
-              variant="primary"
-              onClick={() => setIsCreateTeamModalOpen(true)}
-            >
-              Create Your First Team
-            </Button>
+            <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <Button
+                variant="primary"
+                onClick={() => setIsCreateTeamModalOpen(true)}
+              >
+                Create Your First Team
+              </Button>
+              <Link to="/search?type=teams">
+                <Button variant="primary" icon={<SearchIcon size={16} />}>
+                  Find Teams
+                </Button>
+              </Link>
+            </div>
           </div>
         ) : (
           <>


### PR DESCRIPTION
Polished the chat page layout and empty states.

Changes

Renamed the chat page title from “Messages” to “Chats”
Split the conversation list and chat area into separate side-by-side sections
Removed the outer background/shadow from the conversation list wrapper
Styled each conversation list item as its own card
Matched conversation item background/shadow behavior to the map-view remote/unmapped cards
Moved the conversation list scrollbar to the left and made it narrower
Added a light-green speech-bubble pointer for the selected conversation
Removed the chevron icon from the selected conversation item
Updated compact chat header behavior so it appears when the selected conversation is scrolled out of view
Removed the chat box entirely when there are no conversations
Centered and updated the empty chat state copy
Added Find People and Find Teams buttons to the empty chat state
Added Find Teams next to Create Your First Team in the My Teams empty state
Verification

Ran npm run build
Build passes
Existing Vite chunk-size warning remains unchanged