### PR TITLE
Improve application modal role selection UX

### DIFF
--- a/src/components/teams/TeamApplicationModal.jsx
+++ b/src/components/teams/TeamApplicationModal.jsx
@@ -1,10 +1,39 @@
-import React, { useState, useEffect } from "react";
-import { Send, Save, Users, SendHorizontal, UserSearch, MapPin, Globe, Check, CircleDot } from "lucide-react";
+import React, { lazy, Suspense, useState, useEffect } from "react";
+import {
+  Send,
+  Save,
+  Users,
+  SendHorizontal,
+  UserSearch,
+  MapPin,
+  Globe,
+  Check,
+  FlaskConical,
+  ChevronRight,
+  ChevronUp,
+} from "lucide-react";
 import { vacantRoleService } from "../../services/vacantRoleService";
+import { teamService } from "../../services/teamService";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
 import ScreenAlert from "../common/ScreenAlert";
 import TeamDetailsModal from "./TeamDetailsModal";
+import CardMetaItem from "../common/CardMetaItem";
+import CardMetaRow from "../common/CardMetaRow";
+import RoleBadgePill from "../common/RoleBadgePill";
+import Tooltip from "../common/Tooltip";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import {
+  DEMO_ROLE_TOOLTIP,
+  DEMO_TEAM_TOOLTIP,
+  isSyntheticRole,
+  isSyntheticTeam,
+} from "../../utils/userHelpers";
+
+const VacantRoleDetailsModal = lazy(() => import("./VacantRoleDetailsModal"));
+
+const idsMatch = (left, right) =>
+  left != null && right != null && String(left) === String(right);
 
 /**
  * TeamApplicationModal Component
@@ -33,15 +62,19 @@ const TeamApplicationModal = ({
   const [success, setSuccess] = useState(null);
   const [isDraft, setIsDraft] = useState(false);
   const [isTeamDetailsOpen, setIsTeamDetailsOpen] = useState(false);
+  const [hydratedTeam, setHydratedTeam] = useState(null);
 
   // Vacant role selection state
   const [vacantRoles, setVacantRoles] = useState([]);
   const [loadingRoles, setLoadingRoles] = useState(false);
   const [selectedRoleId, setSelectedRoleId] = useState(null);
+  const [detailsRole, setDetailsRole] = useState(null);
+  const [isRoleSectionExpanded, setIsRoleSectionExpanded] = useState(false);
 
   // Resolve teamId
   const effectiveTeamId =
     teamId ?? team?.id ?? team?.teamId ?? team?.team_id ?? null;
+  const displayTeam = hydratedTeam ? { ...team, ...hydratedTeam } : team;
 
   // Fetch open vacant roles when modal opens
   useEffect(() => {
@@ -70,46 +103,109 @@ const TeamApplicationModal = ({
     fetchRoles();
   }, [isOpen, effectiveTeamId]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      setHydratedTeam(null);
+      return;
+    }
+
+    if (!effectiveTeamId) return;
+
+    const hasMemberCount =
+      team?.current_members_count !== undefined ||
+      team?.currentMembersCount !== undefined ||
+      team?.member_count !== undefined ||
+      team?.memberCount !== undefined ||
+      team?.members_count !== undefined ||
+      team?.membersCount !== undefined ||
+      Array.isArray(team?.members);
+    const hasMaxMembers =
+      team?.max_members !== undefined || team?.maxMembers !== undefined;
+
+    if (hasMemberCount && hasMaxMembers) {
+      setHydratedTeam(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchTeamDetails = async () => {
+      try {
+        const response = await teamService.getTeamById(effectiveTeamId);
+        if (cancelled) return;
+        setHydratedTeam(response?.data ?? response ?? null);
+      } catch (err) {
+        console.warn("Could not fetch team details for application modal:", err);
+        if (!cancelled) setHydratedTeam(null);
+      }
+    };
+
+    fetchTeamDetails();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, effectiveTeamId, team]);
+
   // Pre-select the initial role when roles load
   useEffect(() => {
     if (isOpen && initialRoleId && vacantRoles.length > 0) {
-      const exists = vacantRoles.some((r) => r.id === initialRoleId);
+      const exists = vacantRoles.some((r) => idsMatch(r.id, initialRoleId));
       setSelectedRoleId(exists ? initialRoleId : null);
     } else if (isOpen && !initialRoleId) {
       setSelectedRoleId(null);
     }
   }, [isOpen, initialRoleId, vacantRoles]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      setIsRoleSectionExpanded(false);
+      return;
+    }
+
+    setIsRoleSectionExpanded(Boolean(initialRoleId));
+  }, [isOpen, initialRoleId, effectiveTeamId]);
+
   // ============ Helper Functions ============
 
   const getTeamAvatar = () => {
     return (
-      team?.teamavatar_url ||
-      team?.teamavatarUrl ||
-      team?.avatar_url ||
-      team?.avatarUrl ||
+      displayTeam?.teamavatar_url ||
+      displayTeam?.teamavatarUrl ||
+      displayTeam?.avatar_url ||
+      displayTeam?.avatarUrl ||
       null
     );
   };
 
   const getMemberCount = () => {
     return (
-      team?.current_members_count ??
-      team?.currentMembersCount ??
-      team?.member_count ??
-      team?.memberCount ??
-      team?.members?.length ??
+      displayTeam?.current_members_count ??
+      displayTeam?.currentMembersCount ??
+      displayTeam?.member_count ??
+      displayTeam?.memberCount ??
+      displayTeam?.members_count ??
+      displayTeam?.membersCount ??
+      displayTeam?.members?.length ??
       0
     );
   };
 
   const getMaxMembers = () => {
-    const max = team?.max_members ?? team?.maxMembers;
+    const max = displayTeam?.max_members ?? displayTeam?.maxMembers;
     return max === null || max === undefined ? "∞" : max;
   };
 
+  const getTeamLocation = () => {
+    const isRemote = displayTeam?.isRemote ?? displayTeam?.is_remote;
+    if (isRemote) return "Remote";
+
+    const parts = [displayTeam?.city, displayTeam?.country].filter(Boolean);
+    return parts.length > 0 ? parts.join(", ") : null;
+  };
+
   const getTeamInitials = () => {
-    const name = team?.name;
+    const name = displayTeam?.name;
     if (!name || typeof name !== "string") return "?";
 
     const words = name.trim().split(/\s+/);
@@ -142,13 +238,21 @@ const TeamApplicationModal = ({
   };
 
   const handleRoleCardClick = (roleId) => {
-    setSelectedRoleId((prev) => (prev === roleId ? null : roleId));
+    setSelectedRoleId((prev) => (idsMatch(prev, roleId) ? null : roleId));
+  };
+
+  const handleRoleDetailsKeyDown = (event, role) => {
+    if (event.target.closest("button")) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+
+    event.preventDefault();
+    setDetailsRole(role);
   };
 
   // ============ Handlers ============
 
   const handleTeamClick = () => {
-    if (team?.id) setIsTeamDetailsOpen(true);
+    if (displayTeam?.id) setIsTeamDetailsOpen(true);
   };
 
   const handleSubmit = async (saveAsDraft = false) => {
@@ -189,6 +293,8 @@ const TeamApplicationModal = ({
     setSuccess(null);
     setIsDraft(false);
     setSelectedRoleId(null);
+    setDetailsRole(null);
+    setIsRoleSectionExpanded(false);
     onClose();
   };
 
@@ -235,6 +341,18 @@ const TeamApplicationModal = ({
     </div>
   );
 
+  const teamLocation = getTeamLocation();
+  const teamIsRemote = displayTeam?.isRemote ?? displayTeam?.is_remote;
+  const showDemoTeam = isSyntheticTeam(displayTeam);
+  const shouldShowRolePicker =
+    loadingRoles || vacantRoles.length > 0 || isRoleSectionExpanded;
+  const roleAvailabilityLabel =
+    vacantRoles.length === 1
+      ? "1 open role available"
+      : `${vacantRoles.length} open roles available`;
+  const selectedRole =
+    vacantRoles.find((role) => idsMatch(role.id, selectedRoleId)) ?? null;
+
   return (
     <>
       <Modal
@@ -272,11 +390,11 @@ const TeamApplicationModal = ({
               title="View team details"
             >
               <div className="avatar">
-                <div className="w-12 h-12 rounded-full relative">
+                <div className="w-12 h-12 rounded-full relative overflow-hidden">
                   {getTeamAvatar() ? (
                     <img
                       src={getTeamAvatar()}
-                      alt={team?.name || "Team"}
+                      alt={displayTeam?.name || "Team"}
                       className="object-cover w-full h-full rounded-full"
                       onError={(e) => {
                         e.target.style.display = "none";
@@ -297,106 +415,276 @@ const TeamApplicationModal = ({
                       {getTeamInitials()}
                     </span>
                   </div>
+                  {showDemoTeam && (
+                    <DemoAvatarOverlay
+                      textClassName="text-[7px]"
+                      textTranslateClassName="-translate-y-[3px]"
+                    />
+                  )}
                 </div>
               </div>
 
               <div className="flex-1 min-w-0">
                 <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
-                  {team?.name || "Unknown Team"}
+                  {displayTeam?.name || "Unknown Team"}
                 </h4>
-                <p className="text-sm text-base-content/70 flex items-center">
-                  <Users size={14} className="mr-1 text-primary" />
-                  {getMemberCount()}/{getMaxMembers()}
-                </p>
+                <CardMetaRow className="text-sm">
+                  <CardMetaItem icon={Users}>
+                    {getMemberCount()}/{getMaxMembers()}
+                  </CardMetaItem>
+                  {teamLocation && (
+                    <CardMetaItem icon={teamIsRemote ? Globe : MapPin}>
+                      {teamLocation}
+                    </CardMetaItem>
+                  )}
+                  {showDemoTeam && (
+                    <Tooltip
+                      content={DEMO_TEAM_TOOLTIP}
+                      wrapperClassName="flex items-center gap-0.5 min-w-0 text-base-content/50"
+                    >
+                      <FlaskConical
+                        size={10}
+                        className="text-base-content/50 shrink-0 mt-[1px]"
+                      />
+                      <span className="text-base-content/50 leading-tight break-words">
+                        Demo Team
+                      </span>
+                    </Tooltip>
+                  )}
+                </CardMetaRow>
               </div>
             </div>
           </div>
 
-          {team?.description && (
-            <p className="text-sm text-base-content/80">{team.description}</p>
+          {displayTeam?.description && (
+            <p className="text-sm text-base-content/80">{displayTeam.description}</p>
           )}
 
           {/* Vacant role selection */}
