### PR TITLE
UI/chat page polish3

### DIFF
--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Users, User, ChevronRight } from "lucide-react";
+import { Users, User, ChevronRight, Search } from "lucide-react";
 import { Link } from "react-router-dom";
 import Tooltip from "../common/Tooltip";
 import { CountBadge } from "../common/NotificationBadge";
 import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
-import { formatRelativeChatTimestamp } from "../../utils/dateHelpers";
+import { formatRelativeChatTimestamp, formatShortRelativeChatTimestamp } from "../../utils/dateHelpers";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import UserAvatar from "../users/UserAvatar";
@@ -21,6 +21,41 @@ import {
   mergeResolvedUserData,
 } from "../../utils/chatEntityResolvers";
 
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const renderHighlightedText = (value, query) => {
+  const text = String(value ?? "");
+  const terms = String(query ?? "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(escapeRegExp);
+
+  if (!text || terms.length === 0) return text;
+
+  const matcher = new RegExp(`(${terms.join("|")})`, "gi");
+  const parts = text.split(matcher);
+
+  return parts.map((part, index) => {
+    if (!part) return null;
+
+    const isMatch = terms.some((term) =>
+      new RegExp(`^${term}$`, "i").test(part),
+    );
+
+    if (!isMatch) return part;
+
+    return (
+      <mark
+        key={`${part}-${index}`}
+        className="rounded-full bg-yellow-100 px-1.5 py-0.5 text-[var(--color-primary-focus)]"
+      >
+        {part}
+      </mark>
+    );
+  });
+};
+
 const ConversationList = ({
   conversations,
   activeConversationId,
@@ -28,6 +63,9 @@ const ConversationList = ({
   loading,
   onActiveConversationVisibilityChange,
   teamMembersRefreshSignal = null,
+  emptyState = null,
+  searchQuery = "",
+  chatVisible = true,
 }) => {
   // State for team details modal
   const [isTeamModalOpen, setIsTeamModalOpen] = useState(false);
@@ -239,29 +277,34 @@ const ConversationList = ({
   }
 
   if (conversations.length === 0) {
+    const emptyTitle = emptyState?.title || "No conversations yet";
+    const emptyDescription =
+      emptyState?.description ||
+      `Start chatting with other people or team members by visiting their profile and clicking "Send Message"`;
+    const showEmptyActions = emptyState?.showActions !== false;
+
     return (
       <div className="flex flex-col items-center justify-center h-full p-4 text-center">
-        <p className="text-base-content/70 mb-2">No conversations yet</p>
-        <p className="text-sm text-base-content/50">
-          Start chatting with other people or team members by visiting their
-          profile and clicking "Send Message"
-        </p>
-        <div className="mt-5 flex flex-col items-center justify-center gap-3 sm:flex-row">
-          <Link
-            to="/search?type=users"
-            className="btn btn-sm btn-primary gap-2"
-          >
-            <User size={16} />
-            Find People
-          </Link>
-          <Link
-            to="/search?type=teams"
-            className="btn btn-sm btn-primary gap-2"
-          >
-            <Users size={16} />
-            Find Teams
-          </Link>
-        </div>
+        <p className="text-base-content/70 mb-2">{emptyTitle}</p>
+        <p className="text-sm text-base-content/50">{emptyDescription}</p>
+        {showEmptyActions && (
+          <div className="mt-5 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Link
+              to="/search?type=users"
+              className="btn btn-sm btn-primary gap-2"
+            >
+              <User size={16} />
+              Find People
+            </Link>
+            <Link
+              to="/search?type=teams"
+              className="btn btn-sm btn-primary gap-2"
+            >
+              <Users size={16} />
+              Find Teams
+            </Link>
+          </div>
+        )}
       </div>
     );
   }
@@ -301,9 +344,18 @@ const ConversationList = ({
           const displayName = isTeam
             ? conversationData?.name
             : directDisplayName || DELETED_USER_DISPLAY_NAME;
+          const isSearchActive = Boolean(searchQuery.trim());
+          const previewText =
+            isSearchActive && conversation.searchMatchPreview
+              ? conversation.searchMatchPreview
+              : conversation.lastMessage || "No messages yet";
+          const timestamp =
+            isSearchActive && conversation.searchMatchCreatedAt
+              ? conversation.searchMatchCreatedAt
+              : conversation.updatedAt;
 
           const isActive =
-            String(activeConversationId) === String(conversation.id);
+            chatVisible && String(activeConversationId) === String(conversation.id);
 
           return (
             <div
@@ -429,51 +481,91 @@ const ConversationList = ({
                               : undefined
                         }
                       >
-                        {displayName || "Unknown"}
+                        {renderHighlightedText(displayName || "Unknown", searchQuery)}
                       </h3>
                     </Tooltip>
                   </div>
                   <Tooltip
                     content={
-                      (conversation.lastMessage?.length ?? 0) > 60
-                        ? conversation.lastMessage
+                      (previewText?.length ?? 0) > 60
+                        ? previewText
                         : undefined
                     }
                     position="bottom"
                     wrapperClassName="block min-w-0 overflow-hidden"
                   >
                     <p className="text-sm text-base-content/70 truncate">
-                      {conversation.lastMessage || "No messages yet"}
+                      {renderHighlightedText(
+                        previewText,
+                        searchQuery,
+                      )}
                     </p>
                   </Tooltip>
                   <div className="flex items-center min-w-0 gap-2">
                     <p
-                      className="lomir-conversation-kind text-xs truncate flex-1 min-w-0 flex items-center gap-1"
+                      className="lomir-conversation-kind text-xs flex-1 min-w-0 flex items-center gap-1 overflow-hidden"
                       style={{ color: "#036b0c" }}
                     >
                       {isTeam ? (
                         <>
                           <Users size={12} className="flex-shrink-0" />
-                          <span className="lomir-conversation-kind-label">Team Chat</span>
+                          <span className={`lomir-conversation-kind-label whitespace-nowrap ${isSearchActive && chatVisible ? "hidden sm:inline md:hidden" : "inline"}`}>
+                            {renderHighlightedText("Team Chat", searchQuery)}
+                          </span>
                         </>
                       ) : (
                         <>
                           <User size={12} className="flex-shrink-0" />
-                          <span className="lomir-conversation-kind-label">DM Chat</span>
+                          <span className={`lomir-conversation-kind-label whitespace-nowrap ${isSearchActive && chatVisible ? "hidden sm:inline md:hidden" : "inline"}`}>
+                            {renderHighlightedText("Direct Message Chat", searchQuery)}
+                          </span>
                         </>
                       )}
+                      {isSearchActive && conversation.searchMatchCount > 0 && (() => {
+                        const count = conversation.searchMatchCount;
+                        const matchWord = count === 1 ? "match" : "matches";
+                        const query = searchQuery.trim();
+                        return (
+                          <>
+                            <Search size={12} className="flex-shrink-0 ml-2" />
+                            {chatVisible ? (
+                              /* Split-view: narrow column */
+                              <>
+                                <span className="whitespace-nowrap sm:hidden">{count}</span>
+                                <span className="truncate whitespace-nowrap hidden sm:inline md:hidden">
+                                  {count} search {matchWord} for &ldquo;{query}&rdquo;
+                                </span>
+                                <span className="whitespace-nowrap hidden md:inline">{count}</span>
+                              </>
+                            ) : (
+                              /* Full-width: show full text at sm+ */
+                              <>
+                                <span className="whitespace-nowrap sm:hidden">{count}</span>
+                                <span className="truncate whitespace-nowrap hidden sm:inline">
+                                  {count} search {matchWord} for &ldquo;{query}&rdquo;
+                                </span>
+                              </>
+                            )}
+                          </>
+                        );
+                      })()}
                     </p>
                     <span className="flex-shrink-0 ml-2 text-xs whitespace-nowrap" style={{ color: "#036b0c" }}>
-                      {formatRelativeChatTimestamp(conversation.updatedAt)}
+                      {chatVisible ? (
+                        <>
+                          <span className="md:hidden">{formatRelativeChatTimestamp(timestamp)}</span>
+                          <span className="hidden md:inline">{formatShortRelativeChatTimestamp(timestamp)}</span>
+                        </>
+                      ) : formatRelativeChatTimestamp(timestamp)}
                     </span>
                   </div>
                 </div>
 
-                {!isActive && (
+                {(!isActive || chatVisible) && (
                   <Tooltip content="Open conversation" position="top" wrapperClassName="inline-flex items-center flex-shrink-0 ml-1 -mr-4">
                     <button
                       onClick={() => onSelectConversation(conversation.id)}
-                      className="flex items-center justify-center p-2 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+                      className={`flex items-center justify-center p-2 transition-opacity ${isActive ? "" : "md:opacity-0 md:group-hover:opacity-100"}`}
                     >
                       <ChevronRight size={16} className="text-base-content/70" />
                     </button>

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -357,9 +357,8 @@ const ConversationList = ({
           const isActive =
             chatVisible && String(activeConversationId) === String(conversation.id);
 
-          return (
+          const conversationCard = (
             <div
-              key={`${conversation.type}-${conversation.id}`}
               ref={isActive ? activeConversationRef : null}
               className={`
                 p-4 mr-4 cursor-pointer rounded-lg border shadow-soft transition-all duration-300 hover:shadow-md group
@@ -562,10 +561,23 @@ const ConversationList = ({
                 </div>
 
                 {(!isActive || chatVisible) && (
-                  <Tooltip content="Open conversation" position="top" wrapperClassName="inline-flex items-center flex-shrink-0 ml-1 -mr-4">
+                  <Tooltip
+                    content={isActive ? "Deselect Conversation" : "Open conversation"}
+                    position="top"
+                    wrapperClassName="inline-flex items-center flex-shrink-0 ml-1 -mr-4"
+                  >
                     <button
-                      onClick={() => onSelectConversation(conversation.id)}
-                      className={`flex items-center justify-center p-2 transition-opacity ${isActive ? "" : "md:opacity-0 md:group-hover:opacity-100"}`}
+                      type="button"
+                      aria-label={isActive ? "Deselect Conversation" : "Open conversation"}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onSelectConversation(conversation.id);
+                      }}
+                      className={`flex items-center justify-center p-2 transition-opacity ${
+                        isActive
+                          ? "opacity-0"
+                          : "md:opacity-0 md:group-hover:opacity-100"
+                      }`}
                     >
                       <ChevronRight size={16} className="text-base-content/70" />
                     </button>
@@ -573,6 +585,17 @@ const ConversationList = ({
                 )}
               </div>
             </div>
+          );
+
+          return (
+            <Tooltip
+              key={`${conversation.type}-${conversation.id}`}
+              content={isActive ? "Deselect Conversation" : undefined}
+              position="top"
+              wrapperClassName="block"
+            >
+              {conversationCard}
+            </Tooltip>
           );
         })}
       </div>

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -64,7 +64,7 @@ const parseIdNameToken = (token) => {
  * Parse system messages (join notifications, invitation responses)
  * Returns structured data if it's a system message, null otherwise
  */
-const parseSystemMessage = (content) => {
+export const parseSystemMessage = (content) => {
   if (!content) return null;
 
   // Pattern 1: Team join message
@@ -399,6 +399,41 @@ const parseSystemMessage = (content) => {
   return null;
 };
 
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const renderHighlightedSearchText = (value, query) => {
+  const text = String(value ?? "");
+  const terms = String(query ?? "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(escapeRegExp);
+
+  if (!text || terms.length === 0) return text;
+
+  const matcher = new RegExp(`(${terms.join("|")})`, "gi");
+  const parts = text.split(matcher);
+
+  return parts.map((part, index) => {
+    if (!part) return null;
+
+    const isMatch = terms.some((term) =>
+      new RegExp(`^${term}$`, "i").test(part),
+    );
+
+    if (!isMatch) return part;
+
+    return (
+      <mark
+        key={`${part}-${index}`}
+        className="rounded-full bg-yellow-100 px-1.5 py-0.5 text-[var(--color-primary-focus)]"
+      >
+        {part}
+      </mark>
+    );
+  });
+};
+
 const MessageDisplay = ({
   messages,
   currentUserId,
@@ -418,6 +453,7 @@ const MessageDisplay = ({
   onEditMessage,
   onLeaveTeam,
   onConversationHeaderVisibilityChange,
+  searchQuery = "",
 }) => {
   const messagesEndRef = useRef(null);
   const highlightedMessageRef = useRef(null);
@@ -450,6 +486,31 @@ const MessageDisplay = ({
   const [editingContent, setEditingContent] = useState("");
   const [editingError, setEditingError] = useState(null);
   const [savingEditMessageId, setSavingEditMessageId] = useState(null);
+
+  const highlightEventContent = useCallback(
+    (node) => {
+      if (node == null || typeof node === "boolean") return node;
+      if (typeof node === "string" || typeof node === "number") {
+        return renderHighlightedSearchText(node, searchQuery);
+      }
+      if (Array.isArray(node)) {
+        return node.map((child, index) => (
+          <React.Fragment key={index}>
+            {highlightEventContent(child)}
+          </React.Fragment>
+        ));
+      }
+      if (React.isValidElement(node)) {
+        const children = node.props?.children;
+        if (children == null) return node;
+        return React.cloneElement(node, {
+          children: highlightEventContent(children),
+        });
+      }
+      return node;
+    },
+    [searchQuery],
+  );
 
   const setConversationHeaderRef = useCallback((node) => {
     setConversationHeaderElement(node);
@@ -905,7 +966,11 @@ const MessageDisplay = ({
     const safe = (name || "").trim();
     if (!safe) return null;
     if (safe === DELETED_USER_DISPLAY_NAME) {
-      return <span className="font-medium text-base-content/50">{safe}</span>;
+      return (
+        <span className="font-medium text-base-content/50">
+          {renderHighlightedSearchText(safe, searchQuery)}
+        </span>
+      );
     }
 
     return (
@@ -916,7 +981,7 @@ const MessageDisplay = ({
           onClick={() => handleMentionClick(safe)}
           disabled={resolvingName}
         >
-          {safe}
+          {renderHighlightedSearchText(safe, searchQuery)}
         </button>
       </Tooltip>
     );
@@ -926,7 +991,9 @@ const MessageDisplay = ({
     const safeName = (name || "").trim() || "User";
     if (!userId) {
       return safeName === DELETED_USER_DISPLAY_NAME ? (
-        <span className="font-medium text-base-content/50">{safeName}</span>
+        <span className="font-medium text-base-content/50">
+          {renderHighlightedSearchText(safeName, searchQuery)}
+        </span>
       ) : (
         <Mention name={safeName} />
       );
@@ -939,7 +1006,7 @@ const MessageDisplay = ({
           className="font-medium underline underline-offset-2 hover:no-underline hover:text-primary transition-colors"
           onClick={() => handleUserClick(userId, safeName)}
         >
-          {safeName}
+          {renderHighlightedSearchText(safeName, searchQuery)}
         </button>
       </Tooltip>
     );
@@ -963,7 +1030,13 @@ const MessageDisplay = ({
     const safeName = (name || "").trim() || "Team";
 
     // legacy / missing id => non-clickable fallback
-    if (!teamId) return <span className="font-medium">"{safeName}"</span>;
+    if (!teamId) {
+      return (
+        <span className="font-medium">
+          "{renderHighlightedSearchText(safeName, searchQuery)}"
+        </span>
+      );
+    }
 
     return (
       <Tooltip content={`Open ${safeName}`} position="top">
@@ -972,7 +1045,7 @@ const MessageDisplay = ({
           className="font-medium underline underline-offset-2 hover:no-underline hover:text-primary transition-colors"
           onClick={() => openTeamModal(teamId)}
         >
-          "{safeName}"
+          "{renderHighlightedSearchText(safeName, searchQuery)}"
         </button>
       </Tooltip>
     );
@@ -1426,7 +1499,7 @@ const MessageDisplay = ({
         >
           <span className="text-sm font-medium event-message-text">
             <PartyPopper size={16} className="event-inline-icon ml-1" />{" "}
-            {messageText}.
+            {highlightEventContent(messageText)}.
           </span>
         </div>
 
@@ -1467,7 +1540,7 @@ const MessageDisplay = ({
         <div className="event-banner event-banner--success mb-3">
           <span className="text-sm font-medium event-message-text">
             <UserPlus size={16} className="event-inline-icon mr-1" />
-            {welcomeText}
+            {highlightEventContent(welcomeText)}
             <PartyPopper size={16} className="event-inline-icon ml-1" />
           </span>
         </div>
@@ -1500,7 +1573,7 @@ const MessageDisplay = ({
         <div className="event-banner event-banner--neutral mb-3">
           <span className="text-sm font-medium event-message-text">
             <UserMinus size={16} className="event-inline-icon mr-1" />
-            {leaveText}
+            {highlightEventContent(leaveText)}
           </span>
         </div>
 
@@ -1541,7 +1614,7 @@ const MessageDisplay = ({
         <div className="event-banner event-banner--neutral mb-3">
           <span className="text-sm font-medium event-message-text">
             <UserMinus size={16} className="event-inline-icon mr-1" />
-            {text}
+            {highlightEventContent(text)}
           </span>
         </div>
 
@@ -1586,7 +1659,7 @@ const MessageDisplay = ({
       <div className="flex flex-col items-center w-full my-4">
         <div className="event-banner event-banner--success mb-3">
           <span className="text-sm font-medium event-message-text">
-            {messageText}
+            {highlightEventContent(messageText)}
             <PartyPopper size={16} className="event-inline-icon ml-1" />
           </span>
         </div>
@@ -1624,7 +1697,7 @@ const MessageDisplay = ({
         <div className="event-banner event-banner--success mb-3">
           <span className="text-sm font-medium event-message-text">
             <UserPlus size={16} className="event-inline-icon mr-1" />
-            {welcomeText}
+            {highlightEventContent(welcomeText)}
             <PartyPopper size={16} className="event-inline-icon ml-1" />
           </span>
         </div>
@@ -1656,7 +1729,7 @@ const MessageDisplay = ({
                   }
                 `}
               >
-                <p>{parsedMessage.personalMessage}</p>
+                <p>{renderHighlightedSearchText(parsedMessage.personalMessage, searchQuery)}</p>
                 <div
                   className={`
                     flex justify-end items-center text-xs mt-1 
@@ -1733,7 +1806,7 @@ const MessageDisplay = ({
       <div className="flex flex-col items-center w-full my-4">
         <div className="event-banner event-banner--neutral mb-3">
           <span className="text-sm font-medium event-message-text">
-            {messageText}
+            {highlightEventContent(messageText)}
           </span>
         </div>
 
@@ -1818,7 +1891,7 @@ const MessageDisplay = ({
       <div className="flex flex-col items-center w-full my-4">
         <div className="event-banner event-banner--neutral mb-3">
           <span className="text-sm font-medium event-message-text">
-            {messageText}
+            {highlightEventContent(messageText)}
           </span>
         </div>
 
@@ -1843,19 +1916,19 @@ const MessageDisplay = ({
       <>
         Your decline response to <Mention name={parsedMessage.applicantName} />
         {"'s"} application for{" "}
-        <span className="font-medium">{parsedMessage.teamName}</span>
+        <span className="font-medium">{renderHighlightedSearchText(parsedMessage.teamName, searchQuery)}</span>
       </>
     ) : (
       <>
         Response to your application for{" "}
-        <span className="font-medium">{parsedMessage.teamName}</span>
+        <span className="font-medium">{renderHighlightedSearchText(parsedMessage.teamName, searchQuery)}</span>
       </>
     );
 
     return (
       <div className="flex flex-col w-full my-4">
         <div className="event-banner event-banner--neutral mb-3 mx-auto">
-          <span className="text-sm event-message-text">{bannerContent}</span>
+          <span className="text-sm event-message-text">{highlightEventContent(bannerContent)}</span>
         </div>
 
         {parsedMessage.personalMessage && (
@@ -1877,7 +1950,7 @@ const MessageDisplay = ({
                   }
                 `}
               >
-                <p>{parsedMessage.personalMessage}</p>
+                <p>{renderHighlightedSearchText(parsedMessage.personalMessage, searchQuery)}</p>
                 <div
                   className={`
                     flex justify-end items-center text-xs mt-1 
@@ -1973,7 +2046,7 @@ const MessageDisplay = ({
       <div className="flex flex-col items-center w-full my-4">
         <div className="event-banner event-banner--neutral mb-3">
           <span className="text-sm font-medium event-message-text">
-            {messageText}
+            {highlightEventContent(messageText)}
           </span>
         </div>
 
@@ -1999,7 +2072,7 @@ const MessageDisplay = ({
         <div className="event-banner event-banner--info mb-3 mx-auto">
           <span className="text-sm event-message-text">
             Response to invitation for{" "}
-            <span className="font-medium">{parsedMessage.teamName}</span>
+            <span className="font-medium">{renderHighlightedSearchText(parsedMessage.teamName, searchQuery)}</span>
           </span>
         </div>
 
@@ -2024,7 +2097,7 @@ const MessageDisplay = ({
                   }
                 `}
               >
-                <p>{parsedMessage.personalMessage}</p>
+                <p>{renderHighlightedSearchText(parsedMessage.personalMessage, searchQuery)}</p>
                 <div
                   className={`
                     flex justify-end items-center text-xs mt-1 
@@ -2082,7 +2155,7 @@ const MessageDisplay = ({
       <div className="flex flex-col items-center w-full my-4">
         <div className="event-banner event-banner--neutral mb-3">
           <span className="text-sm font-medium event-message-text">
-            {messageText}
+            {highlightEventContent(messageText)}
           </span>
         </div>
 
@@ -2192,7 +2265,7 @@ const MessageDisplay = ({
         <div className={`event-banner ${bannerClass} mb-3`}>
           <span className="text-sm font-medium event-message-text">
             <RoleIcon size={16} className="event-inline-icon mr-1" />
-            {messageText}
+            {highlightEventContent(messageText)}
             {isPromotion && !isCurrentUser && (
               <PartyPopper size={16} className="event-inline-icon ml-1" />
             )}
@@ -2268,7 +2341,7 @@ const MessageDisplay = ({
         <div className="event-banner event-banner--owner mb-3">
           <span className="text-sm font-medium event-message-text">
             <Crown size={16} className="event-inline-icon mr-1" />
-            {messageText}
+            {highlightEventContent(messageText)}
             <PartyPopper size={16} className="event-inline-icon ml-1" />
           </span>
         </div>
@@ -2322,7 +2395,7 @@ const MessageDisplay = ({
       <div className="flex flex-col items-center w-full my-4">
         <div className="event-banner event-banner--neutral mb-3">
           <span className="text-sm font-medium event-message-text">
-            {messageText}
+            {highlightEventContent(messageText)}
           </span>
         </div>
 
@@ -2356,7 +2429,7 @@ const MessageDisplay = ({
           }}
         >
           <span className="text-sm font-medium event-message-text">
-            {messageText}
+            {highlightEventContent(messageText)}
           </span>
 
           {onLeaveTeam && (
@@ -3052,7 +3125,10 @@ const MessageDisplay = ({
                                 {/* Text content */}
                                 {message.content && !isEditing && (
                                   <p>
-                                    <MessageText content={message.content} />
+                                    <MessageText
+                                      content={message.content}
+                                      searchQuery={searchQuery}
+                                    />
                                   </p>
                                 )}
 

--- a/src/components/chat/MessageText.jsx
+++ b/src/components/chat/MessageText.jsx
@@ -95,6 +95,41 @@ const shortenForDisplay = (href) => {
   }
 };
 
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const renderHighlightedText = (value, query) => {
+  const text = String(value ?? "");
+  const terms = String(query ?? "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(escapeRegExp);
+
+  if (!text || terms.length === 0) return text;
+
+  const matcher = new RegExp(`(${terms.join("|")})`, "gi");
+  const parts = text.split(matcher);
+
+  return parts.map((part, index) => {
+    if (!part) return null;
+
+    const isMatch = terms.some((term) =>
+      new RegExp(`^${term}$`, "i").test(part),
+    );
+
+    if (!isMatch) return part;
+
+    return (
+      <mark
+        key={`${part}-${index}`}
+        className="rounded-full bg-yellow-100 px-1.5 py-0.5 text-[var(--color-primary-focus)]"
+      >
+        {part}
+      </mark>
+    );
+  });
+};
+
 // --- UI ------------------------------------------------------
 
 const LinkChip = ({ href }) => {
@@ -143,11 +178,17 @@ const PlainLink = ({ href }) => (
   </Tooltip>
 );
 
-export default function MessageText({ content }) {
+export default function MessageText({ content, searchQuery = "" }) {
   if (!content) return null;
 
   const matches = findUrls(content);
-  if (matches.length === 0) return <span>{content}</span>;
+  if (matches.length === 0) {
+    return (
+      <span className="whitespace-pre-wrap break-words">
+        {renderHighlightedText(content, searchQuery)}
+      </span>
+    );
+  }
 
   const parts = [];
   let last = 0;
@@ -177,7 +218,11 @@ export default function MessageText({ content }) {
     <span className="whitespace-pre-wrap break-words">
       {parts.map((p, idx) => {
         if (p.type === "text")
-          return <React.Fragment key={idx}>{p.value}</React.Fragment>;
+          return (
+            <React.Fragment key={idx}>
+              {renderHighlightedText(p.value, searchQuery)}
+            </React.Fragment>
+          );
         if (p.type === "file")
           return (
             <React.Fragment key={idx}>

--- a/src/components/common/Alert.jsx
+++ b/src/components/common/Alert.jsx
@@ -25,12 +25,13 @@ const Alert = ({
     success: "alert-success",
     warning: "alert-warning",
     error: "alert-error",
+    violet: "bg-violet-600",
   };
   const content = children ?? message;
 
   return (
     <div
-      className={`alert ${alertClasses[type]} !text-white shadow-sm w-fit transition-opacity duration-1000 ${fading ? "opacity-0" : "opacity-100"} ${className}`}
+      className={`alert ${alertClasses[type]} !text-white w-fit transition-opacity duration-1000 ${fading ? "opacity-0" : "opacity-100"} ${className}`}
     >
       <div className="flex items-center gap-2">
         {type === "info" && (
@@ -90,6 +91,21 @@ const Alert = ({
               strokeLinejoin="round"
               strokeWidth="2"
               d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        )}
+        {type === "violet" && (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="stroke-current flex-shrink-0 w-6 h-6"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
         )}

--- a/src/components/common/ScreenAlert.jsx
+++ b/src/components/common/ScreenAlert.jsx
@@ -18,7 +18,7 @@ const ScreenAlert = ({ alerts, type, message, onClose }) => {
             type={alert.type}
             message={alert.message}
             onClose={alert.onClose}
-            className="pointer-events-auto max-w-full shadow-[0_24px_70px_rgba(31,41,55,0.26),0_8px_24px_rgba(31,41,55,0.16)] ring-1 ring-white/25"
+            className="pointer-events-auto max-w-full shadow-[0_4px_10px_rgba(0,0,0,0.12),0_12px_30px_rgba(0,0,0,0.18),0_28px_56px_rgba(0,0,0,0.14)] ring-1 ring-white/20"
           />
         ))}
       </div>

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -2238,23 +2238,33 @@ const Chat = () => {
   const totalSearchMatches = isChatSearchActive
     ? filteredConversations.reduce((sum, conv) => sum + (conv.searchMatchCount || 0), 0)
     : 0;
+  const chatSearchPlaceholder = "Search chats...";
+  const chatSearchInputWidth = `${Math.max(
+    chatSearchQuery.length,
+    chatSearchPlaceholder.length,
+  )}ch`;
 
   const chatSearchAction = (
-    <div className="flex flex-col items-start sm:items-end">
-      <label className="input input-bordered flex h-10 items-center gap-2 rounded-lg bg-base-100 !w-48">
+    <div className="flex max-w-full flex-col items-start sm:items-end">
+      <label className="input input-bordered flex h-10 w-fit max-w-full items-center gap-2 rounded-lg bg-base-100">
         <Search size={16} className="shrink-0 text-base-content/50" />
         <input
           type="search"
-          className="text-sm flex-1 min-w-0"
-          placeholder="Search chats..."
+          className="min-w-0 text-sm"
+          placeholder={chatSearchPlaceholder}
           aria-label="Search chats"
           value={chatSearchQuery}
           onChange={(event) => setChatSearchQuery(event.target.value)}
+          style={{
+            width: chatSearchInputWidth,
+            minWidth: `${chatSearchPlaceholder.length}ch`,
+            maxWidth: "min(42vw, 24rem)",
+          }}
         />
         {chatSearchQuery && (
           <button
             type="button"
-            className="btn btn-ghost btn-xs h-6 min-h-0 w-6 p-0"
+            className="btn btn-ghost btn-xs ml-auto h-6 min-h-0 w-6 p-0"
             onClick={() => setChatSearchQuery("")}
             aria-label="Clear chat search"
           >

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -763,6 +763,7 @@ const Chat = () => {
 
   useEffect(() => {
     setSearchChatVisible(false);
+    setHighlightMessageIds([]);
   }, [chatSearchQuery]);
 
   useEffect(() => {
@@ -1061,12 +1062,7 @@ const Chat = () => {
           let fetchedMessages = messagesResponse.data || [];
           let nextHasMoreMessages = messagesResponse.hasMore || false;
 
-          if (
-            shouldRevealSearchTarget &&
-            !fetchedMessages.some(
-              (msg) => String(msg.id) === String(searchTarget.messageId),
-            )
-          ) {
+          if (shouldRevealSearchTarget) {
             let oldestMessage = fetchedMessages[0];
             let loadedCount = fetchedMessages.length;
 
@@ -1096,14 +1092,6 @@ const Chat = () => {
               loadedCount += earlierMessages.length;
               nextHasMoreMessages = earlierResponse.hasMore || false;
               oldestMessage = earlierMessages[0];
-
-              if (
-                fetchedMessages.some(
-                  (msg) => String(msg.id) === String(searchTarget.messageId),
-                )
-              ) {
-                break;
-              }
             }
           }
 
@@ -1119,12 +1107,23 @@ const Chat = () => {
               (msg) => String(msg.id) === String(searchTarget.messageId),
             )
           ) {
-            setHighlightMessageIds([searchTarget.messageId]);
+            const query = searchTarget.query;
+            const allMatchingIds = query
+              ? fetchedMessages
+                  .filter((msg) => buildMessageSearchText(msg).includes(query))
+                  .map((msg) => msg.id)
+                  .filter(Boolean)
+              : [];
+            // Put the target (most recent match) first so the view scrolls to it
+            const highlightIds = [
+              searchTarget.messageId,
+              ...allMatchingIds.filter(
+                (id) => String(id) !== String(searchTarget.messageId),
+              ),
+            ];
+            setHighlightMessageIds(highlightIds);
             pendingChatSearchTargetRef.current = null;
-
-            setTimeout(() => {
-              setHighlightMessageIds([]);
-            }, 4000);
+            // No auto-clear — highlights persist until search query changes
           } else if (highlightUser) {
             if (shouldRevealSearchTarget) {
               pendingChatSearchTargetRef.current = null;
@@ -2178,6 +2177,7 @@ const Chat = () => {
             conversationId: id,
             type,
             messageId: conversation.searchMatchMessageId,
+            query: normalizedChatSearchQuery,
           }
         : null;
 
@@ -2240,12 +2240,12 @@ const Chat = () => {
     : 0;
 
   const chatSearchAction = (
-    <div className="w-fit">
-      <label className="input input-bordered flex h-10 items-center gap-2 rounded-lg bg-base-100">
+    <div className="flex flex-col items-start sm:items-end">
+      <label className="input input-bordered flex h-10 items-center gap-2 rounded-lg bg-base-100 !w-48">
         <Search size={16} className="shrink-0 text-base-content/50" />
         <input
           type="search"
-          className="text-sm w-36"
+          className="text-sm flex-1 min-w-0"
           placeholder="Search chats..."
           aria-label="Search chats"
           value={chatSearchQuery}
@@ -2263,7 +2263,7 @@ const Chat = () => {
         )}
       </label>
       {isChatSearchActive && !isNoSearchResults && (
-        <p className="mt-1 text-xs text-base-content/60">
+        <p className="mt-1 text-xs text-base-content/60 sm:text-right">
           {filteredConversations.length} of {conversations.length} chats
           {searchingChatMessages
             ? " · searching messages..."

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   LogOut,
   ChevronRight,
@@ -6,11 +6,13 @@ import {
   Users,
   User,
   Trash2,
+  Search,
+  X,
 } from "lucide-react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import PageContainer from "../components/layout/PageContainer";
 import ConversationList from "../components/chat/ConversationList";
-import MessageDisplay from "../components/chat/MessageDisplay";
+import MessageDisplay, { parseSystemMessage } from "../components/chat/MessageDisplay";
 import MessageInput from "../components/chat/MessageInput";
 import { useAuth } from "../contexts/AuthContext";
 import { messageService } from "../services/messageService";
@@ -115,6 +117,9 @@ const isDirectConversationForPartner = (conversation, partnerId) =>
   conversation?.type === "direct" &&
   String(getConversationPartnerId(conversation)) === String(partnerId);
 
+const CHAT_SEARCH_PAGE_SIZE = 100;
+const CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION = 500;
+
 const dedupeConversations = (list) =>
   (list || []).filter((conv, index, self) => {
     if (conv.type === "direct") {
@@ -131,6 +136,282 @@ const dedupeConversations = (list) =>
 
     return index === self.findIndex((candidate) => candidate.id === conv.id);
   });
+
+const getConversationSearchKey = (conversation) =>
+  `${conversation?.type || "direct"}:${conversation?.id}`;
+
+const normalizeChatSearchText = (value) =>
+  String(value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+const countChatSearchMatches = (value, normalizedQuery) => {
+  if (!value || !normalizedQuery) return 0;
+
+  let count = 0;
+  let startIndex = 0;
+
+  while (startIndex < value.length) {
+    const matchIndex = value.indexOf(normalizedQuery, startIndex);
+    if (matchIndex === -1) break;
+
+    count += 1;
+    startIndex = matchIndex + normalizedQuery.length;
+  }
+
+  return count;
+};
+
+const addSearchPart = (parts, value) => {
+  if (value == null) return;
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => addSearchPart(parts, item));
+    return;
+  }
+
+  if (typeof value === "object") return;
+
+  const text = String(value).trim();
+  if (text) parts.push(text);
+};
+
+const addUserSearchParts = (parts, user) => {
+  if (!user) return;
+  const hasUserText =
+    user.name ||
+    user.username ||
+    user.userName ||
+    user.firstName ||
+    user.first_name ||
+    user.lastName ||
+    user.last_name;
+
+  if (!hasUserText) return;
+
+  addSearchPart(parts, [
+    user.name,
+    user.username,
+    user.userName,
+    user.firstName,
+    user.first_name,
+    user.lastName,
+    user.last_name,
+    formatDisplayName(user),
+  ]);
+};
+
+const buildMessageSearchText = (message) => {
+  const parts = [];
+  const parsedSystemMessage = parseSystemMessage(message?.content);
+  const systemMessageText = buildSystemMessageSearchSnippet(parsedSystemMessage);
+
+  addSearchPart(parts, [
+    message?.content,
+    systemMessageText,
+    message?.fileName,
+    message?.file_name,
+    message?.senderUsername,
+    message?.sender_username,
+  ]);
+  addUserSearchParts(parts, message?.sender);
+  addUserSearchParts(parts, {
+    firstName: message?.senderFirstName,
+    first_name: message?.sender_first_name,
+    lastName: message?.senderLastName,
+    last_name: message?.sender_last_name,
+    username: message?.senderUsername || message?.sender_username,
+  });
+
+  return normalizeChatSearchText(parts.join(" "));
+};
+
+const buildSystemMessageSearchSnippet = (parsedMessage) => {
+  if (!parsedMessage) return "";
+
+  switch (parsedMessage.type) {
+    case "application_approved_dm":
+      return [
+        `You approved ${parsedMessage.applicantName}'s application for ${parsedMessage.teamName}`,
+        `Your application to ${parsedMessage.teamName} was approved by ${parsedMessage.approverName}`,
+        parsedMessage.hasPersonalMessage ? "who added this message" : "Welcome to the team",
+      ].join(". ");
+    case "application_approved":
+      return [
+        `Your application was approved by ${parsedMessage.approverName}. Welcome to the team`,
+        `${parsedMessage.applicantName} has applied successfully and was added by ${parsedMessage.approverName}. Say hello to them`,
+      ].join(". ");
+    case "application_declined":
+      return [
+        `You declined ${parsedMessage.applicantName}'s application for ${parsedMessage.teamName}`,
+        `Your application to ${parsedMessage.teamName} was declined by ${parsedMessage.approverName}`,
+        parsedMessage.hasPersonalMessage
+          ? "who added this message"
+          : "Want to reach out to them in this chat",
+      ].join(". ");
+    case "application_response":
+      return `Response to your application for ${parsedMessage.teamName}. Your decline response to ${parsedMessage.applicantName}'s application for ${parsedMessage.teamName}. ${parsedMessage.personalMessage || ""}`;
+    case "invitation_declined":
+      return [
+        `You declined ${parsedMessage.inviterName}'s invitation for ${parsedMessage.teamName}`,
+        `Your invitation for ${parsedMessage.teamName} was declined by ${parsedMessage.inviteeName}`,
+        parsedMessage.hasPersonalMessage
+          ? "who added this message"
+          : "Want to reach out to them in this chat",
+      ].join(". ");
+    case "invitation_response":
+      return `Response to your invitation for ${parsedMessage.teamName}. ${parsedMessage.personalMessage || ""}`;
+    case "team_join":
+      return `${parsedMessage.userName} joined the team. You joined the team. Welcome aboard. ${parsedMessage.personalMessage || ""}`;
+    case "team_leave":
+      return `${parsedMessage.userName} has left the team. You have left the team.`;
+    case "member_removed_public":
+      return `${parsedMessage.userName} has been removed from the team. You removed ${parsedMessage.userName} from the team.`;
+    case "invitation_cancelled":
+      return `${parsedMessage.cancellerName} cancelled your invitation to join ${parsedMessage.teamName}. You cancelled your invitation for ${parsedMessage.inviteeName} to join ${parsedMessage.teamName}.`;
+    case "application_cancelled":
+      return `${parsedMessage.applicantName} cancelled their application for ${parsedMessage.teamName}. You cancelled your application for ${parsedMessage.teamName}.`;
+    case "member_removed":
+      return `You were removed from ${parsedMessage.teamName} by ${parsedMessage.removerName}. You removed ${parsedMessage.memberName} from ${parsedMessage.teamName}.`;
+    case "role_changed":
+      return `Your role in ${parsedMessage.teamName} was changed to ${parsedMessage.newRole} by ${parsedMessage.changerName}. You changed ${parsedMessage.memberName}'s role to ${parsedMessage.newRole} in ${parsedMessage.teamName}.`;
+    case "ownership_team":
+      return `${parsedMessage.prevOwnerName} transferred ownership to ${parsedMessage.newOwnerName}`;
+    case "ownership_transferred":
+      return `${parsedMessage.prevOwnerName} transferred ownership of ${parsedMessage.teamName} to you. You transferred team ownership of ${parsedMessage.teamName} to ${parsedMessage.newOwnerName}. Congratulations`;
+    case "team_deleted":
+      return `${parsedMessage.ownerName} has initiated the deletion of the team ${parsedMessage.teamName}. You initiated the deletion of the team ${parsedMessage.teamName}. The team is archived and inactive now.`;
+    default:
+      return "";
+  }
+};
+
+const buildMessageSearchSnippet = (message) => {
+  const parsedSystemMessage = parseSystemMessage(message?.content);
+  const systemMessageText = buildSystemMessageSearchSnippet(parsedSystemMessage);
+  const senderName = [
+    message?.senderFirstName || message?.sender_first_name,
+    message?.senderLastName || message?.sender_last_name,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  const sender =
+    senderName ||
+    message?.senderUsername ||
+    message?.sender_username ||
+    message?.sender?.username ||
+    "";
+  const body =
+    systemMessageText ||
+    message?.content ||
+    message?.fileName ||
+    message?.file_name ||
+    (message?.imageUrl || message?.image_url ? "Image" : "") ||
+    (message?.fileUrl || message?.file_url ? "File" : "");
+
+  return [sender, body].filter(Boolean).join(": ");
+};
+
+const getMessageSearchId = (message) =>
+  message?.id || message?.messageId || message?.message_id || null;
+
+const getMessageSearchTimestamp = (message) => {
+  const timestamp =
+    message?.createdAt ||
+    message?.created_at ||
+    message?.sentAt ||
+    message?.sent_at ||
+    message?.updatedAt ||
+    message?.updated_at;
+  const parsedDate = normalizeTimestampToDate(timestamp);
+
+  return parsedDate?.getTime() ?? 0;
+};
+
+const getMessageSearchTimestampValue = (message) =>
+  message?.createdAt ||
+  message?.created_at ||
+  message?.sentAt ||
+  message?.sent_at ||
+  message?.updatedAt ||
+  message?.updated_at ||
+  null;
+
+const buildMessageSearchSnippets = (messages) =>
+  (messages || [])
+    .map((message, index) => ({
+      message,
+      index,
+      timestamp: getMessageSearchTimestamp(message),
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp || a.index - b.index)
+    .map(({ message }) => ({
+      id: getMessageSearchId(message),
+      text: buildMessageSearchSnippet(message),
+      timestamp: getMessageSearchTimestampValue(message),
+    }))
+    .filter((snippet) => snippet.text);
+
+const buildLatestMatchPreview = (snippet, normalizedQuery) => {
+  const text = String(snippet || "").trim();
+  if (!text || !normalizedQuery) return text;
+
+  const normalizedText = normalizeChatSearchText(text);
+  const matchIndex = normalizedText.indexOf(normalizedQuery);
+  if (matchIndex === -1 || text.length <= 120) return text;
+
+  const contextBefore = 36;
+  const contextAfter = 72;
+  const start = Math.max(0, matchIndex - contextBefore);
+  const end = Math.min(
+    text.length,
+    matchIndex + normalizedQuery.length + contextAfter,
+  );
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < text.length ? "..." : "";
+
+  return `${prefix}${text.slice(start, end).trim()}${suffix}`;
+};
+
+const buildMessagesSearchText = (messages) =>
+  normalizeChatSearchText((messages || []).map(buildMessageSearchText).join(" "));
+
+const buildConversationSearchText = (conversation) => {
+  const parts = [];
+  const isTeam = conversation?.type === "team";
+
+  addSearchPart(parts, [
+    conversation?.type,
+    conversation?.lastMessage,
+    conversation?.last_message,
+    conversation?.lastMessage?.content,
+    conversation?.last_message?.content,
+  ]);
+
+  if (isTeam) {
+    const team = conversation?.team || {};
+    addSearchPart(parts, [
+      "team",
+      "team chat",
+      team.name,
+      team.teamName,
+      team.team_name,
+      team.description,
+    ]);
+
+    (team.members || conversation?.members || []).forEach((member) => {
+      addUserSearchParts(parts, member?.user || member);
+      addSearchPart(parts, [member?.role, member?.roleName, member?.role_name]);
+    });
+  } else {
+    addSearchPart(parts, ["direct", "dm", "direct message"]);
+    addUserSearchParts(parts, conversation?.partner || conversation?.partnerUser);
+  }
+
+  return normalizeChatSearchText(parts.join(" "));
+};
 
 const Chat = () => {
   const { conversationId } = useParams();
@@ -162,11 +443,20 @@ const Chat = () => {
     useState(false);
   const [isActiveConversationVisible, setIsActiveConversationVisible] =
     useState(true);
+  const [chatSearchQuery, setChatSearchQuery] = useState("");
+  const [chatMessageSearchIndex, setChatMessageSearchIndex] = useState({});
+  const [chatMessageSearchSnippets, setChatMessageSearchSnippets] = useState({});
+  const [searchingChatMessages, setSearchingChatMessages] = useState(false);
+  const [searchNoResultsToastQuery, setSearchNoResultsToastQuery] = useState(null);
+  const searchNoResultsQueryRef = useRef(null);
+  const [searchChatVisible, setSearchChatVisible] = useState(false);
   const typingTimeoutRef = useRef(null);
   const messagesContainerRef = useRef(null);
   const pendingScrollAdjustmentRef = useRef(null);
   const conversationsRef = useRef([]);
   const activeConversationRef = useRef(null);
+  const chatSearchLoadingKeysRef = useRef(new Set());
+  const pendingChatSearchTargetRef = useRef(null);
   const [loadingMessages, setLoadingMessages] = useState(false);
 
   // ---- Message de-duplication (focus: ownership/system duplicates) ----
@@ -250,6 +540,11 @@ const Chat = () => {
     !isActiveConversationVisible;
   const showEmptyConversationState =
     !loading && conversations.length === 0 && !conversationId;
+  const normalizedChatSearchQuery = useMemo(
+    () => normalizeChatSearchText(chatSearchQuery.trim()),
+    [chatSearchQuery],
+  );
+  const isChatSearchActive = normalizedChatSearchQuery.length > 0;
 
   useEffect(() => {
     conversationsRef.current = conversations;
@@ -258,6 +553,217 @@ const Chat = () => {
   useEffect(() => {
     activeConversationRef.current = activeConversation;
   }, [activeConversation]);
+
+  const fetchConversationSearchText = useCallback(async (conversation) => {
+    const conversationType = conversation?.type || "direct";
+    const allMessages = [];
+    let before;
+    let hasMore = true;
+
+    while (
+      hasMore &&
+      allMessages.length < CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION
+    ) {
+      const remaining =
+        CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION - allMessages.length;
+      const response = await messageService.getMessages(
+        conversation.id,
+        conversationType,
+        {
+          before,
+          limit: Math.min(CHAT_SEARCH_PAGE_SIZE, remaining),
+        },
+      );
+      const pageMessages = Array.isArray(response?.data) ? response.data : [];
+
+      if (pageMessages.length === 0) {
+        break;
+      }
+
+      allMessages.push(...pageMessages);
+      hasMore = Boolean(response?.hasMore);
+      before = pageMessages[0]?.id;
+
+      if (!before) {
+        break;
+      }
+    }
+
+    return {
+      text: buildMessagesSearchText(allMessages),
+      snippets: buildMessageSearchSnippets(allMessages),
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!conversationId || messages.length === 0) return;
+
+    const key = `${conversationType}:${conversationId}`;
+    const activeMessagesSearchText = buildMessagesSearchText(messages);
+
+    setChatMessageSearchIndex((prev) => ({
+      ...prev,
+      [key]: normalizeChatSearchText(
+        `${prev[key] || ""} ${activeMessagesSearchText}`,
+      ),
+    }));
+    setChatMessageSearchSnippets((prev) => ({
+      ...prev,
+      [key]: buildMessageSearchSnippets(messages),
+    }));
+  }, [conversationId, conversationType, messages]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !isChatSearchActive || conversations.length === 0) {
+      setSearchingChatMessages(false);
+      return;
+    }
+
+    const missingConversations = conversations.filter((conversation) => {
+      const key = getConversationSearchKey(conversation);
+      return (
+        !chatMessageSearchIndex[key] &&
+        !chatSearchLoadingKeysRef.current.has(key)
+      );
+    });
+
+    if (missingConversations.length === 0) {
+      setSearchingChatMessages(chatSearchLoadingKeysRef.current.size > 0);
+      return;
+    }
+
+    missingConversations.forEach((conversation) => {
+      chatSearchLoadingKeysRef.current.add(getConversationSearchKey(conversation));
+    });
+    setSearchingChatMessages(true);
+
+    Promise.allSettled(
+      missingConversations.map(async (conversation) => ({
+        key: getConversationSearchKey(conversation),
+        result: await fetchConversationSearchText(conversation),
+      })),
+    ).then((results) => {
+      setChatMessageSearchIndex((prev) => {
+        const next = { ...prev };
+
+        results.forEach((result, index) => {
+          if (result.status === "fulfilled") {
+            next[result.value.key] = result.value.result.text || " ";
+            return;
+          }
+
+          next[getConversationSearchKey(missingConversations[index])] = " ";
+        });
+
+        return next;
+      });
+      setChatMessageSearchSnippets((prev) => {
+        const next = { ...prev };
+
+        results.forEach((result, index) => {
+          if (result.status === "fulfilled") {
+            next[result.value.key] = result.value.result.snippets || [];
+            return;
+          }
+
+          next[getConversationSearchKey(missingConversations[index])] = [];
+        });
+
+        return next;
+      });
+
+      results.forEach((result, index) => {
+        const key =
+          result.status === "fulfilled"
+            ? result.value.key
+            : getConversationSearchKey(missingConversations[index]);
+        chatSearchLoadingKeysRef.current.delete(key);
+      });
+      setSearchingChatMessages(chatSearchLoadingKeysRef.current.size > 0);
+    });
+  }, [
+    chatMessageSearchIndex,
+    conversations,
+    fetchConversationSearchText,
+    isAuthenticated,
+    isChatSearchActive,
+  ]);
+
+  const filteredConversations = useMemo(() => {
+    if (!isChatSearchActive) return conversations;
+
+    return conversations
+      .map((conversation) => {
+        const key = getConversationSearchKey(conversation);
+        const conversationSearchText = buildConversationSearchText(conversation);
+        const messageSearchText = chatMessageSearchIndex[key] || "";
+        const searchMatchCount =
+          countChatSearchMatches(
+            conversationSearchText,
+            normalizedChatSearchQuery,
+          ) +
+          countChatSearchMatches(messageSearchText, normalizedChatSearchQuery);
+        const matchedMessageSnippet = [
+          ...(chatMessageSearchSnippets[key] || []),
+        ]
+          .reverse()
+          .find((snippet) =>
+            normalizeChatSearchText(snippet.text).includes(
+              normalizedChatSearchQuery,
+            ),
+          );
+        const nextConversation = matchedMessageSnippet
+          ? {
+              ...conversation,
+              searchMatchPreview: buildLatestMatchPreview(
+                matchedMessageSnippet.text,
+                normalizedChatSearchQuery,
+              ),
+              searchMatchMessageId: matchedMessageSnippet.id,
+              searchMatchCreatedAt: matchedMessageSnippet.timestamp,
+            }
+          : conversation;
+
+        return {
+          conversation: nextConversation,
+          searchMatchCount,
+        };
+      })
+      .filter(({ searchMatchCount }) => searchMatchCount > 0)
+      .sort((a, b) => {
+        if (b.searchMatchCount !== a.searchMatchCount) {
+          return b.searchMatchCount - a.searchMatchCount;
+        }
+
+        const aDate = getConversationUpdatedAt(a.conversation)?.getTime() ?? 0;
+        const bDate = getConversationUpdatedAt(b.conversation)?.getTime() ?? 0;
+        return bDate - aDate;
+      })
+      .map(({ conversation, searchMatchCount }) => ({ ...conversation, searchMatchCount }));
+  }, [
+    chatMessageSearchIndex,
+    chatMessageSearchSnippets,
+    conversations,
+    isChatSearchActive,
+    normalizedChatSearchQuery,
+  ]);
+
+  useEffect(() => {
+    if (isChatSearchActive && !searchingChatMessages && filteredConversations.length === 0) {
+      const query = chatSearchQuery.trim();
+      if (searchNoResultsQueryRef.current !== query) {
+        searchNoResultsQueryRef.current = query;
+        setSearchNoResultsToastQuery(query);
+      }
+    } else {
+      searchNoResultsQueryRef.current = null;
+      setSearchNoResultsToastQuery(null);
+    }
+  }, [isChatSearchActive, searchingChatMessages, filteredConversations.length, chatSearchQuery]);
+
+  useEffect(() => {
+    setSearchChatVisible(false);
+  }, [chatSearchQuery]);
 
   useEffect(() => {
     setIsActiveConversationVisible(true);
@@ -547,14 +1053,83 @@ const Chat = () => {
             conversationId,
             type,
           );
-          const fetchedMessages = messagesResponse.data || [];
-          setHasMoreMessages(messagesResponse.hasMore || false);
+          const searchTarget = pendingChatSearchTargetRef.current;
+          const shouldRevealSearchTarget =
+            searchTarget?.messageId &&
+            String(searchTarget.conversationId) === String(conversationId) &&
+            searchTarget.type === type;
+          let fetchedMessages = messagesResponse.data || [];
+          let nextHasMoreMessages = messagesResponse.hasMore || false;
+
+          if (
+            shouldRevealSearchTarget &&
+            !fetchedMessages.some(
+              (msg) => String(msg.id) === String(searchTarget.messageId),
+            )
+          ) {
+            let oldestMessage = fetchedMessages[0];
+            let loadedCount = fetchedMessages.length;
+
+            while (
+              nextHasMoreMessages &&
+              oldestMessage?.id &&
+              loadedCount < CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION
+            ) {
+              const remaining =
+                CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION - loadedCount;
+              const earlierResponse = await messageService.getMessages(
+                conversationId,
+                type,
+                {
+                  before: oldestMessage.id,
+                  limit: Math.min(50, remaining),
+                },
+              );
+              const earlierMessages = earlierResponse.data || [];
+
+              if (earlierMessages.length === 0) {
+                nextHasMoreMessages = false;
+                break;
+              }
+
+              fetchedMessages = [...earlierMessages, ...fetchedMessages];
+              loadedCount += earlierMessages.length;
+              nextHasMoreMessages = earlierResponse.hasMore || false;
+              oldestMessage = earlierMessages[0];
+
+              if (
+                fetchedMessages.some(
+                  (msg) => String(msg.id) === String(searchTarget.messageId),
+                )
+              ) {
+                break;
+              }
+            }
+          }
+
+          setHasMoreMessages(nextHasMoreMessages);
           setMessages(dedupeMessages(fetchedMessages));
 
           // Check if we need to highlight messages from a specific user (from notification)
           const highlightUser = searchParams.get("highlightUser");
 
-          if (highlightUser) {
+          if (
+            shouldRevealSearchTarget &&
+            fetchedMessages.some(
+              (msg) => String(msg.id) === String(searchTarget.messageId),
+            )
+          ) {
+            setHighlightMessageIds([searchTarget.messageId]);
+            pendingChatSearchTargetRef.current = null;
+
+            setTimeout(() => {
+              setHighlightMessageIds([]);
+            }, 4000);
+          } else if (highlightUser) {
+            if (shouldRevealSearchTarget) {
+              pendingChatSearchTargetRef.current = null;
+            }
+
             // Highlight the most recent messages from this user (join message + response)
             const userMessages = fetchedMessages
               .filter((msg) => String(msg.senderId) === String(highlightUser))
@@ -574,6 +1149,10 @@ const Chat = () => {
               }, 4000);
             }
           } else {
+            if (shouldRevealSearchTarget) {
+              pendingChatSearchTargetRef.current = null;
+            }
+
             // Default behavior: highlight unread messages
             const unreadIds = fetchedMessages
               .filter((msg) => msg.senderId !== user?.id && !msg.readAt)
@@ -1580,9 +2159,27 @@ const Chat = () => {
   };
 
   const selectConversation = (id) => {
+    // Deselect only when the chat panel is currently visible for this conversation
+    if (showChatView && String(id) === String(conversationId)) {
+      setShowChatView(false);
+      navigate("/chat");
+      return;
+    }
+
     // Find the conversation to get its type
-    const conversation = conversations.find((c) => c.id === id);
+    const conversation =
+      filteredConversations.find((c) => c.id === id) ||
+      conversations.find((c) => c.id === id);
     const type = conversation?.type || "direct";
+
+    pendingChatSearchTargetRef.current =
+      isChatSearchActive && conversation?.searchMatchMessageId
+        ? {
+            conversationId: id,
+            type,
+            messageId: conversation.searchMatchMessageId,
+          }
+        : null;
 
     // Reset unread count for selected conversation
     setConversations((prev) =>
@@ -1591,6 +2188,11 @@ const Chat = () => {
 
     // Show chat view on mobile/tablet when conversation is selected
     setShowChatView(true);
+
+    // When search is active, reveal the chat panel
+    if (isChatSearchActive) {
+      setSearchChatVisible(true);
+    }
 
     // Navigate with type parameter
     navigate(`/chat/${id}?type=${type}`);
@@ -1630,14 +2232,72 @@ const Chat = () => {
       icon: <LogOut size={16} />,
     },
   }[pendingChatActionType];
+  const isNoSearchResults =
+    isChatSearchActive && !searchingChatMessages && filteredConversations.length === 0;
+  const hideChatDuringSearch = isChatSearchActive && !searchChatVisible;
+  const totalSearchMatches = isChatSearchActive
+    ? filteredConversations.reduce((sum, conv) => sum + (conv.searchMatchCount || 0), 0)
+    : 0;
+
+  const chatSearchAction = (
+    <div className="w-fit">
+      <label className="input input-bordered flex h-10 items-center gap-2 rounded-lg bg-base-100">
+        <Search size={16} className="shrink-0 text-base-content/50" />
+        <input
+          type="search"
+          className="text-sm w-36"
+          placeholder="Search chats..."
+          aria-label="Search chats"
+          value={chatSearchQuery}
+          onChange={(event) => setChatSearchQuery(event.target.value)}
+        />
+        {chatSearchQuery && (
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs h-6 min-h-0 w-6 p-0"
+            onClick={() => setChatSearchQuery("")}
+            aria-label="Clear chat search"
+          >
+            <X size={14} />
+          </button>
+        )}
+      </label>
+      {isChatSearchActive && !isNoSearchResults && (
+        <p className="mt-1 text-xs text-base-content/60">
+          {filteredConversations.length} of {conversations.length} chats
+          {searchingChatMessages
+            ? " · searching messages..."
+            : ` · ${totalSearchMatches} ${totalSearchMatches === 1 ? "match" : "matches"}`}
+        </p>
+      )}
+    </div>
+  );
+  const chatSearchEmptyState =
+    isChatSearchActive && searchingChatMessages
+      ? {
+          title: "Searching chats...",
+          description: `Looking through message history for "${chatSearchQuery.trim()}".`,
+          showActions: false,
+        }
+      : null;
 
   return (
     <PageContainer
       title="Chats"
+      action={chatSearchAction}
       className="p-0"
       variant="muted"
     >
       <ScreenAlert type="error" message={error} onClose={() => setError(null)} />
+      <ScreenAlert
+        type="violet"
+        message={
+          searchNoResultsToastQuery
+            ? `No user names, team names, or messages match "${searchNoResultsToastQuery}". Try a different search term.`
+            : null
+        }
+        onClose={() => setSearchNoResultsToastQuery(null)}
+      />
 
       <Modal
         isOpen={Boolean(pendingChatAction)}
@@ -1681,17 +2341,15 @@ const Chat = () => {
         <div
           data-conversation-list-viewport="true"
           className={`lomir-conversation-list-scrollbar overflow-y-auto transition-all duration-300 ${
-            showEmptyConversationState
+            showEmptyConversationState || hideChatDuringSearch || !conversationId || !showChatView
               ? "w-full"
-              : showChatView
-                ? "hidden md:block md:w-1/3"
-                : "w-full md:w-1/3"
+              : "hidden md:block md:w-1/3"
           }`}
           style={{ direction: "rtl" }}
         >
           <div className="h-full" style={{ direction: "ltr" }}>
             <ConversationList
-              conversations={conversations}
+              conversations={isNoSearchResults ? conversations : filteredConversations}
               activeConversationId={conversationId}
               onSelectConversation={selectConversation}
               loading={loading}
@@ -1700,12 +2358,15 @@ const Chat = () => {
                 handleActiveConversationVisibilityChange
               }
               teamMembersRefreshSignal={teamMembersRefreshSignal}
+              emptyState={isNoSearchResults ? null : chatSearchEmptyState}
+              searchQuery={isNoSearchResults ? "" : chatSearchQuery}
+              chatVisible={!hideChatDuringSearch && showChatView}
             />
           </div>
         </div>
 
         {/* Message Display - Right Side */}
-        {!showEmptyConversationState && (
+        {!showEmptyConversationState && !hideChatDuringSearch && conversationId && showChatView && (
         <div className={`bg-white shadow-soft rounded-xl overflow-hidden flex flex-col min-w-0 transition-all duration-300 ${
           showChatView ? "w-full md:w-2/3" : "hidden md:flex md:w-2/3"
         }`}>
@@ -1872,6 +2533,7 @@ const Chat = () => {
                   onDeleteMessage={handleDeleteMessage}
                   onEditMessage={handleEditMessage}
                   onLeaveTeam={handleLeaveTeam}
+                  searchQuery={chatSearchQuery}
                 />
               </div>
 

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -178,6 +178,13 @@ export const formatRelativeChatTimestamp = (value) => {
   return formatDistanceToNow(date, { addSuffix: true }).replace("about ", "");
 };
 
+export const formatShortRelativeChatTimestamp = (value) => {
+  return formatRelativeChatTimestamp(value).replace(
+    "less than a minute ago",
+    "< minute ago",
+  );
+};
+
 export const formatLocalTime = (value) => {
   const date = normalizeTimestampToDate(value);
   if (!date) return "";


### PR DESCRIPTION
## Summary

This PR polishes the chat page search and conversation list UX.

It improves chat search so users can search across conversation metadata and message history, see clearer match feedback, and navigate to highlighted message results more reliably. It also refines selected conversation behavior and makes the chat search bar more compact and responsive.

## Changes

- Added richer chat search behavior across conversations and message history
- Shows match counts and clearer search feedback in the conversation list
- Highlights matching search text in conversations and messages
- Adds no-results toast feedback for chat searches
- Improves responsive labels and timestamps in the conversation list
- Loads a fuller message window around search matches for better context
- Keeps selected conversation cards highlighted while changing their tooltip to `Deselect Conversation`
- Hides the selected conversation chevron while preserving the deselect interaction
- Makes the chat search bar content-sized with `Search chats...` as the minimum width
- Keeps the clear `X` aligned to the right when the search bar stretches on small screens

## Testing

- Ran `npm run build`
- Build passed
- Existing Vite large chunk warning remains
