### PR TITLE
Refactor/optimization

### DIFF
--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -412,6 +412,7 @@ const MessageNotifications = () => {
     search: location.search,
   });
   const { isAuthenticated, user } = useAuth();
+  const prevIsAuthenticatedRef = useRef(false);
 
   useEffect(() => {
     locationRef.current = {
@@ -419,13 +420,19 @@ const MessageNotifications = () => {
       search: location.search,
     };
   }, [location.pathname, location.search]);
-  
+
   useEffect(() => {
-    // Clear the session flag on logout so the next login can show the toast.
     if (!isAuthenticated) {
-      sessionStorage.removeItem('lomir:initial_unread_checked');
+      // Only clear the flag when transitioning from authenticated → not (i.e. logout),
+      // not on the initial mount where isAuthenticated starts false while auth resolves.
+      if (prevIsAuthenticatedRef.current) {
+        sessionStorage.removeItem('lomir:initial_unread_checked');
+      }
+      prevIsAuthenticatedRef.current = false;
       return;
     }
+
+    prevIsAuthenticatedRef.current = true;
 
     // Only show once per tab session (persists across page refreshes, cleared on logout).
     if (sessionStorage.getItem('lomir:initial_unread_checked')) return;

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -74,14 +74,14 @@ const BADGE_CATEGORY_ICON = {
 };
 
 const NOTIFICATION_TOAST_TYPES = {
-  invitation_received:  { icon: 'Mail',         label: 'Team Invitation',      color: '#3b82f6' },
-  role_invitation:      { icon: 'Mail',         label: 'Role Invitation',      color: '#3b82f6' },
-  invitation_accepted:  { icon: 'UserCheck',    label: 'Invitation Accepted',  color: '#16a34a' },
-  invitation_declined:  { icon: 'UserX',        label: 'Invitation Declined',  color: '#f97316' },
-  invitation_cancelled: { icon: 'CircleX',      label: 'Invitation Cancelled', color: '#6b7280' },
-  application_received: { icon: 'UserPlus',     label: 'New Application',      color: '#3b82f6' },
+  invitation_received:  { icon: 'Mail',         label: 'Team Invitation',      color: '#ec4899', senderPrefix: 'Invited by ' },
+  role_invitation:      { icon: 'Mail',         label: 'Role Invitation',      color: '#ec4899', senderPrefix: 'Invited by ' },
+  invitation_accepted:  { icon: 'UserCheck',    label: 'Invitation Accepted',  color: '#16a34a', senderColor: '#15803d', senderPrefix: 'Accepted by ' },
+  invitation_declined:  { icon: 'UserX',        label: 'Invitation Declined',  color: '#6b7280', senderPrefix: 'Declined by ' },
+  invitation_cancelled: { icon: 'CircleX',      label: 'Invitation Cancelled', color: '#6b7280', senderPrefix: 'Cancelled by ' },
+  application_received: { icon: 'Mail',         label: 'New Application',      color: '#ec4899', senderPrefix: 'Applied by ' },
   application_approved: { icon: 'CheckCircle',  label: 'Application Approved', color: '#16a34a', senderColor: '#15803d', senderPrefix: 'Approved by ' },
-  application_rejected: { icon: 'CircleX',      label: 'Application Declined', color: '#f97316' },
+  application_rejected: { icon: 'CircleX',      label: 'Application Declined', color: '#6b7280', senderPrefix: 'Declined by ' },
   member_removed:       { icon: 'UserMinus',    label: 'Removed from Team',    senderPrefix: 'Removed by ' },
 };
 
@@ -474,7 +474,10 @@ const MessageNotifications = () => {
       const eventContent = pickEventContent(message);
 
       // These system messages are shown via notification:new toast instead.
-      if (/APPLICATION_APPROVED:|MEMBER_REMOVED|INVITATION_DECLINED|INVITATION_CANCELLED/i.test(eventContent)) return;
+      if (/APPLICATION_APPROVED:|APPLICATION_DECLINED:|MEMBER_REMOVED|INVITATION_DECLINED|INVITATION_CANCELLED/i.test(eventContent)) return;
+
+      // Team join messages (👋/🎯) are visible in the team chat and covered by notification:new for the inviter.
+      if ((message.team_id || message.teamId) && /^[\u{1F44B}\u{1F3AF}]/u.test(eventContent.trim())) return;
 
       const eventPreview =
         getRoleEventTypePreview(message) ||
@@ -573,13 +576,21 @@ const MessageNotifications = () => {
     if (!payload?.title) return;
     const config = NOTIFICATION_TOAST_TYPES[payload.type];
     if (!config) return;
+    const isRoleInvite = (['invitation_received', 'invitation_cancelled', 'invitation_declined'].includes(payload.type) && !!payload.roleName)
+      || (payload.type === 'invitation_accepted' && !!payload.filledRoleName);
     setNotifications((prev) => [
       ...prev,
       {
         id: `notif-${payload.type}-${Date.now()}`,
         isEvent: true,
         headerIconName: config.icon,
-        headerLabel: config.label,
+        secondaryHeaderIconName: isRoleInvite ? 'UserSearch' : null,
+        headerLabel: isRoleInvite
+          ? payload.type === 'invitation_cancelled' ? 'Team & Role Invite Cancelled'
+            : payload.type === 'invitation_accepted' ? 'Team & Role Invite Accepted'
+            : payload.type === 'invitation_declined' ? 'Team & Role Invite Declined'
+            : 'Team & Role Invitation'
+          : config.label,
         eventIcon: config.icon,
         eventColor: config.color || null,
         text: payload.title,
@@ -683,6 +694,9 @@ const MessageNotifications = () => {
         const HeaderIcon = notification.headerIconName
           ? EVENT_PREVIEW_ICONS[notification.headerIconName] || Clock
           : isEvent ? Clock : MessageCircle;
+        const SecondaryHeaderIcon = notification.secondaryHeaderIconName
+          ? EVENT_PREVIEW_ICONS[notification.secondaryHeaderIconName] || null
+          : null;
         const headerLabel = notification.headerLabel || (isEvent ? 'New Event' : 'New Message');
         const EventIcon = isEvent
           ? EVENT_PREVIEW_ICONS[renderEventPreview.icon] || Clock
@@ -700,6 +714,7 @@ const MessageNotifications = () => {
           >
             <h4 className="text-xs font-medium text-primary-focus flex items-center gap-1.5 mb-2">
               <HeaderIcon size={12} strokeWidth={2.2} aria-hidden="true" />
+              {SecondaryHeaderIcon && <SecondaryHeaderIcon size={12} strokeWidth={2.2} aria-hidden="true" />}
               <span>{headerLabel}</span>
             </h4>
             {isEvent ? (

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
   AlertTriangle,
   Award,
+  CheckCircle,
   CircleX,
   Clock,
   Compass,
@@ -10,6 +11,7 @@ import {
   Heart,
   Lightbulb,
   LogOut,
+  Mail,
   MessageCircle,
   Pencil,
   SendHorizontal,
@@ -21,6 +23,7 @@ import {
   UserPlus,
   UserSearch,
   Users,
+  UserX,
 } from 'lucide-react';
 import { CATEGORY_COLORS, DEFAULT_COLOR } from '../../constants/badgeConstants';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -39,13 +42,16 @@ import {
 const EVENT_PREVIEW_ICONS = {
   AlertTriangle,
   Award,
+  CheckCircle,
   CircleX,
+  Clock,
   Compass,
   Crown,
   FileText,
   Heart,
   Lightbulb,
   LogOut,
+  Mail,
   Pencil,
   SendHorizontal,
   Settings,
@@ -56,6 +62,7 @@ const EVENT_PREVIEW_ICONS = {
   UserPlus,
   UserSearch,
   Users,
+  UserX,
 };
 
 const BADGE_CATEGORY_ICON = {
@@ -64,6 +71,17 @@ const BADGE_CATEGORY_ICON = {
   'Creative Thinking': 'Lightbulb',
   'Leadership Qualities': 'Compass',
   'Personal Attributes': 'Heart',
+};
+
+const NOTIFICATION_TOAST_TYPES = {
+  invitation_received:  { icon: 'Mail',         label: 'Team Invitation' },
+  role_invitation:      { icon: 'Mail',         label: 'Role Invitation' },
+  invitation_accepted:  { icon: 'UserCheck',    label: 'Invitation Accepted' },
+  invitation_declined:  { icon: 'UserX',        label: 'Invitation Declined' },
+  invitation_cancelled: { icon: 'CircleX',      label: 'Invitation Cancelled' },
+  application_received: { icon: 'UserPlus',     label: 'New Application' },
+  application_approved: { icon: 'CheckCircle',  label: 'Application Approved' },
+  application_rejected: { icon: 'CircleX',      label: 'Application Declined' },
 };
 
 const ROLE_CHANGE_PREVIEW = {
@@ -532,6 +550,27 @@ const MessageNotifications = () => {
     ]);
   }, []);
 
+  const handleNotificationNew = useCallback((payload) => {
+    if (!payload?.title) return;
+    const config = NOTIFICATION_TOAST_TYPES[payload.type];
+    if (!config) return;
+    setNotifications((prev) => [
+      ...prev,
+      {
+        id: `notif-${payload.type}-${Date.now()}`,
+        isEvent: true,
+        headerIconName: config.icon,
+        headerLabel: config.label,
+        eventIcon: config.icon,
+        text: payload.title,
+        navigateTo: '/teams/my-teams',
+        time: new Date(),
+        expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
+        removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
+      },
+    ]);
+  }, []);
+
   useSocketEvents(
     isAuthenticated
       ? {
@@ -539,6 +578,7 @@ const MessageNotifications = () => {
           'message:deleted': handleMessageDeleted,
           'role:statusChanged': handleRoleStatusChanged,
           'badge:awarded': handleBadgeAwarded,
+          'notification:new': handleNotificationNew,
         }
       : null,
     [
@@ -547,6 +587,7 @@ const MessageNotifications = () => {
       handleMessageDeleted,
       handleRoleStatusChanged,
       handleBadgeAwarded,
+      handleNotificationNew,
     ],
   );
   

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
   AlertTriangle,
   Award,
@@ -24,9 +24,9 @@ import {
 } from 'lucide-react';
 import { CATEGORY_COLORS, DEFAULT_COLOR } from '../../constants/badgeConstants';
 import { useLocation, useNavigate } from 'react-router-dom';
-import socketService from '../../services/socketService';
 import { messageService } from '../../services/messageService';
 import { useAuth } from '../../contexts/AuthContext';
+import useSocketEvents from '../../hooks/useSocketEvents';
 import { getEventPreview } from '../../utils/eventPreview';
 import {
   getMessageSenderDisplayName,
@@ -404,15 +404,15 @@ const MessageNotifications = () => {
   
   useEffect(() => {
     if (!isAuthenticated) return;
-    
+
     // Fetch initial unread count
     const fetchUnreadCount = async () => {
       try {
         const response = await messageService.getUnreadCount();
         const count = response.data?.count ?? response.count ?? 0;
         if (count > 0) {
-          setNotifications([{ 
-            id: 'initial', 
+          setNotifications([{
+            id: 'initial',
             text: `You have ${count} unread messages`,
             expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
             removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
@@ -422,146 +422,133 @@ const MessageNotifications = () => {
         console.error('Error fetching unread count:', error);
       }
     };
-    
+
     fetchUnreadCount();
-    
-    let detachMessageListener = null;
+  }, [isAuthenticated]);
 
-    const attachMessageListener = (socket) => {
-      if (!socket) return;
+  const handleNewMessage = useCallback((message) => {
+    if (isOwnMessage(message, user?.id)) return;
 
-      if (detachMessageListener) {
-        detachMessageListener();
-      }
+    const isInConversation = isMessageForCurrentChatPath(
+      message,
+      locationRef.current.pathname,
+      locationRef.current.search,
+      user?.id,
+    );
 
-      const handleNewMessage = (message) => {
-        if (isOwnMessage(message, user?.id)) return;
-
-        const isInConversation = isMessageForCurrentChatPath(
-          message,
-          locationRef.current.pathname,
-          locationRef.current.search,
-          user?.id,
-        );
-        
-        if (!isInConversation) {
-          const target = getMessageConversationTarget(message, user?.id);
-          const eventContent = pickEventContent(message);
-          const eventPreview =
-            getRoleEventTypePreview(message) ||
-            getEventPreview(eventContent, user) ||
-            getFallbackRoleEventPreview(eventContent);
-          setNotifications(prev => [
-            ...prev, 
-            {
-              id: message.id || `${target.type}-${target.conversationId}-${Date.now()}`,
-              conversationId: target.conversationId,
-              conversationType: target.type,
-              senderId: message.senderId || message.sender_id,
-              senderName: eventPreview?.senderName || getNotificationSenderName(message),
-              senderPrefix: eventPreview?.senderPrefix ?? null,
-              text: eventPreview?.text || getMessagePreviewText(message),
-              isEvent: Boolean(eventPreview),
-              eventIcon: eventPreview?.icon || null,
-              eventColor: eventPreview?.color || null,
-              eventBackgroundColor: eventPreview?.backgroundColor || null,
-              time: new Date(),
-              expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
-              removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
-            }
-          ]);
+    if (!isInConversation) {
+      const target = getMessageConversationTarget(message, user?.id);
+      const eventContent = pickEventContent(message);
+      const eventPreview =
+        getRoleEventTypePreview(message) ||
+        getEventPreview(eventContent, user) ||
+        getFallbackRoleEventPreview(eventContent);
+      setNotifications(prev => [
+        ...prev,
+        {
+          id: message.id || `${target.type}-${target.conversationId}-${Date.now()}`,
+          conversationId: target.conversationId,
+          conversationType: target.type,
+          senderId: message.senderId || message.sender_id,
+          senderName: eventPreview?.senderName || getNotificationSenderName(message),
+          senderPrefix: eventPreview?.senderPrefix ?? null,
+          text: eventPreview?.text || getMessagePreviewText(message),
+          isEvent: Boolean(eventPreview),
+          eventIcon: eventPreview?.icon || null,
+          eventColor: eventPreview?.color || null,
+          eventBackgroundColor: eventPreview?.backgroundColor || null,
+          time: new Date(),
+          expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
+          removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
         }
-      };
-      
-      const handleMessageDeleted = (payload) => {
-        setNotifications((prev) =>
-          prev.filter((n) => String(n.id) !== String(payload.messageId)),
-        );
-      };
+      ]);
+    }
+  }, [user]);
 
-      const handleRoleStatusChanged = (payload) => {
-        const preview = getRoleStatusChangedPreview(payload);
-        if (!preview) return;
-        const id = `role-status-${payload.roleId}-${payload.userType}-${Date.now()}`;
-        setNotifications((prev) => [
-          // Replace any existing toast for the same role + change type so
-          // repeated edits don't stack up.
-          ...prev.filter(
-            (n) =>
-              !(
-                n.roleId === payload.roleId &&
-                n.roleChangeType === payload.roleChangeType &&
-                n.userType === payload.userType
-              ),
+  const handleMessageDeleted = useCallback((payload) => {
+    setNotifications((prev) =>
+      prev.filter((n) => String(n.id) !== String(payload.messageId)),
+    );
+  }, []);
+
+  const handleRoleStatusChanged = useCallback((payload) => {
+    const preview = getRoleStatusChangedPreview(payload);
+    if (!preview) return;
+    const id = `role-status-${payload.roleId}-${payload.userType}-${Date.now()}`;
+    setNotifications((prev) => [
+      // Replace any existing toast for the same role + change type so
+      // repeated edits don't stack up.
+      ...prev.filter(
+        (n) =>
+          !(
+            n.roleId === payload.roleId &&
+            n.roleChangeType === payload.roleChangeType &&
+            n.userType === payload.userType
           ),
-          {
-            id,
-            isEvent: true,
-            roleId: payload.roleId,
-            roleChangeType: payload.roleChangeType,
-            userType: payload.userType,
-            eventIcon: preview.icon,
-            eventColor: preview.color,
-            text: preview.text,
-            senderPrefix: 'by ',
-            senderName: payload.actorName || null,
-            navigateTo: payload.userType === 'applicant'
-              ? `/teams/my-teams?openApplication=${payload.applicationId}`
-              : `/teams/my-teams?openInvitation=${payload.invitationId}`,
-            time: new Date(),
-            expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
-            removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
-          },
-        ]);
-      };
+      ),
+      {
+        id,
+        isEvent: true,
+        roleId: payload.roleId,
+        roleChangeType: payload.roleChangeType,
+        userType: payload.userType,
+        eventIcon: preview.icon,
+        eventColor: preview.color,
+        text: preview.text,
+        senderPrefix: 'by ',
+        senderName: payload.actorName || null,
+        navigateTo: payload.userType === 'applicant'
+          ? `/teams/my-teams?openApplication=${payload.applicationId}`
+          : `/teams/my-teams?openInvitation=${payload.invitationId}`,
+        time: new Date(),
+        expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
+        removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
+      },
+    ]);
+  }, []);
 
-      const handleBadgeAwarded = (payload) => {
-        const { badgeName, badgeCategory, awarderName } = payload;
-        if (!badgeName) return;
-        const categoryColor = CATEGORY_COLORS[badgeCategory] || DEFAULT_COLOR;
-        const id = `badge-awarded-${payload.badgeId}-${Date.now()}`;
-        setNotifications((prev) => [
-          ...prev,
-          {
-            id,
-            isEvent: true,
-            headerIconName: 'Award',
-            headerLabel: 'New Badge for you!',
-            eventIcon: BADGE_CATEGORY_ICON[badgeCategory] || 'Award',
-            eventColor: categoryColor,
-            text: `You received the "${badgeName}" badge!`,
-            senderPrefix: 'by ',
-            senderName: awarderName || null,
-            navigateTo: `/profile?scrollTo=badges&highlightBadge=${encodeURIComponent(badgeName)}`,
-            time: new Date(),
-            expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
-            removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
-          },
-        ]);
-      };
+  const handleBadgeAwarded = useCallback((payload) => {
+    const { badgeName, badgeCategory, awarderName } = payload;
+    if (!badgeName) return;
+    const categoryColor = CATEGORY_COLORS[badgeCategory] || DEFAULT_COLOR;
+    const id = `badge-awarded-${payload.badgeId}-${Date.now()}`;
+    setNotifications((prev) => [
+      ...prev,
+      {
+        id,
+        isEvent: true,
+        headerIconName: 'Award',
+        headerLabel: 'New Badge for you!',
+        eventIcon: BADGE_CATEGORY_ICON[badgeCategory] || 'Award',
+        eventColor: categoryColor,
+        text: `You received the "${badgeName}" badge!`,
+        senderPrefix: 'by ',
+        senderName: awarderName || null,
+        navigateTo: `/profile?scrollTo=badges&highlightBadge=${encodeURIComponent(badgeName)}`,
+        time: new Date(),
+        expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
+        removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
+      },
+    ]);
+  }, []);
 
-      socket.on('message:received', handleNewMessage);
-      socket.on('message:deleted', handleMessageDeleted);
-      socket.on('role:statusChanged', handleRoleStatusChanged);
-      socket.on('badge:awarded', handleBadgeAwarded);
-
-      detachMessageListener = () => {
-        socket.off('message:received', handleNewMessage);
-        socket.off('message:deleted', handleMessageDeleted);
-        socket.off('role:statusChanged', handleRoleStatusChanged);
-        socket.off('badge:awarded', handleBadgeAwarded);
-      };
-    };
-
-    const unsubscribeSocketReady = socketService.onSocketReady(attachMessageListener);
-    
-    return () => {
-      unsubscribeSocketReady();
-      if (detachMessageListener) {
-        detachMessageListener();
-      }
-    };
-  }, [isAuthenticated, user?.id]);
+  useSocketEvents(
+    isAuthenticated
+      ? {
+          'message:received': handleNewMessage,
+          'message:deleted': handleMessageDeleted,
+          'role:statusChanged': handleRoleStatusChanged,
+          'badge:awarded': handleBadgeAwarded,
+        }
+      : null,
+    [
+      isAuthenticated,
+      handleNewMessage,
+      handleMessageDeleted,
+      handleRoleStatusChanged,
+      handleBadgeAwarded,
+    ],
+  );
   
   // Remove notification when clicked and navigate to the appropriate destination
   const handleNotificationClick = (notification) => {

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -74,14 +74,14 @@ const BADGE_CATEGORY_ICON = {
 };
 
 const NOTIFICATION_TOAST_TYPES = {
-  invitation_received:  { icon: 'Mail',         label: 'Team Invitation' },
-  role_invitation:      { icon: 'Mail',         label: 'Role Invitation' },
-  invitation_accepted:  { icon: 'UserCheck',    label: 'Invitation Accepted' },
-  invitation_declined:  { icon: 'UserX',        label: 'Invitation Declined' },
-  invitation_cancelled: { icon: 'CircleX',      label: 'Invitation Cancelled' },
-  application_received: { icon: 'UserPlus',     label: 'New Application' },
+  invitation_received:  { icon: 'Mail',         label: 'Team Invitation',      color: '#3b82f6' },
+  role_invitation:      { icon: 'Mail',         label: 'Role Invitation',      color: '#3b82f6' },
+  invitation_accepted:  { icon: 'UserCheck',    label: 'Invitation Accepted',  color: '#16a34a' },
+  invitation_declined:  { icon: 'UserX',        label: 'Invitation Declined',  color: '#f97316' },
+  invitation_cancelled: { icon: 'CircleX',      label: 'Invitation Cancelled', color: '#6b7280' },
+  application_received: { icon: 'UserPlus',     label: 'New Application',      color: '#3b82f6' },
   application_approved: { icon: 'CheckCircle',  label: 'Application Approved', color: '#16a34a', senderColor: '#15803d', senderPrefix: 'Approved by ' },
-  application_rejected: { icon: 'CircleX',      label: 'Application Declined' },
+  application_rejected: { icon: 'CircleX',      label: 'Application Declined', color: '#f97316' },
   member_removed:       { icon: 'UserMinus',    label: 'Removed from Team',    senderPrefix: 'Removed by ' },
 };
 
@@ -474,7 +474,7 @@ const MessageNotifications = () => {
       const eventContent = pickEventContent(message);
 
       // These system messages are shown via notification:new toast instead.
-      if (/APPLICATION_APPROVED:|MEMBER_REMOVED/i.test(eventContent)) return;
+      if (/APPLICATION_APPROVED:|MEMBER_REMOVED|INVITATION_DECLINED|INVITATION_CANCELLED/i.test(eventContent)) return;
 
       const eventPreview =
         getRoleEventTypePreview(message) ||

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -82,6 +82,7 @@ const NOTIFICATION_TOAST_TYPES = {
   application_received: { icon: 'UserPlus',     label: 'New Application' },
   application_approved: { icon: 'CheckCircle',  label: 'Application Approved', color: '#16a34a', senderColor: '#15803d', senderPrefix: 'Approved by ' },
   application_rejected: { icon: 'CircleX',      label: 'Application Declined' },
+  member_removed:       { icon: 'UserMinus',    label: 'Removed from Team',    senderPrefix: 'Removed by ' },
 };
 
 const ROLE_CHANGE_PREVIEW = {
@@ -472,8 +473,8 @@ const MessageNotifications = () => {
       const target = getMessageConversationTarget(message, user?.id);
       const eventContent = pickEventContent(message);
 
-      // APPLICATION_APPROVED system messages are shown via notification:new toast instead.
-      if (/APPLICATION_APPROVED:/i.test(eventContent)) return;
+      // These system messages are shown via notification:new toast instead.
+      if (/APPLICATION_APPROVED:|MEMBER_REMOVED/i.test(eventContent)) return;
 
       const eventPreview =
         getRoleEventTypePreview(message) ||

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -421,9 +421,16 @@ const MessageNotifications = () => {
   }, [location.pathname, location.search]);
   
   useEffect(() => {
-    if (!isAuthenticated) return;
+    // Clear the session flag on logout so the next login can show the toast.
+    if (!isAuthenticated) {
+      sessionStorage.removeItem('lomir:initial_unread_checked');
+      return;
+    }
 
-    // Fetch initial unread count
+    // Only show once per tab session (persists across page refreshes, cleared on logout).
+    if (sessionStorage.getItem('lomir:initial_unread_checked')) return;
+    sessionStorage.setItem('lomir:initial_unread_checked', '1');
+
     const fetchUnreadCount = async () => {
       try {
         const response = await messageService.getUnreadCount();

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -80,7 +80,7 @@ const NOTIFICATION_TOAST_TYPES = {
   invitation_declined:  { icon: 'UserX',        label: 'Invitation Declined' },
   invitation_cancelled: { icon: 'CircleX',      label: 'Invitation Cancelled' },
   application_received: { icon: 'UserPlus',     label: 'New Application' },
-  application_approved: { icon: 'CheckCircle',  label: 'Application Approved' },
+  application_approved: { icon: 'CheckCircle',  label: 'Application Approved', color: '#16a34a', senderColor: '#15803d', senderPrefix: 'Approved by ' },
   application_rejected: { icon: 'CircleX',      label: 'Application Declined' },
 };
 
@@ -471,6 +471,10 @@ const MessageNotifications = () => {
     if (!isInConversation) {
       const target = getMessageConversationTarget(message, user?.id);
       const eventContent = pickEventContent(message);
+
+      // APPLICATION_APPROVED system messages are shown via notification:new toast instead.
+      if (/APPLICATION_APPROVED:/i.test(eventContent)) return;
+
       const eventPreview =
         getRoleEventTypePreview(message) ||
         getEventPreview(eventContent, user) ||
@@ -576,7 +580,11 @@ const MessageNotifications = () => {
         headerIconName: config.icon,
         headerLabel: config.label,
         eventIcon: config.icon,
+        eventColor: config.color || null,
         text: payload.title,
+        senderName: payload.actorName || null,
+        senderPrefix: config.senderPrefix || null,
+        senderColor: config.senderColor || null,
         navigateTo: '/teams/my-teams',
         time: new Date(),
         expiresAt: Date.now() + NOTIFICATION_VISIBLE_MS,
@@ -719,7 +727,10 @@ const MessageNotifications = () => {
               <p className="text-sm">{renderTextWithMentions(notification.text)}</p>
             )}
             {isEvent && notification.senderName && (
-              <p className="text-[11px] mt-0.5 text-primary-focus truncate">
+              <p
+                className="text-[11px] mt-0.5 text-primary-focus truncate"
+                style={notification.senderColor ? { color: notification.senderColor } : undefined}
+              >
                 {notification.senderPrefix ?? "by "}{notification.senderName}
               </p>
             )}

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -25,7 +25,7 @@ import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { getUserInitials, isSyntheticUser } from "../../utils/userHelpers";
 import { messageService } from "../../services/messageService";
 import { notificationService } from "../../services/notificationService";
-import socketService from "../../services/socketService";
+import useSocketEvents from "../../hooks/useSocketEvents";
 import NotificationBadge from "../common/NotificationBadge";
 import {
   getMessageConversationTarget,
@@ -189,7 +189,7 @@ const Navbar = () => {
     locationSearchRef.current = location.search;
   }, [location.pathname, location.search]);
 
-  // Initial fetch and socket setup for messages
+  // Initial fetch for messages
   useEffect(() => {
     if (!isAuthenticated) {
       setUnreadMessageCount(0);
@@ -201,62 +201,36 @@ const Navbar = () => {
 
     lastMessageFetchRef.current = Date.now();
     fetchUnreadMessageCount();
-
-    let detachSocketListeners = null;
-
-    const attachSocketListeners = (socket) => {
-      if (!socket) return;
-
-      if (detachSocketListeners) {
-        detachSocketListeners();
-      }
-
-      const handleNewMessage = (message) => {
-        if (isOwnMessage(message, user?.id)) return;
-
-        const isInThisConversation = isMessageForCurrentChatPath(
-          message,
-          locationPathRef.current,
-          locationSearchRef.current,
-          user?.id,
-        );
-
-        if (!isInThisConversation) {
-          setUnreadMessageCount((prev) => prev + 1);
-          setFirstUnreadMessage(getMessageConversationTarget(message, user?.id));
-        }
-      };
-
-      const handleMessagesRead = () => {
-        fetchUnreadMessageCount();
-      };
-
-      const handleMessageDeleted = () => {
-        fetchUnreadMessageCount();
-      };
-
-      socket.on("message:received", handleNewMessage);
-      socket.on("messages:read", handleMessagesRead);
-      socket.on("message:deleted", handleMessageDeleted);
-
-      detachSocketListeners = () => {
-        socket.off("message:received", handleNewMessage);
-        socket.off("messages:read", handleMessagesRead);
-        socket.off("message:deleted", handleMessageDeleted);
-      };
-    };
-
-    const unsubscribeSocketReady = socketService.onSocketReady(attachSocketListeners);
-
-    return () => {
-      unsubscribeSocketReady();
-      if (detachSocketListeners) {
-        detachSocketListeners();
-      }
-    };
   }, [isAuthenticated, fetchUnreadMessageCount, user?.id]);
 
-  // Initial fetch and socket setup for notifications
+  const handleNewMessage = useCallback((message) => {
+    if (isOwnMessage(message, user?.id)) return;
+
+    const isInThisConversation = isMessageForCurrentChatPath(
+      message,
+      locationPathRef.current,
+      locationSearchRef.current,
+      user?.id,
+    );
+
+    if (!isInThisConversation) {
+      setUnreadMessageCount((prev) => prev + 1);
+      setFirstUnreadMessage(getMessageConversationTarget(message, user?.id));
+    }
+  }, [user?.id]);
+
+  useSocketEvents(
+    isAuthenticated
+      ? {
+          "message:received": handleNewMessage,
+          "messages:read": fetchUnreadMessageCount,
+          "message:deleted": fetchUnreadMessageCount,
+        }
+      : null,
+    [isAuthenticated, handleNewMessage, fetchUnreadMessageCount],
+  );
+
+  // Initial fetch for notifications
   useEffect(() => {
     if (!isAuthenticated) {
       setUnreadNotificationCount(0);
@@ -268,43 +242,25 @@ const Navbar = () => {
 
     lastNotificationFetchRef.current = Date.now();
     fetchUnreadNotificationCount();
+  }, [isAuthenticated, fetchUnreadNotificationCount]);
 
-    let detachNotificationListener = null;
-
-    const attachNotificationListener = (socket) => {
-      if (!socket) return;
-
-      if (detachNotificationListener) {
-        detachNotificationListener();
-      }
-
-      const handleNewNotification = () => {
-        // Team events often create both a bell notification and a system chat
-        // message, so refresh both badge sources.
-        fetchUnreadNotificationCount();
-        fetchUnreadMessageCount();
-      };
-
-      socket.on("notification:new", handleNewNotification);
-      socket.on("notification:updated", handleNewNotification);
-      socket.on("notification:deleted", handleNewNotification);
-
-      detachNotificationListener = () => {
-        socket.off("notification:new", handleNewNotification);
-        socket.off("notification:updated", handleNewNotification);
-        socket.off("notification:deleted", handleNewNotification);
-      };
-    };
-
-    const unsubscribeSocketReady = socketService.onSocketReady(attachNotificationListener);
-
-    return () => {
-      unsubscribeSocketReady();
-      if (detachNotificationListener) {
-        detachNotificationListener();
-      }
-    };
+  const handleNewNotification = useCallback(() => {
+    // Team events often create both a bell notification and a system chat
+    // message, so refresh both badge sources.
+    fetchUnreadNotificationCount();
+    fetchUnreadMessageCount();
   }, [isAuthenticated, fetchUnreadMessageCount, fetchUnreadNotificationCount]);
+
+  useSocketEvents(
+    isAuthenticated
+      ? {
+          "notification:new": handleNewNotification,
+          "notification:updated": handleNewNotification,
+          "notification:deleted": handleNewNotification,
+        }
+      : null,
+    [isAuthenticated, handleNewNotification],
+  );
 
   // Refetch message count when path changes
   useEffect(() => {

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -249,7 +249,7 @@ const Navbar = () => {
     // message, so refresh both badge sources.
     fetchUnreadNotificationCount();
     fetchUnreadMessageCount();
-  }, [isAuthenticated, fetchUnreadMessageCount, fetchUnreadNotificationCount]);
+  }, [fetchUnreadMessageCount, fetchUnreadNotificationCount]);
 
   useSocketEvents(
     isAuthenticated

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -461,9 +461,9 @@ const Navbar = () => {
                 className="btn btn-circle avatar bg-primary text-white btn-sm sm:btn-md"
               >
                 <div className="rounded-full flex items-center justify-center text-sm sm:text-base relative overflow-hidden w-full h-full">
-                  {(user.avatarUrl || user.avatar_url) && !imageError ? (
+                  {user.avatarUrl && !imageError ? (
                     <img
-                      src={user.avatarUrl || user.avatar_url}
+                      src={user.avatarUrl}
                       alt="Profile"
                       className="rounded-full object-cover w-full h-full"
                       onError={() => setImageError(true)}

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -30,7 +30,7 @@ import TeamInvitationDetailsModal from "./TeamInvitationDetailsModal";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { userService } from "../../services/userService";
-import socketService from "../../services/socketService";
+import useSocketEvents from "../../hooks/useSocketEvents";
 import { useAuth } from "../../contexts/AuthContext";
 import Alert from "../common/Alert";
 import ConfirmModal from "../common/ConfirmModal";
@@ -824,72 +824,48 @@ const TeamCard = ({
     fetchSentInvitations();
   }, [fetchSentInvitations]);
 
-  useEffect(() => {
-    if (effectiveVariant !== "member" || !teamData?.id || !canManageInvitations) {
-      return undefined;
+  const handleTeamRequestEvent = useCallback((payload = {}) => {
+    const payloadTeamId = payload.teamId ?? payload.team_id ?? null;
+    if (payloadTeamId != null && String(payloadTeamId) !== String(teamData.id)) {
+      return;
     }
 
-    let detachSocketListeners = null;
+    const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
+    const shouldRefreshApplications =
+      !type ||
+      type.includes("application") ||
+      type === "member_joined" ||
+      type === "role_filled";
+    const shouldRefreshInvitations =
+      !type ||
+      type.includes("invitation") ||
+      type.includes("invite");
 
-    const attachSocketListeners = (socket) => {
-      if (!socket) return;
+    if (shouldRefreshApplications) {
+      fetchPendingApplications();
+    }
 
-      if (detachSocketListeners) {
-        detachSocketListeners();
-      }
+    if (shouldRefreshInvitations) {
+      fetchSentInvitations();
+    }
+  }, [fetchPendingApplications, fetchSentInvitations, teamData?.id]);
 
-      const handleTeamRequestEvent = (payload = {}) => {
-        const payloadTeamId = payload.teamId ?? payload.team_id ?? null;
-        if (payloadTeamId != null && String(payloadTeamId) !== String(teamData.id)) {
-          return;
+  useSocketEvents(
+    effectiveVariant === "member" && teamData?.id && canManageInvitations
+      ? {
+          "notification:new": handleTeamRequestEvent,
+          "notification:updated": handleTeamRequestEvent,
+          "notification:deleted": handleTeamRequestEvent,
         }
-
-        const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
-        const shouldRefreshApplications =
-          !type ||
-          type.includes("application") ||
-          type === "member_joined" ||
-          type === "role_filled";
-        const shouldRefreshInvitations =
-          !type ||
-          type.includes("invitation") ||
-          type.includes("invite");
-
-        if (shouldRefreshApplications) {
-          fetchPendingApplications();
-        }
-
-        if (shouldRefreshInvitations) {
-          fetchSentInvitations();
-        }
-      };
-
-      socket.on("notification:new", handleTeamRequestEvent);
-      socket.on("notification:updated", handleTeamRequestEvent);
-      socket.on("notification:deleted", handleTeamRequestEvent);
-
-      detachSocketListeners = () => {
-        socket.off("notification:new", handleTeamRequestEvent);
-        socket.off("notification:updated", handleTeamRequestEvent);
-        socket.off("notification:deleted", handleTeamRequestEvent);
-      };
-    };
-
-    const unsubscribeSocketReady = socketService.onSocketReady(attachSocketListeners);
-
-    return () => {
-      unsubscribeSocketReady();
-      if (detachSocketListeners) {
-        detachSocketListeners();
-      }
-    };
-  }, [
-    canManageInvitations,
-    effectiveVariant,
-    fetchPendingApplications,
-    fetchSentInvitations,
-    teamData?.id,
-  ]);
+      : null,
+    [
+      canManageInvitations,
+      effectiveVariant,
+      fetchPendingApplications,
+      fetchSentInvitations,
+      teamData?.id,
+    ],
+  );
 
   useEffect(() => {
     const fetchCompleteTeamData = async () => {

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -21,7 +21,7 @@ import TeamApplicationsModal from "../teams/TeamApplicationsModal";
 import { getUserInitials } from "../../utils/userHelpers";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
-import socketService from "../../services/socketService";
+import useSocketEvents from "../../hooks/useSocketEvents";
 
 const normalizeId = (value) => {
   if (value === null || value === undefined || value === "") return null;
@@ -851,58 +851,36 @@ const TeamInviteModal = ({
     selectedTeamInvitations,
   ]);
 
-  useEffect(() => {
-    if (!isOpen || !selectedTeamForModal?.id) return undefined;
+  const handleTeamRequestEvent = useCallback((payload = {}) => {
+    const payloadTeamId = payload.teamId ?? payload.team_id ?? null;
+    if (
+      payloadTeamId != null &&
+      String(payloadTeamId) !== String(selectedTeamForModal.id)
+    ) {
+      return;
+    }
 
-    let detachSocketListeners = null;
+    const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
+    if (
+      !type ||
+      type.includes("invitation") ||
+      type.includes("invite") ||
+      type.includes("application")
+    ) {
+      refreshSelectedTeamRequests();
+    }
+  }, [refreshSelectedTeamRequests, selectedTeamForModal?.id]);
 
-    const attachSocketListeners = (socket) => {
-      if (!socket) return;
-
-      if (detachSocketListeners) {
-        detachSocketListeners();
-      }
-
-      const handleTeamRequestEvent = (payload = {}) => {
-        const payloadTeamId = payload.teamId ?? payload.team_id ?? null;
-        if (
-          payloadTeamId != null &&
-          String(payloadTeamId) !== String(selectedTeamForModal.id)
-        ) {
-          return;
+  useSocketEvents(
+    isOpen && selectedTeamForModal?.id
+      ? {
+          "notification:new": handleTeamRequestEvent,
+          "notification:updated": handleTeamRequestEvent,
+          "notification:deleted": handleTeamRequestEvent,
         }
-
-        const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
-        if (
-          !type ||
-          type.includes("invitation") ||
-          type.includes("invite") ||
-          type.includes("application")
-        ) {
-          refreshSelectedTeamRequests();
-        }
-      };
-
-      socket.on("notification:new", handleTeamRequestEvent);
-      socket.on("notification:updated", handleTeamRequestEvent);
-      socket.on("notification:deleted", handleTeamRequestEvent);
-
-      detachSocketListeners = () => {
-        socket.off("notification:new", handleTeamRequestEvent);
-        socket.off("notification:updated", handleTeamRequestEvent);
-        socket.off("notification:deleted", handleTeamRequestEvent);
-      };
-    };
-
-    const unsubscribeSocketReady = socketService.onSocketReady(attachSocketListeners);
-
-    return () => {
-      unsubscribeSocketReady();
-      if (detachSocketListeners) {
-        detachSocketListeners();
-      }
-    };
-  }, [isOpen, refreshSelectedTeamRequests, selectedTeamForModal?.id]);
+      : null,
+    [isOpen, refreshSelectedTeamRequests, selectedTeamForModal?.id],
+  );
 
   // Handle cancel invitation (called from TeamInvitesModal)
   const handleCancelInvitation = async (invitationId) => {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -6,16 +6,23 @@ import { setUserTimezone } from "../utils/dateHelpers";
 const AuthContext = createContext(null);
 
 const normalizeHiddenBadgeIds = (source = {}) => {
-  if (Array.isArray(source.hidden_badge_ids)) return source.hidden_badge_ids;
   if (Array.isArray(source.hiddenBadgeIds)) return source.hiddenBadgeIds;
   return [];
 };
 
 const normalizeHiddenAwardIds = (source = {}) => {
-  if (Array.isArray(source.hidden_award_ids)) return source.hidden_award_ids;
   if (Array.isArray(source.hiddenAwardIds)) return source.hiddenAwardIds;
   return [];
 };
+
+const normalizeAuthUser = (userData, { defaultIsPublic = false } = {}) => ({
+  ...userData,
+  isPublic:
+    userData?.isPublic !== undefined ? userData.isPublic : defaultIsPublic,
+  hideBadges: userData?.hideBadges !== undefined ? userData.hideBadges : false,
+  hiddenBadgeIds: normalizeHiddenBadgeIds(userData),
+  hiddenAwardIds: normalizeHiddenAwardIds(userData),
+});
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
@@ -34,53 +41,10 @@ export const AuthProvider = ({ children }) => {
             },
           });
 
-          // Ensure we have both snake_case and camelCase versions of properties
           const userData = response.data.data.user;
-          const enhancedUserData = {
-            ...userData,
-            // Add camelCase versions if missing
-            firstName: userData.first_name || userData.firstName,
-            lastName: userData.last_name || userData.lastName,
-            postalCode: userData.postal_code || userData.postalCode,
-            avatarUrl: userData.avatar_url || userData.avatarUrl,
-            isPublic:
-              userData.is_public !== undefined
-                ? userData.is_public
-                : userData.isPublic !== undefined
-                  ? userData.isPublic
-                  : true,
-            hideBadges:
-              userData.hide_badges !== undefined
-                ? userData.hide_badges
-                : userData.hideBadges !== undefined
-                  ? userData.hideBadges
-                  : false,
-            hiddenBadgeIds:
-              normalizeHiddenBadgeIds(userData),
-            hiddenAwardIds:
-              normalizeHiddenAwardIds(userData),
-            // Add snake_case versions if missing
-            first_name: userData.first_name || userData.firstName,
-            last_name: userData.last_name || userData.lastName,
-            postal_code: userData.postal_code || userData.postalCode,
-            avatar_url: userData.avatar_url || userData.avatarUrl,
-            is_public:
-              userData.is_public !== undefined
-                ? userData.is_public
-                : userData.isPublic !== undefined
-                ? userData.isPublic
-                : true,
-            hide_badges:
-              userData.hide_badges !== undefined
-                ? userData.hide_badges
-                : userData.hideBadges !== undefined
-                  ? userData.hideBadges
-                  : false,
-            hidden_badge_ids:
-              normalizeHiddenBadgeIds(userData),
-            hidden_award_ids:
-              normalizeHiddenAwardIds(userData),
-          };
+          const enhancedUserData = normalizeAuthUser(userData, {
+            defaultIsPublic: true,
+          });
           setUser(enhancedUserData);
           setUserTimezone(enhancedUserData);
           setError(null);
@@ -133,49 +97,7 @@ export const AuthProvider = ({ children }) => {
       // If no verification required (shouldn't happen with new flow, but just in case)
       const { token, user } = response.data.data;
 
-      const enhancedUser = {
-        ...user,
-        firstName: user.first_name || user.firstName,
-        lastName: user.last_name || user.lastName,
-        postalCode: user.postal_code || user.postalCode,
-        avatarUrl: user.avatar_url || user.avatarUrl,
-        isPublic:
-          user.is_public !== undefined
-            ? user.is_public
-            : user.isPublic !== undefined
-              ? user.isPublic
-              : false,
-        hideBadges:
-          user.hide_badges !== undefined
-            ? user.hide_badges
-            : user.hideBadges !== undefined
-              ? user.hideBadges
-              : false,
-        hiddenBadgeIds:
-          normalizeHiddenBadgeIds(user),
-        hiddenAwardIds:
-          normalizeHiddenAwardIds(user),
-        first_name: user.first_name || user.firstName,
-        last_name: user.last_name || user.lastName,
-        postal_code: user.postal_code || user.postalCode,
-        avatar_url: user.avatar_url || user.avatarUrl,
-        is_public:
-          user.is_public !== undefined
-            ? user.is_public
-            : user.isPublic !== undefined
-              ? user.isPublic
-              : false,
-        hide_badges:
-          user.hide_badges !== undefined
-            ? user.hide_badges
-            : user.hideBadges !== undefined
-              ? user.hideBadges
-              : false,
-        hidden_badge_ids:
-          normalizeHiddenBadgeIds(user),
-        hidden_award_ids:
-          normalizeHiddenAwardIds(user),
-      };
+      const enhancedUser = normalizeAuthUser(user);
 
       localStorage.setItem("token", token);
       setToken(token);
@@ -214,52 +136,7 @@ export const AuthProvider = ({ children }) => {
       const response = await api.post("/api/auth/login", credentials);
       const { token, user } = response.data.data;
 
-      // Enhance user data with both snake_case and camelCase
-      const enhancedUser = {
-        ...user,
-        // Add camelCase versions
-        firstName: user.first_name || user.firstName,
-        lastName: user.last_name || user.lastName,
-        postalCode: user.postal_code || user.postalCode,
-        avatarUrl: user.avatar_url || user.avatarUrl,
-        isPublic:
-          user.is_public !== undefined
-            ? user.is_public
-            : user.isPublic !== undefined
-              ? user.isPublic
-              : false,
-        hideBadges:
-          user.hide_badges !== undefined
-            ? user.hide_badges
-            : user.hideBadges !== undefined
-              ? user.hideBadges
-              : false,
-        hiddenBadgeIds:
-          normalizeHiddenBadgeIds(user),
-        hiddenAwardIds:
-          normalizeHiddenAwardIds(user),
-        // Add snake_case versions
-        first_name: user.first_name || user.firstName,
-        last_name: user.last_name || user.lastName,
-        postal_code: user.postal_code || user.postalCode,
-        avatar_url: user.avatar_url || user.avatarUrl,
-        is_public:
-          user.is_public !== undefined
-            ? user.is_public
-            : user.isPublic !== undefined
-              ? user.isPublic
-              : false,
-        hide_badges:
-          user.hide_badges !== undefined
-            ? user.hide_badges
-            : user.hideBadges !== undefined
-              ? user.hideBadges
-              : false,
-        hidden_badge_ids:
-          normalizeHiddenBadgeIds(user),
-        hidden_award_ids:
-          normalizeHiddenAwardIds(user),
-      };
+      const enhancedUser = normalizeAuthUser(user);
 
       localStorage.setItem("token", token);
       setToken(token);
@@ -293,116 +170,12 @@ export const AuthProvider = ({ children }) => {
 
   // Update user data
   const updateUser = (userData) => {
-    // Create a new object that preserves existing properties and adds new ones
     setUser((prevUser) => {
-      if (!prevUser) return userData;
+      const definedUpdates = Object.fromEntries(
+        Object.entries(userData || {}).filter(([, value]) => value !== undefined),
+      );
+      const newUser = normalizeAuthUser({ ...(prevUser || {}), ...definedUpdates });
 
-      // Start with a copy of the previous user data
-      const newUser = { ...prevUser };
-
-      // Add all new properties
-      Object.keys(userData).forEach((key) => {
-        if (userData[key] !== undefined) {
-          newUser[key] = userData[key];
-        }
-      });
-
-      // Specifically handle visibility properties to ensure both versions exist
-      if (userData.is_public !== undefined) {
-        newUser.is_public = userData.is_public;
-        newUser.isPublic = userData.is_public;
-      } else if (userData.isPublic !== undefined) {
-        newUser.isPublic = userData.isPublic;
-        newUser.is_public = userData.isPublic;
-      }
-
-      if (userData.hide_badges !== undefined) {
-        newUser.hide_badges = userData.hide_badges;
-        newUser.hideBadges = userData.hide_badges;
-      } else if (userData.hideBadges !== undefined) {
-        newUser.hideBadges = userData.hideBadges;
-        newUser.hide_badges = userData.hideBadges;
-      }
-
-      if (userData.hidden_badge_ids !== undefined) {
-        newUser.hidden_badge_ids = Array.isArray(userData.hidden_badge_ids)
-          ? userData.hidden_badge_ids
-          : [];
-        newUser.hiddenBadgeIds = Array.isArray(userData.hidden_badge_ids)
-          ? userData.hidden_badge_ids
-          : [];
-      } else if (userData.hiddenBadgeIds !== undefined) {
-        newUser.hiddenBadgeIds = Array.isArray(userData.hiddenBadgeIds)
-          ? userData.hiddenBadgeIds
-          : [];
-        newUser.hidden_badge_ids = Array.isArray(userData.hiddenBadgeIds)
-          ? userData.hiddenBadgeIds
-          : [];
-      }
-
-      if (userData.hidden_award_ids !== undefined) {
-        newUser.hidden_award_ids = Array.isArray(userData.hidden_award_ids)
-          ? userData.hidden_award_ids
-          : [];
-        newUser.hiddenAwardIds = Array.isArray(userData.hidden_award_ids)
-          ? userData.hidden_award_ids
-          : [];
-      } else if (userData.hiddenAwardIds !== undefined) {
-        newUser.hiddenAwardIds = Array.isArray(userData.hiddenAwardIds)
-          ? userData.hiddenAwardIds
-          : [];
-        newUser.hidden_award_ids = Array.isArray(userData.hiddenAwardIds)
-          ? userData.hiddenAwardIds
-          : [];
-      }
-
-      if (userData.is_synthetic !== undefined) {
-        newUser.is_synthetic = userData.is_synthetic;
-        newUser.isSynthetic = userData.is_synthetic;
-      } else if (userData.isSynthetic !== undefined) {
-        newUser.isSynthetic = userData.isSynthetic;
-        newUser.is_synthetic = userData.isSynthetic;
-      }
-
-      // Ensure we don't override with undefined values
-      if (newUser.is_public === undefined && newUser.isPublic === undefined) {
-        // Keep the existing values if both are undefined
-        newUser.is_public = prevUser.is_public;
-        newUser.isPublic = prevUser.isPublic;
-      }
-
-      // Handle other property pairs to ensure both snake_case and camelCase exist
-      if (userData.first_name !== undefined) {
-        newUser.first_name = userData.first_name;
-        newUser.firstName = userData.first_name;
-      } else if (userData.firstName !== undefined) {
-        newUser.firstName = userData.firstName;
-        newUser.first_name = userData.firstName;
-      }
-
-      if (userData.last_name !== undefined) {
-        newUser.last_name = userData.last_name;
-        newUser.lastName = userData.last_name;
-      } else if (userData.lastName !== undefined) {
-        newUser.lastName = userData.lastName;
-        newUser.last_name = userData.lastName;
-      }
-
-      if (userData.postal_code !== undefined) {
-        newUser.postal_code = userData.postal_code;
-        newUser.postalCode = userData.postal_code;
-      } else if (userData.postalCode !== undefined) {
-        newUser.postalCode = userData.postalCode;
-        newUser.postal_code = userData.postalCode;
-      }
-
-      if (userData.avatar_url !== undefined) {
-        newUser.avatar_url = userData.avatar_url;
-        newUser.avatarUrl = userData.avatar_url;
-      } else if (userData.avatarUrl !== undefined) {
-        newUser.avatarUrl = userData.avatarUrl;
-        newUser.avatar_url = userData.avatarUrl;
-      }
       setUserTimezone(newUser);
       return newUser;
     });

--- a/src/hooks/useSocketEvents.js
+++ b/src/hooks/useSocketEvents.js
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import socketService from "../services/socketService";
+
+const useSocketEvents = (eventHandlers, deps = []) => {
+  useEffect(() => {
+    const isSetupFunction = typeof eventHandlers === "function";
+    const entries = Object.entries(eventHandlers || {}).filter(
+      ([, handler]) => typeof handler === "function",
+    );
+
+    if (!isSetupFunction && entries.length === 0) return undefined;
+
+    let detachListeners = null;
+
+    const attachListeners = (socket) => {
+      if (!socket) return;
+
+      if (detachListeners) {
+        detachListeners();
+      }
+
+      if (isSetupFunction) {
+        const cleanup = eventHandlers(socket);
+        detachListeners = typeof cleanup === "function" ? cleanup : null;
+        return;
+      }
+
+      entries.forEach(([eventName, handler]) => {
+        socket.on(eventName, handler);
+      });
+
+      detachListeners = () => {
+        entries.forEach(([eventName, handler]) => {
+          socket.off(eventName, handler);
+        });
+        detachListeners = null;
+      };
+    };
+
+    const unsubscribeSocketReady = socketService.onSocketReady(attachListeners);
+
+    return () => {
+      unsubscribeSocketReady();
+      if (detachListeners) {
+        detachListeners();
+      }
+    };
+  }, deps);
+};
+
+export default useSocketEvents;

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -17,6 +17,7 @@ import MessageInput from "../components/chat/MessageInput";
 import { useAuth } from "../contexts/AuthContext";
 import { messageService } from "../services/messageService";
 import socketService from "../services/socketService";
+import useSocketEvents from "../hooks/useSocketEvents";
 import { userService } from "../services/userService";
 import { teamService } from "../services/teamService";
 import ScreenAlert from "../components/common/ScreenAlert";
@@ -1526,11 +1527,9 @@ const Chat = () => {
   );
 
   // Set up WebSocket event listeners
-  useEffect(() => {
-    const socket = socketService.getSocket();
-
+  useSocketEvents((socket) => {
     if (!socket || !isAuthenticated) {
-      return;
+      return undefined;
     }
 
     // Handle online users

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -159,7 +159,7 @@ const MyTeams = () => {
 
     try {
       setLoadingInvitations(true);
-      const response = await teamService.getUserPendingInvitations();
+      const response = await teamService.getUserReceivedInvitations();
 
       if (response.success) {
         setPendingInvitations(response.data || []);

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -7,7 +7,7 @@ import TeamCard from "../components/teams/TeamCard";
 import Section from "../components/layout/Section";
 import Pagination from "../components/common/Pagination";
 import { teamService } from "../services/teamService";
-import socketService from "../services/socketService";
+import useSocketEvents from "../hooks/useSocketEvents";
 import { useAuth } from "../contexts/AuthContext";
 import {
   Plus,
@@ -177,50 +177,28 @@ const MyTeams = () => {
     fetchPendingInvitations();
   }, [fetchPendingApplications, fetchPendingInvitations]);
 
-  useEffect(() => {
-    if (!user?.id) return undefined;
+  const handleRequestNotification = useCallback((payload = {}) => {
+    const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
 
-    let detachSocketListeners = null;
+    if (!type || type.includes("application")) {
+      fetchPendingApplications();
+    }
 
-    const attachSocketListeners = (socket) => {
-      if (!socket) return;
+    if (!type || type.includes("invitation") || type.includes("invite")) {
+      fetchPendingInvitations();
+    }
+  }, [fetchPendingApplications, fetchPendingInvitations]);
 
-      if (detachSocketListeners) {
-        detachSocketListeners();
-      }
-
-      const handleRequestNotification = (payload = {}) => {
-        const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
-
-        if (!type || type.includes("application")) {
-          fetchPendingApplications();
+  useSocketEvents(
+    user?.id
+      ? {
+          "notification:new": handleRequestNotification,
+          "notification:updated": handleRequestNotification,
+          "notification:deleted": handleRequestNotification,
         }
-
-        if (!type || type.includes("invitation") || type.includes("invite")) {
-          fetchPendingInvitations();
-        }
-      };
-
-      socket.on("notification:new", handleRequestNotification);
-      socket.on("notification:updated", handleRequestNotification);
-      socket.on("notification:deleted", handleRequestNotification);
-
-      detachSocketListeners = () => {
-        socket.off("notification:new", handleRequestNotification);
-        socket.off("notification:updated", handleRequestNotification);
-        socket.off("notification:deleted", handleRequestNotification);
-      };
-    };
-
-    const unsubscribeSocketReady = socketService.onSocketReady(attachSocketListeners);
-
-    return () => {
-      unsubscribeSocketReady();
-      if (detachSocketListeners) {
-        detachSocketListeners();
-      }
-    };
-  }, [fetchPendingApplications, fetchPendingInvitations, user?.id]);
+      : null,
+    [handleRequestNotification, user?.id],
+  );
 
   // Fetch teams when page or limit changes
   useEffect(() => {

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -120,8 +120,7 @@ const Profile = () => {
   const displayBadges = Array.isArray(displayUser?.badges)
     ? displayUser.badges
     : [];
-  const hiddenAwardIds =
-    displayUser?.hidden_award_ids ?? displayUser?.hiddenAwardIds ?? [];
+  const hiddenAwardIds = displayUser?.hiddenAwardIds ?? [];
 
   // Auto-fill city from postal code lookup
   const { getSuggestedUpdates } = useLocationAutoFill({
@@ -157,9 +156,7 @@ const Profile = () => {
       }
 
       // Fall back to user context data
-      if (user.is_public === true) return true;
       if (user.isPublic === true) return true;
-      if (user.is_public === false) return false;
       if (user.isPublic === false) return false;
 
       // Default to hidden profile if not specified
@@ -184,26 +181,22 @@ const Profile = () => {
 
         // Update form data directly from API response
         setFormData({
-          firstName: apiUserData.firstName || apiUserData.first_name || "",
-          lastName: apiUserData.lastName || apiUserData.last_name || "",
+          firstName: apiUserData.firstName || "",
+          lastName: apiUserData.lastName || "",
           username: apiUserData.username || "",
           email: apiUserData.email || apiUserData.email || "",
           bio: apiUserData.bio || "",
-          postalCode: apiUserData.postalCode || apiUserData.postal_code || "",
+          postalCode: apiUserData.postalCode || "",
           city: apiUserData.city || "",
           country: apiUserData.country || "",
           isPublic:
-            apiUserData.isPublic !== undefined
-              ? apiUserData.isPublic
-              : apiUserData.is_public !== undefined
-                ? apiUserData.is_public
-                : true,
+            apiUserData.isPublic !== undefined ? apiUserData.isPublic : true,
           profileImage: null,
         });
 
         // Set image preview if available
-        if (apiUserData.avatarUrl || apiUserData.avatar_url) {
-          setImagePreview(apiUserData.avatarUrl || apiUserData.avatar_url);
+        if (apiUserData.avatarUrl) {
+          setImagePreview(apiUserData.avatarUrl);
         }
 
         // Store API user locally (includes badges totals as `badges`)
@@ -235,26 +228,22 @@ const Profile = () => {
     // Initialize form data from context if available and we haven't loaded from API yet
     if (user && !initialDataLoaded) {
       setFormData({
-        firstName: user.firstName || user.first_name || "",
-        lastName: user.lastName || user.last_name || "",
+        firstName: user.firstName || "",
+        lastName: user.lastName || "",
         username: user.username || "",
         email: user.email || "",
         bio: user.bio || "",
         city: user.city || "",
-        postalCode: user.postalCode || user.postal_code || "",
+        postalCode: user.postalCode || "",
         country: user.country || "",
         isPublic:
-          user.is_public !== undefined
-            ? user.is_public
-            : user.isPublic !== undefined
-              ? user.isPublic
-              : true,
+          user.isPublic !== undefined ? user.isPublic : true,
         profileImage: null,
       });
 
       // Set image preview if available
-      if (user.avatar_url || user.avatarUrl) {
-        setImagePreview(user.avatar_url || user.avatarUrl);
+      if (user.avatarUrl) {
+        setImagePreview(user.avatarUrl);
       }
     }
 
@@ -289,7 +278,7 @@ const Profile = () => {
   // Reset image error state when user changes
   useEffect(() => {
     setImageError(false);
-  }, [user?.avatarUrl, user?.avatar_url]);
+  }, [user?.avatarUrl]);
 
   // Auto-fill city and country when postal code lookup returns a result
   useEffect(() => {
@@ -462,7 +451,6 @@ const Profile = () => {
         // Update the user context to remove avatar
         const updatedUser = {
           ...user,
-          avatar_url: null,
           avatarUrl: null,
         };
         updateUser(updatedUser);
@@ -600,7 +588,7 @@ const Profile = () => {
 
       updateLocalUserBadges((currentUser) => {
         const hiddenIds =
-          currentUser.hidden_award_ids ?? currentUser.hiddenAwardIds ?? [];
+          currentUser.hiddenAwardIds ?? [];
         const nextHiddenIds = hiddenIds
           .map((value) => String(value))
           .includes(String(awardId))
@@ -609,7 +597,6 @@ const Profile = () => {
 
         return {
           ...currentUser,
-          hidden_award_ids: nextHiddenIds,
           hiddenAwardIds: nextHiddenIds,
         };
       });
@@ -646,14 +633,13 @@ const Profile = () => {
 
       updateLocalUserBadges((currentUser) => {
         const hiddenIds =
-          currentUser.hidden_award_ids ?? currentUser.hiddenAwardIds ?? [];
+          currentUser.hiddenAwardIds ?? [];
         const nextHiddenIds = hiddenIds.filter(
           (value) => String(value) !== String(awardId),
         );
 
         return {
           ...currentUser,
-          hidden_award_ids: nextHiddenIds,
           hiddenAwardIds: nextHiddenIds,
         };
       });
@@ -820,15 +806,15 @@ const Profile = () => {
 
       // Create an object to hold the updated user data
       const userData = {
-        first_name: formData.firstName,
-        last_name: formData.lastName,
+        firstName: formData.firstName,
+        lastName: formData.lastName,
         username: formData.username.trim(),
         email: formData.email,
         bio: formData.bio,
-        postal_code: formData.postalCode,
+        postalCode: formData.postalCode,
         city: formData.city,
         country: formData.country,
-        is_public: formData.isPublic,
+        isPublic: formData.isPublic,
       };
 
       // Handle image upload if a new image was selected
@@ -840,8 +826,8 @@ const Profile = () => {
         );
         if (uploadResult.success) {
           avatarUrl = uploadResult.url;
-          userData.avatar_url = avatarUrl;
-          userData.avatar_file_id = uploadResult.fileId;
+          userData.avatarUrl = avatarUrl;
+          userData.avatarFileId = uploadResult.fileId;
           setImagePreview(avatarUrl);
         } else {
           console.error("Avatar upload failed:", uploadResult.error);
@@ -879,14 +865,12 @@ const Profile = () => {
         // Create updated user object with correct avatar URL
         const updatedUser = {
           ...user,
-          is_public: formData.isPublic,
           isPublic: formData.isPublic,
-          first_name: formData.firstName,
-          last_name: formData.lastName,
+          firstName: formData.firstName,
+          lastName: formData.lastName,
           username: formData.username.trim(),
           email: formData.email, // Include email in the updated user object
           bio: formData.bio,
-          postal_code: formData.postalCode,
           city: formData.city,
           country: formData.country,
           // Pick up geocoded state & coordinates from the API response
@@ -895,11 +879,7 @@ const Profile = () => {
           longitude: response.data?.longitude ?? user.longitude,
           // Use the avatar URL from ImageKit if we uploaded a new image,
           // otherwise use the response data or keep the existing avatar
-          avatar_url: avatarUrl || response.data?.avatar_url || user.avatar_url,
-          avatarUrl: avatarUrl || response.data?.avatar_url || user.avatarUrl,
-          // Also set camelCase versions
-          firstName: formData.firstName,
-          lastName: formData.lastName,
+          avatarUrl: avatarUrl || response.data?.avatarUrl || user.avatarUrl,
           userName: formData.username,
           postalCode: formData.postalCode,
         };
@@ -913,15 +893,15 @@ const Profile = () => {
         // Reset form data with updated values
         setFormData((prev) => ({
           ...prev,
-          firstName: updatedUser.first_name || updatedUser.firstName || "",
-          lastName: updatedUser.last_name || updatedUser.lastName || "",
+          firstName: updatedUser.firstName || "",
+          lastName: updatedUser.lastName || "",
           username: updatedUser.username || "",
           email: updatedUser.email || "", // Keep the email in the form data
           bio: updatedUser.bio || "",
-          postalCode: updatedUser.postal_code || updatedUser.postalCode || "",
+          postalCode: updatedUser.postalCode || "",
           city: updatedUser.city || "",
           country: updatedUser.country || "",
-          isPublic: updatedUser.is_public || updatedUser.isPublic || false,
+          isPublic: updatedUser.isPublic || false,
           profileImage: null, // Reset profile image after successful update
         }));
       }
@@ -975,7 +955,7 @@ const Profile = () => {
   }
 
   const profileLocation = {
-    postalCode: displayUser.postalCode || displayUser.postal_code || "",
+    postalCode: displayUser.postalCode || "",
     city: displayUser.city || "",
     state: displayUser.state || "",
     country: displayUser.country || "",
@@ -1052,7 +1032,7 @@ const Profile = () => {
                 <div className="w-full max-w-md mt-5">
                   <ImageUploader
                     currentImage={
-                      imagePreview || user?.avatar_url || user?.avatarUrl
+                      imagePreview || user?.avatarUrl
                     }
                     onImageSelect={(file, previewUrl) => {
                       setFormData((prev) => ({
@@ -1068,7 +1048,7 @@ const Profile = () => {
                     disabled={loading}
                     loading={avatarDeleteLoading}
                     showRemoveButton={
-                      !!(imagePreview || user?.avatar_url || user?.avatarUrl) &&
+                      !!(imagePreview || user?.avatarUrl) &&
                       !formData.profileImage
                     }
                     removeButtonText="Remove Current Picture"
@@ -1254,9 +1234,9 @@ const Profile = () => {
               <div className="mb-4 md:mb-0 md:mr-8 flex-shrink-0">
                 <div className="avatar placeholder">
                   <div className="bg-[var(--color-primary-focus)] text-primary-content rounded-full w-32 h-32 relative overflow-hidden">
-                    {(user.avatarUrl || user.avatar_url) && !imageError ? (
+                    {user.avatarUrl && !imageError ? (
                       <img
-                        src={user.avatarUrl || user.avatar_url}
+                        src={user.avatarUrl}
                         alt="Profile"
                         className="rounded-full object-cover w-full h-full"
                         onError={() => setImageError(true)}
@@ -1273,8 +1253,8 @@ const Profile = () => {
               <div className="flex-grow min-w-0">
                 {/* Name */}
                 <h2 className="text-3xl font-bold leading-[120%] mb-[0.2em]">
-                  {user.firstName || user.first_name || ""}{" "}
-                  {user.lastName || user.last_name || ""}
+                  {user.firstName || ""}{" "}
+                  {user.lastName || ""}
                 </h2>
 
                 {/* Username, visibility, and date in one row */}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -211,9 +211,7 @@ const Settings = () => {
 
   // ── Visibility ───────────────────────────────────────────────
   const [visibilityLoading, setVisibilityLoading] = useState(false);
-  const [isPublic, setIsPublic] = useState(
-    user?.is_public ?? user?.isPublic ?? false,
-  );
+  const [isPublic, setIsPublic] = useState(user?.isPublic ?? false);
 
   const handleVisibilityChange = async (e) => {
     const newValue = e.target.checked;
@@ -223,8 +221,8 @@ const Settings = () => {
 
     try {
       setVisibilityLoading(true);
-      await userService.updateUser(user.id, { is_public: newValue });
-      updateUser({ is_public: newValue, isPublic: newValue });
+      await userService.updateUser(user.id, { isPublic: newValue });
+      updateUser({ isPublic: newValue });
       setSuccess("Profile visibility updated");
     } catch {
       setIsPublic(!newValue); // revert on failure

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -49,10 +49,8 @@ api.interceptors.response.use(
         console.error("API Error:", error.response.data);
       }
 
-      if (
-        !skipAuthRedirect &&
-        (error.response.status === 401 || error.response.status === 403)
-      ) {
+      // 401 = invalid/expired token → log out. 403 = forbidden resource → stay logged in.
+      if (!skipAuthRedirect && error.response.status === 401) {
         localStorage.removeItem("token");
         window.location.href = "/login";
       }

--- a/src/services/searchService.js
+++ b/src/services/searchService.js
@@ -132,22 +132,6 @@ export const searchService = {
     return normalizeSearchResponse(response.data);
   },
 
-  async getRecommended(userId, isAuthenticated = false) {
-    const response = await api.get("/api/search/recommended", {
-      params: {
-        userId,
-        authenticated: isAuthenticated,
-      },
-    });
-
-    if (response.data?.data?.teams) {
-      response.data.data.teams =
-        response.data.data.teams.map(normalizeTeamData);
-    }
-
-    return response.data;
-  },
-
   async getAllUsersAndTeams(criteria = {}) {
     const params = buildSearchParams(criteria);
     const response = await api.get("/api/search/all", { params });

--- a/src/services/searchService.js
+++ b/src/services/searchService.js
@@ -17,15 +17,7 @@ export const getApiErrorMessage = (error) => {
   return "Something went wrong";
 };
 
-const normalizePublicFlag = (item) =>
-  item?.is_public === true ||
-  item?.is_public === 1 ||
-  item?.is_public === "true" ||
-  item?.is_public === "1" ||
-  item?.isPublic === true ||
-  item?.isPublic === 1 ||
-  item?.isPublic === "true" ||
-  item?.isPublic === "1";
+const normalizePublicFlag = (item) => item?.isPublic === true;
 
 /**
  * Normalize team data to ensure consistent property names

--- a/src/services/tagService.js
+++ b/src/services/tagService.js
@@ -1,35 +1,79 @@
 import api from "./api";
 
+const TAG_CACHE_TTL_MS = 10 * 60 * 1000;
+
+let structuredTagsCache = null;
+let structuredTagsCacheExpiresAt = 0;
+let structuredTagsRequest = null;
+const popularTagsCache = new Map();
+
+const cloneTagData = (data) => {
+  if (typeof structuredClone === "function") {
+    return structuredClone(data);
+  }
+
+  return JSON.parse(JSON.stringify(data));
+};
+
+const isCacheFresh = (expiresAt) => expiresAt > Date.now();
+
+const getPopularTagsCacheKey = (limit, supercategory) =>
+  JSON.stringify([limit, supercategory || null]);
+
+const clearTagCaches = () => {
+  structuredTagsCache = null;
+  structuredTagsCacheExpiresAt = 0;
+  structuredTagsRequest = null;
+  popularTagsCache.clear();
+};
+
 export const tagService = {
   // Fetch structured tags
   getStructuredTags: async () => {
     try {
-      const response = await api.get("/api/tags/structured");
+      if (structuredTagsCache && isCacheFresh(structuredTagsCacheExpiresAt)) {
+        return cloneTagData(structuredTagsCache);
+      }
 
-      const processedData = (response.data || []).map((supercat) => ({
-        ...supercat,
+      if (structuredTagsRequest) {
+        const cachedData = await structuredTagsRequest;
+        return cloneTagData(cachedData);
+      }
 
-        // IMPORTANT: supercat.id is a STRING (e.g. "Business & Entrepreneurship") — keep it
-        id: supercat?.id,
-        name: supercat?.name,
+      structuredTagsRequest = api.get("/api/tags/structured").then((response) => {
+        const processedData = (response.data || []).map((supercat) => ({
+          ...supercat,
 
-        categories: (supercat?.categories || []).map((cat) => ({
-          ...cat,
+          // IMPORTANT: supercat.id is a STRING (e.g. "Business & Entrepreneurship") — keep it
+          id: supercat?.id,
+          name: supercat?.name,
 
-          // IMPORTANT: cat.id may also be a STRING — keep it
-          id: cat?.id,
-          name: cat?.name,
+          categories: (supercat?.categories || []).map((cat) => ({
+            ...cat,
 
-          // Leaf tags are the selectable focus areas → ensure tag.id is numeric
-          tags: (cat?.tags || []).map((tag) => ({
-            ...tag,
-            id: Number(tag?.id),
+            // IMPORTANT: cat.id may also be a STRING — keep it
+            id: cat?.id,
+            name: cat?.name,
+
+            // Leaf tags are the selectable focus areas → ensure tag.id is numeric
+            tags: (cat?.tags || []).map((tag) => ({
+              ...tag,
+              id: Number(tag?.id),
+            })),
           })),
-        })),
-      }));
+        }));
 
-      return processedData;
+        structuredTagsCache = processedData;
+        structuredTagsCacheExpiresAt = Date.now() + TAG_CACHE_TTL_MS;
+        structuredTagsRequest = null;
+
+        return processedData;
+      });
+
+      const processedData = await structuredTagsRequest;
+      return cloneTagData(processedData);
     } catch (error) {
+      structuredTagsRequest = null;
       console.error("Error fetching structured tags:", error);
       throw error;
     }
@@ -39,6 +83,7 @@ export const tagService = {
   createTag: async (tagData) => {
     try {
       const response = await api.post("/api/tags/create", tagData);
+      clearTagCaches();
       return response.data;
     } catch (error) {
       console.error("Error creating tag:", error);
@@ -65,12 +110,26 @@ export const tagService = {
    */
   getPopularTags: async (limit = 10, supercategory = null) => {
     try {
+      const cacheKey = getPopularTagsCacheKey(limit, supercategory);
+      const cachedEntry = popularTagsCache.get(cacheKey);
+
+      if (cachedEntry && isCacheFresh(cachedEntry.expiresAt)) {
+        return cloneTagData(cachedEntry.data);
+      }
+
       const params = { limit };
       if (supercategory) {
         params.supercategory = supercategory;
       }
       const response = await api.get("/api/tags/popular", { params });
-      return response.data.data || [];
+      const popularTags = response.data.data || [];
+
+      popularTagsCache.set(cacheKey, {
+        data: popularTags,
+        expiresAt: Date.now() + TAG_CACHE_TTL_MS,
+      });
+
+      return cloneTagData(popularTags);
     } catch (error) {
       console.error("Error fetching popular tags:", error);
       return [];

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -507,17 +507,6 @@ export const teamService = {
     }
   },
 
-  // LIAS to match the naming pattern used in MyTeams.jsx:
-  getUserPendingInvitations: async () => {
-    try {
-      const response = await api.get("/api/teams/invitations/received");
-      return response.data;
-    } catch (error) {
-      console.error("Error fetching user pending invitations:", error);
-      throw error;
-    }
-  },
-
   respondToInvitation: async (invitationId, action, responseMessage = "", fillRole = false) => {
     try {
       const response = await api.put(`/api/teams/invitations/${invitationId}`, {


### PR DESCRIPTION
Summary
Notification toast system overhaul — All notification:new socket events now show structured toasts with consistent colour coding, impersonal titles, and a "by [Name]" sender row. Covered types: team/role invitations (received, accepted, declined, cancelled), applications (received, approved, rejected), and member removal. Combined team+role events show dual header icons (Mail + UserSearch) and a context-aware label ("Team & Role Invitation", "Team & Role Invite Accepted", etc.).
Duplicate toast fixes — Eliminated redundant toasts caused by message:received system messages arriving alongside notification:new for the same event. Suppressed APPLICATION_APPROVED:, APPLICATION_DECLINED:, INVITATION_DECLINED, INVITATION_CANCELLED, and team join messages (👋/🎯) from the toast pipeline.
Unread-message toast regression — Toast showing "You have N unread messages" was firing on every page refresh. Fixed by gating it with a sessionStorage flag that persists across refreshes and is only cleared on actual logout (using a useRef to distinguish initial mount from logout transition).
Bell live update fix — Restored real-time badge increment on notification:new events that had been dropped during a prior refactor.
Auth interceptor fix — API interceptor was logging users out on HTTP 403 (Forbidden). Only 401 (Unauthorized) should trigger logout; 403 means authenticated but not permitted.
useSocketEvents hook — Extracted reusable hook that attaches/detaches socket listeners on reconnect, replacing scattered socketService.on/off calls across components.
Code cleanup — Removed duplicate invitation helpers, dead search service code, and refactored auth user case normalisation. Added caching to tag service lookups.
Test plan
 Receive a team invitation → single pink toast, "Invited by [Name]", bell increments
 Receive a combined team+role invitation → dual icons, "Team & Role Invitation" label
 Accept/decline/cancel each invitation type → correct label, colour, and sender row; no duplicate toast
 Apply to a team → admin sees single pink "New Application" toast with "Applied by [Name]"
 Application approved/rejected → applicant sees single toast with approver name; no system-message ghost toast
 Remove a member → member sees single "Removed from Team" toast; not logged out
 Log in → unread-message toast appears once; page refresh → no repeat toast; logout + login → toast appears again
 Trigger a 403 response → user stays logged in