### PR TITLE
Disable fill buttons for filled/closed roles and add real-time role s…

### DIFF
--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -234,14 +234,18 @@ export const parseSystemMessage = (content) => {
   }
 
   // Pattern 4C: Open role marked as filled message
-  // Format: ✅ ROLE_FILLED: teamId:teamName | roleId:roleName | userId:userName
+  // Format: ✅ ROLE_FILLED: teamId:teamName | roleId:roleName | filledUserId:filledUserName | filledById:filledByName
+  // (filledBy token is optional for backwards compatibility)
   const roleFilledMatch = content.match(
-    /^(?:✅\s*)?ROLE_FILLED:\s*(.+?)\s+\|\s+(.+?)\s+\|\s+(.+)$/,
+    /^(?:✅\s*)?ROLE_FILLED:\s*(.+?)\s+\|\s+(.+?)\s+\|\s+(.+?)(?:\s+\|\s+(.+))?$/,
   );
   if (roleFilledMatch) {
     const team = parseIdNameToken(roleFilledMatch[1].trim());
     const role = parseIdNameToken(roleFilledMatch[2].trim());
     const user = parseIdNameToken(roleFilledMatch[3].trim());
+    const filledBy = roleFilledMatch[4]
+      ? parseIdNameToken(roleFilledMatch[4].trim())
+      : { id: null, name: null };
 
     return {
       type: "role_filled",
@@ -251,6 +255,8 @@ export const parseSystemMessage = (content) => {
       roleName: role.name,
       userId: user.id,
       userName: user.name,
+      filledById: filledBy.id,
+      filledByName: filledBy.name,
     };
   }
 
@@ -349,14 +355,18 @@ export const parseSystemMessage = (content) => {
   }
 
   // Pattern 4G: Application approved + role filled combined message
-  // Format: ✅ ROLE_APPLICATION_FILLED: teamId:teamName | roleId:roleName | applicantId:applicantName
+  // Format: ✅ ROLE_APPLICATION_FILLED: teamId:teamName | roleId:roleName | applicantId:applicantName | approverId:approverName
+  // (approver token is optional for backwards compatibility)
   const roleApplicationFilledMatch = content.match(
-    /^(?:✅\s*)?ROLE_APPLICATION_FILLED:\s*(.+?)\s+\|\s+(.+?)\s+\|\s+(.+)$/,
+    /^(?:✅\s*)?ROLE_APPLICATION_FILLED:\s*(.+?)\s+\|\s+(.+?)\s+\|\s+(.+?)(?:\s+\|\s+(.+))?$/,
   );
   if (roleApplicationFilledMatch) {
     const team = parseIdNameToken(roleApplicationFilledMatch[1].trim());
     const role = parseIdNameToken(roleApplicationFilledMatch[2].trim());
     const applicant = parseIdNameToken(roleApplicationFilledMatch[3].trim());
+    const approver = roleApplicationFilledMatch[4]
+      ? parseIdNameToken(roleApplicationFilledMatch[4].trim())
+      : { id: null, name: null };
 
     return {
       type: "role_application_filled",
@@ -366,6 +376,8 @@ export const parseSystemMessage = (content) => {
       roleName: role.name,
       applicantId: applicant.id,
       applicantName: applicant.name,
+      approverId: approver.id,
+      approverName: approver.name,
     };
   }
 
@@ -788,7 +800,9 @@ const getEventReactionPreview = (content) => {
       };
     case "role_application_filled":
       return {
-        text: `${parsedMessage.applicantName} has applied successfully for the role "${parsedMessage.roleName}" in this team and is now filling that role.`,
+        text: parsedMessage.approverName
+          ? `The role "${parsedMessage.roleName}" has been filled by ${parsedMessage.applicantName}, approved by ${parsedMessage.approverName}.`
+          : `The role "${parsedMessage.roleName}" has been filled by ${parsedMessage.applicantName}.`,
         Icon: UserCheck,
         color: EVENT_REACTION_PREVIEW_COLORS.role,
       };
@@ -862,9 +876,11 @@ const getEventReactionPreview = (content) => {
       };
     case "role_filled":
       return {
-        text: parsedMessage.userName
-          ? `${parsedMessage.userName} is now filling the role ${parsedMessage.roleName}.`
-          : `The role ${parsedMessage.roleName} was marked as filled.`,
+        text: parsedMessage.userName && parsedMessage.filledByName
+          ? `The role ${parsedMessage.roleName} has been filled by ${parsedMessage.userName}, approved by ${parsedMessage.filledByName}.`
+          : parsedMessage.userName
+          ? `The role ${parsedMessage.roleName} has been filled by ${parsedMessage.userName}.`
+          : `The role ${parsedMessage.roleName} has been marked filled.`,
         Icon: UserCheck,
         color: EVENT_REACTION_PREVIEW_COLORS.role,
       };
@@ -2401,20 +2417,35 @@ const MessageDisplay = ({
       />
     );
 
-    const messageText = parsedMessage.applicantName &&
-      parsedMessage.applicantName.trim().toLowerCase() !== "someone" ? (
-      <>
-        <MentionById
-          userId={parsedMessage.applicantId}
-          name={parsedMessage.applicantName}
-        />{" "}
-        has applied successfully for the role {roleMention} in this team and is
-        now filling that role.
-      </>
+    const hasKnownApplicant =
+      parsedMessage.applicantName &&
+      parsedMessage.applicantName.trim().toLowerCase() !== "someone";
+    const hasKnownApprover =
+      parsedMessage.approverName &&
+      parsedMessage.approverName.trim().toLowerCase() !== "someone";
+    const applicantMention = hasKnownApplicant ? (
+      <MentionById
+        userId={parsedMessage.applicantId}
+        name={parsedMessage.applicantName}
+      />
     ) : (
+      "someone"
+    );
+    const approverMention = hasKnownApprover ? (
+      <MentionById
+        userId={parsedMessage.approverId}
+        name={parsedMessage.approverName}
+      />
+    ) : null;
+
+    const messageText = (
       <>
-        An application for the role {roleMention} was approved and the role is
-        now filled.
+        The role {roleMention} has been filled by {applicantMention}
+        {approverMention ? (
+          <span>, approved by {approverMention}.</span>
+        ) : (
+          "."
+        )}
       </>
     );
 
@@ -2688,6 +2719,9 @@ const MessageDisplay = ({
     const hasKnownFilledUser =
       parsedMessage.userName &&
       parsedMessage.userName.trim().toLowerCase() !== "someone";
+    const hasKnownFilledBy =
+      parsedMessage.filledByName &&
+      parsedMessage.filledByName.trim().toLowerCase() !== "someone";
 
     const roleMention = (
       <RoleMentionById
@@ -2698,13 +2732,24 @@ const MessageDisplay = ({
         filledAt={message.createdAt}
       />
     );
+    const filledByMention = hasKnownFilledBy ? (
+      <MentionById
+        userId={parsedMessage.filledById}
+        name={parsedMessage.filledByName}
+      />
+    ) : null;
     const messageText = hasKnownFilledUser ? (
       <>
+        The role {roleMention} has been filled by{" "}
         <MentionById
           userId={parsedMessage.userId}
           name={parsedMessage.userName}
-        />{" "}
-        is now filling the role {roleMention}.
+        />
+        {filledByMention ? (
+          <span>, approved by {filledByMention}.</span>
+        ) : (
+          "."
+        )}
       </>
     ) : (
       <>The role {roleMention} was marked as filled.</>
@@ -4084,11 +4129,12 @@ const MessageDisplay = ({
                 const parsedMessage = parseSystemMessage(message.content);
 
                 if (parsedMessage) {
-                  const isHighlighted = highlightMessageIds.includes(
-                    message.id,
+                  const isHighlighted = highlightMessageIds.some(
+                    (id) => String(id) === String(message.id),
                   );
                   const isFirstHighlighted =
-                    isHighlighted && message.id === highlightMessageIds[0];
+                    isHighlighted &&
+                    String(message.id) === String(highlightMessageIds[0]);
 
                   const wrapperClass = isHighlighted
                     ? "message-highlight rounded-xl p-2"
@@ -4158,7 +4204,7 @@ const MessageDisplay = ({
                       content.props.children,
                     );
                     let attachedReactButton = false;
-                    const nextChildren = children.map((child) => {
+                    const nextChildren = children.map((child, i) => {
                       if (
                         attachedReactButton ||
                         !React.isValidElement(child) ||
@@ -4171,7 +4217,7 @@ const MessageDisplay = ({
 
                       attachedReactButton = true;
                       return (
-                        <div className="relative inline-flex max-w-full">
+                        <div key={child.key ?? i} className="relative inline-flex max-w-full">
                           {child}
                           {renderReactButton()}
                         </div>
@@ -4448,12 +4494,12 @@ const MessageDisplay = ({
 
                     <div className="space-y-1">
                       {messageGroup.messages.map((message, messageIndex) => {
-                        const isHighlighted = highlightMessageIds.includes(
-                          message.id,
+                        const isHighlighted = highlightMessageIds.some(
+                          (id) => String(id) === String(message.id),
                         );
                         const isFirstHighlighted =
                           isHighlighted &&
-                          message.id === highlightMessageIds[0];
+                          String(message.id) === String(highlightMessageIds[0]);
 
                         const isDeleted = !!(
                           message.deletedAt || message.deleted_at

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -1,9 +1,25 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { MessageCircle } from 'lucide-react';
+import {
+  AlertTriangle,
+  CircleX,
+  Clock,
+  Crown,
+  FileText,
+  LogOut,
+  MessageCircle,
+  Pencil,
+  Shield,
+  User,
+  UserCheck,
+  UserMinus,
+  UserPlus,
+  UserSearch,
+} from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import socketService from '../../services/socketService';
 import { messageService } from '../../services/messageService';
 import { useAuth } from '../../contexts/AuthContext';
+import { getEventPreview } from '../../utils/eventPreview';
 import {
   getMessageSenderDisplayName,
   getMessageConversationTarget,
@@ -11,6 +27,319 @@ import {
   isMessageForCurrentChatPath,
   isOwnMessage,
 } from '../../utils/messageNotificationUtils';
+
+const EVENT_PREVIEW_ICONS = {
+  AlertTriangle,
+  CircleX,
+  Crown,
+  FileText,
+  LogOut,
+  Pencil,
+  Shield,
+  User,
+  UserCheck,
+  UserMinus,
+  UserPlus,
+  UserSearch,
+};
+
+const NOTIFICATION_VISIBLE_MS = 20000;
+const NOTIFICATION_FADE_MS = 700;
+
+const EVENT_CONTENT_KEYS = [
+  "content",
+  "message",
+  "text",
+  "body",
+  "lastMessage",
+  "last_message",
+  "latestMessage",
+  "latest_message",
+];
+
+const pickEventContent = (message) => {
+  for (const key of EVENT_CONTENT_KEYS) {
+    const value = message?.[key];
+    if (typeof value === "string" && value.trim()) return value;
+    if (value && typeof value === "object") {
+      const nested = pickEventContent(value);
+      if (nested) return nested;
+    }
+  }
+
+  return "";
+};
+
+const getFallbackRoleEventPreview = (content) => {
+  const text = String(content || "");
+  const actorCreatedRoleMatch = text.match(
+    /^(.+?)\s+created\s+(?:a\s+)?(?:new\s+)?role:\s*(.+)$/i,
+  );
+
+  if (actorCreatedRoleMatch) {
+    const roleName = actorCreatedRoleMatch[2]?.trim() || "Vacant Role";
+    return {
+      text: `New role ${roleName} created.`,
+      icon: "UserSearch",
+      color: "#f59e0b",
+      roleName,
+      senderPrefix: "by ",
+    };
+  }
+
+  const previewPhraseMatch = text.match(
+    /^(New role open|Vacant role created|Role updated|Role edited|Role removed|Role deleted|Role closed|Role reopened):\s*(.+)$/i,
+  );
+
+  if (previewPhraseMatch) {
+    const label = previewPhraseMatch[1].toLowerCase();
+    const roleName = previewPhraseMatch[2]?.trim() || "Vacant Role";
+    const icon =
+      label === "role updated" || label === "role edited"
+        ? "Pencil"
+        : label === "role removed" || label === "role deleted"
+          ? "UserMinus"
+          : label === "role closed"
+            ? "CircleX"
+            : "UserSearch";
+
+    return {
+      text:
+        label === "role updated" || label === "role edited"
+          ? `Role edited: ${roleName}`
+          : label === "new role open" || label === "vacant role created"
+            ? `New role ${roleName} created.`
+          : label === "role removed" || label === "role deleted"
+            ? `Role deleted: ${roleName}`
+          : text,
+      icon,
+      color:
+        label === "role removed" || label === "role deleted" || label === "role closed"
+          ? "#6b7280"
+          : "#f59e0b",
+      roleName,
+      senderPrefix:
+        label === "new role open" ||
+        label === "vacant role created" ||
+        label === "role removed" ||
+        label === "role deleted" ||
+        label === "role closed" ||
+        label === "role reopened"
+          ? "by "
+          : undefined,
+    };
+  }
+
+  const filledPhraseMatch = text.match(/^(?:The role\s+)?(.+?)\s+(?:was marked as filled|has been marked filled)\.?$/i);
+  if (filledPhraseMatch) {
+    const roleName = filledPhraseMatch[1]?.trim() || "Vacant Role";
+    return {
+      text: `The role ${roleName} has been marked filled.`,
+      icon: "UserCheck",
+      color: "#f59e0b",
+      roleName,
+    };
+  }
+
+  const reopenedPhraseMatch = text.match(/^(.+?)\s+is open again\.?$/i);
+  if (reopenedPhraseMatch) {
+    return {
+      text,
+      icon: "UserSearch",
+      color: "#f59e0b",
+      roleName: reopenedPhraseMatch[1]?.trim() || "Vacant Role",
+    };
+  }
+
+  const roleEventMatch = text.match(
+    /(?:ROLE_CREATED|ROLE_UPDATED|ROLE_DELETED|ROLE_CLOSED|ROLE_FILLED|ROLE_REOPENED_ADMIN|ROLE_REOPENED):\s*(.+?)\s+\|\s+(.+?)(?:\s+\|\s+(.+?))?(?:\s+\|\s+(.+))?$/,
+  );
+
+  if (!roleEventMatch) return null;
+
+  const eventType = roleEventMatch[0].split(":")[0].replace(/[^\w]/g, "");
+  const roleToken = roleEventMatch[2] || "";
+  const roleName = roleToken.includes(":")
+    ? roleToken.split(":").slice(1).join(":").trim()
+    : roleToken.trim();
+  const filledUserToken = eventType === "ROLE_FILLED" ? roleEventMatch[3] || "" : "";
+  const filledByToken = eventType === "ROLE_FILLED" ? roleEventMatch[4] || "" : "";
+  const filledUserName = filledUserToken.includes(":")
+    ? filledUserToken.split(":").slice(1).join(":").trim()
+    : filledUserToken.trim();
+  const filledByName = filledByToken.includes(":")
+    ? filledByToken.split(":").slice(1).join(":").trim()
+    : filledByToken.trim();
+
+  const labels = {
+    ROLE_CREATED: `New role ${roleName || "Vacant Role"} created.`,
+    ROLE_UPDATED: `Role edited: ${roleName || "Vacant Role"}`,
+    ROLE_DELETED: `Role deleted: ${roleName || "Vacant Role"}`,
+    ROLE_CLOSED: `Role closed: ${roleName || "Vacant Role"}`,
+    ROLE_FILLED: filledUserName && filledByName
+      ? `The role ${roleName || "Vacant Role"} has been filled by ${filledUserName}, approved by ${filledByName}.`
+      : filledUserName
+        ? `The role ${roleName || "Vacant Role"} has been filled by ${filledUserName}.`
+        : `The role ${roleName || "Vacant Role"} has been marked filled.`,
+    ROLE_REOPENED: `Role reopened: ${roleName || "Vacant Role"}`,
+    ROLE_REOPENED_ADMIN: `Role reopened: ${roleName || "Vacant Role"}`,
+  };
+
+  return {
+    text: labels[eventType] || `Role event: ${roleName || "Vacant Role"}`,
+    icon:
+      eventType === "ROLE_FILLED"
+        ? "UserCheck"
+        : eventType === "ROLE_DELETED"
+          ? "UserMinus"
+          : eventType === "ROLE_CLOSED"
+            ? "CircleX"
+            : eventType === "ROLE_UPDATED"
+              ? "Pencil"
+              : "UserSearch",
+    color: eventType === "ROLE_DELETED" || eventType === "ROLE_CLOSED"
+      ? "#6b7280"
+      : "#f59e0b",
+    senderPrefix:
+      eventType === "ROLE_UPDATED" || eventType === "ROLE_CREATED"
+        || eventType === "ROLE_DELETED" ||
+        eventType === "ROLE_CLOSED" ||
+        eventType === "ROLE_FILLED" ||
+        eventType === "ROLE_REOPENED" ||
+        eventType === "ROLE_REOPENED_ADMIN"
+        ? "by "
+        : undefined,
+  };
+};
+
+const getRoleEventTypePreview = (message) => {
+  const rawType =
+    message?.eventType ??
+    message?.event_type ??
+    message?.notificationType ??
+    message?.notification_type ??
+    message?.type;
+  const type = String(rawType || "").toLowerCase();
+
+  if (!type.startsWith("role_")) return null;
+
+  const roleName =
+    message?.roleName ??
+    message?.role_name ??
+    message?.role?.roleName ??
+    message?.role?.role_name ??
+    "Vacant Role";
+  const filledUserName =
+    message?.filledUserName ??
+    message?.filled_user_name ??
+    message?.filledByUserName ??
+    message?.filled_by_user_name ??
+    message?.filledByUser?.name ??
+    message?.filled_by_user?.name ??
+    null;
+  const filledActorName =
+    message?.filledByName ??
+    message?.filled_by_name ??
+    message?.actorName ??
+    message?.actor_name ??
+    null;
+  const labels = {
+    role_created: `New role ${roleName} created.`,
+    role_updated: `Role edited: ${roleName}`,
+    role_deleted: `Role deleted: ${roleName}`,
+    role_closed: `Role closed: ${roleName}`,
+    role_filled: filledUserName && filledActorName
+      ? `The role ${roleName} has been filled by ${filledUserName}, approved by ${filledActorName}.`
+      : filledUserName
+        ? `The role ${roleName} has been filled by ${filledUserName}.`
+        : `The role ${roleName} has been marked filled.`,
+    role_reopened: `Role reopened: ${roleName}`,
+    role_reopened_admin: `Role reopened: ${roleName}`,
+  };
+
+  if (!labels[type]) return null;
+
+  return {
+    text: labels[type],
+    icon:
+      type === "role_filled"
+        ? "UserCheck"
+        : type === "role_deleted"
+          ? "UserMinus"
+          : type === "role_closed"
+            ? "CircleX"
+            : type === "role_updated"
+              ? "Pencil"
+              : "UserSearch",
+    color:
+      type === "role_deleted" || type === "role_closed"
+        ? "#6b7280"
+        : "#f59e0b",
+    senderPrefix:
+      type === "role_updated" ||
+      type === "role_created" ||
+      type === "role_deleted" ||
+      type === "role_closed" ||
+      type === "role_filled" ||
+      type === "role_reopened" ||
+      type === "role_reopened_admin"
+        ? "by "
+        : undefined,
+  };
+};
+
+const MENTION_REGEX = /@\[([^\]]+)\]\([^)]+\)/g;
+
+const renderTextWithMentions = (text) => {
+  if (!text || !text.includes("@[")) return text;
+  const parts = [];
+  let last = 0;
+  let m;
+  MENTION_REGEX.lastIndex = 0;
+  while ((m = MENTION_REGEX.exec(text)) !== null) {
+    if (m.index > last) parts.push(text.slice(last, m.index));
+    parts.push(
+      <span key={m.index} className="font-semibold text-primary">
+        @{m[1]}
+      </span>,
+    );
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts;
+};
+
+const getNotificationSenderName = (message) => {
+  const sender = message?.sender || {};
+  const firstName =
+    message?.senderFirstName ??
+    message?.sender_first_name ??
+    sender?.firstName ??
+    sender?.first_name ??
+    "";
+  const lastName =
+    message?.senderLastName ??
+    message?.sender_last_name ??
+    sender?.lastName ??
+    sender?.last_name ??
+    "";
+  const fullName = `${firstName} ${lastName}`.trim();
+
+  return [
+    message?.senderDisplayName ??
+      message?.sender_display_name ??
+      message?.senderName ??
+      message?.sender_name ??
+      sender?.displayName ??
+      sender?.display_name ??
+      sender?.name,
+    fullName,
+    message?.senderUsername,
+    message?.sender_username,
+    sender?.username,
+    getMessageSenderDisplayName(message),
+  ].find((value) => String(value || "").trim());
+};
 
 const MessageNotifications = () => {
   const [notifications, setNotifications] = useState([]);
@@ -40,7 +369,9 @@ const MessageNotifications = () => {
         if (count > 0) {
           setNotifications([{ 
             id: 'initial', 
-            text: `You have ${count} unread messages` 
+            text: `You have ${count} unread messages`,
+            expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
+            removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
           }]);
         }
       } catch (error) {
@@ -71,6 +402,11 @@ const MessageNotifications = () => {
         
         if (!isInConversation) {
           const target = getMessageConversationTarget(message, user?.id);
+          const eventContent = pickEventContent(message);
+          const eventPreview =
+            getRoleEventTypePreview(message) ||
+            getEventPreview(eventContent, user) ||
+            getFallbackRoleEventPreview(eventContent);
           setNotifications(prev => [
             ...prev, 
             {
@@ -78,9 +414,16 @@ const MessageNotifications = () => {
               conversationId: target.conversationId,
               conversationType: target.type,
               senderId: message.senderId || message.sender_id,
-              senderName: getMessageSenderDisplayName(message),
-              text: getMessagePreviewText(message),
-              time: new Date()
+              senderName: eventPreview?.senderName || getNotificationSenderName(message),
+              senderPrefix: eventPreview?.senderPrefix ?? null,
+              text: eventPreview?.text || getMessagePreviewText(message),
+              isEvent: Boolean(eventPreview),
+              eventIcon: eventPreview?.icon || null,
+              eventColor: eventPreview?.color || null,
+              eventBackgroundColor: eventPreview?.backgroundColor || null,
+              time: new Date(),
+              expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
+              removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
             }
           ]);
         }
@@ -124,20 +467,39 @@ const MessageNotifications = () => {
     }
   };
   
-  // Auto-dismiss notifications after 5 seconds
+  // Auto-dismiss each notification after its own 20 second visibility window,
+  // with a short fade-out phase before removal.
   useEffect(() => {
-    if (notifications.length > 0) {
-      const timeout = setTimeout(() => {
-        setNotifications(prev => {
-          if (prev.length > 0) {
-            const [_, ...rest] = prev;
-            return rest;
-          }
-          return prev;
-        });
-      }, 5000);
-      
-      return () => clearTimeout(timeout);
+    if (notifications.length === 0) return undefined;
+
+    const now = Date.now();
+    const nextTransition = Math.min(
+      ...notifications.map((notification) =>
+        notification.isExiting
+          ? notification.removeAt || now
+          : notification.expiresAt || now,
+      ),
+    );
+    const timeout = setTimeout(() => {
+      const timestamp = Date.now();
+      setNotifications((prev) =>
+        prev
+          .map((notification) =>
+            !notification.isExiting &&
+            notification.expiresAt &&
+            notification.expiresAt <= timestamp
+              ? { ...notification, isExiting: true }
+              : notification,
+          )
+          .filter(
+            (notification) =>
+              !notification.removeAt || notification.removeAt > timestamp,
+          ),
+      );
+    }, Math.max(0, nextTransition - now));
+
+    return () => {
+      clearTimeout(timeout);
     }
   }, [notifications]);
   
@@ -145,24 +507,74 @@ const MessageNotifications = () => {
   
   return (
     <div className="fixed bottom-4 right-4 z-50 space-y-2">
-      {notifications.map(notification => (
-        <div 
-          key={notification.id}
-          className="bg-white text-black rounded-lg rounded-br-none shadow-lg p-4 max-w-xs animate-slide-in cursor-pointer"
-          onClick={() => handleNotificationClick(notification)}
-        >
-          <h4 className="text-xs font-medium text-primary-focus flex items-center gap-1.5 mb-2">
-            <MessageCircle size={12} strokeWidth={2.2} aria-hidden="true" />
-            <span>New Message</span>
-          </h4>
-          <p className="text-sm">{notification.text}</p>
-          {notification.senderName && (
-            <p className="text-[11px] mt-0.5 text-primary-focus truncate">
-              from {notification.senderName}
-            </p>
-          )}
-        </div>
-      ))}
+      {notifications.map(notification => {
+        const renderEventPreview =
+          (notification.isEvent && {
+            text: notification.text,
+            icon: notification.eventIcon,
+            color: notification.eventColor,
+            backgroundColor: notification.eventBackgroundColor,
+          }) ||
+          getFallbackRoleEventPreview(notification.text) ||
+          getEventPreview(notification.text, user);
+        const isEvent = Boolean(renderEventPreview);
+        const HeaderIcon = isEvent ? Clock : MessageCircle;
+        const EventIcon = isEvent
+          ? EVENT_PREVIEW_ICONS[renderEventPreview.icon] || Clock
+          : MessageCircle;
+
+        return (
+          <div
+            key={notification.id}
+            className={`bg-white text-black rounded-lg rounded-br-none shadow-lg p-4 max-w-xs cursor-pointer ${
+              notification.isExiting
+                ? "animate-toast-fade-out"
+                : "animate-slide-in"
+            }`}
+            onClick={() => handleNotificationClick(notification)}
+          >
+            <h4 className="text-xs font-medium text-primary-focus flex items-center gap-1.5 mb-2">
+              <HeaderIcon size={12} strokeWidth={2.2} aria-hidden="true" />
+              <span>{isEvent ? "New Event" : "New Message"}</span>
+            </h4>
+            {isEvent ? (
+              <p
+                className="text-sm font-medium truncate"
+                style={{
+                  color: renderEventPreview.color || undefined,
+                  ...(renderEventPreview.backgroundColor
+                    ? {
+                        backgroundColor: renderEventPreview.backgroundColor,
+                        borderRadius: "0.375rem",
+                        maxWidth: "100%",
+                        paddingLeft: "3px",
+                        paddingRight: "3px",
+                        width: "fit-content",
+                      }
+                    : {}),
+                }}
+              >
+                <span className="flex min-w-0 items-center gap-1">
+                  <EventIcon size={14} className="flex-shrink-0" />
+                  <span className="truncate">{renderEventPreview.text}</span>
+                </span>
+              </p>
+            ) : (
+              <p className="text-sm">{renderTextWithMentions(notification.text)}</p>
+            )}
+            {isEvent && notification.senderName && (
+              <p className="text-[11px] mt-0.5 text-primary-focus truncate">
+                {notification.senderPrefix ?? "by "}{notification.senderName}
+              </p>
+            )}
+            {!isEvent && notification.senderName && (
+              <p className="text-[11px] mt-0.5 text-primary-focus truncate">
+                from {notification.senderName}
+              </p>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -2,7 +2,24 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useAuth } from "../../contexts/AuthContext";
 import LomirLogo from "../../assets/images/Lomir-logowordmark-color.svg";
-import { Bell, MessageCircle, Search, User, Settings, LogOut } from "lucide-react";
+import {
+  AlertTriangle,
+  Award,
+  Bell,
+  CircleX,
+  Crown,
+  LogOut,
+  Mail,
+  MessageCircle,
+  Pencil,
+  Search,
+  Settings,
+  User,
+  UserCheck,
+  UserMinus,
+  UserPlus,
+  UserSearch,
+} from "lucide-react";
 import Colors from "../../utils/Colors";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { getUserInitials, isSyntheticUser } from "../../utils/userHelpers";
@@ -20,38 +37,72 @@ const buildMessageTooltip = (count, teamCount, senderCount, mentionCount) => {
   if (!count && !mentionCount) return undefined;
   const parts = [];
   if (count) {
-    const msg = `${count} unread message${count !== 1 ? "s" : ""}`;
-    const sub = [];
-    if (teamCount > 0) sub.push(`in ${teamCount} team${teamCount !== 1 ? "s" : ""}`);
-    if (senderCount > 0) sub.push(`from ${senderCount} person${senderCount !== 1 ? "s" : ""}`);
-    parts.push(sub.length ? `${msg} ${sub.join(" and ")}` : msg);
+    parts.push(`${count} unread message${count !== 1 ? "s" : ""}`);
+    if (teamCount > 0) parts.push(`in ${teamCount} team${teamCount !== 1 ? "s" : ""}`);
+    if (senderCount > 0) parts.push(`from ${senderCount} person${senderCount !== 1 ? "s" : ""}`);
   }
   if (mentionCount) parts.push(`${mentionCount} mention${mentionCount !== 1 ? "s" : ""}`);
   return parts.join("\n");
 };
 
-const buildNotificationTooltip = (count, types) => {
+// tc = number of distinct teams for this notification type
+const teamSuffix = (tc) => tc > 1 ? ` in ${tc} teams` : "";
+const inYourTeam = (tc) => tc > 1 ? `in ${tc} of your teams` : "in one of your teams";
+const yourTeams = (tc) => tc > 1 ? `in ${tc} of your teams` : "one of your teams";
+
+const NOTIFICATION_TYPE_META = [
+  { keys: ["invitationReceived", "invitation_received"],             Icon: Mail,          text: (p, n, tc) => `${p(n, "team invitation")} for you${teamSuffix(tc)}` },
+  { keys: ["roleInvitation", "role_invitation"],                     Icon: UserSearch,    text: (p, n, tc) => `${p(n, "role invitation")} for you${teamSuffix(tc)}` },
+  { keys: ["roleAssigned", "role_assigned"],                         Icon: UserCheck,     text: (p, n, tc) => `${p(n, "role assignment")} ${inYourTeam(tc)}` },
+  { keys: ["invitationAccepted", "invitation_accepted"],             Icon: UserCheck,     text: (p, n, tc) => `${p(n, "invitation")} accepted${teamSuffix(tc)}` },
+  { keys: ["applicationReceived", "application_received"],           Icon: Mail,          text: (p, n, tc) => `${p(n, "team application")} to review${teamSuffix(tc)}` },
+  { keys: ["applicationApproved", "application_approved"],           Icon: UserPlus,      text: (p, n, tc) => `${p(n, "team")} joined successfully${teamSuffix(tc)}` },
+  { keys: ["applicationRejected", "application_rejected"],           Icon: CircleX,       text: (p, n, tc) => `Your team application${n !== 1 ? `s (${n})` : ""} rejected${teamSuffix(tc)}` },
+  { keys: ["badgeAwarded", "badge_awarded"],                         Icon: Award,         text: (p, n)     => `${p(n, "new badge award")} for you` },
+  { keys: ["memberJoined", "member_joined"],                         Icon: UserPlus,      text: (p, n, tc) => `${p(n, "new member")} joined ${yourTeams(tc)}` },
+  { keys: ["memberLeft", "member_left"],                             Icon: LogOut,        text: (p, n, tc) => `${p(n, "member")} left ${yourTeams(tc)}` },
+  { keys: ["memberRemoved", "member_removed"],                       Icon: UserMinus,     text: (p, n, tc) => `Removed from ${tc > 1 ? `${tc} of your teams` : "a team"}` },
+  { keys: ["roleChanged", "role_changed"],                           Icon: Pencil,        text: (p, n, tc) => `${p(n, "role change")} ${inYourTeam(tc)}` },
+  { keys: ["roleCreated", "role_created"],                           Icon: UserSearch,    text: (p, n, tc) => `${p(n, "new role")} opened ${inYourTeam(tc)}` },
+  { keys: ["roleUpdated", "role_updated"],                           Icon: Pencil,        text: (p, n, tc) => `${n} role${n !== 1 ? "s" : ""} edited ${inYourTeam(tc)}` },
+  { keys: ["roleDeleted", "role_deleted"],                           Icon: UserMinus,     text: (p, n, tc) => `${p(n, "role")} deleted ${inYourTeam(tc)}` },
+  { keys: ["roleClosed", "role_closed"],                             Icon: CircleX,       text: (p, n, tc) => `${p(n, "role")} closed ${inYourTeam(tc)}` },
+  { keys: ["roleFilled", "role_filled"],                             Icon: UserCheck,     text: (p, n, tc) => `${p(n, "role")} filled ${inYourTeam(tc)}` },
+  { keys: ["roleReopened", "role_reopened", "role_reopened_admin"],  Icon: UserSearch,    text: (p, n, tc) => `${p(n, "role")} reopened ${inYourTeam(tc)}` },
+  { keys: ["ownershipTransferred", "ownership_transferred"],         Icon: Crown,         text: (p, n)     => `${p(n, "ownership transfer")}` },
+  { keys: ["teamDeleted", "team_deleted"],                           Icon: AlertTriangle, text: (p, n)     => `${p(n, "team")} deleted` },
+  { keys: ["invitationDeclined", "invitation_declined"],             Icon: CircleX,       text: (p, n, tc) => `Your invitation${n !== 1 ? `s (${n})` : ""} declined${teamSuffix(tc)}` },
+  { keys: ["invitationCancelled", "invitation_cancelled"],           Icon: CircleX,       text: (p, n, tc) => `Your invitation${n !== 1 ? `s (${n})` : ""} cancelled${teamSuffix(tc)}` },
+  { keys: ["applicationCancelled", "application_cancelled"],               Icon: CircleX,       text: (p, n, tc) => `${p(n, "team application")} withdrawn${teamSuffix(tc)}` },
+  { keys: ["roleApplicationCancelled", "role_application_cancelled"],      Icon: CircleX,       text: (p, n, tc) => `${p(n, "role application")} withdrawn${teamSuffix(tc)}` },
+];
+
+const buildNotificationTooltip = (count, types, teamCounts) => {
   if (!count || !types) return undefined;
   const p = (n, s) => `${n} ${s}${n !== 1 ? "s" : ""}`;
-  const lines = [
-    types.invitationReceived && `${p(types.invitationReceived, "team invitation")} for you`,
-    types.roleInvitation && `${p(types.roleInvitation, "role invitation")} for you`,
-    types.invitationAccepted && `${p(types.invitationAccepted, "invitation")} accepted`,
-    types.applicationReceived && `${p(types.applicationReceived, "team application")} to review`,
-    types.applicationApproved && `${p(types.applicationApproved, "team")} joined successfully`,
-    types.applicationRejected && `${p(types.applicationRejected, "team application")} rejected`,
-    types.badgeAwarded && `${p(types.badgeAwarded, "new badge award")} for you`,
-    types.memberJoined && `${p(types.memberJoined, "new member")} joined your team`,
-    types.memberLeft && `${p(types.memberLeft, "member")} left your team`,
-    types.memberRemoved && `Removed from ${p(types.memberRemoved, "team")}`,
-    types.roleChanged && `${p(types.roleChanged, "role change")} in your team`,
-    types.ownershipTransferred && `${p(types.ownershipTransferred, "ownership transfer")}`,
-    types.teamDeleted && `${p(types.teamDeleted, "team")} deleted`,
-    types.invitationDeclined && `${p(types.invitationDeclined, "invitation")} declined`,
-    types.invitationCancelled && `${p(types.invitationCancelled, "invitation")} cancelled`,
-    types.applicationCancelled && `${p(types.applicationCancelled, "application")} cancelled`,
-  ].filter(Boolean);
-  return lines.length ? lines.join("\n") : `${p(count, "notification")}`;
+  const typeCount = (...keys) =>
+    keys.reduce((sum, key) => sum + (Number(types[key]) || 0), 0);
+  const typeTeamCount = (...keys) =>
+    keys.reduce((max, key) => Math.max(max, Number(teamCounts?.[key]) || 0), 0);
+
+  const lines = NOTIFICATION_TYPE_META.map(({ keys, Icon, text }) => {
+    const n = typeCount(...keys);
+    const tc = typeTeamCount(...keys);
+    return n ? { Icon, label: text(p, n, tc) } : null;
+  }).filter(Boolean);
+
+  if (!lines.length) return `${p(count, "notification")}`;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {lines.map(({ Icon, label }, i) => (
+        <div key={i} className="flex items-center gap-1.5">
+          <Icon size={11} strokeWidth={2.5} className="flex-shrink-0 opacity-70" />
+          <span>{label}</span>
+        </div>
+      ))}
+    </div>
+  );
 };
 
 const Navbar = () => {
@@ -67,6 +118,7 @@ const Navbar = () => {
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
   const [firstUnreadNotification, setFirstUnreadNotification] = useState(null);
   const [notificationTypeCounts, setNotificationTypeCounts] = useState({});
+  const [notificationTypeTeamCounts, setNotificationTypeTeamCounts] = useState({});
   const location = useLocation();
   const navigate = useNavigate();
   const lastMessageFetchRef = useRef(0);
@@ -79,6 +131,10 @@ const Navbar = () => {
     "inline-flex items-center text-[var(--color-primary)] hover:text-[var(--color-primary-focus)] hover:drop-shadow-neon transition duration-200";
   const navLinkClasses =
     "text-[var(--color-primary)] text-center border-2 border-transparent rounded-full px-2 py-1 transition-all duration-300";
+  const messageMentionNotificationCount =
+    notificationTypeCounts.messageMention ||
+    notificationTypeCounts.message_mention ||
+    0;
 
   // Fetch unread message count
   const fetchUnreadMessageCount = useCallback(async () => {
@@ -104,6 +160,7 @@ const Navbar = () => {
       setUnreadNotificationCount(response.data?.count || 0);
       setFirstUnreadNotification(response.data?.firstUnread || null);
       setNotificationTypeCounts(response.data?.typeCounts || {});
+      setNotificationTypeTeamCounts(response.data?.typeTeamCounts || {});
     } catch (error) {
       console.error("Error fetching unread notification count:", error);
     }
@@ -203,6 +260,7 @@ const Navbar = () => {
       setUnreadNotificationCount(0);
       setFirstUnreadNotification(null);
       setNotificationTypeCounts({});
+      setNotificationTypeTeamCounts({});
       return;
     }
 
@@ -219,8 +277,10 @@ const Navbar = () => {
       }
 
       const handleNewNotification = () => {
-        // Refetch to get the latest count and firstUnread
+        // Team events often create both a bell notification and a system chat
+        // message, so refresh both badge sources.
         fetchUnreadNotificationCount();
+        fetchUnreadMessageCount();
       };
 
       socket.on("notification:new", handleNewNotification);
@@ -242,7 +302,7 @@ const Navbar = () => {
         detachNotificationListener();
       }
     };
-  }, [isAuthenticated, fetchUnreadNotificationCount]);
+  }, [isAuthenticated, fetchUnreadMessageCount, fetchUnreadNotificationCount]);
 
   // Refetch message count when path changes
   useEffect(() => {
@@ -278,6 +338,7 @@ const Navbar = () => {
       setUnreadNotificationCount(fresh?.count || 0);
       setFirstUnreadNotification(fresh?.firstUnread || null);
       setNotificationTypeCounts(fresh?.typeCounts || {});
+      setNotificationTypeTeamCounts(fresh?.typeTeamCounts || {});
       freshFirst = fresh?.firstUnread || null;
     } catch (error) {
       console.error("Error fetching notifications:", error);
@@ -346,8 +407,8 @@ const Navbar = () => {
               >
                 <NotificationBadge
                   variant="alert"
-                  count={unreadNotificationCount - (notificationTypeCounts.messageMention || 0)}
-                  title={buildNotificationTooltip(unreadNotificationCount - (notificationTypeCounts.messageMention || 0), notificationTypeCounts)}
+                  count={unreadNotificationCount - messageMentionNotificationCount}
+                  title={buildNotificationTooltip(unreadNotificationCount - messageMentionNotificationCount, notificationTypeCounts, notificationTypeTeamCounts)}
                 >
                   <Bell size={22} strokeWidth={2.2} />
                 </NotificationBadge>
@@ -363,7 +424,7 @@ const Navbar = () => {
                 <NotificationBadge
                   variant="message"
                   count={unreadMessageCount}
-                  title={buildMessageTooltip(unreadMessageCount, messageTeamCount, messageSenderCount, notificationTypeCounts.messageMention)}
+                  title={buildMessageTooltip(unreadMessageCount, messageTeamCount, messageSenderCount, messageMentionNotificationCount)}
                 >
                   <MessageCircle size={22} strokeWidth={2.2} />
                 </NotificationBadge>

--- a/src/components/teams/CreateVacantRoleModal.jsx
+++ b/src/components/teams/CreateVacantRoleModal.jsx
@@ -9,8 +9,6 @@ import FormSectionDivider from "../common/FormSectionDivider";
 import TagInput from "../tags/TagInput";
 import Tooltip from "../common/Tooltip";
 import { vacantRoleService } from "../../services/vacantRoleService";
-import { messageService } from "../../services/messageService";
-import { buildRoleCreatedMessage, buildRoleUpdatedMessage } from "../../utils/roleEventMessages";
 import { useLocationAutoFill } from "../../hooks/useLocationAutoFill";
 import { getCategoryIcon, getBadgeIcon } from "../../utils/badgeIconUtils";
 import {
@@ -291,43 +289,8 @@ const CreateVacantRoleModal = ({
 
       if (isEditMode) {
         await vacantRoleService.updateVacantRole(teamId, existingRole.id, payload);
-        try {
-          await messageService.sendMessage(
-            teamId,
-            buildRoleUpdatedMessage({
-              teamId,
-              teamName: team?.name,
-              role: {
-                id: existingRole.id,
-                roleName: formData.roleName.trim(),
-              },
-              updatedBy: currentUser,
-            }),
-            "team",
-          );
-        } catch (messageError) {
-          console.warn("Role updated, but chat event could not be sent:", messageError);
-        }
       } else {
-        const createdRoleResponse = await vacantRoleService.createVacantRole(teamId, payload);
-        const createdRole = createdRoleResponse?.data ?? createdRoleResponse;
-        try {
-          await messageService.sendMessage(
-            teamId,
-            buildRoleCreatedMessage({
-              teamId,
-              teamName: team?.name,
-              role: {
-                id: createdRole?.id ?? null,
-                roleName: formData.roleName.trim(),
-              },
-              creator: currentUser,
-            }),
-            "team",
-          );
-        } catch (messageError) {
-          console.warn("Role created, but chat event could not be sent:", messageError);
-        }
+        await vacantRoleService.createVacantRole(teamId, payload);
       }
 
       setSubmitSuccess(true);

--- a/src/components/teams/TeamApplicationButton.jsx
+++ b/src/components/teams/TeamApplicationButton.jsx
@@ -54,9 +54,11 @@ const TeamApplicationButton = ({
         // Use roleId from the modal's selection (user may have changed it)
         const selectedRoleId = applicationData.roleId ?? roleId;
 
+        let submitResponse = null;
+
         if (selectedRoleId) {
           try {
-            await teamService.applyToJoinTeam(effectiveTeamId, {
+            submitResponse = await teamService.applyToJoinTeam(effectiveTeamId, {
               ...applicationData,
               roleId: selectedRoleId,
             });
@@ -67,14 +69,14 @@ const TeamApplicationButton = ({
 
             // Some backend environments still only support generic team
             // applications. Fall back to the existing team-only payload.
-            await teamService.applyToJoinTeam(effectiveTeamId, applicationData);
+            submitResponse = await teamService.applyToJoinTeam(effectiveTeamId, applicationData);
           }
         } else {
-          await teamService.applyToJoinTeam(effectiveTeamId, applicationData);
+          submitResponse = await teamService.applyToJoinTeam(effectiveTeamId, applicationData);
         }
 
+        onSuccess?.(applicationData, submitResponse);
         await onAfterSubmit?.();
-        onSuccess?.(applicationData);
 
         if (!applicationData.isDraft) {
           closeApplicationModal();

--- a/src/components/teams/TeamApplicationModal.jsx
+++ b/src/components/teams/TeamApplicationModal.jsx
@@ -203,7 +203,7 @@ const TeamApplicationModal = ({
       )}
       <div>
         <h2 className="text-xl font-medium text-primary">
-          {isInternal ? "Apply to fill a role in your team" : "Apply to join this Team"}
+          {isInternal ? "Apply to fill this role within your team" : "Apply to join this Team"}
         </h2>
       </div>
     </div>
@@ -230,7 +230,7 @@ const TeamApplicationModal = ({
         disabled={loading || !message.trim() || (isInternal && !selectedRoleId)}
         icon={<Send size={16} />}
       >
-        {loading ? "Sending..." : isInternal ? "Send Role Application" : "Send Application"}
+        {loading ? "Sending..." : isInternal ? "Apply to fill this role within your team" : "Send Application"}
       </Button>
     </div>
   );

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Check, X as Decline, User, Mail, MessageSquare, AlertTriangle } from "lucide-react";
+import { Check, UserCheck, X as Decline, User, Mail, MessageSquare, AlertTriangle } from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
 import PersonRequestCard from "../common/PersonRequestCard";
 import Button from "../common/Button";
 import Modal from "../common/Modal";
+import Tooltip from "../common/Tooltip";
 import UserDetailsModal from "../users/UserDetailsModal";
 import VacantRoleCard from "./VacantRoleCard";
 import TeamApplicationDetailsModal from "./TeamApplicationDetailsModal";
@@ -11,11 +12,7 @@ import { matchingService } from "../../services/matchingService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { messageService } from "../../services/messageService";
 import { useAuth } from "../../contexts/AuthContext";
-import {
-  buildRoleApplicationFilledMessage,
-  buildRoleReopenedMessage,
-} from "../../utils/roleEventMessages";
-import { resolveFilledRoleUser } from "../../utils/vacantRoleUtils";
+import { buildRoleApplicationFilledMessage } from "../../utils/roleEventMessages";
 
 const ROLE_CANDIDATE_FETCH_MIN_LIMIT = 20;
 const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
@@ -49,6 +46,7 @@ const extractCandidateMatchData = (candidateLike) => {
  * @param {Array} applications - Array of pending application objects
  * @param {Function} onApplicationAction - Callback to handle approve/decline
  * @param {string} teamName - Name of the team (for display)
+ * @param {string|number|null} highlightApplicationId - Application ID to scroll to + highlight (optional)
  * @param {string|number|null} highlightUserId - User ID to scroll to + highlight (optional)
  */
 const TeamApplicationsModal = ({
@@ -59,6 +57,7 @@ const TeamApplicationsModal = ({
   onApplicationAction,
   onRoleStatusChanged,
   teamName,
+  highlightApplicationId = null,
   highlightUserId = null,
 }) => {
   // ============ Auth ============
@@ -76,6 +75,7 @@ const TeamApplicationsModal = ({
   const [applicationDetailsFor, setApplicationDetailsFor] = useState(null);
   const [roleCandidateMatchMap, setRoleCandidateMatchMap] = useState({});
   const [selfRoleMatchMap, setSelfRoleMatchMap] = useState({});
+  const [polledRoleStatusMap, setPolledRoleStatusMap] = useState({});
 
   // ============ Refs ============
   const highlightedRef = useRef(null);
@@ -91,7 +91,8 @@ const TeamApplicationsModal = ({
   const handleApplicationAction = async (
     applicationId,
     action,
-    response = ""
+    response = "",
+    fillRoleOverride = null
   ) => {
     try {
       setLoading(true);
@@ -100,9 +101,20 @@ const TeamApplicationsModal = ({
       // Determine if the admin toggled "Mark role as filled" for this application's role
       let fillRole = false;
       const application = applications.find((app) => app.id === applicationId);
+      const isInternalRoleApplication = Boolean(
+        application?.isInternalRoleApplication ??
+          application?.is_internal_role_application ??
+          false,
+      );
       if (action === "approve") {
         const appRoleId = application?.role?.id ?? null;
-        if (appRoleId && roleStatusOverrides[appRoleId]?.status === "filled") {
+        if (fillRoleOverride !== null && fillRoleOverride !== undefined) {
+          fillRole = Boolean(fillRoleOverride);
+        } else if (
+          appRoleId &&
+          (isInternalRoleApplication ||
+            roleStatusOverrides[appRoleId]?.status === "filled")
+        ) {
           fillRole = true;
         }
       }
@@ -118,6 +130,7 @@ const TeamApplicationsModal = ({
               teamName,
               role: application.role,
               applicant: application.applicant ?? null,
+              approver: currentUser ?? null,
             }),
             "team",
           );
@@ -209,29 +222,6 @@ const TeamApplicationsModal = ({
 
         await vacantRoleService.updateVacantRoleStatus(teamId, roleId, "open", null);
 
-        if (originalRole) {
-          try {
-            await messageService.sendMessage(
-              teamId,
-              buildRoleReopenedMessage({
-                teamId,
-                teamName,
-                role: originalRole,
-                filledUser: resolveFilledRoleUser(originalRole, {
-                  viewAsUserId: currentUser?.id,
-                  viewAsUser: currentUser,
-                }),
-              }),
-              "team",
-            );
-          } catch (messageError) {
-            console.warn(
-              "Role reopened, but chat event could not be sent:",
-              messageError,
-            );
-          }
-        }
-
         // Clear any local override to reflect the server state
         setRoleStatusOverrides((prev) => {
           const next = { ...prev };
@@ -289,18 +279,23 @@ const TeamApplicationsModal = ({
 
   // ============ Effects ============
   useEffect(() => {
-    if (isOpen && highlightUserId && highlightedRef.current) {
-      // Small delay to ensure modal is rendered
-      const t = setTimeout(() => {
+    if (!isOpen || (!highlightApplicationId && !highlightUserId)) return;
+
+    let frameId = null;
+    const t = setTimeout(() => {
+      frameId = window.requestAnimationFrame(() => {
         highlightedRef.current?.scrollIntoView({
           behavior: "smooth",
           block: "center",
         });
-      }, 100);
+      });
+    }, 150);
 
-      return () => clearTimeout(t);
-    }
-  }, [isOpen, highlightUserId]);
+    return () => {
+      clearTimeout(t);
+      if (frameId != null) window.cancelAnimationFrame(frameId);
+    };
+  }, [applications.length, highlightApplicationId, highlightUserId, isOpen]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -468,6 +463,60 @@ const TeamApplicationsModal = ({
     };
   }, [isOpen, applications]);
 
+  // Poll role status every 20s so VacantRoleCard reflects changes made by others
+  useEffect(() => {
+    if (!isOpen || !teamId) return;
+
+    const roleIds = [
+      ...new Set(
+        applications
+          .map(
+            (app) =>
+              app?.role?.id ?? app?.roleId ?? app?.role_id ?? null,
+          )
+          .filter(Boolean)
+          .map(String),
+      ),
+    ];
+
+    if (roleIds.length === 0) return;
+
+    let isCancelled = false;
+
+    const pollRoles = async () => {
+      try {
+        const results = await Promise.allSettled(
+          roleIds.map((id) =>
+            vacantRoleService.getVacantRoleById(teamId, id),
+          ),
+        );
+        if (isCancelled) return;
+        const nextMap = {};
+        results.forEach((result, i) => {
+          if (result.status === "fulfilled") {
+            const payload = result.value?.data ?? result.value;
+            const roleData =
+              payload?.success !== undefined
+                ? payload?.data ?? null
+                : payload?.data?.data ?? payload?.data ?? payload;
+            if (roleData) nextMap[roleIds[i]] = roleData;
+          }
+        });
+        setPolledRoleStatusMap((prev) => ({ ...prev, ...nextMap }));
+      } catch {
+        // silent — keep showing last known state
+      }
+    };
+
+    pollRoles();
+    const intervalId = setInterval(pollRoles, 20_000);
+
+    return () => {
+      isCancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [isOpen, teamId, applications]);
+
   // ============ Render ============
   return (
     <RequestListModal
@@ -545,10 +594,12 @@ const TeamApplicationsModal = ({
           application?.is_synthetic ??
           application?.isSynthetic;
         const roleOverride = roleId ? roleStatusOverrides[roleId] : null;
+        const polledRole = roleId ? polledRoleStatusMap[String(roleId)] : null;
         const role =
           application?.role && roleId
             ? {
                 ...application.role,
+                ...(polledRole ?? {}),
                 is_synthetic:
                   application.role.is_synthetic ??
                   application.role.isSynthetic ??
@@ -559,15 +610,20 @@ const TeamApplicationsModal = ({
                   syntheticRoleFlag,
                 status:
                   roleOverride?.status ??
+                  polledRole?.status ??
                   application.role.status ??
                   "open",
                 filledBy:
                   roleOverride?.filledBy ??
+                  polledRole?.filledBy ??
+                  polledRole?.filled_by ??
                   application.role.filledBy ??
                   application.role.filled_by ??
                   null,
                 filledByUser:
                   roleOverride?.filledByUser ??
+                  polledRole?.filledByUser ??
+                  polledRole?.filled_by_user ??
                   application.role.filledByUser ??
                   application.role.filled_by_user ??
                   null,
@@ -575,6 +631,7 @@ const TeamApplicationsModal = ({
             : application?.role
               ? {
                   ...application.role,
+                  ...(polledRole ?? {}),
                   is_synthetic:
                     application.role.is_synthetic ??
                     application.role.isSynthetic ??
@@ -591,6 +648,14 @@ const TeamApplicationsModal = ({
             : null;
         const isSelfApplication =
           currentUser?.id === (application.applicant?.id ?? application.applicant_id);
+        const isInternalRoleApplication = Boolean(
+          application?.isInternalRoleApplication ??
+            application?.is_internal_role_application ??
+            false,
+        );
+        const hasRoleApplication = roleId != null;
+        const isExternalRoleApplication =
+          hasRoleApplication && !isInternalRoleApplication;
         const selfRoleMatch =
           roleId != null && isSelfApplication
             ? selfRoleMatchMap[String(roleId)] ?? null
@@ -598,9 +663,45 @@ const TeamApplicationsModal = ({
 
         // Normalize types to avoid "1" vs 1 mismatches
         const isHighlighted =
-          highlightUserId != null &&
-          applicantId != null &&
-          String(applicantId) === String(highlightUserId);
+          (highlightApplicationId != null &&
+            String(application.id) === String(highlightApplicationId)) ||
+          (highlightUserId != null &&
+            applicantId != null &&
+            String(applicantId) === String(highlightUserId));
+
+        // Role availability guards
+        const serverRoleStatus =
+          polledRole?.status ?? application.role?.status ?? "open";
+        const isServerFilled = serverRoleStatus === "filled";
+        const isServerClosed = serverRoleStatus === "closed";
+        const isRoleUnavailable = isServerFilled || isServerClosed;
+
+        const applicationTeamOwnerId =
+          application.ownerId ?? application.owner_id ?? null;
+        const isCurrentUserOwner =
+          applicationTeamOwnerId != null &&
+          currentUser?.id != null &&
+          String(currentUser.id) === String(applicationTeamOwnerId);
+
+        const filledByUserId =
+          application.role?.filledBy ?? application.role?.filled_by ?? null;
+        const isCurrentUserFilledBy =
+          filledByUserId != null &&
+          currentUser?.id != null &&
+          String(currentUser.id) === String(filledByUserId);
+
+        // Restrict the status toggle on the role card for unavailable roles:
+        // filled → only owner or the person filling it; closed → only owner
+        const canManageStatusForRole =
+          !isSelfApplication &&
+          (!isServerFilled || isCurrentUserOwner || isCurrentUserFilledBy) &&
+          (!isServerClosed || isCurrentUserOwner);
+
+        const unavailableTooltip = isInternalRoleApplication
+          ? (isServerFilled ? "This role is already filled" : "This role is closed")
+          : (isServerFilled
+              ? "This role is already filled — you can still add this person to the team"
+              : "This role is closed — you can still add this person to the team");
 
         return (
           <div
@@ -608,7 +709,7 @@ const TeamApplicationsModal = ({
             ref={isHighlighted ? highlightedRef : null}
             className={`transition-all duration-300 ${
               isHighlighted
-                ? "ring-2 ring-primary/30 rounded-xl bg-primary/5"
+                ? "ring-2 ring-green-500/70 ring-offset-2 rounded-xl bg-green-50"
                 : ""
             } ${isSelfApplication ? "opacity-60" : ""}`}
           >
@@ -643,7 +744,7 @@ const TeamApplicationsModal = ({
                           null
                         }
                         canManage={false}
-                        canManageStatus={!isSelfApplication}
+                        canManageStatus={canManageStatusForRole}
                         onViewApplicationDetails={
                           isSelfApplication
                             ? () => setApplicationDetailsFor(application)
@@ -717,7 +818,20 @@ const TeamApplicationsModal = ({
                     <span>Another owner or admin must review your application.</span>
                   </div>
                 ) : (
-                  <div className="flex justify-end space-x-2">
+                  <div className="flex flex-wrap justify-end gap-2">
+                    {isRoleUnavailable && (isExternalRoleApplication || isInternalRoleApplication) && (
+                      <Tooltip content={unavailableTooltip}>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={true}
+                          className="border border-base-content/30 text-base-content/40"
+                          icon={<UserCheck size={16} />}
+                        >
+                          {isInternalRoleApplication ? "Accept & Fill Role" : "Fill Role & Add to Team"}
+                        </Button>
+                      </Tooltip>
+                    )}
                     <Button
                       variant="errorOutline"
                       size="sm"
@@ -733,21 +847,61 @@ const TeamApplicationsModal = ({
                     >
                       Decline
                     </Button>
-                    <Button
-                      variant="successOutline"
-                      size="sm"
-                      onClick={() =>
-                        handleApplicationAction(
-                          application.id,
-                          "approve",
-                          responses[application.id] || ""
-                        )
-                      }
-                      disabled={loading}
-                      icon={<Check size={16} />}
-                    >
-                      Accept & Add to Team
-                    </Button>
+                    {isExternalRoleApplication ? (
+                      <>
+                        {!isRoleUnavailable && (
+                          <Button
+                            variant="successOutline"
+                            size="sm"
+                            onClick={() =>
+                              handleApplicationAction(
+                                application.id,
+                                "approve",
+                                responses[application.id] || "",
+                                true
+                              )
+                            }
+                            disabled={loading}
+                            icon={<Check size={16} />}
+                          >
+                            Fill Role & Add to Team
+                          </Button>
+                        )}
+                        <Button
+                          variant="successOutline"
+                          size="sm"
+                          onClick={() =>
+                            handleApplicationAction(
+                              application.id,
+                              "approve",
+                              responses[application.id] || "",
+                              false
+                            )
+                          }
+                          disabled={loading}
+                          icon={<Check size={16} />}
+                        >
+                          Add to Team Only
+                        </Button>
+                      </>
+                    ) : isInternalRoleApplication && isRoleUnavailable ? null : (
+                      <Button
+                        variant="successOutline"
+                        size="sm"
+                        onClick={() =>
+                          handleApplicationAction(
+                            application.id,
+                            "approve",
+                            responses[application.id] || "",
+                            isInternalRoleApplication
+                          )
+                        }
+                        disabled={loading}
+                        icon={<Check size={16} />}
+                      >
+                        {isInternalRoleApplication ? "Accept & Fill Role" : "Accept & Add to Team"}
+                      </Button>
+                    )}
                   </div>
                 )
               }

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -30,6 +30,7 @@ import TeamInvitationDetailsModal from "./TeamInvitationDetailsModal";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { userService } from "../../services/userService";
+import socketService from "../../services/socketService";
 import { useAuth } from "../../contexts/AuthContext";
 import Alert from "../common/Alert";
 import ConfirmModal from "../common/ConfirmModal";
@@ -378,6 +379,8 @@ const TeamCard = ({
 
   autoOpenApplications = false,
   highlightApplicantId = null,
+  highlightApplicationId = null,
+  highlightInvitationId = null,
   onApplicationsModalClosed,
 }) => {
   const isInternalRoleApplication =
@@ -820,6 +823,73 @@ const TeamCard = ({
   useEffect(() => {
     fetchSentInvitations();
   }, [fetchSentInvitations]);
+
+  useEffect(() => {
+    if (effectiveVariant !== "member" || !teamData?.id || !canManageInvitations) {
+      return undefined;
+    }
+
+    let detachSocketListeners = null;
+
+    const attachSocketListeners = (socket) => {
+      if (!socket) return;
+
+      if (detachSocketListeners) {
+        detachSocketListeners();
+      }
+
+      const handleTeamRequestEvent = (payload = {}) => {
+        const payloadTeamId = payload.teamId ?? payload.team_id ?? null;
+        if (payloadTeamId != null && String(payloadTeamId) !== String(teamData.id)) {
+          return;
+        }
+
+        const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
+        const shouldRefreshApplications =
+          !type ||
+          type.includes("application") ||
+          type === "member_joined" ||
+          type === "role_filled";
+        const shouldRefreshInvitations =
+          !type ||
+          type.includes("invitation") ||
+          type.includes("invite");
+
+        if (shouldRefreshApplications) {
+          fetchPendingApplications();
+        }
+
+        if (shouldRefreshInvitations) {
+          fetchSentInvitations();
+        }
+      };
+
+      socket.on("notification:new", handleTeamRequestEvent);
+      socket.on("notification:updated", handleTeamRequestEvent);
+      socket.on("notification:deleted", handleTeamRequestEvent);
+
+      detachSocketListeners = () => {
+        socket.off("notification:new", handleTeamRequestEvent);
+        socket.off("notification:updated", handleTeamRequestEvent);
+        socket.off("notification:deleted", handleTeamRequestEvent);
+      };
+    };
+
+    const unsubscribeSocketReady = socketService.onSocketReady(attachSocketListeners);
+
+    return () => {
+      unsubscribeSocketReady();
+      if (detachSocketListeners) {
+        detachSocketListeners();
+      }
+    };
+  }, [
+    canManageInvitations,
+    effectiveVariant,
+    fetchPendingApplications,
+    fetchSentInvitations,
+    teamData?.id,
+  ]);
 
   useEffect(() => {
     const fetchCompleteTeamData = async () => {
@@ -1528,6 +1598,16 @@ const TeamCard = ({
       await fetchSentInvitations();
     } catch (error) {
       console.error("Error canceling invitation:", error);
+      throw error;
+    }
+  };
+
+  const handleCancelRoleInvitation = async (invitationId) => {
+    try {
+      await teamService.cancelRoleInvitation(invitationId);
+      await fetchSentInvitations();
+    } catch (error) {
+      console.error("Error canceling role invitation:", error);
       throw error;
     }
   };
@@ -2389,6 +2469,7 @@ const TeamCard = ({
             onApplicationAction={handleApplicationAction}
             onRoleStatusChanged={handleVacantRoleStatusChange}
             teamName={teamData.name}
+            highlightApplicationId={highlightApplicationId}
             highlightUserId={highlightApplicantId}
           />
         )}
@@ -2404,7 +2485,9 @@ const TeamCard = ({
             teamId={teamData.id}
             invitations={pendingSentInvitations}
             onCancelInvitation={handleCancelInvitation}
+            onCancelRoleInvitation={handleCancelRoleInvitation}
             teamName={teamData.name}
+            highlightInvitationId={highlightInvitationId}
           />
         )}
 
@@ -2959,6 +3042,7 @@ const TeamCard = ({
           onApplicationAction={handleApplicationAction}
           onRoleStatusChanged={handleVacantRoleStatusChange}
           teamName={teamData.name}
+          highlightApplicationId={highlightApplicationId}
           highlightUserId={highlightApplicantId}
         />
       )}
@@ -2975,7 +3059,9 @@ const TeamCard = ({
           teamId={teamData.id}
           invitations={pendingSentInvitations}
           onCancelInvitation={handleCancelInvitation}
+          onCancelRoleInvitation={handleCancelRoleInvitation}
           teamName={teamData.name}
+          highlightInvitationId={highlightInvitationId}
         />
       )}
 

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -41,6 +41,7 @@ import { UI_TEXT } from "../../constants/uiText";
 import { tagService } from "../../services/tagService";
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import TeamApplicationButton from "./TeamApplicationButton";
+import TeamApplicationDetailsModal from "./TeamApplicationDetailsModal";
 import TeamInvitationDetailsModal from "./TeamInvitationDetailsModal";
 import TeamMembersSection from "./TeamMembersSection";
 import TeamFocusAreaSection from "./TeamFocusAreaSection";
@@ -178,6 +179,9 @@ const TeamDetailsModal = ({
   const [leaveLoading, setLeaveLoading] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isInvitationModalOpen, setIsInvitationModalOpen] = useState(false);
+  const [localPendingApplication, setLocalPendingApplication] = useState(null);
+  const [isApplicationDetailsOpen, setIsApplicationDetailsOpen] =
+    useState(false);
 
   const [teamImageError, setTeamImageError] = useState(false);
   const showHighlightsForContext = !isFromSearch || showMatchHighlights;
@@ -403,6 +407,11 @@ const TeamDetailsModal = ({
   useEffect(() => {
     setIsModalVisible(isOpen);
   }, [isOpen]);
+
+  useEffect(() => {
+    setLocalPendingApplication(null);
+    setIsApplicationDetailsOpen(false);
+  }, [effectiveTeamId]);
 
   useEffect(() => {
     if (isModalVisible && effectiveTeamId) {
@@ -1169,14 +1178,25 @@ const TeamDetailsModal = ({
     }
 
     // Pending application CTA
-    const hasApp = Boolean((hasPendingApplication || pendingApplication) && !isMember);
+    const effectivePendingApplication =
+      localPendingApplication ?? pendingApplication;
+    const hasApp = Boolean(
+      (hasPendingApplication || effectivePendingApplication) && !isMember,
+    );
 
     if (hasApp) {
       return (
         <div className="mt-6 border-t border-base-200 pt-4">
           <Button
             variant="primary"
-            onClick={() => onViewApplicationDetails?.()}
+            onClick={() => {
+              if (effectivePendingApplication) {
+                setIsApplicationDetailsOpen(true);
+                return;
+              }
+
+              onViewApplicationDetails?.();
+            }}
             className="w-full"
             icon={<SendHorizontal size={16} />}
           >
@@ -1222,7 +1242,20 @@ const TeamDetailsModal = ({
             disabled={loading}
             className="w-full"
             onAfterSubmit={fetchTeamDetails}
-            onSuccess={(applicationData) => {
+            onSuccess={(applicationData, submitResponse) => {
+              const submittedApplication = submitResponse?.data ?? {};
+              setLocalPendingApplication({
+                id: submittedApplication.applicationId,
+                applicationId: submittedApplication.applicationId,
+                status: submittedApplication.status ?? "pending",
+                message: applicationData.message,
+                created_at: new Date().toISOString(),
+                team: team ?? { id: effectiveTeamId },
+                isInternalRoleApplication:
+                  submittedApplication.isInternalRoleApplication ?? false,
+                is_internal_role_application:
+                  submittedApplication.isInternalRoleApplication ?? false,
+              });
               setNotification({
                 type: "success",
                 message: applicationData.isDraft
@@ -1749,6 +1782,20 @@ const TeamDetailsModal = ({
           onClose={() => setIsInvitationModalOpen(false)}
           onAccept={handleInvitationAccept}
           onDecline={handleInvitationDecline}
+        />
+      )}
+
+      {(localPendingApplication || pendingApplication) && (
+        <TeamApplicationDetailsModal
+          isOpen={isApplicationDetailsOpen}
+          application={localPendingApplication ?? pendingApplication}
+          onClose={() => setIsApplicationDetailsOpen(false)}
+          onCancel={async (applicationId) => {
+            await teamService.cancelApplication(applicationId);
+            setLocalPendingApplication(null);
+            setIsApplicationDetailsOpen(false);
+            await fetchTeamDetails(true);
+          }}
         />
       )}
     </>

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -4,6 +4,7 @@ import {
   MessageSquare,
   Users,
   Check,
+  UserCheck,
   X,
   MailOpen,
   UserPlus,
@@ -278,6 +279,11 @@ const TeamInvitationDetailsModal = ({
           isSynthetic: syntheticRoleFlag,
         };
 
+  const roleStatus = roleForCard?.status;
+  const isRoleFilled = hasRoleInvitation && roleStatus === "filled";
+  const isRoleClosed = hasRoleInvitation && roleStatus === "closed";
+  const isRoleUnavailable = isRoleFilled || isRoleClosed;
+
   // Custom header
   const customHeader = (
     <div>
@@ -304,6 +310,27 @@ const TeamInvitationDetailsModal = ({
 
         {/* Buttons (right) */}
         <div className="flex flex-wrap justify-end gap-2">
+          {isRoleUnavailable && (
+            <Tooltip
+              content={
+                isInternal
+                  ? (isRoleFilled ? "This role is already filled" : "This role is closed")
+                  : (isRoleFilled
+                      ? "This role is already filled — you can still join the team"
+                      : "This role is closed — you can still join the team")
+              }
+            >
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={true}
+                className="border border-base-content/30 text-base-content/40"
+                icon={<UserCheck size={16} />}
+              >
+                {isInternal ? "Accept Role" : "Accept & Fill Role"}
+              </Button>
+            </Tooltip>
+          )}
           <Button
             variant="errorOutline"
             size="sm"
@@ -315,15 +342,17 @@ const TeamInvitationDetailsModal = ({
           </Button>
           {hasRoleInvitation && isInternal ? (
             // Internal role invite: user is already a member, just accept/fill the role
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={handleAcceptWithRole}
-              disabled={isControlsDisabled}
-              icon={<Check size={16} />}
-            >
-              {isAcceptRoleLoading ? "Accepting..." : "Accept Role"}
-            </Button>
+            !isRoleUnavailable && (
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleAcceptWithRole}
+                disabled={isControlsDisabled}
+                icon={<Check size={16} />}
+              >
+                {isAcceptRoleLoading ? "Accepting..." : "Accept Role"}
+              </Button>
+            )
           ) : hasRoleInvitation ? (
             // External invite with a role: offer team-only or fill-role options
             <>
@@ -336,15 +365,17 @@ const TeamInvitationDetailsModal = ({
               >
                 {isAcceptTeamLoading ? "Joining..." : "Join Team Only"}
               </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleAcceptWithRole}
-                disabled={isControlsDisabled}
-                icon={<Check size={16} />}
-              >
-                {isAcceptRoleLoading ? "Joining..." : "Accept & Fill Role"}
-              </Button>
+              {!isRoleUnavailable && (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleAcceptWithRole}
+                  disabled={isControlsDisabled}
+                  icon={<Check size={16} />}
+                >
+                  {isAcceptRoleLoading ? "Joining..." : "Accept & Fill Role"}
+                </Button>
+              )}
             </>
           ) : (
             // No role: simple accept

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import {
   Users,
   Send,
@@ -21,6 +21,7 @@ import TeamApplicationsModal from "../teams/TeamApplicationsModal";
 import { getUserInitials } from "../../utils/userHelpers";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
+import socketService from "../../services/socketService";
 
 const normalizeId = (value) => {
   if (value === null || value === undefined || value === "") return null;
@@ -805,6 +806,104 @@ const TeamInviteModal = ({
     );
   };
 
+  const refreshSelectedTeamRequests = useCallback(async () => {
+    if (!selectedTeamForModal?.id) return;
+
+    const teamId = selectedTeamForModal.id;
+    const [invitationsResult, applicationsResult] = await Promise.allSettled([
+      teamService.getTeamSentInvitations(teamId),
+      teamService.getTeamApplications(teamId),
+    ]);
+
+    const allInvitations =
+      invitationsResult.status === "fulfilled"
+        ? invitationsResult.value?.data || []
+        : selectedTeamInvitations;
+    const allApplications =
+      applicationsResult.status === "fulfilled"
+        ? applicationsResult.value?.data || []
+        : selectedTeamApplications;
+
+    setSelectedTeamInvitations(allInvitations);
+    setSelectedTeamApplications(allApplications);
+    setTeamStatusData((prev) => ({
+      ...prev,
+      [teamId]: {
+        ...prev[teamId],
+        allInvitations,
+        allApplications,
+        hasInviteForUser: allInvitations.some(
+          (inv) =>
+            (inv.invitee?.id === inviteeId || inv.invitee_id === inviteeId) &&
+            inv.status === "pending",
+        ),
+        hasApplicationFromUser: allApplications.some(
+          (app) =>
+            (app.applicant?.id === inviteeId || app.applicant_id === inviteeId) &&
+            app.status === "pending",
+        ),
+      },
+    }));
+  }, [
+    inviteeId,
+    selectedTeamApplications,
+    selectedTeamForModal?.id,
+    selectedTeamInvitations,
+  ]);
+
+  useEffect(() => {
+    if (!isOpen || !selectedTeamForModal?.id) return undefined;
+
+    let detachSocketListeners = null;
+
+    const attachSocketListeners = (socket) => {
+      if (!socket) return;
+
+      if (detachSocketListeners) {
+        detachSocketListeners();
+      }
+
+      const handleTeamRequestEvent = (payload = {}) => {
+        const payloadTeamId = payload.teamId ?? payload.team_id ?? null;
+        if (
+          payloadTeamId != null &&
+          String(payloadTeamId) !== String(selectedTeamForModal.id)
+        ) {
+          return;
+        }
+
+        const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
+        if (
+          !type ||
+          type.includes("invitation") ||
+          type.includes("invite") ||
+          type.includes("application")
+        ) {
+          refreshSelectedTeamRequests();
+        }
+      };
+
+      socket.on("notification:new", handleTeamRequestEvent);
+      socket.on("notification:updated", handleTeamRequestEvent);
+      socket.on("notification:deleted", handleTeamRequestEvent);
+
+      detachSocketListeners = () => {
+        socket.off("notification:new", handleTeamRequestEvent);
+        socket.off("notification:updated", handleTeamRequestEvent);
+        socket.off("notification:deleted", handleTeamRequestEvent);
+      };
+    };
+
+    const unsubscribeSocketReady = socketService.onSocketReady(attachSocketListeners);
+
+    return () => {
+      unsubscribeSocketReady();
+      if (detachSocketListeners) {
+        detachSocketListeners();
+      }
+    };
+  }, [isOpen, refreshSelectedTeamRequests, selectedTeamForModal?.id]);
+
   // Handle cancel invitation (called from TeamInvitesModal)
   const handleCancelInvitation = async (invitationId) => {
     try {
@@ -835,6 +934,50 @@ const TeamInviteModal = ({
       }
     } catch (err) {
       console.error("Error canceling invitation:", err);
+      throw err;
+    }
+  };
+
+  const handleCancelRoleInvitation = async (invitationId) => {
+    try {
+      const result = await teamService.cancelRoleInvitation(invitationId);
+
+      if (selectedTeamForModal) {
+        const teamId = selectedTeamForModal.id;
+        const canceledInvitation =
+          result?.data?.canceledInvitation ?? result?.canceledInvitation ?? false;
+        const updatedInvitations = canceledInvitation
+          ? selectedTeamInvitations.filter((inv) => inv.id !== invitationId)
+          : selectedTeamInvitations.map((inv) =>
+              inv.id === invitationId
+                ? {
+                    ...inv,
+                    role: null,
+                    roleId: null,
+                    role_id: null,
+                    roleName: null,
+                    role_name: null,
+                  }
+                : inv,
+            );
+
+        setSelectedTeamInvitations(updatedInvitations);
+        setTeamStatusData((prev) => ({
+          ...prev,
+          [teamId]: {
+            ...prev[teamId],
+            allInvitations: updatedInvitations,
+            hasInviteForUser: updatedInvitations.some(
+              (inv) =>
+                (inv.invitee?.id === inviteeId ||
+                  inv.invitee_id === inviteeId) &&
+                inv.status === "pending"
+            ),
+          },
+        }));
+      }
+    } catch (err) {
+      console.error("Error canceling role invitation:", err);
       throw err;
     }
   };
@@ -1305,7 +1448,9 @@ const TeamInviteModal = ({
         teamId={selectedTeamForModal?.id}
         invitations={selectedTeamInvitations}
         onCancelInvitation={handleCancelInvitation}
+        onCancelRoleInvitation={handleCancelRoleInvitation}
         teamName={selectedTeamForModal?.name}
+        highlightInvitationId={selectedTeamInvitations?.[0]?.id ?? null}
         highlightUserId={inviteeId}
       />
 
@@ -1317,6 +1462,7 @@ const TeamInviteModal = ({
         applications={selectedTeamApplications}
         onApplicationAction={handleApplicationAction}
         teamName={selectedTeamForModal?.name}
+        highlightApplicationId={selectedTeamApplications?.[0]?.id ?? null}
         highlightUserId={inviteeId}
       />
     </>

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -17,6 +17,7 @@ import VacantRoleCard from "./VacantRoleCard";
 import { matchingService } from "../../services/matchingService";
 import { userService } from "../../services/userService";
 import { vacantRoleService } from "../../services/vacantRoleService";
+import teamService from "../../services/teamService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
 import {
@@ -198,6 +199,7 @@ const computeRoleUserMatch = ({
  * @param {Array} invitations - Array of pending invitation objects
  * @param {Function} onCancelInvitation - Callback to cancel an invitation
  * @param {string} teamName - Name of the team (for display)
+ * @param {string|number|null} highlightInvitationId - Invitation ID to scroll to + highlight (optional)
  * @param {string|number|null} highlightUserId - User ID to scroll to + highlight (optional)
  */
 const TeamInvitesModal = ({
@@ -206,7 +208,9 @@ const TeamInvitesModal = ({
   teamId = null,
   invitations = [],
   onCancelInvitation,
+  onCancelRoleInvitation,
   teamName,
+  highlightInvitationId = null,
   highlightUserId = null,
 }) => {
   // ============ State ============
@@ -218,6 +222,8 @@ const TeamInvitesModal = ({
   const [localInviteeRoleMatchMap, setLocalInviteeRoleMatchMap] = useState({});
   const [pendingCancelInvitationId, setPendingCancelInvitationId] =
     useState(null);
+  const [pendingCancelType, setPendingCancelType] = useState("team");
+  const [hydratedRoleMap, setHydratedRoleMap] = useState({});
 
   // ============ Refs ============
   const highlightedRef = useRef(null);
@@ -229,18 +235,23 @@ const TeamInvitesModal = ({
 
   // ============ Scroll to highlighted invitation ============
   useEffect(() => {
-    if (isOpen && highlightUserId && highlightedRef.current) {
-      // Small delay to ensure modal is rendered
-      const t = setTimeout(() => {
+    if (!isOpen || (!highlightInvitationId && !highlightUserId)) return;
+
+    let frameId = null;
+    const t = setTimeout(() => {
+      frameId = window.requestAnimationFrame(() => {
         highlightedRef.current?.scrollIntoView({
           behavior: "smooth",
           block: "center",
         });
-      }, 100);
+      });
+    }, 150);
 
-      return () => clearTimeout(t);
-    }
-  }, [isOpen, highlightUserId]);
+    return () => {
+      clearTimeout(t);
+      if (frameId != null) window.cancelAnimationFrame(frameId);
+    };
+  }, [highlightInvitationId, highlightUserId, invitations.length, isOpen]);
 
   useEffect(() => {
     const selfRoleIds = [
@@ -533,16 +544,72 @@ const TeamInvitesModal = ({
     };
   }, [isOpen, invitations]);
 
+  // Poll role status every 20s so VacantRoleCard reflects changes made by others
+  useEffect(() => {
+    if (!isOpen || !teamId) return;
+
+    const roleIds = [
+      ...new Set(
+        invitations
+          .map(
+            (inv) =>
+              inv?.role?.id ?? inv?.roleId ?? inv?.role_id ?? null,
+          )
+          .filter(Boolean)
+          .map(String),
+      ),
+    ];
+
+    if (roleIds.length === 0) return;
+
+    let isCancelled = false;
+
+    const pollRoles = async () => {
+      try {
+        const results = await Promise.allSettled(
+          roleIds.map((id) =>
+            vacantRoleService.getVacantRoleById(teamId, id),
+          ),
+        );
+        if (isCancelled) return;
+        const nextMap = {};
+        results.forEach((result, i) => {
+          if (result.status === "fulfilled") {
+            const payload = result.value?.data ?? result.value;
+            const roleData =
+              payload?.success !== undefined
+                ? payload?.data ?? null
+                : payload?.data?.data ?? payload?.data ?? payload;
+            if (roleData) nextMap[roleIds[i]] = roleData;
+          }
+        });
+        setHydratedRoleMap((prev) => ({ ...prev, ...nextMap }));
+      } catch {
+        // silent — keep showing last known state
+      }
+    };
+
+    pollRoles();
+    const intervalId = setInterval(pollRoles, 20_000);
+
+    return () => {
+      isCancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [isOpen, teamId, invitations]);
+
   // ============ Handlers ============
 
-  const handleCancelInvitation = (invitationId) => {
+  const handleCancelInvitation = (invitationId, type = "team") => {
     if (!invitationId) return;
+    setPendingCancelType(type);
     setPendingCancelInvitationId(invitationId);
   };
 
   const closeCancelInvitationModal = () => {
     if (loading) return;
     setPendingCancelInvitationId(null);
+    setPendingCancelType("team");
   };
 
   const confirmCancelInvitation = async () => {
@@ -552,10 +619,23 @@ const TeamInvitesModal = ({
       setLoading(true);
       setError(null);
 
-      await onCancelInvitation(pendingCancelInvitationId);
+      if (pendingCancelType === "role") {
+        if (onCancelRoleInvitation) {
+          await onCancelRoleInvitation(pendingCancelInvitationId);
+        } else {
+          await teamService.cancelRoleInvitation(pendingCancelInvitationId);
+        }
+      } else {
+        await onCancelInvitation(pendingCancelInvitationId);
+      }
 
-      setSuccess("Invitation canceled successfully!");
+      setSuccess(
+        pendingCancelType === "role"
+          ? "Role invitation canceled successfully!"
+          : "Team invitation canceled successfully!",
+      );
       setPendingCancelInvitationId(null);
+      setPendingCancelType("team");
 
       // Clear success after 3 seconds
       setTimeout(() => setSuccess(null), 3000);
@@ -606,6 +686,13 @@ const TeamInvitesModal = ({
     pendingCancelInvitation?.invitee
       ? getDisplayName(pendingCancelInvitation.invitee)
       : "this user";
+  const pendingCancelIsRole = pendingCancelType === "role";
+  const pendingCancelTitle = pendingCancelIsRole
+    ? "Cancel Role Invitation"
+    : "Cancel Team Invitation";
+  const pendingCancelButtonLabel = pendingCancelIsRole
+    ? "Cancel Role Invitation"
+    : "Cancel Team Invitation";
 
   return (
     <RequestListModal
@@ -627,7 +714,7 @@ const TeamInvitesModal = ({
         <Modal
           isOpen={Boolean(pendingCancelInvitationId)}
           onClose={closeCancelInvitationModal}
-          title="Cancel Invitation"
+          title={pendingCancelTitle}
           position="center"
           size="small"
           bodyClassName="p-4"
@@ -649,14 +736,15 @@ const TeamInvitesModal = ({
                 disabled={loading}
                 icon={<Trash2 size={16} />}
               >
-                {loading ? "Canceling..." : "Cancel Invitation"}
+                {loading ? "Canceling..." : pendingCancelButtonLabel}
               </Button>
             </div>
           }
         >
           <p className="text-sm text-base-content/80">
-            Cancel the invitation for {pendingInviteeName}? They will no longer
-            be able to respond to it.
+            {pendingCancelIsRole
+              ? `Cancel the role invitation for ${pendingInviteeName}?`
+              : `Cancel the team invitation for ${pendingInviteeName}? They will no longer be able to respond to it.`}
           </p>
         </Modal>
       }
@@ -677,9 +765,11 @@ const TeamInvitesModal = ({
           invitation?.roleIsSynthetic ??
           invitation?.is_synthetic ??
           invitation?.isSynthetic;
+        const polledRole = roleId ? hydratedRoleMap[String(roleId)] : null;
         const roleForCard = invitation?.role
           ? {
               ...invitation.role,
+              ...(polledRole ?? {}),
               is_synthetic:
                 invitation.role.is_synthetic ??
                 invitation.role.isSynthetic ??
@@ -695,6 +785,7 @@ const TeamInvitesModal = ({
               role_name: invitation?.role_name ?? invitation?.roleName,
               is_synthetic: syntheticRoleFlag,
               isSynthetic: syntheticRoleFlag,
+              ...(polledRole ?? {}),
             };
         const isSelfInvitation =
           currentUser?.id === (invitation.invitee?.id ?? invitation.invitee_id);
@@ -710,12 +801,18 @@ const TeamInvitesModal = ({
           roleId != null && inviteeId != null
             ? localInviteeRoleMatchMap[String(roleId)]?.[String(inviteeId)] ?? null
             : null;
+        const hasRoleInvitation = roleId != null;
+        const isInternalInvitation = Boolean(
+          invitation?.isInternal ?? invitation?.is_internal ?? false,
+        );
 
         // Normalize types to avoid "1" vs 1 mismatches
         const isHighlighted =
-          highlightUserId != null &&
-          inviteeId != null &&
-          String(inviteeId) === String(highlightUserId);
+          (highlightInvitationId != null &&
+            String(invitation.id) === String(highlightInvitationId)) ||
+          (highlightUserId != null &&
+            inviteeId != null &&
+            String(inviteeId) === String(highlightUserId));
         const showInviteeUsername =
           invitation.invitee?.username &&
           (getDisplayName(invitation.invitee) !== invitation.invitee?.username ||
@@ -728,7 +825,7 @@ const TeamInvitesModal = ({
             ref={isHighlighted ? highlightedRef : null}
             className={`bg-base-200/30 rounded-lg border border-base-300 p-4 transition-all duration-300 ${
               isHighlighted
-                ? "ring-2 ring-primary ring-offset-2 bg-primary/5"
+                ? "ring-2 ring-green-500/70 ring-offset-2 border-green-400 bg-green-50"
                 : ""
             }`}
           >
@@ -890,15 +987,27 @@ const TeamInvitesModal = ({
               )}
 
               {/* Action Button (right) */}
-              <div className="flex justify-end">
-                <Button
-                  variant="errorOutline"
-                  size="sm"
-                  onClick={() => handleCancelInvitation(invitation.id)}
-                  disabled={loading}
-                >
-                  {loading ? "Canceling..." : "Cancel Invitation"}
-                </Button>
+              <div className="flex flex-wrap justify-end gap-2">
+                {hasRoleInvitation && (
+                  <Button
+                    variant="errorOutline"
+                    size="sm"
+                    onClick={() => handleCancelInvitation(invitation.id, "role")}
+                    disabled={loading}
+                  >
+                    {loading ? "Canceling..." : "Cancel Role Invitation"}
+                  </Button>
+                )}
+                {(!hasRoleInvitation || !isInternalInvitation) && (
+                  <Button
+                    variant="errorOutline"
+                    size="sm"
+                    onClick={() => handleCancelInvitation(invitation.id, "team")}
+                    disabled={loading}
+                  >
+                    {loading ? "Canceling..." : "Cancel Team Invitation"}
+                  </Button>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -182,7 +182,7 @@ const VacantRoleCard = ({
   onEdit,
   onDelete,
   onStatusChange,
-  allowedStatusActions = ["filled", "closed", "open"],
+  allowedStatusActions = ["closed", "open"],
   statusActionLoading = false,
   matchScore = null,
   matchDetails = null,
@@ -669,7 +669,8 @@ const VacantRoleCard = ({
   const canMarkFilled =
     canUpdateStatus &&
     status === "open" &&
-    statusActions.includes("filled");
+    statusActions.includes("filled") &&
+    Boolean(viewAsUser);
   const canCloseRole =
     canUpdateStatus &&
     status === "open" &&
@@ -686,6 +687,7 @@ const VacantRoleCard = ({
     canReopenRole;
   const canOpenBadgeMenu = hasBadgeActions && !statusActionLoading;
   const isFilled = status === "filled";
+  const isClosed = status === "closed";
   const filledUser = isFilled
     ? resolveFilledRoleUser(role, { viewAsUserId, viewAsUser })
     : null;
@@ -704,6 +706,12 @@ const VacantRoleCard = ({
         label: "Filled",
         badgeColorClass: "badge-role-filled",
       }
+    : isClosed
+    ? {
+        icon: XCircle,
+        label: "Closed",
+        badgeColorClass: "badge-role-closed",
+      }
     : {
         icon: UserSearch,
         label: "Vacant",
@@ -711,9 +719,13 @@ const VacantRoleCard = ({
       };
   const cardColorClass = isFilled
     ? "bg-green-50 hover:bg-green-100"
+    : isClosed
+    ? "bg-gray-50 hover:bg-gray-100"
     : "bg-amber-50 hover:bg-amber-100/70";
   const initialsAvatarClass = isFilled
     ? "bg-[var(--color-primary-focus)] text-white"
+    : isClosed
+    ? "bg-slate-400 text-white"
     : "bg-amber-500 text-white";
   const isMiniView = viewMode === "mini";
   const avatarSizeClass = isMiniView ? "w-10 h-10" : "w-12 h-12";
@@ -914,9 +926,9 @@ const VacantRoleCard = ({
 
   const resolvedTeam =
     team ??
-    ((role.teamId ?? role.team_id)
+    ((role.teamId ?? role.team_id ?? teamContext?.id)
       ? {
-          id: role.teamId ?? role.team_id,
+          id: role.teamId ?? role.team_id ?? teamContext?.id,
           name:
             role.teamName ??
             role.team_name ??

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -381,6 +381,11 @@ const VacantRoleDetailsModal = ({
       .filter((id) => id != null)
       .map(String),
   );
+  const viewerIsTeamMember = Boolean(
+    isTeamMember ||
+      canManage ||
+      (currentUser?.id != null && currentTeamMemberIds.has(String(currentUser.id))),
+  );
   const teamMemberScoreMap = useMemo(() => {
     const map = {};
 
@@ -397,7 +402,7 @@ const VacantRoleDetailsModal = ({
 
     return map;
   }, [roleTeamMembers]);
-  const canViewTeamMemberMatches = canManage || isTeamMember;
+  const canViewTeamMemberMatches = canManage || viewerIsTeamMember;
   const teamMemberIdsKey = JSON.stringify(
     [
       ...new Set(
@@ -564,7 +569,7 @@ const VacantRoleDetailsModal = ({
             null,
           fallbackTeam,
           fallbackRole,
-          { isInternalRoleApplication: isTeamMember },
+          { isInternalRoleApplication: viewerIsTeamMember },
         )
       : null;
     const seededInvitation = hasActiveInvitationStatus(
@@ -596,7 +601,7 @@ const VacantRoleDetailsModal = ({
             null,
           fallbackTeam,
           fallbackRole,
-          { isInternal: isTeamMember },
+          { isInternal: viewerIsTeamMember },
         )
       : null;
 
@@ -633,7 +638,7 @@ const VacantRoleDetailsModal = ({
               foundApplication,
               fallbackTeam,
               fallbackRole,
-              { isInternalRoleApplication: isTeamMember },
+              { isInternalRoleApplication: viewerIsTeamMember },
             )
           : null;
       }
@@ -656,7 +661,7 @@ const VacantRoleDetailsModal = ({
               foundInvitation,
               fallbackTeam,
               fallbackRole,
-              { isInternal: isTeamMember },
+              { isInternal: viewerIsTeamMember },
             )
           : null;
       }
@@ -682,7 +687,7 @@ const VacantRoleDetailsModal = ({
     displayRole,
     isAuthenticated,
     isOpen,
-    isTeamMember,
+    viewerIsTeamMember,
     role,
     roleId,
     roleNameForStatusMatch,
@@ -1244,6 +1249,29 @@ const VacantRoleDetailsModal = ({
     }
   };
 
+  const handleCancelRoleInvitation = async (invitationId) => {
+    await teamService.cancelRoleInvitation(invitationId);
+    setRoleInvitations((prev) => prev.filter((invitation) => invitation.id !== invitationId));
+
+    try {
+      const refreshed = await teamService.getTeamSentInvitations(teamId);
+      const invitations = refreshed.data || [];
+      const currentRoleId = roleId;
+      setRoleInvitations(
+        invitations.filter((invitation) => {
+          const invitationRoleId =
+            invitation.role?.id ?? invitation.roleId ?? invitation.role_id ?? null;
+          return (
+            invitationRoleId != null &&
+            String(invitationRoleId) === String(currentRoleId)
+          );
+        }),
+      );
+    } catch (e) {
+      console.warn("Could not refresh invitations:", e);
+    }
+  };
+
   const handleViewerApplicationCancel = async (applicationId) => {
     await teamService.cancelApplication(applicationId);
     setViewerRoleApplicationRecord(null);
@@ -1731,7 +1759,7 @@ const VacantRoleDetailsModal = ({
           {modalStatusTitle}
         </h2>
       </div>
-      {!isFilledRole && isTeamMember && (tags.length > 0 || badges.length > 0) && !hideActions && (
+      {!isFilledRole && viewerIsTeamMember && (tags.length > 0 || badges.length > 0) && !hideActions && (
         <div className="flex items-center space-x-2">
           <Button
             variant="ghost"
@@ -2984,7 +3012,7 @@ const VacantRoleDetailsModal = ({
               <>
                 {isAuthenticated &&
                   !viewerRoleStatusLoading &&
-                  !isTeamMember &&
+                  !viewerIsTeamMember &&
                   isRoleOpen && (
                   <div className="mt-6 border-t border-base-200 pt-4">
                     <TeamApplicationButton
@@ -2992,14 +3020,37 @@ const VacantRoleDetailsModal = ({
                       teamId={teamId}
                       roleId={roleId}
                       className="w-full"
-                      buttonLabel="Apply to join Team and to fill this Role"
+                      buttonLabel="Apply to join team and to fill this role"
+                      onSuccess={(applicationData, submitResponse) => {
+                        const submittedApplication = submitResponse?.data ?? {};
+                        setViewerRoleApplicationRecord(
+                          buildRoleStatusRecord(
+                            {
+                              id: submittedApplication.applicationId,
+                              applicationId: submittedApplication.applicationId,
+                              status: submittedApplication.status ?? "pending",
+                              message: applicationData.message,
+                              created_at: new Date().toISOString(),
+                              roleId,
+                              role_id: roleId,
+                              teamId,
+                              team_id: teamId,
+                              isInternalRoleApplication: false,
+                              is_internal_role_application: false,
+                            },
+                            applicationTeam,
+                            displayRole,
+                            { isInternalRoleApplication: false },
+                          ),
+                        );
+                      }}
                     />
                   </div>
                 )}
 
                 {isAuthenticated &&
                   !viewerRoleStatusLoading &&
-                  isTeamMember &&
+                  viewerIsTeamMember &&
                   isRoleOpen &&
                   !applicationsLoading && (
                   <div className="mt-6 border-t border-base-200 pt-4">
@@ -3009,7 +3060,7 @@ const VacantRoleDetailsModal = ({
                       onClick={() => setIsInternalApplicationOpen(true)}
                       icon={<UserSearch size={16} />}
                     >
-                      Apply to fill this Role within your Team
+                      Apply to fill this role within your team
                     </Button>
                   </div>
                 )}
@@ -3054,6 +3105,7 @@ const VacantRoleDetailsModal = ({
         teamId={teamId}
         invitations={roleInvitations}
         onCancelInvitation={handleCancelInvitation}
+        onCancelRoleInvitation={handleCancelRoleInvitation}
         teamName={teamName}
         highlightUserId={highlightInviteeId}
       />
@@ -3078,10 +3130,31 @@ const VacantRoleDetailsModal = ({
       isInternal={true}
       onSubmit={async (applicationData) => {
         try {
-          await teamService.applyToJoinTeam(teamId, {
+          const submitResponse = await teamService.applyToJoinTeam(teamId, {
             ...applicationData,
             roleId: applicationData.roleId ?? roleId,
           });
+          const submittedApplication = submitResponse?.data ?? {};
+          setViewerRoleApplicationRecord(
+            buildRoleStatusRecord(
+              {
+                id: submittedApplication.applicationId,
+                applicationId: submittedApplication.applicationId,
+                status: submittedApplication.status ?? "pending",
+                message: applicationData.message,
+                created_at: new Date().toISOString(),
+                roleId,
+                role_id: roleId,
+                teamId,
+                team_id: teamId,
+                isInternalRoleApplication: true,
+                is_internal_role_application: true,
+              },
+              applicationTeam,
+              displayRole,
+              { isInternalRoleApplication: true },
+            ),
+          );
         } catch (error) {
           throw new Error(
             error.response?.data?.message || "Failed to submit role application"

--- a/src/components/teams/VacantRolesSection.jsx
+++ b/src/components/teams/VacantRolesSection.jsx
@@ -14,16 +14,7 @@ import ConfirmModal from "../common/ConfirmModal";
 import ScreenAlert from "../common/ScreenAlert";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { matchingService } from "../../services/matchingService";
-import { messageService } from "../../services/messageService";
 import { useAuth } from "../../contexts/AuthContext";
-import {
-  buildRoleFilledMessage,
-  buildRoleReopenedMessage,
-  buildRoleReopenedAdminMessage,
-  buildRoleClosedMessage,
-  buildRoleDeletedMessage,
-} from "../../utils/roleEventMessages";
-import { resolveFilledRoleUser } from "../../utils/vacantRoleUtils";
 
 /**
  * VacantRolesSection Component
@@ -166,73 +157,6 @@ const VacantRolesSection = ({
           ? { ...roleBeforeChange, ...updatedRole }
           : roleBeforeChange;
 
-      if (newStatus === "open" && roleBeforeChange) {
-        const prevStatus = roleBeforeChange.status ?? roleBeforeChange.role_status;
-        try {
-          if (prevStatus === "closed") {
-            await messageService.sendMessage(
-              teamId,
-              buildRoleReopenedAdminMessage({
-                teamId,
-                teamName: team?.name,
-                role: roleBeforeChange,
-                reopenedBy: user,
-              }),
-              "team",
-            );
-          } else {
-            await messageService.sendMessage(
-              teamId,
-              buildRoleReopenedMessage({
-                teamId,
-                teamName: team?.name,
-                role: roleBeforeChange,
-                filledUser: resolveFilledRoleUser(roleBeforeChange, {
-                  viewAsUserId: user?.id,
-                  viewAsUser: user,
-                }),
-              }),
-              "team",
-            );
-          }
-        } catch (messageError) {
-          console.warn("Role reopened, but chat event could not be sent:", messageError);
-        }
-      }
-
-      if (newStatus === "filled" && roleBeforeChange) {
-        try {
-          await messageService.sendMessage(
-            teamId,
-            buildRoleFilledMessage({
-              teamId,
-              teamName: team?.name,
-              role: eventRole,
-            }),
-            "team",
-          );
-        } catch (messageError) {
-          console.warn("Role filled, but chat event could not be sent:", messageError);
-        }
-      }
-
-      if (newStatus === "closed" && roleBeforeChange) {
-        try {
-          await messageService.sendMessage(
-            teamId,
-            buildRoleClosedMessage({
-              teamId,
-              teamName: team?.name,
-              role: roleBeforeChange,
-              closedBy: user,
-            }),
-            "team",
-          );
-        } catch (messageError) {
-          console.warn("Role closed, but chat event could not be sent:", messageError);
-        }
-      }
-
       setNotification({
         type: "success",
         message: `Role ${newStatus === "filled" ? "marked as filled" : newStatus === "closed" ? "closed" : "reopened"} successfully`,
@@ -265,20 +189,6 @@ const VacantRolesSection = ({
     try {
       setDeleteRoleLoading(true);
       await vacantRoleService.deleteVacantRole(teamId, pendingDeleteRoleId);
-      try {
-        await messageService.sendMessage(
-          teamId,
-          buildRoleDeletedMessage({
-            teamId,
-            teamName: team?.name,
-            role: roleSnapshot,
-            deletedBy: user,
-          }),
-          "team",
-        );
-      } catch (messageError) {
-        console.warn("Role deleted, but chat event could not be sent:", messageError);
-      }
       setNotification({
         type: "success",
         message: "Vacant role deleted successfully",

--- a/src/hooks/useHydratedRole.js
+++ b/src/hooks/useHydratedRole.js
@@ -32,6 +32,8 @@ const extractRoleMatchData = (roleLike) => {
   };
 };
 
+const ROLE_STATUS_POLL_INTERVAL_MS = 20_000;
+
 export const useHydratedRole = ({ isOpen, roleId, teamId }) => {
   const [hydratedRole, setHydratedRole] = useState(null);
   const [roleMatchScore, setRoleMatchScore] = useState(null);
@@ -47,6 +49,7 @@ export const useHydratedRole = ({ isOpen, roleId, teamId }) => {
 
     let isCancelled = false;
 
+    // Full fetch on open: role details + match scores
     const fetchRole = async () => {
       try {
         const [detailsRes, rolesRes, matchRes] = await Promise.allSettled([
@@ -102,10 +105,24 @@ export const useHydratedRole = ({ isOpen, roleId, teamId }) => {
       }
     };
 
+    // Lightweight poll: only role details, to pick up status changes while modal is open
+    const pollRoleStatus = async () => {
+      try {
+        const res = await vacantRoleService.getVacantRoleById(teamId, roleId);
+        if (isCancelled) return;
+        const roleData = extractRolePayload(res);
+        if (roleData) setHydratedRole(roleData);
+      } catch {
+        // silent — modal keeps showing last known state
+      }
+    };
+
     fetchRole();
+    const intervalId = setInterval(pollRoleStatus, ROLE_STATUS_POLL_INTERVAL_MS);
 
     return () => {
       isCancelled = true;
+      clearInterval(intervalId);
     };
   }, [isOpen, roleId, teamId]);
 

--- a/src/hooks/useMyTeamsSort.js
+++ b/src/hooks/useMyTeamsSort.js
@@ -137,10 +137,10 @@ const useMyTeamsSort = ({ teams = [], onSortChange } = {}) => {
           const [applicationsResponse, invitationsResponse] = await Promise.all(
             [
               teamService
-                .getTeamApplications(team.id, { skipAuthRedirect: true })
+                .getTeamApplications(team.id, { skipAuthRedirect: true, skipErrorLog: true })
                 .catch(() => ({ data: [] })),
               teamService
-                .getTeamSentInvitations(team.id, { skipAuthRedirect: true })
+                .getTeamSentInvitations(team.id, { skipAuthRedirect: true, skipErrorLog: true })
                 .catch(() => ({ data: [] })),
             ],
           );

--- a/src/index.css
+++ b/src/index.css
@@ -619,6 +619,12 @@ body {
   border: none;
 }
 
+.badge-role-closed {
+  background-color: #6b7280;
+  color: white;
+  border: none;
+}
+
 /* Neon Effect */
 .neon {
   color: var(--color-primary);
@@ -710,7 +716,22 @@ body {
 }
 
 .animate-slide-in {
-  animation: slide-in 0.3s ease-out forwards;
+  animation: slide-in 0.38s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes toast-fade-out {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(16px);
+    opacity: 0;
+  }
+}
+
+.animate-toast-fade-out {
+  animation: toast-fade-out 0.7s ease-in forwards;
 }
 
 /* Highlight animation for unread messages - fading green outline */

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -325,6 +325,66 @@ const buildMessageSearchSnippet = (message) => {
 const getMessageSearchId = (message) =>
   message?.id || message?.messageId || message?.message_id || null;
 
+const NOTIFICATION_EVENT_MESSAGE_MARKERS = {
+  application_approved: ["APPLICATION_APPROVED"],
+  application_rejected: ["APPLICATION_DECLINED"],
+  application_cancelled: ["APPLICATION_CANCELLED"],
+  role_application_cancelled: ["APPLICATION_CANCELLED"],
+  invitation_declined: ["INVITATION_DECLINED"],
+  invitation_cancelled: ["INVITATION_CANCELLED"],
+  member_left: ["MEMBER_LEFT", "MEMBER_REMOVED_PUBLIC"],
+  member_removed: ["MEMBER_REMOVED"],
+  ownership_transferred: ["OWNERSHIP_TRANSFERRED"],
+  role_changed: ["ROLE_CHANGED"],
+  role_created: ["ROLE_CREATED"],
+  role_updated: ["ROLE_UPDATED"],
+  role_deleted: ["ROLE_DELETED"],
+  role_closed: ["ROLE_CLOSED"],
+  role_filled: [
+    "ROLE_FILLED",
+    "ROLE_APPLICATION_FILLED",
+    "ROLE_INVITATION_FILLED",
+  ],
+  role_reopened: ["ROLE_REOPENED"],
+  role_reopened_admin: ["ROLE_REOPENED_ADMIN"],
+  team_deleted: ["TEAM_DELETED"],
+};
+
+const getNotificationEventHighlightIds = (messages, eventTarget) => {
+  const type = String(eventTarget?.type || "").toLowerCase();
+  if (!type) return [];
+
+  const markers = NOTIFICATION_EVENT_MESSAGE_MARKERS[type] || [];
+  const referenceId = eventTarget.referenceId
+    ? String(eventTarget.referenceId)
+    : "";
+  const actorId = eventTarget.actorId ? String(eventTarget.actorId) : "";
+  const matchingMessages = (messages || []).filter((message) => {
+    const content = String(message?.content || "");
+    const normalizedContent = content.toUpperCase();
+    const markerMatches =
+      markers.length === 0 ||
+      markers.some((marker) => normalizedContent.includes(marker));
+
+    if (!markerMatches) return false;
+
+    const referenceMatches =
+      !referenceId ||
+      content.includes(`| ${referenceId}:`) ||
+      content.includes(`:${referenceId}:`) ||
+      String(message?.id) === referenceId;
+    const actorMatches =
+      !actorId ||
+      String(message?.senderId ?? message?.sender_id ?? "") === actorId ||
+      content.includes(`${actorId}:`);
+
+    return referenceMatches && actorMatches;
+  });
+
+  const target = matchingMessages[matchingMessages.length - 1];
+  return target?.id ? [target.id] : [];
+};
+
 const buildConversationLastMessagePreview = (message) => {
   if (message?.content) return message.content;
 
@@ -1032,6 +1092,19 @@ const Chat = () => {
 
         const urlParams = new URLSearchParams(window.location.search);
         const type = urlParams.get("type") || "direct";
+        const highlightedMessageId =
+          urlParams.get("highlightMessage") || urlParams.get("messageId");
+        const highlightedEventTarget = {
+          type:
+            urlParams.get("highlightEvent") ||
+            urlParams.get("highlightEventType") ||
+            "",
+          referenceId:
+            urlParams.get("highlightRef") ||
+            urlParams.get("highlightReferenceId") ||
+            "",
+          actorId: urlParams.get("highlightActor") || "",
+        };
 
         let conversationDetails;
         try {
@@ -1205,7 +1278,14 @@ const Chat = () => {
             conversationId,
             type,
           );
-          const searchTarget = pendingChatSearchTargetRef.current;
+          const searchTarget = highlightedMessageId
+            ? {
+                conversationId,
+                type,
+                messageId: highlightedMessageId,
+                query: null,
+              }
+            : pendingChatSearchTargetRef.current;
           const shouldRevealSearchTarget =
             searchTarget?.messageId &&
             String(searchTarget.conversationId) === String(conversationId) &&
@@ -1273,6 +1353,10 @@ const Chat = () => {
 
           // Check if we need to highlight messages from a specific user (from notification)
           const highlightUser = searchParams.get("highlightUser");
+          const eventHighlightIds = getNotificationEventHighlightIds(
+            fetchedMessages,
+            highlightedEventTarget,
+          );
 
           if (
             shouldRevealSearchTarget &&
@@ -1297,6 +1381,15 @@ const Chat = () => {
             setHighlightMessageIds(highlightIds);
             pendingChatSearchTargetRef.current = null;
             // No auto-clear — highlights persist until search query changes
+          } else if (eventHighlightIds.length > 0) {
+            if (shouldRevealSearchTarget) {
+              pendingChatSearchTargetRef.current = null;
+            }
+
+            setHighlightMessageIds(eventHighlightIds);
+            setTimeout(() => {
+              setHighlightMessageIds([]);
+            }, 3500);
           } else if (highlightUser) {
             if (shouldRevealSearchTarget) {
               pendingChatSearchTargetRef.current = null;
@@ -1613,6 +1706,36 @@ const Chat = () => {
       });
     };
 
+    const refreshTeamEventMessages = async (payload) => {
+      const teamId = payload?.teamId ?? payload?.team_id;
+      if (!teamId) return;
+
+      refreshConversationList();
+
+      const urlParams = new URLSearchParams(window.location.search);
+      const currentType = urlParams.get("type") || "direct";
+
+      if (
+        currentType !== "team" ||
+        String(teamId) !== String(conversationId)
+      ) {
+        return;
+      }
+
+      try {
+        const messagesResponse = await messageService.getMessages(
+          teamId,
+          "team",
+        );
+        const fetchedMessages = messagesResponse.data || [];
+        setHasMoreMessages(messagesResponse.hasMore || false);
+        setMessages(dedupeMessages(fetchedMessages));
+        socketService.markMessagesAsRead(teamId, "team");
+      } catch (err) {
+        console.error("Error refreshing team event messages:", err);
+      }
+    };
+
     // Handle typing indicators
     const handleTypingUpdate = async (data) => {
       if (String(data.conversationId) !== String(conversationId)) {
@@ -1911,6 +2034,7 @@ const Chat = () => {
     socket.on("team:member_kicked", handleKickedFromTeam);
     socket.on("message:deleted", handleMessageDeleted);
     socket.on("message:edited", handleMessageEdited);
+    socket.on("notification:new", refreshTeamEventMessages);
 
     // Cleanup function to remove listeners
     return () => {
@@ -1924,6 +2048,7 @@ const Chat = () => {
       socket.off("team:member_kicked", handleKickedFromTeam);
       socket.off("message:deleted", handleMessageDeleted);
       socket.off("message:edited", handleMessageEdited);
+      socket.off("notification:new", refreshTeamEventMessages);
     };
   }, [
     conversationId,

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -7,6 +7,7 @@ import TeamCard from "../components/teams/TeamCard";
 import Section from "../components/layout/Section";
 import Pagination from "../components/common/Pagination";
 import { teamService } from "../services/teamService";
+import socketService from "../services/socketService";
 import { useAuth } from "../contexts/AuthContext";
 import {
   Plus,
@@ -71,6 +72,9 @@ const MyTeams = () => {
   // URL params for highlighting
   const [searchParams, setSearchParams] = useSearchParams();
   const highlightId = searchParams.get("highlight");
+  const highlightApplicationId = searchParams.get("highlightApplication");
+  const highlightApplicantId = searchParams.get("highlightApplicant") || highlightId;
+  const highlightInvitationId = searchParams.get("highlightInvitation");
   const openTeamId = searchParams.get("team");
   const shouldOpenApplications =
     searchParams.get("openApplications") === "true";
@@ -164,6 +168,51 @@ const MyTeams = () => {
     fetchPendingInvitations();
   }, [fetchPendingApplications, fetchPendingInvitations]);
 
+  useEffect(() => {
+    if (!user?.id) return undefined;
+
+    let detachSocketListeners = null;
+
+    const attachSocketListeners = (socket) => {
+      if (!socket) return;
+
+      if (detachSocketListeners) {
+        detachSocketListeners();
+      }
+
+      const handleRequestNotification = (payload = {}) => {
+        const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
+
+        if (!type || type.includes("application")) {
+          fetchPendingApplications();
+        }
+
+        if (!type || type.includes("invitation") || type.includes("invite")) {
+          fetchPendingInvitations();
+        }
+      };
+
+      socket.on("notification:new", handleRequestNotification);
+      socket.on("notification:updated", handleRequestNotification);
+      socket.on("notification:deleted", handleRequestNotification);
+
+      detachSocketListeners = () => {
+        socket.off("notification:new", handleRequestNotification);
+        socket.off("notification:updated", handleRequestNotification);
+        socket.off("notification:deleted", handleRequestNotification);
+      };
+    };
+
+    const unsubscribeSocketReady = socketService.onSocketReady(attachSocketListeners);
+
+    return () => {
+      unsubscribeSocketReady();
+      if (detachSocketListeners) {
+        detachSocketListeners();
+      }
+    };
+  }, [fetchPendingApplications, fetchPendingInvitations, user?.id]);
+
   // Fetch teams when page or limit changes
   useEffect(() => {
     if (user?.id) {
@@ -204,7 +253,7 @@ const MyTeams = () => {
     }
 
     // Clear URL params after 5 seconds (so refresh doesn't keep highlighting)
-    if (highlightId || openTeamId) {
+    if (highlightId || highlightApplicationId || highlightInvitationId || openTeamId) {
       const timer = setTimeout(() => {
         setSearchParams({});
       }, 5000);
@@ -221,7 +270,14 @@ const MyTeams = () => {
         clearTimeout(openApplicationsTimer);
       }
     };
-  }, [highlightId, openTeamId, shouldOpenApplications, setSearchParams]);
+  }, [
+    highlightApplicationId,
+    highlightId,
+    highlightInvitationId,
+    openTeamId,
+    shouldOpenApplications,
+    setSearchParams,
+  ]);
 
   // Handler for page changes
   const handlePageChange = (newPage) => {
@@ -916,9 +972,15 @@ const MyTeams = () => {
                       }
                       highlightApplicantId={
                         team.id === autoOpenApplicationsTeamId
-                          ? highlightId
+                          ? highlightApplicantId
                           : null
                       }
+                      highlightApplicationId={
+                        team.id === autoOpenApplicationsTeamId
+                          ? highlightApplicationId
+                          : null
+                      }
+                      highlightInvitationId={highlightInvitationId}
                       onApplicationsModalClosed={() =>
                         setAutoOpenApplicationsTeamId(null)
                       }
@@ -960,9 +1022,15 @@ const MyTeams = () => {
                       }
                       highlightApplicantId={
                         team.id === autoOpenApplicationsTeamId
-                          ? highlightId
+                          ? highlightApplicantId
                           : null
                       }
+                      highlightApplicationId={
+                        team.id === autoOpenApplicationsTeamId
+                          ? highlightApplicationId
+                          : null
+                      }
+                      highlightInvitationId={highlightInvitationId}
                       onApplicationsModalClosed={() =>
                         setAutoOpenApplicationsTeamId(null)
                       }

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -2329,6 +2329,7 @@ const SearchPage = () => {
                             showBadges: sortBy === "match",
                           }}
                           teamContext={{
+                            id: item.teamId ?? item.team_id,
                             name: item.teamName ?? item.team_name,
                             avatarUrl: item.teamAvatarUrl ?? item.team_avatar_url,
                           }}
@@ -2399,6 +2400,7 @@ const SearchPage = () => {
                             showBadges: sortBy === "match",
                           }}
                           teamContext={{
+                            id: item.teamId ?? item.team_id,
                             name: item.teamName ?? item.team_name,
                             avatarUrl: item.teamAvatarUrl ?? item.team_avatar_url,
                           }}
@@ -2447,6 +2449,7 @@ const SearchPage = () => {
                         showBadges: sortBy === "match",
                       }}
                       teamContext={{
+                        id: role.teamId ?? role.team_id,
                         name: role.teamName ?? role.team_name,
                         avatarUrl: role.teamAvatarUrl ?? role.team_avatar_url,
                       }}
@@ -2476,6 +2479,7 @@ const SearchPage = () => {
                         showBadges: sortBy === "match",
                       }}
                       teamContext={{
+                        id: role.teamId ?? role.team_id,
                         name: role.teamName ?? role.team_name,
                         avatarUrl: role.teamAvatarUrl ?? role.team_avatar_url,
                       }}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -42,8 +42,12 @@ api.interceptors.response.use(
   },
   (error) => {
     if (error.response) {
-      console.error("API Error:", error.response.data);
       const skipAuthRedirect = error.config?.skipAuthRedirect === true;
+      const skipErrorLog = error.config?.skipErrorLog === true;
+
+      if (!skipErrorLog) {
+        console.error("API Error:", error.response.data);
+      }
 
       if (
         !skipAuthRedirect &&

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -543,5 +543,17 @@ export const teamService = {
       throw error;
     }
   },
+
+  cancelRoleInvitation: async (invitationId) => {
+    try {
+      const response = await api.delete(
+        `/api/teams/invitations/${invitationId}/role`,
+      );
+      return response.data;
+    } catch (error) {
+      console.error(`Error canceling role invitation ${invitationId}:`, error);
+      throw error;
+    }
+  },
 };
 export default teamService;

--- a/src/utils/eventPreview.js
+++ b/src/utils/eventPreview.js
@@ -213,12 +213,19 @@ export const getEventPreview = (lastMessage, currentUser = null) => {
         parsedMessage.applicantName,
         currentUser,
       );
+      const approverName = getActorLabel(
+        parsedMessage.approverId,
+        parsedMessage.approverName,
+        currentUser,
+      );
 
       return {
         text: `${possessive(applicantName || "Applicant")} application was approved${teamText(parsedMessage.teamName)}`,
         icon: "UserPlus",
         bannerClass: "event-banner--success",
         color: EVENT_PREVIEW_TEXT_COLORS["event-banner--success"],
+        senderName: approverName || parsedMessage.approverName || null,
+        senderPrefix: "by ",
       };
     }
 
@@ -243,18 +250,21 @@ export const getEventPreview = (lastMessage, currentUser = null) => {
         parsedMessage.applicantName,
         currentUser,
       );
-      const hasKnownApplicant =
-        applicantName && applicantName.trim().toLowerCase() !== "someone";
+      const approverName = getActorLabel(
+        parsedMessage.approverId,
+        parsedMessage.approverName,
+        currentUser,
+      );
 
       return {
-        text: hasKnownApplicant
-          ? applicantName === "You"
-            ? `You applied successfully for ${parsedMessage.roleName} and are now filling that role`
-            : `${applicantName} applied for ${parsedMessage.roleName} and is now filling that role`
-          : `An application for ${parsedMessage.roleName} was approved and the role is now filled`,
+        text: approverName
+          ? `The role ${parsedMessage.roleName} has been filled by ${applicantName || "Someone"}, approved by ${approverName}.`
+          : `The role ${parsedMessage.roleName} has been filled by ${applicantName || "Someone"}.`,
         icon: "UserCheck",
         bannerClass: null,
         color: EVENT_PREVIEW_TEXT_COLORS.role,
+        senderName: approverName || parsedMessage.approverName || null,
+        senderPrefix: "by ",
       };
     }
 
@@ -323,144 +333,91 @@ export const getEventPreview = (lastMessage, currentUser = null) => {
 
     case "role_closed": {
       const roleName = parsedMessage.roleName || "Vacant Role";
-      const closedByLabel = getActorLabel(
-        parsedMessage.closedById,
-        parsedMessage.closedByName,
-        currentUser,
-      );
       return {
-        text: closedByLabel
-          ? closedByLabel === "You"
-            ? `You closed the role: ${roleName}`
-            : `${closedByLabel} closed the role: ${roleName}`
-          : `Role closed: ${roleName}`,
+        text: `Role closed: ${roleName}`,
         icon: "CircleX",
         bannerClass: "event-banner--neutral",
         color: EVENT_PREVIEW_TEXT_COLORS["event-banner--neutral"],
+        senderPrefix: "by ",
       };
     }
 
     case "role_updated": {
       const roleName = parsedMessage.roleName || "Vacant Role";
-      const updatedByLabel = getActorLabel(
-        parsedMessage.updatedById,
-        parsedMessage.updatedByName,
-        currentUser,
-      );
       return {
-        text: updatedByLabel
-          ? updatedByLabel === "You"
-            ? `You updated the role: ${roleName}`
-            : `${updatedByLabel} updated the role: ${roleName}`
-          : `Role updated: ${roleName}`,
+        text: `Role edited: ${roleName}`,
         icon: "Pencil",
         bannerClass: null,
         color: EVENT_PREVIEW_TEXT_COLORS.role,
+        senderPrefix: "by ",
       };
     }
 
     case "role_deleted": {
       const roleName = parsedMessage.roleName || "Vacant Role";
-      if (!parsedMessage.deletorName) {
-        return {
-          text: `Role removed: ${roleName}`,
-          icon: "UserMinus",
-          bannerClass: "event-banner--neutral",
-          color: EVENT_PREVIEW_TEXT_COLORS["event-banner--neutral"],
-        };
-      }
-      const deletorLabel = getActorLabel(
-        parsedMessage.deletorId,
-        parsedMessage.deletorName,
-        currentUser,
-      );
       return {
-        text: deletorLabel === "You"
-          ? `You deleted the role: ${roleName}`
-          : `${deletorLabel || "Someone"} deleted the role: ${roleName}`,
+        text: `Role deleted: ${roleName}`,
         icon: "UserMinus",
         bannerClass: "event-banner--neutral",
         color: EVENT_PREVIEW_TEXT_COLORS["event-banner--neutral"],
+        senderPrefix: "by ",
       };
     }
 
     case "role_created": {
       const roleName = parsedMessage.roleName || "Vacant Role";
-      if (!parsedMessage.creatorName) {
-        return {
-          text: `New role open: ${roleName}`,
-          icon: "UserSearch",
-          bannerClass: null,
-          color: EVENT_PREVIEW_TEXT_COLORS.role,
-        };
-      }
-      const creatorLabel = getActorLabel(
-        parsedMessage.creatorId,
-        parsedMessage.creatorName,
-        currentUser,
-      );
       return {
-        text: creatorLabel === "You"
-          ? `You created the new role: ${roleName}`
-          : `${creatorLabel || "Someone"} created a new role: ${roleName}`,
+        text: `New role ${roleName} created.`,
         icon: "UserSearch",
         bannerClass: null,
         color: EVENT_PREVIEW_TEXT_COLORS.role,
+        senderPrefix: "by ",
       };
     }
 
     case "role_reopened_admin": {
-      const adminLabel = getActorLabel(
-        parsedMessage.userId,
-        parsedMessage.userName,
-        currentUser,
-      );
       return {
-        text: adminLabel === "You"
-          ? `You reopened the role: ${parsedMessage.roleName}`
-          : `${adminLabel || "Someone"} reopened the role: ${parsedMessage.roleName}`,
+        text: `Role reopened: ${parsedMessage.roleName || "Vacant Role"}`,
         icon: "UserSearch",
         bannerClass: null,
         color: EVENT_PREVIEW_TEXT_COLORS.role,
+        senderPrefix: "by ",
       };
     }
 
     case "role_reopened": {
-      const userName = getActorLabel(
-        parsedMessage.userId,
-        parsedMessage.userName,
-        currentUser,
-      );
-
       return {
-        text:
-          userName === "You"
-            ? `${parsedMessage.roleName} is open again`
-            : `A former team member has left the role ${parsedMessage.roleName}`,
+        text: `Role reopened: ${parsedMessage.roleName || "Vacant Role"}`,
         icon: "UserSearch",
         bannerClass: null,
         color: EVENT_PREVIEW_TEXT_COLORS.role,
+        senderPrefix: "by ",
       };
     }
 
     case "role_filled": {
-      const userName = getActorLabel(
+      const filledUserName = getActorLabel(
         parsedMessage.userId,
         parsedMessage.userName,
         currentUser,
       );
-      const hasKnownFilledUser =
-        userName && userName.trim().toLowerCase() !== "someone";
+      const filledByName = getActorLabel(
+        parsedMessage.filledById,
+        parsedMessage.filledByName,
+        currentUser,
+      );
 
       return {
-        text: hasKnownFilledUser
-          ? userName === "You"
-            ? `You filled ${parsedMessage.roleName}`
-            : `${userName} filled ${parsedMessage.roleName}`
-          : `${parsedMessage.roleName} was marked as filled`,
+        text: filledUserName && filledByName
+          ? `The role ${parsedMessage.roleName} has been filled by ${filledUserName}, approved by ${filledByName}.`
+          : filledUserName
+            ? `The role ${parsedMessage.roleName} has been filled by ${filledUserName}.`
+            : `The role ${parsedMessage.roleName} has been marked filled.`,
         icon: "UserCheck",
         bannerClass: null,
         color: EVENT_PREVIEW_TEXT_COLORS.role,
+        senderName: filledByName || parsedMessage.filledByName || null,
+        senderPrefix: "by ",
       };
     }
 

--- a/src/utils/roleEventMessages.js
+++ b/src/utils/roleEventMessages.js
@@ -105,16 +105,23 @@ export const buildRoleFilledMessage = ({
   teamName,
   role,
   filledUser = null,
+  filledBy = null,
 }) => {
   const resolvedFilledUser = filledUser ?? getFilledRoleUser(role);
   const filledUserId = getUserEventId(resolvedFilledUser);
   const filledUserName =
     getUserEventName(resolvedFilledUser) ??
     (filledUser ? null : getFilledRoleUserName(role));
+  const filledById = getUserEventId(filledBy);
+  const filledByName = getUserEventName(filledBy);
   const roleId = role?.id ?? role?.roleId ?? role?.role_id ?? null;
   const roleName = getRoleEventName(role);
 
-  return `✅ ROLE_FILLED: ${formatIdNameToken(teamId, teamName)} | ${formatIdNameToken(roleId, roleName)} | ${formatIdNameToken(filledUserId, filledUserName || "Someone")}`;
+  const baseMessage = `✅ ROLE_FILLED: ${formatIdNameToken(teamId, teamName)} | ${formatIdNameToken(roleId, roleName)} | ${formatIdNameToken(filledUserId, filledUserName || "Someone")}`;
+
+  return filledById != null || filledByName
+    ? `${baseMessage} | ${formatIdNameToken(filledById, filledByName || "Someone")}`
+    : baseMessage;
 };
 
 export const buildRoleInvitationFilledMessage = ({
@@ -154,11 +161,18 @@ export const buildRoleApplicationFilledMessage = ({
   teamName,
   role,
   applicant = null,
+  approver = null,
 }) => {
   const roleId = role?.id ?? role?.roleId ?? role?.role_id ?? null;
   const roleName = getRoleEventName(role);
   const applicantId = getUserEventId(applicant);
   const applicantName = getUserEventName(applicant) ?? "Someone";
+  const approverId = getUserEventId(approver);
+  const approverName = getUserEventName(approver);
 
-  return `✅ ROLE_APPLICATION_FILLED: ${formatIdNameToken(teamId, teamName)} | ${formatIdNameToken(roleId, roleName)} | ${formatIdNameToken(applicantId, applicantName)}`;
+  const baseMessage = `✅ ROLE_APPLICATION_FILLED: ${formatIdNameToken(teamId, teamName)} | ${formatIdNameToken(roleId, roleName)} | ${formatIdNameToken(applicantId, applicantName)}`;
+
+  return approverId != null || approverName
+    ? `${baseMessage} | ${formatIdNameToken(approverId, approverName || "Someone")}`
+    : baseMessage;
 };


### PR DESCRIPTION
Summary
Role-related chat event messages — team chat now surfaces structured, icon-tagged banners for role lifecycle events (created, filled via application or invitation, closed, updated, deleted, reopened). MessageDisplay renders each type with a distinct icon and colour; MessageNotifications resolves the correct icon and preview text for toast notifications; eventPreview.js covers all new event types for the conversation list.
Disabled action buttons for filled / closed roles — "Fill Role & Add to Team", "Accept & Fill Role", and the equivalent buttons on the invitee side are greyed out (ghost border, UserCheck icon, tooltip) whenever the target role is already filled or closed. "Add to Team Only" / "Join Team Only" remains active. Behaviour is consistent across TeamApplicationsModal, TeamInvitesModal, TeamInvitationDetailsModal, and TeamApplicationDetailsModal.
Closed-role card styling — VacantRoleCard gains a closed state: grey background (bg-gray-50), XCircle badge, and a new .badge-role-closed CSS class. The status toggle is locked for closed roles to the team owner only.
Real-time role status polling — all modals that display a VacantRoleCard now poll the role status every 20 s, so the card updates instantly when another user changes a role's status while the modal is open. useHydratedRole covers TeamApplicationDetailsModal and TeamInvitationDetailsModal; inline polling effects cover TeamApplicationsModal and TeamInvitesModal.
Reply mention styling — @mentions in reply previews now match the text style of the surrounding message.
Changes by area
Chat

MessageDisplay.jsx — renders new role event banner types with icons
MessageNotifications.jsx — toast notifications resolve icons and preview text for all role event types; adds fade-out animation
Chat.jsx — wires notification event-highlight IDs to scroll-to-message on click
Navbar.jsx — propagates role event notification markers
utils/roleEventMessages.js — new message builders for ROLE_FILLED, ROLE_CLOSED, ROLE_UPDATED, ROLE_DELETED, ROLE_REOPENED_ADMIN, ROLE_INVITATION_FILLED, ROLE_INVITATION_ACCEPTED
utils/eventPreview.js — preview text and icons for all new event types
Role availability UX

TeamApplicationsModal.jsx — disabled fill buttons + 20 s role status polling
TeamInvitesModal.jsx — 20 s role status polling for VacantRoleCard
TeamInvitationDetailsModal.jsx — disabled accept buttons for filled/closed roles
VacantRoleCard.jsx — closed-role styling; restrict "Mark as Filled" to users with a viewAsUser context; team ID fallback from teamContext
useHydratedRole.js — 20 s lightweight poll alongside the initial full fetch
index.css — .badge-role-closed, toast fade-out keyframes
Supporting

teamService.js — cancelRoleInvitation endpoint
api.js — skipErrorLog option on request config to suppress noisy 403 console errors
useMyTeamsSort.js — pass skipErrorLog: true when fetching team applications/invitations in background sort
SearchPage.jsx — include id in teamContext passed to VacantRoleCard
Various team modals (TeamCard, TeamDetailsModal, TeamInviteModal, VacantRoleDetailsModal, VacantRolesSection, CreateVacantRoleModal, TeamApplicationButton, TeamApplicationModal, MyTeams) — incremental improvements shipped alongside the above
Test plan
 Open the applications modal for a team that has a filled role — "Fill Role & Add to Team" should be greyed out with tooltip; "Add to Team Only" should still be active
 Same for a closed role — tooltip should say "This role is closed"
 Open an invitation from the invitee side for a filled/closed role — "Accept & Fill Role" greyed out, "Join Team Only" active
 Change a role's status (filled → open, open → closed) while the applications or invites modal is open in another tab — card should update within 20 s without a page reload
 Team chat should show role event banners (filled, closed, reopened, etc.) with correct icons and colours
 Clicking a role event notification toast should scroll to the corresponding event message in chat