### PR TITLE
Add role-status and badge toast notifications for applicants/invitees

### DIFF
--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -1,20 +1,28 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
   AlertTriangle,
+  Award,
   CircleX,
   Clock,
+  Compass,
   Crown,
   FileText,
+  Heart,
+  Lightbulb,
   LogOut,
   MessageCircle,
   Pencil,
+  SendHorizontal,
+  Settings,
   Shield,
   User,
   UserCheck,
   UserMinus,
   UserPlus,
   UserSearch,
+  Users,
 } from 'lucide-react';
+import { CATEGORY_COLORS, DEFAULT_COLOR } from '../../constants/badgeConstants';
 import { useLocation, useNavigate } from 'react-router-dom';
 import socketService from '../../services/socketService';
 import { messageService } from '../../services/messageService';
@@ -30,17 +38,53 @@ import {
 
 const EVENT_PREVIEW_ICONS = {
   AlertTriangle,
+  Award,
   CircleX,
+  Compass,
   Crown,
   FileText,
+  Heart,
+  Lightbulb,
   LogOut,
   Pencil,
+  SendHorizontal,
+  Settings,
   Shield,
   User,
   UserCheck,
   UserMinus,
   UserPlus,
   UserSearch,
+  Users,
+};
+
+const BADGE_CATEGORY_ICON = {
+  'Collaboration Skills': 'Users',
+  'Technical Expertise': 'Settings',
+  'Creative Thinking': 'Lightbulb',
+  'Leadership Qualities': 'Compass',
+  'Personal Attributes': 'Heart',
+};
+
+const ROLE_CHANGE_PREVIEW = {
+  role_updated:       { text: (n, u) => `The role "${n}" you ${u === 'applicant' ? 'applied for' : 'were invited to'} has been updated`,  icon: 'Pencil',     color: '#f59e0b' },
+  role_closed:        { text: (n, u) => `The role "${n}" you ${u === 'applicant' ? 'applied for' : 'were invited to'} has been closed`,   icon: 'CircleX',    color: '#6b7280' },
+  role_filled:        { text: (n, u) => `The role "${n}" you ${u === 'applicant' ? 'applied for' : 'were invited to'} has been filled`,   icon: 'UserCheck',  color: '#f59e0b' },
+  role_deleted:       { text: (n, u) => `The role "${n}" you ${u === 'applicant' ? 'applied for' : 'were invited to'} has been deleted`,  icon: 'UserMinus',  color: '#f59e0b' },
+  role_reopened:      { text: (n, u) => `The role "${n}" you ${u === 'applicant' ? 'applied for' : 'were invited to'} is open again`,    icon: 'UserSearch', color: '#f59e0b' },
+  role_reopened_admin:{ text: (n, u) => `The role "${n}" you ${u === 'applicant' ? 'applied for' : 'were invited to'} is open again`,    icon: 'UserSearch', color: '#f59e0b' },
+};
+
+const getRoleStatusChangedPreview = (payload) => {
+  const { roleChangeType, roleName, userType } = payload;
+  const template = ROLE_CHANGE_PREVIEW[roleChangeType];
+  if (!template) return null;
+  return {
+    text: template.text(roleName || 'Vacant Role', userType),
+    icon: template.icon,
+    color: template.color,
+    senderPrefix: null,
+  };
 };
 
 const NOTIFICATION_VISIBLE_MS = 20000;
@@ -435,12 +479,77 @@ const MessageNotifications = () => {
         );
       };
 