-          {(loadingRoles || vacantRoles.length > 0) && (
+          {shouldShowRolePicker && (
             <div>
-              <p className="text-xs text-base-content/60 mb-2 flex items-center">
-                <UserSearch size={12} className="text-orange-500 mr-1" />
-                Select a role you want to fill in this team:
-              </p>
+              <button
+                type="button"
+                className="flex w-full items-center justify-between text-xs text-base-content/60 mb-2 hover:text-base-content/80 transition-colors"
+                onClick={() => setIsRoleSectionExpanded((value) => !value)}
+                aria-expanded={isRoleSectionExpanded}
+              >
+                <span className="flex min-w-0 items-center">
+                  <UserSearch size={12} className="text-orange-500 mr-1" />
+                  <span className="truncate">
+                    Select a role you want to fill in this team:
+                  </span>
+                </span>
+                <span className="ml-2 flex items-center gap-1 text-base-content/40">
+                  {!isRoleSectionExpanded && vacantRoles.length > 0 && (
+                    <span className="whitespace-nowrap">
+                      {roleAvailabilityLabel}
+                    </span>
+                  )}
+                  {isRoleSectionExpanded ? (
+                    <ChevronUp size={14} />
+                  ) : (
+                    <ChevronRight size={14} />
+                  )}
+                </span>
+              </button>
 
-              {loadingRoles ? (
+              {!isRoleSectionExpanded ? (
+                selectedRole ? (
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => setDetailsRole(selectedRole)}
+                    onKeyDown={(event) =>
+                      handleRoleDetailsKeyDown(event, selectedRole)
+                    }
+                    className="flex items-start gap-3 rounded-xl bg-amber-100 p-3 text-left shadow ring-2 ring-amber-400 transition-all duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                  >
+                    <div className="avatar">
+                      <div className="w-10 h-10 rounded-full relative overflow-hidden">
+                        <div className="avatar-fallback bg-amber-500 text-white flex items-center justify-center w-full h-full rounded-full absolute inset-0">
+                          <span className="text-sm font-medium">
+                            {getRoleInitials(
+                              selectedRole.roleName ??
+                                selectedRole.role_name ??
+                                "Vacant Role",
+                            )}
+                          </span>
+                        </div>
+                        {isSyntheticRole(selectedRole) && (
+                          <DemoAvatarOverlay
+                            textClassName="text-[6px]"
+                            textTranslateClassName="-translate-y-[3px]"
+                          />
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex-1 min-w-0 pt-[1px]">
+                      <div className="flex items-center justify-between">
+                        <h3 className="font-medium text-sm truncate leading-[120%] min-w-0">
+                          {selectedRole.roleName ??
+                            selectedRole.role_name ??
+                            "Vacant Role"}
+                        </h3>
+                        <div className="shrink-0 ml-1">
+                          <RoleBadgePill
+                            icon={Check}
+                            label="Selected"
+                            badgeColorClass="bg-amber-800 text-white"
+                            interactive
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              handleRoleCardClick(selectedRole.id);
+                            }}
+                            className="shrink-0"
+                          />
+                        </div>
+                      </div>
+
+                      {(getRoleLocation(selectedRole) ||
+                        isSyntheticRole(selectedRole)) && (
+                        <CardMetaRow>
+                          {getRoleLocation(selectedRole) && (
+                            <CardMetaItem
+                              icon={
+                                (selectedRole.isRemote ??
+                                  selectedRole.is_remote)
+                                  ? Globe
+                                  : MapPin
+                              }
+                            >
+                              {getRoleLocation(selectedRole)}
+                            </CardMetaItem>
+                          )}
+                          {isSyntheticRole(selectedRole) && (
+                            <Tooltip
+                              content={DEMO_ROLE_TOOLTIP}
+                              wrapperClassName="flex items-center gap-0.5 min-w-0 text-base-content/50"
+                            >
+                              <FlaskConical
+                                size={10}
+                                className="text-base-content/50 shrink-0 mt-[1px]"
+                              />
+                              <span className="text-base-content/50 leading-tight break-words">
+                                Demo
+                              </span>
+                            </Tooltip>
+                          )}
+                        </CardMetaRow>
+                      )}
+                    </div>
+                  </div>
+                ) : null
+              ) : loadingRoles ? (
                 <div className="flex justify-center py-6">
                   <div className="loading loading-spinner loading-md text-primary"></div>
                 </div>
               ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-h-64 overflow-y-auto">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-64 overflow-y-auto p-1">
                   {vacantRoles.map((role) => {
-                    const roleName = role.roleName ?? role.role_name ?? "Vacant Role";
-                    const isSelected = selectedRoleId === role.id;
+                    const roleName =
+                      role.roleName ?? role.role_name ?? "Vacant Role";
+                    const isSelected = idsMatch(selectedRoleId, role.id);
                     const locationText = getRoleLocation(role);
                     const isRemote = role.isRemote ?? role.is_remote;
+                    const showDemoRole = isSyntheticRole(role);
 
                     return (
                       <div
+                        role="button"
+                        tabIndex={0}
                         key={role.id}
-                        onClick={() => handleRoleCardClick(role.id)}
-                        className={`relative flex items-center gap-3 p-3 rounded-xl shadow cursor-pointer transition-all duration-200
+                        onClick={() => setDetailsRole(role)}
+                        onKeyDown={(event) =>
+                          handleRoleDetailsKeyDown(event, role)
+                        }
+                        className={`flex items-start gap-4 p-4 rounded-xl text-left shadow cursor-pointer transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400
                           ${
                             isSelected
                               ? "bg-amber-100 ring-2 ring-amber-400 shadow-md"
-                              : "bg-amber-50 hover:bg-amber-100 hover:shadow-md"
+                              : "bg-amber-50 hover:bg-amber-100/70 hover:shadow-md"
                           }`}
                       >
-                        {/* Selection badge */}
-                        <div className="absolute top-2 right-2">
-                          <span
-                            className={`badge badge-sm gap-1 ${
-                              isSelected
-                                ? ""
-                                : "badge-role-member"
-                            }`}
-                            style={
-                              isSelected
-                                ? {
-                                    backgroundColor: "var(--color-warning, #F59E0B)",
-                                    color: "#ffffff",
-                                  }
-                                : {}
-                            }
-                          >
-                            {isSelected ? (
-                              <Check className="w-3 h-3" />
-                            ) : (
-                              <UserSearch className="w-3 h-3" />
+                        <div className="avatar">
+                          <div className="w-12 h-12 rounded-full relative overflow-hidden">
+                            <div className="avatar-fallback bg-amber-500 text-white flex items-center justify-center w-full h-full rounded-full absolute inset-0">
+                              <span className="text-lg">
+                                {getRoleInitials(roleName)}
+                              </span>
+                            </div>
+                            {showDemoRole && (
+                              <DemoAvatarOverlay
+                                textClassName="text-[7px]"
+                                textTranslateClassName="-translate-y-[3px]"
+                              />
                             )}
-                            {isSelected ? "Selected" : "Select"}
-                          </span>
-                        </div>
-
-                        {/* Role avatar */}
-                        <div className="avatar placeholder flex-shrink-0">
-                          <div className="bg-amber-200 text-amber-800 rounded-full w-10 h-10 flex items-center justify-center">
-                            <span className="text-sm font-medium">
-                              {getRoleInitials(roleName)}
-                            </span>
                           </div>
                         </div>
 
-                        {/* Role info */}
-                        <div className="flex-1 min-w-0 pr-16">
-                          <h4 className="font-medium text-sm text-base-content leading-tight truncate">
-                            {roleName}
-                          </h4>
-                          {locationText && (
-                            <p className="text-xs text-base-content/60 flex items-center mt-0.5">
-                              {isRemote ? (
-                                <Globe size={10} className="mr-1 flex-shrink-0" />
-                              ) : (
-                                <MapPin size={10} className="mr-1 flex-shrink-0" />
-                              )}
-                              <span className="truncate">{locationText}</span>
-                            </p>
-                          )}
+                        <div className="flex-1 min-w-0 pt-[1px]">
+                          <div className="flex flex-col">
+                            <div className="flex items-center justify-between">
+                              <h3 className="font-medium text-base truncate leading-[120%] min-w-0">
+                                {roleName}
+                              </h3>
+                              <div className="shrink-0 ml-1">
+                                <RoleBadgePill
+                                  icon={isSelected ? Check : UserSearch}
+                                  label={isSelected ? "Selected" : "Select"}
+                                  badgeColorClass={
+                                    isSelected
+                                      ? "bg-amber-800 text-white"
+                                      : "badge-role-vacant"
+                                  }
+                                  interactive
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    handleRoleCardClick(role.id);
+                                  }}
+                                  className="shrink-0"
+                                />
+                              </div>
+                            </div>
+
+                            {locationText && (
+                              <CardMetaRow>
+                                <CardMetaItem icon={isRemote ? Globe : MapPin}>
+                                  {locationText}
+                                </CardMetaItem>
+                                {showDemoRole && (
+                                  <Tooltip
+                                    content={DEMO_ROLE_TOOLTIP}
+                                    wrapperClassName="flex items-center gap-0.5 min-w-0 text-base-content/50"
+                                  >
+                                    <FlaskConical
+                                      size={10}
+                                      className="text-base-content/50 shrink-0 mt-[1px]"
+                                    />
+                                    <span className="text-base-content/50 leading-tight break-words">
+                                      Demo
+                                    </span>
+                                  </Tooltip>
+                                )}
+                              </CardMetaRow>
+                            )}
+                            {!locationText && showDemoRole && (
+                              <CardMetaRow>
+                                <Tooltip
+                                  content={DEMO_ROLE_TOOLTIP}
+                                  wrapperClassName="flex items-center gap-0.5 min-w-0 text-base-content/50"
+                                >
+                                  <FlaskConical
+                                    size={10}
+                                    className="text-base-content/50 shrink-0 mt-[1px]"
+                                  />
+                                  <span className="text-base-content/50 leading-tight break-words">
+                                    Demo
+                                  </span>
+                                </Tooltip>
+                              </CardMetaRow>
+                            )}
+                          </div>
                         </div>
                       </div>
                     );
@@ -404,12 +692,12 @@ const TeamApplicationModal = ({
                 </div>
               )}
 
-              {!loadingRoles && selectedRoleId === null && vacantRoles.length > 0 && !isInternal && (
+              {isRoleSectionExpanded && !loadingRoles && selectedRoleId === null && vacantRoles.length > 0 && !isInternal && (
                 <p className="text-xs text-base-content/40 mt-1.5">
                   No role selected — your application will be sent as a general team application.
                 </p>
               )}
-              {!loadingRoles && selectedRoleId === null && vacantRoles.length > 0 && isInternal && (
+              {isRoleSectionExpanded && !loadingRoles && selectedRoleId === null && vacantRoles.length > 0 && isInternal && (
                 <p className="text-xs text-warning/70 mt-1.5">
                   Please select a role to apply for.
                 </p>
@@ -450,11 +738,24 @@ const TeamApplicationModal = ({
       {/* Optional: Team Details Modal (same pattern as TeamInvitationDetailsModal) */}
       <TeamDetailsModal
         isOpen={isTeamDetailsOpen}
-        teamId={team?.id}
-        initialTeamData={team}
+        teamId={displayTeam?.id}
+        initialTeamData={displayTeam}
         onClose={() => setIsTeamDetailsOpen(false)}
         isFromSearch={true}
       />
+
+      <Suspense fallback={null}>
+        {detailsRole && (
+          <VacantRoleDetailsModal
+            isOpen={Boolean(detailsRole)}
+            onClose={() => setDetailsRole(null)}
+            team={displayTeam}
+            role={detailsRole}
+            isTeamMember={isInternal}
+            hideActions={true}
+          />
+        )}
+      </Suspense>
     </>
   );
 };

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -1359,10 +1359,30 @@ const VacantRoleDetailsModal = ({
     team?.name ??
     team?.team_name ??
     null;
+  const roleTeam = displayRole.team ?? {};
   const teamMemberCount =
-    displayRole.teamMemberCount ?? displayRole.team_member_count;
+    displayRole.teamMemberCount ??
+    displayRole.team_member_count ??
+    displayRole.current_members_count ??
+    displayRole.currentMembersCount ??
+    displayRole.member_count ??
+    displayRole.memberCount ??
+    displayRole.members_count ??
+    displayRole.membersCount ??
+    roleTeam.current_members_count ??
+    roleTeam.currentMembersCount ??
+    roleTeam.member_count ??
+    roleTeam.memberCount ??
+    roleTeam.members_count ??
+    roleTeam.membersCount ??
+    (Array.isArray(roleTeam.members) ? roleTeam.members.length : undefined);
   const teamMaxMembers =
-    displayRole.teamMaxMembers ?? displayRole.team_max_members;
+    displayRole.teamMaxMembers ??
+    displayRole.team_max_members ??
+    displayRole.max_members ??
+    displayRole.maxMembers ??
+    roleTeam.max_members ??
+    roleTeam.maxMembers;
   const teamDescription =
     displayRole.teamDescription ?? displayRole.team_description ?? "";
   const teamAvatarUrl =
@@ -1371,6 +1391,27 @@ const VacantRoleDetailsModal = ({
     displayRole.teamAvatarUrl ??
     displayRole.team_avatar_url ??
     null;
+  const teamIsRemote =
+    team?.isRemote ??
+    team?.is_remote ??
+    displayRole.teamIsRemote ??
+    displayRole.team_is_remote ??
+    roleTeam.isRemote ??
+    roleTeam.is_remote;
+  const teamCity =
+    team?.city ?? displayRole.teamCity ?? displayRole.team_city ?? roleTeam.city;
+  const teamCountry =
+    team?.country ??
+    displayRole.teamCountry ??
+    displayRole.team_country ??
+    roleTeam.country;
+  const teamIsSynthetic =
+    team?.is_synthetic ??
+    team?.isSynthetic ??
+    displayRole.teamIsSynthetic ??
+    displayRole.team_is_synthetic ??
+    roleTeam.is_synthetic ??
+    roleTeam.isSynthetic;
   const applicationTeam = {
     ...team,
     id: team?.id ?? teamId,
@@ -1381,8 +1422,14 @@ const VacantRoleDetailsModal = ({
       team?.currentMembersCount ??
       team?.member_count ??
       team?.memberCount ??
+      team?.members_count ??
+      team?.membersCount ??
       teamMemberCount,
     max_members: team?.max_members ?? team?.maxMembers ?? teamMaxMembers,
+    is_remote: teamIsRemote,
+    city: teamCity,
+    country: teamCountry,
+    is_synthetic: teamIsSynthetic,
     teamavatar_url:
       team?.teamavatar_url ??
       team?.teamavatarUrl ??
@@ -3124,7 +3171,7 @@ const VacantRoleDetailsModal = ({
     <TeamApplicationModal
       isOpen={isInternalApplicationOpen}
       onClose={() => setIsInternalApplicationOpen(false)}
-      team={team}
+      team={applicationTeam}
       teamId={teamId}
       initialRoleId={roleId}
       isInternal={true}


### PR DESCRIPTION
Description
This PR refines the frontend application modal, especially the flow for applying to teams and vacant roles.

What Changed

Fixes incorrect team member/max-member count display in the application modal.
Hydrates team data when the modal receives incomplete team metadata.
Adds team location and demo data indicators to the team header.
Adds demo overlays to team and role avatars.
Updates the role picker cards to match the invite modal grid/card styling.
Collapses the role selection section by default for generic team applications.
Keeps the role section expanded when opening from a role application action.
Shows the selected role even when the role picker is collapsed.
Splits role-card interactions:
Clicking the badge selects/deselects the role.
Clicking the rest of the card opens role details.
Adds open-role availability text, e.g. 3 open roles available.
Testing

Ran npm run build successfully.
Build still shows the existing non-blocking Vite warning about VacantRoleDetailsModal being both dynamically and statically imported.