### PR TITLE
Fix/reopen roles former members

### DIFF
--- a/src/components/chat/MessageInput.jsx
+++ b/src/components/chat/MessageInput.jsx
@@ -96,6 +96,19 @@ const MessageInput = ({
       : { status: "none" };
 
   useEffect(() => {
+    if (disabled) {
+      if (typingTimerRef.current) {
+        clearTimeout(typingTimerRef.current);
+      }
+      if (isTypingRef.current) {
+        const urlParams = new URLSearchParams(window.location.search);
+        const type = urlParams.get("type") || "direct";
+        onTyping(false, type);
+        isTypingRef.current = false;
+      }
+      return undefined;
+    }
+
     const urlParams = new URLSearchParams(window.location.search);
     const type = urlParams.get("type") || "direct";
 
@@ -123,7 +136,7 @@ const MessageInput = ({
         clearTimeout(typingTimerRef.current);
       }
     };
-  }, [message, onTyping]);
+  }, [disabled, message, onTyping]);
 
   const detectMention = (value, cursorPos) => {
     const beforeCursor = value.slice(0, cursorPos);
@@ -173,6 +186,7 @@ const MessageInput = ({
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    if (disabled) return;
     if (!message.trim()) return;
 
     const urlParams = new URLSearchParams(window.location.search);
@@ -193,16 +207,19 @@ const MessageInput = ({
   };
 
   const handleEmojiSelect = (emoji) => {
+    if (disabled) return;
     setMessage((prev) => prev + emoji);
   };
 
   const handleImageSelect = async (file, previewUrl) => {
+    if (disabled) return;
     if (onSendImage) {
       await onSendImage(file, previewUrl);
     }
   };
 
   const handleFileSelect = async (file) => {
+    if (disabled) return;
     if (onSendFile) {
       await onSendFile(file);
     }

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -31,6 +31,7 @@ import { messageService } from '../../services/messageService';
 import { useAuth } from '../../contexts/AuthContext';
 import useSocketEvents from '../../hooks/useSocketEvents';
 import { getEventPreview } from '../../utils/eventPreview';
+import { parseSystemMessage } from './MessageDisplay';
 import {
   getMessageSenderDisplayName,
   getMessageConversationTarget,
@@ -83,6 +84,7 @@ const NOTIFICATION_TOAST_TYPES = {
   application_approved: { icon: 'CheckCircle',  label: 'Application Approved', color: '#16a34a', senderColor: '#15803d', senderPrefix: 'Approved by ' },
   application_rejected: { icon: 'CircleX',      label: 'Application Declined', color: '#6b7280', senderPrefix: 'Declined by ' },
   member_removed:       { icon: 'UserMinus',    label: 'Removed from Team',    senderPrefix: 'Removed by ' },
+  member_removed_public:{ icon: 'UserMinus',    label: 'Removed from Team',    senderPrefix: null },
 };
 
 const ROLE_CHANGE_PREVIEW = {
@@ -108,6 +110,7 @@ const getRoleStatusChangedPreview = (payload) => {
 
 const NOTIFICATION_VISIBLE_MS = 20000;
 const NOTIFICATION_FADE_MS = 700;
+const TEAM_REMOVAL_SUPPRESS_MS = 15000;
 
 const EVENT_CONTENT_KEYS = [
   "content",
@@ -225,11 +228,14 @@ const getFallbackRoleEventPreview = (content) => {
   const roleName = roleToken.includes(":")
     ? roleToken.split(":").slice(1).join(":").trim()
     : roleToken.trim();
-  const filledUserToken = eventType === "ROLE_FILLED" ? roleEventMatch[3] || "" : "";
+  const actorToken =
+    eventType === "ROLE_FILLED" || eventType === "ROLE_REOPENED"
+      ? roleEventMatch[3] || ""
+      : "";
   const filledByToken = eventType === "ROLE_FILLED" ? roleEventMatch[4] || "" : "";
-  const filledUserName = filledUserToken.includes(":")
-    ? filledUserToken.split(":").slice(1).join(":").trim()
-    : filledUserToken.trim();
+  const filledUserName = actorToken.includes(":")
+    ? actorToken.split(":").slice(1).join(":").trim()
+    : actorToken.trim();
   const filledByName = filledByToken.includes(":")
     ? filledByToken.split(":").slice(1).join(":").trim()
     : filledByToken.trim();
@@ -244,7 +250,9 @@ const getFallbackRoleEventPreview = (content) => {
       : filledUserName
         ? `The role ${roleName || "Vacant Role"} has been filled by ${filledUserName}.`
         : `The role ${roleName || "Vacant Role"} has been marked filled.`,
-    ROLE_REOPENED: `Role reopened: ${roleName || "Vacant Role"}`,
+    ROLE_REOPENED: filledUserName
+      ? `${filledUserName} left the role ${roleName || "Vacant Role"}. It is open again.`
+      : `Role reopened: ${roleName || "Vacant Role"}`,
     ROLE_REOPENED_ADMIN: `Role reopened: ${roleName || "Vacant Role"}`,
   };
 
@@ -297,6 +305,8 @@ const getRoleEventTypePreview = (message) => {
     message?.filled_user_name ??
     message?.filledByUserName ??
     message?.filled_by_user_name ??
+    message?.userName ??
+    message?.user_name ??
     message?.filledByUser?.name ??
     message?.filled_by_user?.name ??
     null;
@@ -316,7 +326,9 @@ const getRoleEventTypePreview = (message) => {
       : filledUserName
         ? `The role ${roleName} has been filled by ${filledUserName}.`
         : `The role ${roleName} has been marked filled.`,
-    role_reopened: `Role reopened: ${roleName}`,
+    role_reopened: filledUserName
+      ? `${filledUserName} left the role ${roleName}. It is open again.`
+      : `Role reopened: ${roleName}`,
     role_reopened_admin: `Role reopened: ${roleName}`,
   };
 
@@ -349,6 +361,170 @@ const getRoleEventTypePreview = (message) => {
         ? "by "
         : undefined,
   };
+};
+
+const getRoleReopenedToastKey = (content, message = null) => {
+  const rawType =
+    message?.eventType ??
+    message?.event_type ??
+    message?.notificationType ??
+    message?.notification_type ??
+    message?.type;
+  const normalizedType = String(rawType || "").toLowerCase();
+
+  if (normalizedType === "role_reopened") {
+    const roleId = message?.roleId ?? message?.role_id ?? message?.role?.id ?? "";
+    const userId =
+      message?.userId ??
+      message?.user_id ??
+      message?.filledByUserId ??
+      message?.filled_by_user_id ??
+      message?.filledByUser?.id ??
+      message?.filled_by_user?.id ??
+      "";
+    const teamId = message?.teamId ?? message?.team_id ?? message?.team?.id ?? "";
+
+    return `role-reopened:${teamId}:${roleId}:${userId}`;
+  }
+
+  const match = String(content || "").match(
+    /(?:ROLE_REOPENED):\s*(.+?)\s+\|\s+(.+?)\s+\|\s+(.+)$/,
+  );
+
+  if (!match) return null;
+
+  return `role-reopened:${match[1].trim()}:${match[2].trim()}:${match[3].trim()}`;
+};
+
+const getTeamIdFromMessage = (message, parsedMessage = null) =>
+  parsedMessage?.teamId ??
+  message?.teamId ??
+  message?.team_id ??
+  message?.team?.id ??
+  null;
+
+const getTeamIdFromPayload = (payload) =>
+  payload?.teamId ??
+  payload?.team_id ??
+  payload?.team?.id ??
+  payload?.data?.teamId ??
+  payload?.data?.team_id ??
+  payload?.metadata?.teamId ??
+  payload?.metadata?.team_id ??
+  null;
+
+const getPayloadText = (payload) =>
+  [
+    payload?.title,
+    payload?.message,
+    payload?.content,
+    payload?.text,
+    payload?.body,
+    payload?.data?.title,
+    payload?.data?.message,
+    payload?.data?.content,
+    payload?.metadata?.title,
+    payload?.metadata?.message,
+    payload?.metadata?.content,
+  ]
+    .filter((value) => typeof value === 'string')
+    .join(' ');
+
+const getRemovedMemberIdFromPayload = (payload) =>
+  payload?.memberId ??
+  payload?.member_id ??
+  payload?.removedUserId ??
+  payload?.removed_user_id ??
+  payload?.targetUserId ??
+  payload?.target_user_id ??
+  payload?.data?.memberId ??
+  payload?.data?.member_id ??
+  payload?.metadata?.memberId ??
+  payload?.metadata?.member_id ??
+  null;
+
+const getRoleEventUserIdFromPayload = (payload) =>
+  payload?.userId ??
+  payload?.user_id ??
+  payload?.filledByUserId ??
+  payload?.filled_by_user_id ??
+  payload?.filledByUser?.id ??
+  payload?.filled_by_user?.id ??
+  payload?.data?.userId ??
+  payload?.data?.user_id ??
+  payload?.metadata?.userId ??
+  payload?.metadata?.user_id ??
+  null;
+
+const isCurrentUserName = (name, user) => {
+  const normalizedName = String(name || '').trim().toLowerCase();
+  if (!normalizedName) return false;
+
+  const userFullName = `${user?.firstName || user?.first_name || ''} ${user?.lastName || user?.last_name || ''}`
+    .trim()
+    .toLowerCase();
+
+  return (
+    normalizedName === userFullName ||
+    normalizedName === String(user?.username || '').trim().toLowerCase()
+  );
+};
+
+const isMemberRoleChange = (parsedMessage) =>
+  parsedMessage?.type === 'role_changed' &&
+  String(parsedMessage.newRole || '').trim().toLowerCase() === 'member';
+
+const isMemberRoleChangeForCurrentUser = (parsedMessage, user) => (
+  isMemberRoleChange(parsedMessage) &&
+  (
+    (parsedMessage.memberId != null && String(parsedMessage.memberId) === String(user?.id)) ||
+    isCurrentUserName(parsedMessage.memberName, user)
+  )
+);
+
+const isRemovalForCurrentUser = (payload, user) => {
+  const type = String(payload?.type ?? payload?.notificationType ?? '').toLowerCase();
+  if (!type.includes('member_removed') && !type.includes('removed')) return false;
+
+  const removedMemberId = getRemovedMemberIdFromPayload(payload);
+  if (removedMemberId != null && String(removedMemberId) === String(user?.id)) {
+    return true;
+  }
+
+  const text = getPayloadText(payload).toLowerCase();
+  return /\byou\b/.test(text) && /removed from/.test(text);
+};
+
+const isTemporaryDemotionToast = (payload) => {
+  const type = String(payload?.type ?? payload?.notificationType ?? '').toLowerCase();
+  const text = getPayloadText(payload).toLowerCase();
+
+  return (
+    type === 'role_changed' &&
+    (text.includes('demoted') ||
+      text.includes('changed to member') ||
+      text.includes('role changed to member') ||
+      text.includes('to member'))
+  );
+};
+
+const buildCurrentUserRemovalText = (payload) => {
+  const title = String(payload?.title || '').trim();
+  if (/^you\b/i.test(title)) return title;
+
+  const teamName =
+    payload?.teamName ??
+    payload?.team_name ??
+    payload?.team?.name ??
+    payload?.data?.teamName ??
+    payload?.data?.team_name ??
+    payload?.metadata?.teamName ??
+    payload?.metadata?.team_name ??
+    null;
+
+  return teamName
+    ? `You were removed from "${teamName}"`
+    : 'You were removed from the team';
 };
 
 const MENTION_REGEX = /@\[([^\]]+)\]\([^)]+\)/g;
@@ -414,6 +590,59 @@ const MessageNotifications = () => {
   });
   const { isAuthenticated, user } = useAuth();
   const prevIsAuthenticatedRef = useRef(false);
+  const currentUserRemovalSuppressionsRef = useRef(new Map());
+
+  const isTeamSuppressedForCurrentUserRemoval = useCallback((teamId) => {
+    if (teamId == null) return false;
+
+    const key = String(teamId);
+    const suppressUntil = currentUserRemovalSuppressionsRef.current.get(key);
+
+    if (!suppressUntil) return false;
+    if (suppressUntil <= Date.now()) {
+      currentUserRemovalSuppressionsRef.current.delete(key);
+      return false;
+    }
+
+    return true;
+  }, []);
+
+  const markTeamSuppressedForCurrentUserRemoval = useCallback((teamId) => {
+    if (teamId == null) return;
+
+    currentUserRemovalSuppressionsRef.current.set(
+      String(teamId),
+      Date.now() + TEAM_REMOVAL_SUPPRESS_MS,
+    );
+  }, []);
+
+  const upsertCurrentUserRemovalToast = useCallback((payload) => {
+    const teamId = getTeamIdFromPayload(payload);
+    markTeamSuppressedForCurrentUserRemoval(teamId);
+
+    const dedupeKey = `current-user-removed:${teamId ?? 'unknown'}`;
+    const now = Date.now();
+
+    setNotifications((prev) => [
+      ...prev.filter((notification) => notification.dedupeKey !== dedupeKey),
+      {
+        id: `notif-current-user-removed-${teamId ?? 'unknown'}-${now}`,
+        dedupeKey,
+        isEvent: true,
+        headerIconName: 'UserMinus',
+        headerLabel: 'Removed from Team',
+        eventIcon: 'UserMinus',
+        eventColor: '#6b7280',
+        text: buildCurrentUserRemovalText(payload),
+        senderPrefix: null,
+        senderName: null,
+        navigateTo: '/chat',
+        time: new Date(),
+        expiresAt: now + NOTIFICATION_VISIBLE_MS,
+        removeAt: now + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
+      },
+    ]);
+  }, [markTeamSuppressedForCurrentUserRemoval]);
 
   useEffect(() => {
     locationRef.current = {
@@ -462,6 +691,50 @@ const MessageNotifications = () => {
   const handleNewMessage = useCallback((message) => {
     if (isOwnMessage(message, user?.id)) return;
 
+    const eventContent = pickEventContent(message);
+    const parsedMessage = parseSystemMessage(eventContent);
+    const teamId = getTeamIdFromMessage(message, parsedMessage);
+
+    if (
+      parsedMessage?.type === 'member_removed_public' &&
+      parsedMessage.userId != null &&
+      String(parsedMessage.userId) === String(user?.id)
+    ) {
+      upsertCurrentUserRemovalToast({
+        type: 'member_removed',
+        teamId,
+        teamName: parsedMessage.teamName,
+        title: parsedMessage.teamName
+          ? `You were removed from "${parsedMessage.teamName}"`
+          : 'You were removed from the team',
+      });
+      return;
+    }
+
+    if (
+      isTeamSuppressedForCurrentUserRemoval(teamId) &&
+      (
+        parsedMessage?.type === 'role_reopened' ||
+        isMemberRoleChange(parsedMessage)
+      )
+    ) {
+      return;
+    }
+
+    if (
+      parsedMessage?.type === 'role_reopened' &&
+      (
+        (parsedMessage.userId != null && String(parsedMessage.userId) === String(user?.id)) ||
+        isCurrentUserName(parsedMessage.userName, user)
+      )
+    ) {
+      return;
+    }
+
+    if (isMemberRoleChangeForCurrentUser(parsedMessage, user)) {
+      return;
+    }
+
     const isInConversation = isMessageForCurrentChatPath(
       message,
       locationRef.current.pathname,
@@ -471,10 +744,9 @@ const MessageNotifications = () => {
 
     if (!isInConversation) {
       const target = getMessageConversationTarget(message, user?.id);
-      const eventContent = pickEventContent(message);
 
       // These system messages are shown via notification:new toast instead.
-      if (/APPLICATION_APPROVED:|APPLICATION_DECLINED:|MEMBER_REMOVED|INVITATION_DECLINED|INVITATION_CANCELLED/i.test(eventContent)) return;
+      if (/APPLICATION_APPROVED:|APPLICATION_DECLINED:|MEMBER_REMOVED:|INVITATION_DECLINED|INVITATION_CANCELLED/i.test(eventContent)) return;
 
       // Team join messages (👋/🎯) are visible in the team chat and covered by notification:new for the inviter.
       if ((message.team_id || message.teamId) && /^[\u{1F44B}\u{1F3AF}]/u.test(eventContent.trim())) return;
@@ -483,10 +755,16 @@ const MessageNotifications = () => {
         getRoleEventTypePreview(message) ||
         getEventPreview(eventContent, user) ||
         getFallbackRoleEventPreview(eventContent);
+      const dedupeKey =
+        getRoleReopenedToastKey(eventContent, message) ||
+        (parsedMessage?.type === 'member_removed_public'
+          ? `member-removed:${teamId ?? ''}:${parsedMessage.userId ?? ''}`
+          : null);
       setNotifications(prev => [
-        ...prev,
+        ...prev.filter((n) => !dedupeKey || n.dedupeKey !== dedupeKey),
         {
           id: message.id || `${target.type}-${target.conversationId}-${Date.now()}`,
+          dedupeKey,
           conversationId: target.conversationId,
           conversationType: target.type,
           senderId: message.senderId || message.sender_id,
@@ -503,7 +781,11 @@ const MessageNotifications = () => {
         }
       ]);
     }
-  }, [user]);
+  }, [
+    isTeamSuppressedForCurrentUserRemoval,
+    upsertCurrentUserRemovalToast,
+    user,
+  ]);
 
   const handleMessageDeleted = useCallback((payload) => {
     setNotifications((prev) =>
@@ -574,14 +856,41 @@ const MessageNotifications = () => {
 
   const handleNotificationNew = useCallback((payload) => {
     if (!payload?.title) return;
+
+    const teamId = getTeamIdFromPayload(payload);
+
+    if (isRemovalForCurrentUser(payload, user)) {
+      upsertCurrentUserRemovalToast(payload);
+      return;
+    }
+
+    if (
+      isTemporaryDemotionToast(payload) ||
+      (
+        isTeamSuppressedForCurrentUserRemoval(teamId) &&
+        ['role_reopened', 'role_changed'].includes(String(payload.type || '').toLowerCase())
+      ) ||
+      (
+        String(payload.type || '').toLowerCase() === 'role_reopened' &&
+        String(getRoleEventUserIdFromPayload(payload) ?? '') === String(user?.id ?? '')
+      )
+    ) {
+      return;
+    }
+
     const config = NOTIFICATION_TOAST_TYPES[payload.type];
     if (!config) return;
     const isRoleInvite = (['invitation_received', 'invitation_cancelled', 'invitation_declined'].includes(payload.type) && !!payload.roleName)
       || (payload.type === 'invitation_accepted' && !!payload.filledRoleName);
+    const dedupeKey =
+      payload.type?.includes?.('member_removed')
+        ? `member-removed:${teamId ?? ''}:${getRemovedMemberIdFromPayload(payload) ?? payload.title}`
+        : `notif-${payload.type}-${teamId ?? ''}-${payload.title}`;
     setNotifications((prev) => [
-      ...prev,
+      ...prev.filter((notification) => notification.dedupeKey !== dedupeKey),
       {
         id: `notif-${payload.type}-${Date.now()}`,
+        dedupeKey,
         isEvent: true,
         headerIconName: config.icon,
         secondaryHeaderIconName: isRoleInvite ? 'UserSearch' : null,
@@ -603,7 +912,11 @@ const MessageNotifications = () => {
         removeAt: Date.now() + NOTIFICATION_VISIBLE_MS + NOTIFICATION_FADE_MS,
       },
     ]);
-  }, []);
+  }, [
+    isTeamSuppressedForCurrentUserRemoval,
+    upsertCurrentUserRemovalToast,
+    user,
+  ]);
 
   useSocketEvents(
     isAuthenticated

--- a/src/components/common/Dropdown.jsx
+++ b/src/components/common/Dropdown.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useRef, useEffect } from "react";
-import { ChevronDown } from "lucide-react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
 
 const Dropdown = ({
   trigger,
@@ -13,21 +13,40 @@ const Dropdown = ({
   hoverDelay = 150,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [menuStyle, setMenuStyle] = useState({});
   const [hoverTimeout, setHoverTimeout] = useState(null);
   const dropdownRef = useRef(null);
+  const menuRef = useRef(null);
 
-  // Position classes
-  const positionClasses = {
-    "bottom-left": "left-0 top-full mt-1",
-    "bottom-right": "right-0 top-full mt-1",
-    "top-left": "left-0 bottom-full mb-1",
-    "top-right": "right-0 bottom-full mb-1",
-  };
+  const computeMenuStyle = useCallback(() => {
+    if (!dropdownRef.current) return;
+    const rect = dropdownRef.current.getBoundingClientRect();
+    const style = { position: "fixed", zIndex: 9999 };
+
+    if (position.startsWith("bottom")) {
+      style.top = rect.bottom + 4;
+    } else {
+      style.bottom = window.innerHeight - rect.top + 4;
+    }
+
+    if (position.endsWith("right")) {
+      style.right = window.innerWidth - rect.right;
+    } else {
+      style.left = rect.left;
+    }
+
+    setMenuStyle(style);
+  }, [position]);
 
   // Handle click outside to close dropdown
   useEffect(() => {
     const handleClickOutside = (event) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target) &&
+        menuRef.current &&
+        !menuRef.current.contains(event.target)
+      ) {
         setIsOpen(false);
       }
     };
@@ -35,6 +54,8 @@ const Dropdown = ({
     if (isOpen) {
       document.addEventListener("mousedown", handleClickOutside);
       document.addEventListener("touchstart", handleClickOutside);
+      window.addEventListener("scroll", () => setIsOpen(false), { passive: true });
+      window.addEventListener("resize", () => setIsOpen(false), { passive: true });
     }
 
     return () => {
@@ -49,6 +70,7 @@ const Dropdown = ({
       if (hoverTimeout) {
         clearTimeout(hoverTimeout);
       }
+      computeMenuStyle();
       setIsOpen(true);
     }
   };
@@ -65,6 +87,9 @@ const Dropdown = ({
   // Handle click events
   const handleClick = () => {
     if (!disabled && !openOnHover) {
+      if (!isOpen) {
+        computeMenuStyle();
+      }
       setIsOpen(!isOpen);
     }
   };
@@ -102,27 +127,26 @@ const Dropdown = ({
         {trigger}
       </div>
 
-      {/* Dropdown Menu */}
-      {isOpen && !disabled && (
+      {/* Dropdown Menu — rendered in a portal to escape stacking contexts */}
+      {isOpen && !disabled && createPortal(
         <>
           {/* Backdrop for mobile/touch devices */}
           <div
-            className="fixed inset-0 z-40 lg:hidden"
+            className="fixed inset-0 z-[9998] lg:hidden"
             onClick={() => setIsOpen(false)}
           />
 
           {/* Dropdown Content */}
           <div
-            className={`
-              absolute z-50 bg-white rounded-lg shadow-lg border border-gray-200 py-1 min-w-32
-              ${positionClasses[position]}
-              ${dropdownClassName}
-            `}
+            ref={menuRef}
+            style={menuStyle}
+            className={`bg-white rounded-lg shadow-lg border border-gray-200 py-1 min-w-32 ${dropdownClassName}`}
             onClick={handleItemClick}
           >
             {children}
           </div>
-        </>
+        </>,
+        document.body
       )}
     </div>
   );

--- a/src/components/common/RoleBadgePill.jsx
+++ b/src/components/common/RoleBadgePill.jsx
@@ -8,6 +8,7 @@ const RoleBadgePill = ({
   loading = false,
   onClick,
   className = "",
+  style,
 }) => {
   const Component = onClick ? "button" : "span";
 
@@ -15,6 +16,7 @@ const RoleBadgePill = ({
     <Component
       type={onClick ? "button" : undefined}
       onClick={onClick}
+      style={style}
       className={`group inline-flex items-center h-6 rounded-full overflow-hidden
   text-xs font-medium
   ${badgeColorClass}
@@ -32,8 +34,9 @@ const RoleBadgePill = ({
         className={`text-xs font-medium leading-none
     max-w-0 overflow-hidden whitespace-nowrap opacity-0
     transition-all duration-200 ease-out
-    group-hover:max-w-[80px] group-hover:opacity-100
-    group-focus-visible:max-w-[80px] group-focus-visible:opacity-100
+    group-hover:max-w-[120px] group-hover:opacity-100
+    group-focus-visible:max-w-[120px] group-focus-visible:opacity-100
+    pl-0 group-hover:pl-1 group-focus-visible:pl-1
     pr-0 group-hover:pr-2 group-focus-visible:pr-2`}
       >
         {label}

--- a/src/components/teams/RoleBadgeDropdown.jsx
+++ b/src/components/teams/RoleBadgeDropdown.jsx
@@ -47,6 +47,13 @@ const RoleBadgeDropdown = ({
 
   const roleInfo = getRoleInfo(member.role);
   const RoleIcon = roleInfo.icon;
+  const memberId =
+    member.user_id ??
+    member.userId ??
+    member.member_id ??
+    member.memberId ??
+    member.user?.id ??
+    member.id;
 
   const getMemberName = () => {
     const first = member.first_name || member.firstName;
@@ -122,7 +129,7 @@ const RoleBadgeDropdown = ({
       if (pendingAction.type === "role") {
         await onRoleChange(pendingAction.newRole);
       } else if (pendingAction.type === "remove") {
-        await onRemoveMember(member.user_id || member.userId);
+        await onRemoveMember(memberId);
       }
 
       setPendingAction(null);

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -11,6 +11,7 @@ import TeamEditForm from "./TeamEditForm";
 import { useAuth } from "../../contexts/AuthContext";
 import { teamService } from "../../services/teamService";
 import { userService } from "../../services/userService";
+import { reopenRolesFilledByMember } from "../../services/teamMemberRoleReopenService";
 import Button from "../common/Button";
 import SendMessageButton from "../common/SendMessageButton";
 import ScreenAlert from "../common/ScreenAlert";
@@ -836,10 +837,21 @@ const TeamDetailsModal = ({
 
     setLeaveLoading(true);
     try {
+      const reopenedRoles = await reopenRolesFilledByMember({
+        teamId: team.id,
+        teamName: team.name,
+        member: user,
+        memberId: user.id,
+        roles: teamRoles,
+      });
+
       await teamService.removeTeamMember(team.id, user.id);
       setNotification({
         type: "success",
-        message: "You have left the team successfully.",
+        message:
+          reopenedRoles.length > 0
+            ? `You have left the team. ${reopenedRoles.length} filled ${reopenedRoles.length === 1 ? "role was" : "roles were"} reopened.`
+            : "You have left the team successfully.",
       });
       setIsLeaveDialogOpen(false);
 

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -14,6 +14,7 @@ import {
 import Modal from "../common/Modal";
 import Button from "../common/Button";
 import ScreenAlert from "../common/ScreenAlert";
+import RoleBadgePill from "../common/RoleBadgePill";
 import UserDetailsModal from "../users/UserDetailsModal";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import TeamInvitesModal from "../teams/TeamInvitesModal";
@@ -225,45 +226,8 @@ const TeamInviteModal = ({
           inviteeId
         );
         const availableTeams = teamsResponse.data || [];
-        const prefilledTeamWasExcluded =
-          normalizedPrefillTeamId != null &&
-          !availableTeams.some((team) => idsMatch(team.id, normalizedPrefillTeamId));
-        let teamsData = availableTeams;
 
-        if (prefilledTeamWasExcluded) {
-          try {
-            const prefilledTeamResponse = await teamService.getTeamById(
-              normalizedPrefillTeamId,
-            );
-            const fetchedPrefilledTeam = unwrapTeamPayload(prefilledTeamResponse);
-
-            if (fetchedPrefilledTeam?.id != null) {
-              teamsData = [fetchedPrefilledTeam, ...availableTeams];
-            } else {
-              teamsData = [
-                {
-                  id: normalizedPrefillTeamId,
-                  name: prefillTeamName || "Prefilled Team",
-                },
-                ...availableTeams,
-              ];
-            }
-          } catch (prefilledTeamError) {
-            console.warn(
-              `Could not fetch prefilled team ${normalizedPrefillTeamId}:`,
-              prefilledTeamError,
-            );
-            teamsData = [
-              {
-                id: normalizedPrefillTeamId,
-                name: prefillTeamName || "Prefilled Team",
-              },
-              ...availableTeams,
-            ];
-          }
-        }
-
-        const uniqueTeams = teamsData.filter((team, index, allTeams) => {
+        const uniqueTeams = availableTeams.filter((team, index, allTeams) => {
           const normalizedTeamId = normalizeId(team?.id);
           if (normalizedTeamId == null) return false;
 
@@ -309,9 +273,15 @@ const TeamInviteModal = ({
               const isExistingMember =
                 team.isInviteeMember === true ||
                 team.is_invitee_member === true ||
-                (prefilledTeamWasExcluded &&
-                  idsMatch(team.id, normalizedPrefillTeamId)) ||
                 isInviteeExistingTeamMember(team, inviteeId);
+
+              let openRoleCount = 0;
+              try {
+                const rolesResponse = await vacantRoleService.getVacantRoles(team.id, "open");
+                openRoleCount = (rolesResponse.data || []).length;
+              } catch {
+                openRoleCount = 0;
+              }
 
               statusData[team.id] = {
                 hasInviteForUser,
@@ -319,6 +289,7 @@ const TeamInviteModal = ({
                 isExistingMember,
                 allInvitations,
                 allApplications,
+                openRoleCount,
               };
             } catch (err) {
               console.warn(`Could not fetch status for team ${team.id}:`, err);
@@ -328,6 +299,7 @@ const TeamInviteModal = ({
                 isExistingMember: false,
                 allInvitations: [],
                 allApplications: [],
+                openRoleCount: 0,
               };
             }
           })
@@ -450,12 +422,19 @@ const TeamInviteModal = ({
   useEffect(() => {
     if (!isOpen || !selectedTeamId || loadingRoles) return;
 
+    const currentSelectedTeam = teams.find((team) => idsMatch(team.id, selectedTeamId));
+    const teamRequiresRole = teamStatusData[currentSelectedTeam?.id]?.isExistingMember === true;
+
     setSelectedRoleId((currentSelectedRoleId) => {
       const selectedRoleStillExists = vacantRoles.find((role) =>
         idsMatch(role.id, currentSelectedRoleId),
       );
       if (selectedRoleStillExists) {
         return normalizeId(selectedRoleStillExists.id);
+      }
+
+      if (teamRequiresRole && vacantRoles.length === 1) {
+        return normalizeId(vacantRoles[0].id);
       }
 
       if (
@@ -478,6 +457,8 @@ const TeamInviteModal = ({
     loadingRoles,
     normalizedPrefillTeamId,
     normalizedPrefillRoleId,
+    teams,
+    teamStatusData,
   ]);
 
   // ============ Helper Functions ============
@@ -605,15 +586,28 @@ const TeamInviteModal = ({
     }
 
     if (isExistingMember) {
+      if (isSelected) {
+        return {
+          type: "existing-member-selected",
+          label: "Invite to Role",
+          icon: Check,
+          clickable: true,
+          customStyle: {
+            backgroundColor: "rgb(20, 83, 45)",
+            border: "none",
+            color: "#ffffff",
+          },
+        };
+      }
       return {
         type: "existing-member",
         label: "Member",
         icon: Users,
         clickable: true,
         customStyle: {
-          backgroundColor: "rgba(107, 114, 128, 0.15)",
-          borderColor: "rgba(107, 114, 128, 0.3)",
-          color: "rgba(31, 41, 55, 0.9)",
+          backgroundColor: "rgba(0, 146, 19, 0.08)",
+          border: "none",
+          color: "rgb(20, 83, 45)",
         },
       };
     }
@@ -622,7 +616,7 @@ const TeamInviteModal = ({
       if (isSelected) {
         return {
           type: "selected",
-          label: "Invite",
+          label: "Invite to Team",
           icon: Check,
           customStyle: {
             backgroundColor: "var(--color-primary-focus)",
@@ -655,18 +649,29 @@ const TeamInviteModal = ({
   };
 
   const orderedTeams = useMemo(() => {
-    if (normalizedPrefillTeamId == null) return teams;
+    const filtered = teams.filter((team) => {
+      const userRole = team.user_role ?? team.userRole;
+      if (userRole && !['owner', 'admin'].includes(userRole)) return false;
 
-    const prefilledTeam = teams.find((team) =>
+      const status = teamStatusData[team.id];
+      if (status?.isExistingMember === true && (status?.openRoleCount ?? 0) === 0) {
+        return false;
+      }
+      return true;
+    });
+
+    if (normalizedPrefillTeamId == null) return filtered;
+
+    const prefilledTeam = filtered.find((team) =>
       idsMatch(team.id, normalizedPrefillTeamId),
     );
-    if (!prefilledTeam) return teams;
+    if (!prefilledTeam) return filtered;
 
     return [
       prefilledTeam,
-      ...teams.filter((team) => !idsMatch(team.id, normalizedPrefillTeamId)),
+      ...filtered.filter((team) => !idsMatch(team.id, normalizedPrefillTeamId)),
     ];
-  }, [teams, normalizedPrefillTeamId]);
+  }, [teams, teamStatusData, normalizedPrefillTeamId]);
 
   const selectedTeam = useMemo(
     () =>
@@ -764,7 +769,8 @@ const TeamInviteModal = ({
     } else if (
       statusBadge.type === "available" ||
       statusBadge.type === "selected" ||
-      statusBadge.type === "existing-member"
+      statusBadge.type === "existing-member" ||
+      statusBadge.type === "existing-member-selected"
     ) {
       if (isTeamSelectable(teamId, team)) {
         const nextTeamId = idsMatch(selectedTeamId, teamId) ? null : teamId;
@@ -1164,7 +1170,7 @@ const TeamInviteModal = ({
                 </p>
               </div>
             ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-h-64 overflow-y-auto">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-64 overflow-y-auto p-1">
                 {orderedTeams.map((team) => {
                   const statusBadge = getTeamStatusBadge(team.id, team);
                   const BadgeIcon = statusBadge?.icon;
@@ -1173,40 +1179,20 @@ const TeamInviteModal = ({
                     <div
                       key={team.id}
                       onClick={() => handleCardClick(team)}
-                      className={`relative flex items-center gap-3 p-3 rounded-xl shadow cursor-pointer transition-all duration-200 
-                        ${
-                          idsMatch(selectedTeamId, team.id)
-                            ? "bg-green-100 ring-2 ring-primary shadow-md"
-                            : "bg-green-50 hover:bg-green-100 hover:shadow-md"
-                        }`}
-                    >
-                      {/* Status badge */}
-                      {statusBadge && (
-                        <div
-                          className="absolute top-2 right-2"
-                          onClick={(e) =>
-                            handleBadgeClick(e, team.id, team, statusBadge)
+                      className={`flex items-start gap-4 p-4 rounded-xl shadow cursor-pointer transition-all duration-200
+                        ${(() => {
+                          const isMember = teamStatusData[team.id]?.isExistingMember === true;
+                          if (idsMatch(selectedTeamId, team.id)) {
+                            return "bg-green-100 ring-2 ring-primary shadow-md";
                           }
-                        >
-                          <span
-                            className={`badge badge-sm gap-1 ${
-                              statusBadge.badgeClass || ""
-                            } ${
-                              statusBadge.clickable
-                                ? "cursor-pointer hover:shadow-md transition-all duration-200"
-                                : ""
-                            }`}
-                            style={statusBadge.customStyle || {}}
-                          >
-                            <BadgeIcon className="w-3 h-3" />
-                            {statusBadge.label}
-                          </span>
-                        </div>
-                      )}
-
+                          return isMember
+                            ? "bg-green-50 hover:bg-green-100 hover:shadow-md"
+                            : "bg-base-200 hover:bg-base-300 hover:shadow-md";
+                        })()}`}
+                    >
                       {/* Team avatar */}
-                      <div className="avatar flex-shrink-0">
-                        <div className="w-10 h-10 rounded-full relative">
+                      <div className="avatar">
+                        <div className="w-12 h-12 rounded-full relative overflow-hidden">
                           {getTeamAvatarUrl(team) ? (
                             <img
                               src={getTeamAvatarUrl(team)}
@@ -1228,7 +1214,7 @@ const TeamInviteModal = ({
                               display: getTeamAvatarUrl(team) ? "none" : "flex",
                             }}
                           >
-                            <span className="text-sm font-medium">
+                            <span className="text-lg">
                               {getTeamInitials(team.name)}
                             </span>
                           </div>
@@ -1236,14 +1222,65 @@ const TeamInviteModal = ({
                       </div>
 
                       {/* Team info */}
-                      <div className="flex-1 min-w-0 pr-2">
-                        <p className="font-medium truncate leading-tight pr-16">
-                          {team.name}
-                        </p>
-                        <p className="text-xs text-base-content/70">
-                          <Users size={12} className="inline mr-1" />
-                          {getMemberCount(team)}/{getMaxMembers(team)} members
-                        </p>
+                      <div className="flex-1 min-w-0 pt-[1px]">
+                        <div className="flex flex-col">
+                          <div className="flex items-center justify-between">
+                            <h3 className="font-medium text-base truncate leading-[120%] min-w-0">
+                              {team.name}
+                            </h3>
+                            {statusBadge && (
+                              <div
+                                className="shrink-0 ml-1"
+                                onClick={(e) =>
+                                  handleBadgeClick(e, team.id, team, statusBadge)
+                                }
+                              >
+                                <RoleBadgePill
+                                  icon={BadgeIcon}
+                                  label={statusBadge.label}
+                                  badgeColorClass={statusBadge.badgeClass || ""}
+                                  interactive={statusBadge.clickable}
+                                  style={statusBadge.customStyle}
+                                />
+                              </div>
+                            )}
+                          </div>
+                          <div className="flex flex-wrap gap-x-1.5 text-xs">
+                            <div className="flex items-start gap-0.5 min-w-0">
+                              <Users size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                              <span className="text-base-content/60 leading-tight break-words">{getMemberCount(team)}/{getMaxMembers(team)}</span>
+                            </div>
+                            {(teamStatusData[team.id]?.openRoleCount ?? 0) > 0 && (
+                              <div className="flex items-start gap-0.5 min-w-0">
+                                <UserSearch size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                                <span className="text-base-content/60 leading-tight break-words">{teamStatusData[team.id].openRoleCount}</span>
+                              </div>
+                            )}
+                            {(() => {
+                              const isRemote = team.isRemote ?? team.is_remote;
+                              const locationParts = [team.city, team.country].filter(Boolean);
+                              const locationText = isRemote ? "Remote" : locationParts.length > 0 ? locationParts.join(", ") : null;
+                              if (!locationText) return null;
+                              return (
+                                <div className="flex items-start gap-0.5 min-w-0">
+                                  {isRemote
+                                    ? <Globe size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                                    : <MapPin size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                                  }
+                                  <span className="text-base-content/60 leading-tight break-words">{locationText}</span>
+                                </div>
+                              );
+                            })()}
+                            {(statusBadge?.type === "existing-member-selected" ||
+                              ((statusBadge?.type === "pending-invite" || statusBadge?.type === "pending-application") &&
+                                teamStatusData[team.id]?.isExistingMember === true)) && (
+                              <div className="flex items-start gap-0.5 min-w-0">
+                                <Users size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                                <span className="text-base-content/60 leading-tight break-words">Member</span>
+                              </div>
+                            )}
+                          </div>
+                        </div>
                       </div>
                     </div>
                   );
@@ -1253,8 +1290,8 @@ const TeamInviteModal = ({
           </div>
 
           {/* Vacant role selection */}
-          {selectedTeamId && (
-            <div>
+          {selectedTeamId && (loadingRoles || vacantRoles.length > 0 || selectedTeamRequiresRole) && (
+            <div className="pt-2">
               <p className="text-xs text-base-content/60 mb-2 flex items-center">
                 <UserSearch size={12} className="text-orange-500 mr-1" />
                 Select a role you want to fill in this team:
@@ -1286,7 +1323,7 @@ const TeamInviteModal = ({
                   </p>
                 </div>
               ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-h-64 overflow-y-auto">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-h-64 overflow-y-auto p-1">
                   {vacantRoles.map((role) => {
                     const roleName =
                       role.roleName ?? role.role_name ?? "Vacant Role";

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -11,6 +11,11 @@ import {
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import ScreenAlert from "../common/ScreenAlert";
 import { teamService } from "../../services/teamService";
+import {
+  fetchRolesFilledByMember,
+  getRolesFilledByMember,
+  reopenRolesFilledByMember,
+} from "../../services/teamMemberRoleReopenService";
 import { userService } from "../../services/userService";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import CardMetaItem from "../common/CardMetaItem";
@@ -53,6 +58,15 @@ const getCachedMemberSyntheticStatus = async (memberId) => {
     throw error;
   }
 };
+
+const getTeamMemberId = (member) =>
+  member?.userId ??
+  member?.user_id ??
+  member?.memberId ??
+  member?.member_id ??
+  member?.user?.id ??
+  member?.id ??
+  null;
 
 /**
  * TeamMembersSection Component
@@ -103,7 +117,7 @@ const TeamMembersSection = ({
     const memberIdsToFetch = [];
 
     members.forEach((member) => {
-      const memberId = member?.userId ?? member?.user_id ?? null;
+      const memberId = getTeamMemberId(member);
       if (memberId == null) return;
 
       const cacheKey = String(memberId);
@@ -190,13 +204,14 @@ const TeamMembersSection = ({
       <div
         className="grid grid-cols-1 sm:grid-cols-2 gap-4"
         key={team.members
-          .map((m) => `${m.user_id || m.userId}-${m.role}`)
+          .map((m) => `${getTeamMemberId(m)}-${m.role}`)
           .join(",")}
       >
         {(isExpanded ? team.members : team.members.slice(0, COLLAPSED_COUNT)).map((member) => {
           // Check which property is available (userId or user_id)
-          const memberId = member.userId || member.user_id;
-          const isCurrentUser = memberId === user?.id;
+          const memberId = getTeamMemberId(member);
+          const isCurrentUser =
+            memberId != null && String(memberId) === String(user?.id);
 
           // Determine if this member should be anonymized
           const anonymize = shouldAnonymizeMember(member);
@@ -225,7 +240,10 @@ const TeamMembersSection = ({
 
           // Role management logic - Owners and admins can manage roles
           const currentUserMember = team.members?.find(
-            (m) => m.user_id === user?.id || m.userId === user?.id,
+            (m) => {
+              const rowMemberId = getTeamMemberId(m);
+              return rowMemberId != null && String(rowMemberId) === String(user?.id);
+            },
           );
           const isAdmin = currentUserMember?.role === "admin";
 
@@ -334,17 +352,65 @@ const TeamMembersSection = ({
                           });
                         }
                       }}
-                      onRemoveMember={async () => {
+                      onRemoveMember={async (resolvedMemberId = memberId) => {
+                        let demotedForRemoval = false;
+
                         try {
-                          await teamService.removeTeamMember(team.id, memberId);
+                          if (resolvedMemberId == null) {
+                            throw new Error("Could not determine member ID");
+                          }
+
+                          const rolesToReopen =
+                            Array.isArray(roles) && roles.length > 0
+                              ? getRolesFilledByMember(roles, resolvedMemberId)
+                              : await fetchRolesFilledByMember(team.id, resolvedMemberId);
+
+                          if (member.role === "admin" && isAdmin && !isOwner) {
+                            await teamService.updateMemberRole(
+                              team.id,
+                              resolvedMemberId,
+                              "member",
+                            );
+                            demotedForRemoval = true;
+                          }
+
+                          await teamService.removeTeamMember(team.id, resolvedMemberId);
+
+                          const reopenedRoles = await reopenRolesFilledByMember({
+                            teamId: team.id,
+                            teamName: team.name,
+                            member,
+                            memberId: resolvedMemberId,
+                            roles: rolesToReopen,
+                            useProvidedRoles: true,
+                          });
+
                           setNotification({
                             type: "success",
-                            message: `${formatDisplayName(member)} has been removed from the team.`,
+                            message:
+                              reopenedRoles.length > 0
+                                ? `${formatDisplayName(member)} has been removed from the team. ${reopenedRoles.length} filled ${reopenedRoles.length === 1 ? "role was" : "roles were"} reopened.`
+                                : `${formatDisplayName(member)} has been removed from the team.`,
                           });
                           if (onMemberRemoved) {
                             await onMemberRemoved();
                           }
                         } catch (error) {
+                          if (demotedForRemoval) {
+                            try {
+                              await teamService.updateMemberRole(
+                                team.id,
+                                resolvedMemberId,
+                                "admin",
+                              );
+                            } catch (restoreError) {
+                              console.error(
+                                "Failed to restore admin role after removal failed:",
+                                restoreError,
+                              );
+                            }
+                          }
+
                           setNotification({
                             type: "error",
                             message:

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   Award,
   Calendar,
@@ -197,6 +198,8 @@ const VacantRoleCard = ({
   notificationHighlight = false,
 }) => {
   const [showMenu, setShowMenu] = useState(false);
+  const [menuPosition, setMenuPosition] = useState(null);
+  const menuTriggerRef = useRef(null);
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [pendingApplicationForRole, setPendingApplicationForRole] =
     useState(null);
@@ -1318,7 +1321,7 @@ const VacantRoleCard = ({
               )}
             </div>
 
-            <div className="relative flex-shrink-0" data-dropdown-menu>
+            <div ref={menuTriggerRef} className="relative flex-shrink-0" data-dropdown-menu>
               <RoleBadgePill
                 icon={badgeConfig.icon}
                 label={badgeConfig.label}
@@ -1329,101 +1332,118 @@ const VacantRoleCard = ({
                   canOpenBadgeMenu
                     ? (e) => {
                         e.stopPropagation();
+                        if (!showMenu && menuTriggerRef.current) {
+                          const rect = menuTriggerRef.current.getBoundingClientRect();
+                          setMenuPosition({
+                            top: rect.bottom + 4,
+                            right: window.innerWidth - rect.right,
+                          });
+                        }
                         setShowMenu(!showMenu);
                       }
                     : undefined
                 }
               />
-
-              {canOpenBadgeMenu && showMenu && (
-                <>
-                  <div
-                    className="fixed inset-0 z-[9]"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowMenu(false);
-                    }}
-                  />
-                  <div className="absolute right-0 top-8 z-20 bg-base-100 border border-base-300 rounded-lg shadow-lg py-1 min-w-[200px]">
-                    {canEditRole && (
-                      <button
-                        className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowMenu(false);
-                          onEdit(role);
-                        }}
-                      >
-                        <Edit size={14} />
-                        Edit Role
-                      </button>
-                    )}
-                    {canMarkFilled && (
-                      <button
-                        className="flex items-start gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowMenu(false);
-                          onStatusChange(role.id, "filled");
-                        }}
-                      >
-                        <CheckCircle
-                          size={14}
-                          className="text-success flex-shrink-0 mt-[2px]"
-                        />
-                        {viewAsUser
-                          ? `Mark role as filled with ${
-                              viewAsUser.firstName ??
-                              viewAsUser.first_name ??
-                              viewAsUser.username ??
-                              "this applicant"
-                            }`
-                          : "Mark Filled"}
-                      </button>
-                    )}
-                    {canCloseRole && (
-                      <button
-                        className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowMenu(false);
-                          onStatusChange(role.id, "closed");
-                        }}
-                      >
-                        <XCircle size={14} className="text-warning" />
-                        Close Role
-                      </button>
-                    )}
-                    {canReopenRole && (
-                      <button
-                        className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowMenu(false);
-                          onStatusChange(role.id, "open");
-                        }}
-                      >
-                        <CheckCircle size={14} className="text-primary" />
-                        Reopen Role
-                      </button>
-                    )}
-                    {canDeleteRole && (
-                      <button
-                        className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left text-error"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setShowMenu(false);
-                          onDelete(role.id);
-                        }}
-                      >
-                        <Trash2 size={14} />
-                        Delete Role
-                      </button>
-                    )}
-                  </div>
-                </>
-              )}
             </div>
+
+            {canOpenBadgeMenu && showMenu && menuPosition && createPortal(
+              <>
+                <div
+                  className="fixed inset-0"
+                  style={{ zIndex: 9998 }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setShowMenu(false);
+                  }}
+                />
+                <div
+                  style={{
+                    position: "fixed",
+                    top: menuPosition.top,
+                    right: menuPosition.right,
+                    zIndex: 9999,
+                  }}
+                  className="bg-base-100 border border-base-300 rounded-lg shadow-lg py-1 min-w-[200px]"
+                >
+                  {canEditRole && (
+                    <button
+                      className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowMenu(false);
+                        onEdit(role);
+                      }}
+                    >
+                      <Edit size={14} />
+                      Edit Role
+                    </button>
+                  )}
+                  {canMarkFilled && (
+                    <button
+                      className="flex items-start gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowMenu(false);
+                        onStatusChange(role.id, "filled");
+                      }}
+                    >
+                      <CheckCircle
+                        size={14}
+                        className="text-success flex-shrink-0 mt-[2px]"
+                      />
+                      {viewAsUser
+                        ? `Mark role as filled with ${
+                            viewAsUser.firstName ??
+                            viewAsUser.first_name ??
+                            viewAsUser.username ??
+                            "this applicant"
+                          }`
+                        : "Mark Filled"}
+                    </button>
+                  )}
+                  {canCloseRole && (
+                    <button
+                      className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowMenu(false);
+                        onStatusChange(role.id, "closed");
+                      }}
+                    >
+                      <XCircle size={14} className="text-warning" />
+                      Close Role
+                    </button>
+                  )}
+                  {canReopenRole && (
+                    <button
+                      className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowMenu(false);
+                        onStatusChange(role.id, "open");
+                      }}
+                    >
+                      <CheckCircle size={14} className="text-primary" />
+                      Reopen Role
+                    </button>
+                  )}
+                  {canDeleteRole && (
+                    <button
+                      className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-base-200 text-left text-error"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowMenu(false);
+                        onDelete(role.id);
+                      }}
+                    >
+                      <Trash2 size={14} />
+                      Delete Role
+                    </button>
+                  )}
+                </div>
+              </>,
+              document.body
+            )}
           </div>
 
           {isMiniView && scoreSubtitleItem && (

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -1759,7 +1759,7 @@ const VacantRoleDetailsModal = ({
           {modalStatusTitle}
         </h2>
       </div>
-      {!isFilledRole && viewerIsTeamMember && (tags.length > 0 || badges.length > 0) && !hideActions && (
+      {!isFilledRole && canManage && !hideActions && (
         <div className="flex items-center space-x-2">
           <Button
             variant="ghost"
@@ -2479,7 +2479,7 @@ const VacantRoleDetailsModal = ({
                         className={`flex items-start rounded-xl shadow p-4 gap-4 transition-all duration-200 hover:shadow-md cursor-pointer text-left w-full ${
                           applicantIsTeamMember
                             ? "bg-green-50 hover:bg-green-100"
-                            : "bg-white hover:bg-base-100"
+                            : "bg-base-200 hover:bg-base-300"
                         }`}
                         onClick={() => {
                           setHighlightApplicantId(applicantId);
@@ -2693,7 +2693,7 @@ const VacantRoleDetailsModal = ({
                         className={`flex items-start rounded-xl shadow p-4 gap-4 transition-all duration-200 hover:shadow-md cursor-pointer text-left w-full ${
                           inviteeIsTeamMember
                             ? "bg-green-50 hover:bg-green-100"
-                            : "bg-white hover:bg-base-100"
+                            : "bg-base-200 hover:bg-base-300"
                         }`}
                         onClick={() => {
                           setHighlightInviteeId(inviteeId);

--- a/src/components/teams/VacantRolesSection.jsx
+++ b/src/components/teams/VacantRolesSection.jsx
@@ -58,14 +58,8 @@ const VacantRolesSection = ({
   const COLLAPSED_COUNT = 4;
   const shouldShowFilledRoles = canManage || isTeamMember;
   const visibleRoles = roles.filter((role) => {
-    if (canManage) return true;
-
-    const normalizedStatus = String(role?.status ?? "").toLowerCase();
-    if (isTeamMember) {
-      return normalizedStatus === "open" || normalizedStatus === "filled";
-    }
-
-    return normalizedStatus === "open";
+    if (canManage || isTeamMember) return true;
+    return String(role?.status ?? "").toLowerCase() === "open";
   });
 
   // Modal state

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -20,6 +20,7 @@ import socketService from "../services/socketService";
 import useSocketEvents from "../hooks/useSocketEvents";
 import { userService } from "../services/userService";
 import { teamService } from "../services/teamService";
+import { reopenRolesFilledByMember } from "../services/teamMemberRoleReopenService";
 import ScreenAlert from "../components/common/ScreenAlert";
 import Button from "../components/common/Button";
 import Modal from "../components/common/Modal";
@@ -79,12 +80,12 @@ const resolveConversationUser = (conversation, userId) => {
     const matchedMember = members.find((member) => {
       const memberUser = member.user || member;
       const memberId =
-        memberUser?.id ??
-        memberUser?.userId ??
-        memberUser?.user_id ??
-        member?.id ??
         member?.userId ??
         member?.user_id ??
+        memberUser?.userId ??
+        memberUser?.user_id ??
+        memberUser?.id ??
+        member?.id ??
         null;
       return String(memberId) === String(userId);
     });
@@ -95,6 +96,126 @@ const resolveConversationUser = (conversation, userId) => {
   }
 
   return null;
+};
+
+const getTeamMemberUserId = (member) => {
+  const memberUser = member?.user || member;
+  return (
+    member?.userId ??
+    member?.user_id ??
+    memberUser?.userId ??
+    memberUser?.user_id ??
+    memberUser?.id ??
+    member?.id ??
+    null
+  );
+};
+
+const isActiveTeamMemberRow = (member) => {
+  if (!member) return false;
+
+  const rawStatus =
+    member.membershipStatus ??
+    member.membership_status ??
+    member.memberStatus ??
+    member.member_status ??
+    member.status ??
+    null;
+  const status = String(rawStatus ?? "").trim().toLowerCase();
+
+  if (
+    status &&
+    ["removed", "left", "former", "inactive", "deleted"].includes(status)
+  ) {
+    return false;
+  }
+
+  return !(
+    member.removedAt ||
+    member.removed_at ||
+    member.leftAt ||
+    member.left_at ||
+    member.deletedAt ||
+    member.deleted_at
+  );
+};
+
+const isUserTeamMember = (members, userId) => {
+  if (userId == null) return false;
+  if (!Array.isArray(members)) return false;
+
+  return members.some((member) => {
+    if (!isActiveTeamMemberRow(member)) return false;
+
+    const memberId = getTeamMemberUserId(member);
+    return memberId != null && String(memberId) === String(userId);
+  });
+};
+
+const getPayloadTeamId = (payload) =>
+  payload?.teamId ??
+  payload?.team_id ??
+  payload?.team?.id ??
+  payload?.data?.teamId ??
+  payload?.data?.team_id ??
+  payload?.metadata?.teamId ??
+  payload?.metadata?.team_id ??
+  null;
+
+const getPayloadType = (payload) =>
+  String(
+    payload?.type ??
+      payload?.notificationType ??
+      payload?.notification_type ??
+      payload?.eventType ??
+      payload?.event_type ??
+      payload?.data?.type ??
+      payload?.metadata?.type ??
+      "",
+  ).toLowerCase();
+
+const getRemovedMemberIdFromPayload = (payload) =>
+  payload?.memberId ??
+  payload?.member_id ??
+  payload?.removedUserId ??
+  payload?.removed_user_id ??
+  payload?.targetUserId ??
+  payload?.target_user_id ??
+  payload?.data?.memberId ??
+  payload?.data?.member_id ??
+  payload?.metadata?.memberId ??
+  payload?.metadata?.member_id ??
+  null;
+
+const getPayloadText = (payload) =>
+  [
+    payload?.message,
+    payload?.content,
+    payload?.text,
+    payload?.body,
+    payload?.title,
+    payload?.data?.message,
+    payload?.data?.content,
+    payload?.metadata?.message,
+    payload?.metadata?.content,
+  ]
+    .filter((value) => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+
+const isCurrentUserRemovalPayload = (payload, userId) => {
+  const type = getPayloadType(payload);
+  if (!type.includes("member_removed") && !type.includes("removed")) {
+    return false;
+  }
+
+  const removedMemberId = getRemovedMemberIdFromPayload(payload);
+  if (removedMemberId != null && String(removedMemberId) === String(userId)) {
+    return true;
+  }
+
+  const text = getPayloadText(payload);
+  return /\byou\b/.test(text) && /removed from/.test(text);
 };
 
 const getConversationUpdatedAt = (conversation) => {
@@ -651,19 +772,103 @@ const Chat = () => {
 
   const teamMembers =
     conversationType === "team" ? activeConversation?.team?.members || [] : [];
+  const isCurrentUserActiveTeamMember =
+    conversationType !== "team" || isUserTeamMember(teamMembers, user?.id);
+  const canSendInActiveConversation =
+    Boolean(activeConversation) && isCurrentUserActiveTeamMember;
+
+  const revokeTeamChatAccess = useCallback(
+    (teamId, message = "You no longer have access to this team chat.") => {
+      if (!teamId) return;
+
+      socketService.leaveConversation(teamId, "team");
+      setError(message);
+      setConversations((prev) =>
+        prev.filter(
+          (conversation) =>
+            !(
+              conversation.type === "team" &&
+              String(conversation.id) === String(teamId)
+            ),
+        ),
+      );
+
+      const activeTeamId =
+        activeConversationRef.current?.team?.id ?? activeConversationRef.current?.id;
+
+      if (
+        String(activeTeamId) === String(teamId) ||
+        (String(conversationId) === String(teamId) &&
+          (searchParams.get("type") || "direct") === "team")
+      ) {
+        setActiveConversation(null);
+        setMessages([]);
+        setTypingUsers({});
+        setReplyingTo(null);
+        setHighlightMessageIds([]);
+        setHasMoreMessages(false);
+        setShowChatView(false);
+        navigate("/chat", { replace: true });
+      }
+    },
+    [conversationId, navigate, searchParams],
+  );
+
+  const refreshActiveTeamMembership = useCallback(
+    async (teamId) => {
+      if (!teamId || !user?.id) return true;
+
+      const response = await teamService.getTeamById(teamId);
+      const teamPayload =
+        response?.data && typeof response.data === "object"
+          ? response.data
+          : response;
+
+      if (!Array.isArray(teamPayload?.members)) {
+        return true;
+      }
+
+      if (!isUserTeamMember(teamPayload.members, user.id)) {
+        revokeTeamChatAccess(teamId);
+        return false;
+      }
+
+      setActiveConversation((prev) => {
+        if (
+          !prev ||
+          prev.type !== "team" ||
+          String(prev.team?.id ?? prev.id) !== String(teamId)
+        ) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          team: {
+            ...prev.team,
+            members: teamPayload.members,
+          },
+        };
+      });
+
+      return true;
+    },
+    [revokeTeamChatAccess, user?.id],
+  );
 
   const mentionParticipants = useMemo(() => {
     if (conversationType === "direct") {
       return conversationPartner ? [conversationPartner] : [];
     }
     const members = teamMembers
+      .filter(isActiveTeamMemberRow)
       .map((m) => m.user || m)
       .filter((m) => {
-        const id = m.id ?? m.userId ?? m.user_id;
+        const id = m.userId ?? m.user_id ?? m.id;
         return id && String(id) !== String(user?.id);
       })
       .map((m) => ({
-        id: m.id ?? m.userId ?? m.user_id,
+        id: m.userId ?? m.user_id ?? m.id,
         firstName: m.firstName || m.first_name || "",
         lastName: m.lastName || m.last_name || "",
         avatarUrl: m.avatarUrl || m.avatar_url || null,
@@ -700,6 +905,49 @@ const Chat = () => {
   useEffect(() => {
     activeConversationRef.current = activeConversation;
   }, [activeConversation]);
+
+  useEffect(() => {
+    if (
+      conversationType !== "team" ||
+      !activeConversation?.team?.id ||
+      !user?.id
+    ) {
+      return undefined;
+    }
+
+    const teamId = activeConversation.team.id;
+    let cancelled = false;
+
+    const checkMembership = async () => {
+      try {
+        if (!cancelled) {
+          await refreshActiveTeamMembership(teamId);
+        }
+      } catch (err) {
+        console.error("Error checking active team chat access:", err);
+      }
+    };
+
+    checkMembership();
+    const intervalId = window.setInterval(checkMembership, 10000);
+
+    const handleFocus = () => {
+      checkMembership();
+    };
+
+    window.addEventListener("focus", handleFocus);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [
+    activeConversation?.team?.id,
+    conversationType,
+    refreshActiveTeamMembership,
+    user?.id,
+  ]);
 
   const fetchConversationSearchText = useCallback(async (conversation) => {
     const conversationType = conversation?.type || "direct";
@@ -1130,6 +1378,25 @@ const Chat = () => {
               }
 
               if (teamDetails?.data?.members) {
+                if (!isUserTeamMember(teamDetails.data.members, user?.id)) {
+                  setError("You no longer have access to this team chat.");
+                  setConversations((prev) =>
+                    prev.filter(
+                      (conversation) =>
+                        !(
+                          conversation.type === "team" &&
+                          String(conversation.id) === String(conversationId)
+                        ),
+                    ),
+                  );
+                  setActiveConversation(null);
+                  setMessages([]);
+                  setLoadingMessages(false);
+                  setShowChatView(false);
+                  navigate("/chat", { replace: true });
+                  return;
+                }
+
                 conversationDetails.data.team = {
                   ...conversationDetails.data.team,
                   avatarUrl:
@@ -1224,6 +1491,25 @@ const Chat = () => {
               }
 
               if (teamDetails?.data?.members) {
+                if (!isUserTeamMember(teamDetails.data.members, user?.id)) {
+                  setError("You no longer have access to this team chat.");
+                  setConversations((prev) =>
+                    prev.filter(
+                      (conversation) =>
+                        !(
+                          conversation.type === "team" &&
+                          String(conversation.id) === String(conversationId)
+                        ),
+                    ),
+                  );
+                  setActiveConversation(null);
+                  setMessages([]);
+                  setLoadingMessages(false);
+                  setShowChatView(false);
+                  navigate("/chat", { replace: true });
+                  return;
+                }
+
                 conversationDetails.data.team = {
                   ...conversationDetails.data.team,
                   avatarUrl:
@@ -1509,13 +1795,7 @@ const Chat = () => {
         conversationType === "team" &&
         parseInt(conversationId, 10) === data.teamId
       ) {
-        setError("You have been removed from this team.");
-        setConversations((prev) =>
-          prev.filter((c) => !(c.type === "team" && c.id === data.teamId)),
-        );
-        navigate("/chat");
-        setActiveConversation(null);
-        setMessages([]);
+        revokeTeamChatAccess(data.teamId, "You have been removed from this team.");
         return;
       }
 
@@ -1523,7 +1803,7 @@ const Chat = () => {
         prev.filter((c) => !(c.type === "team" && c.id === data.teamId)),
       );
     },
-    [conversationId, conversationType, navigate],
+    [conversationId, conversationType, revokeTeamChatAccess],
   );
 
   // Set up WebSocket event listeners
@@ -1566,6 +1846,24 @@ const Chat = () => {
       }
 
       if (isForCurrentConversation) {
+        if (currentType === "team") {
+          const parsedMessage = parseSystemMessage(message.content);
+          const removedMemberId =
+            parsedMessage?.memberId ?? parsedMessage?.userId ?? null;
+
+          if (
+            ["member_removed", "member_removed_public"].includes(parsedMessage?.type) &&
+            removedMemberId != null &&
+            String(removedMemberId) === String(user?.id)
+          ) {
+            revokeTeamChatAccess(
+              messageConvId,
+              "You have been removed from this team.",
+            );
+            return;
+          }
+        }
+
         setMessages((prev) => {
           // If this is our own message, replace the optimistic version
           if (message.senderId === user.id) {
@@ -1706,13 +2004,21 @@ const Chat = () => {
     };
 
     const refreshTeamEventMessages = async (payload) => {
-      const teamId = payload?.teamId ?? payload?.team_id;
-      if (!teamId) return;
-
-      refreshConversationList();
-
       const urlParams = new URLSearchParams(window.location.search);
       const currentType = urlParams.get("type") || "direct";
+      const activeTeamId =
+        activeConversationRef.current?.team?.id ?? activeConversationRef.current?.id;
+      const teamId =
+        getPayloadTeamId(payload) ??
+        (currentType === "team" ? activeTeamId : null);
+      if (!teamId) return;
+
+      if (isCurrentUserRemovalPayload(payload, user?.id)) {
+        revokeTeamChatAccess(teamId, "You have been removed from this team.");
+        return;
+      }
+
+      refreshConversationList();
 
       if (
         currentType !== "team" ||
@@ -1722,6 +2028,12 @@ const Chat = () => {
       }
 
       try {
+        const canStillAccess = await refreshActiveTeamMembership(teamId);
+
+        if (!canStillAccess) {
+          return;
+        }
+
         const messagesResponse = await messageService.getMessages(
           teamId,
           "team",
@@ -1857,10 +2169,11 @@ const Chat = () => {
 
     const handleTeamMemberLeft = (data) => {
       if (!data?.teamId) return;
+      const leftUserId = data.userId ?? data.user_id ?? null;
 
       setTeamMembersRefreshSignal({
         teamId: data.teamId,
-        userId: data.userId ?? null,
+        userId: leftUserId,
         receivedAt: Date.now(),
       });
 
@@ -1881,6 +2194,11 @@ const Chat = () => {
         return;
       }
 
+      if (leftUserId != null && String(leftUserId) === String(user?.id)) {
+        revokeTeamChatAccess(data.teamId, "You have left this team chat.");
+        return;
+      }
+
       teamService
         .getTeamById(data.teamId)
         .then((response) => {
@@ -1890,6 +2208,11 @@ const Chat = () => {
               : response;
 
           if (!Array.isArray(teamPayload?.members)) {
+            return;
+          }
+
+          if (!isUserTeamMember(teamPayload.members, user?.id)) {
+            revokeTeamChatAccess(data.teamId);
             return;
           }
 
@@ -2054,7 +2377,9 @@ const Chat = () => {
     handleKickedFromTeam,
     isAuthenticated,
     navigate,
+    refreshActiveTeamMembership,
     refreshConversationList,
+    revokeTeamChatAccess,
     activeConversation,
     searchParams,
     user?.id,
@@ -2098,6 +2423,13 @@ const Chat = () => {
 
   const executeLeaveTeam = async ({ teamId }) => {
     try {
+      await reopenRolesFilledByMember({
+        teamId,
+        teamName: activeConversation?.team?.name,
+        member: user,
+        memberId: user.id,
+      });
+
       // Call the existing leave team API
       await teamService.removeTeamMember(teamId, user.id);
 
@@ -2109,11 +2441,35 @@ const Chat = () => {
 
       setActiveConversation(null);
       setMessages([]);
+      setShowChatView(false);
       return true;
     } catch (error) {
       console.error("Error leaving team:", error);
       setError("Failed to leave team. Please try again.");
       return false;
+    }
+  };
+
+  const handleTeamDetailsLeave = (teamId) => {
+    if (!teamId) return;
+
+    setConversations((prev) =>
+      prev.filter(
+        (conversation) =>
+          !(conversation.type === "team" && String(conversation.id) === String(teamId)),
+      ),
+    );
+
+    if (String(conversationId) === String(teamId)) {
+      setActiveConversation(null);
+      setMessages([]);
+      setTypingUsers({});
+      setReplyingTo(null);
+      setShowChatView(false);
+      setIsTeamModalOpen(false);
+      setSelectedTeamId(null);
+      setSelectedTeamData(null);
+      navigate("/chat", { replace: true });
     }
   };
 
@@ -2212,7 +2568,12 @@ const Chat = () => {
   };
 
   const handleSendFile = async (file) => {
-    if (!activeConversation || !file) return;
+    if (!canSendInActiveConversation || !file) {
+      if (!isCurrentUserActiveTeamMember) {
+        setError("You no longer have access to this team chat.");
+      }
+      return;
+    }
 
     try {
       // Upload file attachment before sending the message
@@ -2229,6 +2590,11 @@ const Chat = () => {
         type === "team"
           ? activeConversation.team?.id
           : activeConversation.partner?.id;
+
+      if (type === "team") {
+        const canStillAccess = await refreshActiveTeamMembership(targetId);
+        if (!canStillAccess) return;
+      }
 
       // Send message with file via socket
       socketService.sendMessage(
@@ -2248,7 +2614,12 @@ const Chat = () => {
   };
 
   const handleSendImage = async (file, previewUrl) => {
-    if (!activeConversation || !file) return;
+    if (!canSendInActiveConversation || !file) {
+      if (!isCurrentUserActiveTeamMember) {
+        setError("You no longer have access to this team chat.");
+      }
+      return;
+    }
 
     try {
       // Upload image attachment before sending the message
@@ -2265,6 +2636,11 @@ const Chat = () => {
         type === "team"
           ? activeConversation.team?.id
           : activeConversation.partner?.id;
+
+      if (type === "team") {
+        const canStillAccess = await refreshActiveTeamMembership(targetId);
+        if (!canStillAccess) return;
+      }
 
       // Send message with image via socket
       socketService.sendMessage(
@@ -2292,6 +2668,11 @@ const Chat = () => {
 
   const executeDeleteMessage = async ({ messageId }) => {
     try {
+      if ((searchParams.get("type") || "direct") === "team") {
+        const canStillAccess = await refreshActiveTeamMembership(conversationId);
+        if (!canStillAccess) return false;
+      }
+
       // Optimistic UI update
       setMessages((prev) =>
         prev.map((m) =>
@@ -2352,6 +2733,11 @@ const Chat = () => {
     const trimmedContent = content.trim();
     if (!trimmedContent) {
       throw new Error("Message cannot be empty.");
+    }
+
+    if ((searchParams.get("type") || "direct") === "team") {
+      const canStillAccess = await refreshActiveTeamMembership(conversationId);
+      if (!canStillAccess) return;
     }
 
     const previousMessage = messages.find(
@@ -2446,12 +2832,23 @@ const Chat = () => {
     }
   };
 
-  const handleSendMessage = (content) => {
+  const handleSendMessage = async (content) => {
     if (!content.trim() || !conversationId) return;
+    if (!canSendInActiveConversation) {
+      if (!isCurrentUserActiveTeamMember) {
+        setError("You no longer have access to this team chat.");
+      }
+      return;
+    }
 
     // Get type from URL parameters
     const urlParams = new URLSearchParams(window.location.search);
     const type = urlParams.get("type") || "direct";
+
+    if (type === "team") {
+      const canStillAccess = await refreshActiveTeamMembership(conversationId);
+      if (!canStillAccess) return;
+    }
 
     // Create optimistic message (show immediately)
     const optimisticMessage = {
@@ -2586,6 +2983,12 @@ const Chat = () => {
   const isNoSearchResults =
     isChatSearchActive && !searchingChatMessages && filteredConversations.length === 0;
   const hideChatDuringSearch = isChatSearchActive && !searchChatVisible;
+  const shouldShowConversationPanel =
+    !showEmptyConversationState &&
+    !hideChatDuringSearch &&
+    Boolean(conversationId) &&
+    showChatView &&
+    (Boolean(activeConversation) || loadingMessages);
   const totalSearchMatches = isChatSearchActive
     ? filteredConversations.reduce((sum, conv) => sum + (conv.searchMatchCount || 0), 0)
     : 0;
@@ -2702,7 +3105,7 @@ const Chat = () => {
         <div
           data-conversation-list-viewport="true"
           className={`lomir-conversation-list-scrollbar overflow-y-auto transition-all duration-300 ${
-            showEmptyConversationState || hideChatDuringSearch || !conversationId || !showChatView
+            showEmptyConversationState || hideChatDuringSearch || !shouldShowConversationPanel
               ? "w-full"
               : "hidden md:block md:w-1/3"
           }`}
@@ -2728,7 +3131,7 @@ const Chat = () => {
         </div>
 
         {/* Message Display - Right Side */}
-        {!showEmptyConversationState && !hideChatDuringSearch && conversationId && showChatView && (
+        {shouldShowConversationPanel && (
         <div className={`bg-white shadow-soft rounded-xl overflow-hidden flex flex-col min-w-0 transition-all duration-300 ${
           showChatView ? "w-full md:w-2/3" : "hidden md:flex md:w-2/3"
         }`}>
@@ -2938,14 +3341,19 @@ const Chat = () => {
                   </div>
                 )}
 
-                {/* Always show message input */}
+                {conversationType === "team" && !isCurrentUserActiveTeamMember && (
+                  <div className="mx-4 mt-4 rounded-lg bg-base-200 px-4 py-3 text-sm text-base-content/70">
+                    You are no longer a member of this team, so this chat is read-only.
+                  </div>
+                )}
+
                 <div className="p-4">
                   <MessageInput
                     onSendMessage={handleSendMessage}
                     onSendImage={handleSendImage}
                     onSendFile={handleSendFile}
                     onTyping={handleTyping}
-                    disabled={!activeConversation}
+                    disabled={!canSendInActiveConversation}
                     participants={mentionParticipants}
                     replyingTo={replyingTo}
                     onClearReply={handleClearReply}
@@ -2975,6 +3383,7 @@ const Chat = () => {
         teamId={selectedTeamId}
         initialTeamData={selectedTeamData}
         hideMatchData
+        onLeave={handleTeamDetailsLeave}
         onClose={() => { setIsTeamModalOpen(false); setSelectedTeamId(null); setSelectedTeamData(null); }}
       />
 

--- a/src/services/teamMemberRoleReopenService.js
+++ b/src/services/teamMemberRoleReopenService.js
@@ -1,0 +1,105 @@
+import { messageService } from "./messageService";
+import { vacantRoleService } from "./vacantRoleService";
+import { buildRoleReopenedMessage } from "../utils/roleEventMessages";
+import { resolveFilledRoleUser } from "../utils/vacantRoleUtils";
+
+const unwrapData = (response) => {
+  if (!response) return response;
+  if (response.success !== undefined) return response.data;
+  return response.data?.data ?? response.data ?? response;
+};
+
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
+const getRoleId = (role) => role?.id ?? role?.roleId ?? role?.role_id ?? null;
+
+const getFilledById = (role) =>
+  role?.filledByUser?.id ??
+  role?.filled_by_user?.id ??
+  role?.filledByUserId ??
+  role?.filled_by_user_id ??
+  role?.filledBy ??
+  role?.filled_by ??
+  null;
+
+export const getRolesFilledByMember = (roles, memberId) => {
+  if (memberId == null) return [];
+
+  return asArray(roles).filter((role) => {
+    const roleId = getRoleId(role);
+    if (roleId == null) return false;
+
+    const status = String(role?.status ?? "").toLowerCase();
+    const filledById = getFilledById(role);
+
+    return (
+      status === "filled" &&
+      filledById != null &&
+      String(filledById) === String(memberId)
+    );
+  });
+};
+
+export const fetchRolesFilledByMember = async (teamId, memberId) => {
+  const response = await vacantRoleService.getVacantRoles(teamId, "all");
+  return getRolesFilledByMember(unwrapData(response), memberId);
+};
+
+export const reopenRolesFilledByMember = async ({
+  teamId,
+  teamName,
+  member,
+  memberId,
+  roles = null,
+  useProvidedRoles = false,
+}) => {
+  const departingMemberId =
+    memberId ?? member?.id ?? member?.userId ?? member?.user_id ?? null;
+
+  if (!teamId || departingMemberId == null) {
+    return [];
+  }
+
+  const rolesToReopen = Array.isArray(roles) && (useProvidedRoles || roles.length > 0)
+    ? getRolesFilledByMember(roles, departingMemberId)
+    : await fetchRolesFilledByMember(teamId, departingMemberId);
+
+  const reopenedRoles = [];
+
+  for (const role of rolesToReopen) {
+    const roleId = getRoleId(role);
+    if (roleId == null) continue;
+
+    const updateResponse = await vacantRoleService.updateVacantRoleStatus(
+      teamId,
+      roleId,
+      "open",
+      null,
+      { skipChatMessage: true },
+    );
+    const updatedRole = unwrapData(updateResponse);
+    const eventRole =
+      updatedRole && typeof updatedRole === "object"
+        ? { ...role, ...updatedRole }
+        : role;
+
+    try {
+      await messageService.sendMessage(
+        teamId,
+        buildRoleReopenedMessage({
+          teamId,
+          teamName,
+          role,
+          filledUser: member ?? resolveFilledRoleUser(role),
+        }),
+        "team",
+      );
+    } catch (messageError) {
+      console.warn("Role reopened, but chat event could not be sent:", messageError);
+    }
+
+    reopenedRoles.push(eventRole);
+  }
+
+  return reopenedRoles;
+};

--- a/src/services/vacantRoleService.js
+++ b/src/services/vacantRoleService.js
@@ -78,10 +78,10 @@ export const vacantRoleService = {
    * @param {string} status - "open", "filled", or "closed"
    * @param {number|null} filledBy - user ID if status is "filled"
    */
-  async updateVacantRoleStatus(teamId, roleId, status, filledBy = null) {
+  async updateVacantRoleStatus(teamId, roleId, status, filledBy = null, { skipChatMessage = false } = {}) {
     const response = await api.put(
       `/api/teams/${teamId}/vacant-roles/${roleId}/status`,
-      { status, filled_by: filledBy },
+      { status, filled_by: filledBy, skip_chat_message: skipChatMessage || undefined },
     );
     return response.data;
   },

--- a/src/utils/eventPreview.js
+++ b/src/utils/eventPreview.js
@@ -386,12 +386,20 @@ export const getEventPreview = (lastMessage, currentUser = null) => {
     }
 
     case "role_reopened": {
+      const userName = getActorLabel(
+        parsedMessage.userId,
+        parsedMessage.userName,
+        currentUser,
+      );
+
       return {
-        text: `Role reopened: ${parsedMessage.roleName || "Vacant Role"}`,
+        text: userName
+          ? `${userName} left the role ${parsedMessage.roleName || "Vacant Role"}. It is open again.`
+          : `Role reopened: ${parsedMessage.roleName || "Vacant Role"}`,
         icon: "UserSearch",
         bannerClass: null,
         color: EVENT_PREVIEW_TEXT_COLORS.role,
-        senderPrefix: "by ",
+        senderPrefix: userName ? null : "by ",
       };
     }
 


### PR DESCRIPTION
Summary
This branch delivers the role-reopening lifecycle for teams — when a member leaves or is removed, their filled role is automatically reopened — plus a comprehensive overhaul of the notification system, invite modal UX, and a round of socket/service refactoring.

Core feature: Auto-reopen filled roles on member departure
Introduced teamMemberRoleReopenService to detect and reopen roles that were filled by a member who has since left or been removed from the team
Hooked into member-leave and admin-removal flows so the role reverts to open automatically, keeping the team's vacancy list accurate without manual intervention
Notification & toast system
Added toast notifications for invitation and application events (sent, received, accepted, declined, withdrawn)
Color-coded toasts by event type (invitations vs. applications vs. system messages) with distinct icon/accent treatment
Overhauled toast deduplication: single canonical toast per event, suppressing redundant system-message echoes from socket broadcasts
Fixed spurious unread-message toast on page refresh and on initial auth mount
Fixed a regression where the navbar bell indicator stopped updating live on notification events
Fixed logout triggering on 403 responses — only 401 should end the session
Chat event messages for role actions
Role-related actions (application sent/accepted/declined, invitation sent/accepted/declined, role filled/reopened) now emit event messages in the relevant team chat thread
Styled @mentions in reply previews to match full message rendering
Invite modal redesign
Rebuilt TeamInviteModal team cards: larger avatars, open-role count, location/remote badge, and a RoleBadgePill for inline status
List now filters to owner/admin-managed teams only, and hides member teams that have no open roles (nothing actionable to invite into)
Auto-selects the only available role when inviting an existing member into a team
New existing-member-selected badge state for clearer visual feedback
Vacant role UX improvements
"Find matching people" button in the role details modal is now always shown to owners and admins, regardless of whether the role has tags or badges defined
Applicant and invitee cards in the details modal now use bg-base-200 (matching the chat message bubble grey) instead of white
Simplified role visibility logic in VacantRolesSection
Dropdown z-index / stacking context fixes
Dropdown and VacantRoleCard context menus now render via createPortal into document.body, fixing cases where they were clipped or hidden behind modal/card stacking contexts
RoleBadgePill hover label max-width expanded and padding smoothed for a cleaner reveal animation; style prop threaded through for programmatic overrides
Refactoring & performance
Extracted a reusable useSocketEvents hook; migrated team notification socket subscriptions to it
Cached tag service lookups to avoid redundant API calls
Removed dead search service code and duplicate invitation utilities
Refactored auth user object case-normalisation into a single shared path
Test plan
 Leave a team as a member → confirm any role you filled is reopened and visible in the team's vacant roles list
 Have an admin remove a member → same role-reopen behaviour
 Send and receive an invitation — confirm correct colour-coded toast appears once, no duplicate
 Accept/decline an application — confirm single green/red toast with approver name
 Refresh the chat page while having unread messages — confirm no spurious unread toast fires
 Trigger a 403 response — confirm no logout; trigger a 401 — confirm logout
 Open the invite modal as an owner — confirm teams with no open roles are filtered out; verify open-role count and location info on cards
 Open a role details modal as an admin with no tags/badges on the role — confirm "Find matching people" button is visible
 Open a dropdown or context menu inside a modal — confirm it renders on top without clipping