+      const handleRoleStatusChanged = (payload) => {
+        const preview = getRoleStatusChangedPreview(payload);
+        if (!preview) return;
+        const id = `role-status-${payload.roleId}-${payload.userType}-${Date.now()}`;
+        setNotifications((prev) => [
+          // Replace any existing toast for the same role + change type so
+          // repeated edits don't stack up.
+          ...prev.filter(
+            (n) =>
+              !(
+                n.roleId === payload.roleId &&
+                n.roleChangeType === payload.roleChangeType &&
+                n.userType === payload.userType
+              ),
+          ),
+          {
+            id,
+            isEvent: true,
+            roleId: payload.roleId,
+            roleChangeType: payload.roleChangeType,
+            userType: payload.userType,
+            eventIcon: preview.icon,
+            eventColor: preview.color,
+            text: preview.text,
+            senderPrefix: 'by ',
+            senderName: payload.actorName || null,
+            navigateTo: payload.userType === 'applicant'
+              ? `/teams/my-teams?openApplication=${payload.applicationId}`
+              : `/teams/my-teams?openInvitation=${payload.invitationId}`,
+            time: new Date(),
+            expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
+            removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
+          },
+        ]);
+      };
+
+      const handleBadgeAwarded = (payload) => {
+        const { badgeName, badgeCategory, awarderName } = payload;
+        if (!badgeName) return;
+        const categoryColor = CATEGORY_COLORS[badgeCategory] || DEFAULT_COLOR;
+        const id = `badge-awarded-${payload.badgeId}-${Date.now()}`;
+        setNotifications((prev) => [
+          ...prev,
+          {
+            id,
+            isEvent: true,
+            headerIconName: 'Award',
+            headerLabel: 'New Badge for you!',
+            eventIcon: BADGE_CATEGORY_ICON[badgeCategory] || 'Award',
+            eventColor: categoryColor,
+            text: `You received the "${badgeName}" badge!`,
+            senderPrefix: 'by ',
+            senderName: awarderName || null,
+            navigateTo: `/profile?scrollTo=badges&highlightBadge=${encodeURIComponent(badgeName)}`,
+            time: new Date(),
+            expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
+            removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
+          },
+        ]);
+      };
+
       socket.on('message:received', handleNewMessage);
       socket.on('message:deleted', handleMessageDeleted);
+      socket.on('role:statusChanged', handleRoleStatusChanged);
+      socket.on('badge:awarded', handleBadgeAwarded);
 
       detachMessageListener = () => {
         socket.off('message:received', handleNewMessage);
         socket.off('message:deleted', handleMessageDeleted);
+        socket.off('role:statusChanged', handleRoleStatusChanged);
+        socket.off('badge:awarded', handleBadgeAwarded);
       };
     };
 
@@ -454,13 +563,15 @@ const MessageNotifications = () => {
     };
   }, [isAuthenticated, user?.id]);
   
-  // Remove notification when clicked and navigate to conversation
+  // Remove notification when clicked and navigate to the appropriate destination
   const handleNotificationClick = (notification) => {
-    setNotifications(prev => 
+    setNotifications(prev =>
       prev.filter(n => n.id !== notification.id)
     );
-    
-    if (notification.conversationId) {
+
+    if (notification.navigateTo) {
+      navigate(notification.navigateTo);
+    } else if (notification.conversationId) {
       navigate(`/chat/${notification.conversationId}?type=${notification.conversationType || 'direct'}`);
     } else {
       navigate('/chat');
@@ -518,7 +629,10 @@ const MessageNotifications = () => {
           getFallbackRoleEventPreview(notification.text) ||
           getEventPreview(notification.text, user);
         const isEvent = Boolean(renderEventPreview);
-        const HeaderIcon = isEvent ? Clock : MessageCircle;
+        const HeaderIcon = notification.headerIconName
+          ? EVENT_PREVIEW_ICONS[notification.headerIconName] || Clock
+          : isEvent ? Clock : MessageCircle;
+        const headerLabel = notification.headerLabel || (isEvent ? 'New Event' : 'New Message');
         const EventIcon = isEvent
           ? EVENT_PREVIEW_ICONS[renderEventPreview.icon] || Clock
           : MessageCircle;
@@ -535,7 +649,7 @@ const MessageNotifications = () => {
           >
             <h4 className="text-xs font-medium text-primary-focus flex items-center gap-1.5 mb-2">
               <HeaderIcon size={12} strokeWidth={2.2} aria-hidden="true" />
-              <span>{isEvent ? "New Event" : "New Message"}</span>
+              <span>{headerLabel}</span>
             </h4>
             {isEvent ? (
               <p

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -75,6 +75,8 @@ const NOTIFICATION_TYPE_META = [
   { keys: ["invitationCancelled", "invitation_cancelled"],           Icon: CircleX,       text: (p, n, tc) => `Your invitation${n !== 1 ? `s (${n})` : ""} cancelled${teamSuffix(tc)}` },
   { keys: ["applicationCancelled", "application_cancelled"],               Icon: CircleX,       text: (p, n, tc) => `${p(n, "team application")} withdrawn${teamSuffix(tc)}` },
   { keys: ["roleApplicationCancelled", "role_application_cancelled"],      Icon: CircleX,       text: (p, n, tc) => `${p(n, "role application")} withdrawn${teamSuffix(tc)}` },
+  { keys: ["roleStatusChangedApplicant", "role_status_changed_applicant"], Icon: Pencil,        text: (p, n)     => `${p(n, "role")} you applied for changed` },
+  { keys: ["roleStatusChangedInvitee",   "role_status_changed_invitee"],   Icon: Pencil,        text: (p, n)     => `${p(n, "role")} you were invited to changed` },
 ];
 
 const buildNotificationTooltip = (count, types, teamCounts) => {

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -50,6 +50,7 @@ const TeamApplicationDetailsModal = ({
   onClose,
   onCancel,
   onSendReminder,
+  notificationHighlight = false,
 }) => {
   // ============ State ============
   const loading = false;
@@ -432,6 +433,7 @@ const TeamApplicationDetailsModal = ({
               matchDetails={roleMatchDetails}
               canManage={false}
               isTeamMember={false}
+              notificationHighlight={notificationHighlight}
             />
           </div>
         )}

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -55,6 +55,7 @@ const TeamInvitationDetailsModal = ({
   onClose,
   onAccept,
   onDecline,
+  notificationHighlight = false,
 }) => {
   // ============ State ============
   const [loading] = useState(false);
@@ -517,6 +518,7 @@ const TeamInvitationDetailsModal = ({
                 canManage={false}
                 isTeamMember={false}
                 hideActions={true}
+                notificationHighlight={notificationHighlight}
               />
             </div>
           </div>

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -194,6 +194,7 @@ const VacantRoleCard = ({
   teamContext = null,
   activeFilters = { showLocation: true, showTags: true, showBadges: true },
   showSearchResultTypeOverlay = false,
+  notificationHighlight = false,
 }) => {
   const [showMenu, setShowMenu] = useState(false);
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
@@ -1237,7 +1238,7 @@ const VacantRoleCard = ({
         onClick={handleCardClick}
         className={`flex items-start rounded-xl shadow gap-4 transition-all duration-200 hover:shadow-md cursor-pointer ${wrapperPaddingClass} ${cardColorClass} ${
           status !== "open" ? "opacity-70" : ""
-        }`}
+        } ${notificationHighlight ? "role-card-highlight" : ""}`}
       >
         <div className="flex-shrink-0">
           {isFilled && filledUser ? (

--- a/src/index.css
+++ b/src/index.css
@@ -760,6 +760,24 @@ body {
   animation: messageHighlightFadeSent 3s ease-out forwards;
 }
 
+/* Role card highlight: only fades the box-shadow so the card's own background colour is preserved */
+.role-card-highlight {
+  animation: role-card-highlight-fade 3s ease-out forwards;
+  position: relative;
+}
+
+@keyframes role-card-highlight-fade {
+  0% {
+    box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.6), 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  }
+  50% {
+    box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.3), 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  }
+  100% {
+    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  }
+}
+
 @keyframes messageHighlightFadeSent {
   0% {
     box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.6);

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -22,6 +22,8 @@ import {
   Users,
 } from "lucide-react";
 import CreateTeamModal from "../components/teams/CreateTeamModal";
+import TeamApplicationDetailsModal from "../components/teams/TeamApplicationDetailsModal";
+import TeamInvitationDetailsModal from "../components/teams/TeamInvitationDetailsModal";
 import { enrichTeamMatchData } from "../utils/teamMatchUtils";
 import useClientPagination from "../hooks/useClientPagination";
 import useMyTeamsSort from "../hooks/useMyTeamsSort";
@@ -78,6 +80,13 @@ const MyTeams = () => {
   const openTeamId = searchParams.get("team");
   const shouldOpenApplications =
     searchParams.get("openApplications") === "true";
+  // Notification click-through: auto-open the specific application/invitation modal
+  const openApplicationIdParam = searchParams.get("openApplication");
+  const openInvitationIdParam = searchParams.get("openInvitation");
+
+  // State for notification-triggered detail modals
+  const [notifApplicationModal, setNotifApplicationModal] = useState(null); // the application object
+  const [notifInvitationModal, setNotifInvitationModal] = useState(null); // the invitation object
 
   // Ref for scrolling to highlighted invitation
   const highlightedInvitationRef = useRef(null);
@@ -278,6 +287,40 @@ const MyTeams = () => {
     shouldOpenApplications,
     setSearchParams,
   ]);
+
+  // Auto-open application/invitation modal when navigated via notification
+  useEffect(() => {
+    if (openApplicationIdParam && !loadingApplications) {
+      const found = pendingApplications.find(
+        (a) => String(a.id) === openApplicationIdParam,
+      );
+      if (found) {
+        setNotifApplicationModal(found);
+        // Clear the param so a refresh doesn't re-open
+        setSearchParams((prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("openApplication");
+          return next;
+        });
+      }
+    }
+  }, [openApplicationIdParam, pendingApplications, loadingApplications, setSearchParams]);
+
+  useEffect(() => {
+    if (openInvitationIdParam && !loadingInvitations) {
+      const found = pendingInvitations.find(
+        (i) => String(i.id) === openInvitationIdParam,
+      );
+      if (found) {
+        setNotifInvitationModal(found);
+        setSearchParams((prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("openInvitation");
+          return next;
+        });
+      }
+    }
+  }, [openInvitationIdParam, pendingInvitations, loadingInvitations, setSearchParams]);
 
   // Handler for page changes
   const handlePageChange = (newPage) => {
@@ -1065,6 +1108,38 @@ const MyTeams = () => {
         onTeamCreated={handleTeamCreated}
       />
 
+      {/* Notification click-through: application details modal */}
+      {notifApplicationModal && (
+        <TeamApplicationDetailsModal
+          isOpen={true}
+          application={notifApplicationModal}
+          onClose={() => setNotifApplicationModal(null)}
+          onCancel={async (applicationId) => {
+            await handleApplicationCancel(applicationId);
+            setNotifApplicationModal(null);
+          }}
+          onSendReminder={handleSendReminder}
+          notificationHighlight={true}
+        />
+      )}
+
+      {/* Notification click-through: invitation details modal */}
+      {notifInvitationModal && (
+        <TeamInvitationDetailsModal
+          isOpen={true}
+          invitation={notifInvitationModal}
+          onClose={() => setNotifInvitationModal(null)}
+          onAccept={async (invitationId, responseMessage, fillRole) => {
+            await handleInvitationAccept(invitationId, responseMessage, fillRole);
+            setNotifInvitationModal(null);
+          }}
+          onDecline={async (invitationId, responseMessage) => {
+            await handleInvitationDecline(invitationId, responseMessage);
+            setNotifInvitationModal(null);
+          }}
+          notificationHighlight={true}
+        />
+      )}
 
     </PageContainer>
   );


### PR DESCRIPTION
## Summary

Adds real-time role status and badge award notifications for applicants and invitees, including toast UI, navbar notification support, and click-through flows into the relevant frontend views.

## What Changed

- Added socket-driven toast notifications for role status changes such as updated, closed, filled, deleted, and reopened roles.
- Added badge award toasts with an award header, category-specific icon/color, and awarder name.
- Added notification click-through behavior so role status toasts open the matching application or invitation details modal from My Teams.
- Added role card highlight styling when a notification opens an application/invitation modal.
- Added navbar notification tooltip support for `role_status_changed_applicant` and `role_status_changed_invitee`.
- Preserved role card background styling while the temporary highlight animation fades out.

## Testing

Not run; PR description prepared from the branch diff only.