### PR TITLE
feat: deferred role invite flow — display, UX, and SQL fixes

### DIFF
--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -381,6 +381,33 @@ export const parseSystemMessage = (content) => {
     };
   }
 
+  // Pattern 4G.5: Application approved as a deferred role invitation
+  // Format: 📬 ROLE_APPLICATION_DEFERRED_INVITE: teamId:teamName | roleId:roleName | applicantId:applicantName | approverId:approverName | currentRoleId:currentRoleName
+  const roleApplicationDeferredInviteMatch = content.match(
+    /^(?:📬\s*)?ROLE_APPLICATION_DEFERRED_INVITE:\s*(.+?)\s+\|\s+(.+?)\s+\|\s+(.+?)\s+\|\s+(.+?)\s+\|\s+(.+)$/,
+  );
+  if (roleApplicationDeferredInviteMatch) {
+    const team = parseIdNameToken(roleApplicationDeferredInviteMatch[1].trim());
+    const role = parseIdNameToken(roleApplicationDeferredInviteMatch[2].trim());
+    const applicant = parseIdNameToken(roleApplicationDeferredInviteMatch[3].trim());
+    const approver = parseIdNameToken(roleApplicationDeferredInviteMatch[4].trim());
+    const currentRole = parseIdNameToken(roleApplicationDeferredInviteMatch[5].trim());
+
+    return {
+      type: "role_application_deferred_invite",
+      teamId: team.id,
+      teamName: team.name,
+      roleId: role.id,
+      roleName: role.name,
+      applicantId: applicant.id,
+      applicantName: applicant.name,
+      approverId: approver.id,
+      approverName: approver.name,
+      currentRoleId: currentRole.id,
+      currentRoleName: currentRole.name,
+    };
+  }
+
   // Pattern 4H: Invitation accepted + role filled combined message
   // Format: ✅ ROLE_INVITATION_FILLED: teamId:teamName | roleId:roleName | inviteeId:inviteeName
   const roleInvitationFilledMatch = content.match(
@@ -804,6 +831,12 @@ const getEventReactionPreview = (content) => {
           ? `The role "${parsedMessage.roleName}" has been filled by ${parsedMessage.applicantName}, approved by ${parsedMessage.approverName}.`
           : `The role "${parsedMessage.roleName}" has been filled by ${parsedMessage.applicantName}.`,
         Icon: UserCheck,
+        color: EVENT_REACTION_PREVIEW_COLORS.role,
+      };
+    case "role_application_deferred_invite":
+      return {
+        text: `${parsedMessage.applicantName}'s application for "${parsedMessage.roleName}" was approved as a role offer because they already fill "${parsedMessage.currentRoleName}".`,
+        Icon: UserSearch,
         color: EVENT_REACTION_PREVIEW_COLORS.role,
       };
     case "role_invitation_filled":
@@ -1860,6 +1893,32 @@ const MessageDisplay = ({
     });
   };
 
+  const isCurrentViewer = (userId) =>
+    userId != null &&
+    currentUserId != null &&
+    String(userId) === String(currentUserId);
+
+  const userMentionOrYou = (userId, name, { capitalized = false } = {}) => {
+    if (isCurrentViewer(userId)) return capitalized ? "You" : "you";
+
+    return userId ? (
+      <MentionById userId={userId} name={name} />
+    ) : (
+      <Mention name={name} />
+    );
+  };
+
+  const possessiveUserMentionOrYour = (userId, name) => {
+    if (isCurrentViewer(userId)) return "Your";
+
+    return (
+      <>
+        {userMentionOrYou(userId, name)}
+        {"'s"}
+      </>
+    );
+  };
+
   // Group messages by date
   const messagesByDate = messages.reduce((groups, message) => {
     const date = getDateGroupKey(message.createdAt);
@@ -2330,18 +2389,29 @@ const MessageDisplay = ({
     isCurrentUser,
     senderId,
   ) => {
-    const applicant = parsedMessage.applicantName;
-    const approver = parsedMessage.approverName;
+    const isApplicantCurrentUser = isCurrentViewer(parsedMessage.applicantId);
+    const isApproverCurrentUser = isCurrentViewer(parsedMessage.approverId);
 
-    const welcomeText = isCurrentUser ? (
+    const welcomeText = isApplicantCurrentUser ? (
       <>
-        Your application was approved by <Mention name={approver} />. Welcome to
-        the team!
+        Your application was approved by{" "}
+        {userMentionOrYou(parsedMessage.approverId, parsedMessage.approverName)}
+        . Welcome to the team!
+      </>
+    ) : isApproverCurrentUser ? (
+      <>
+        You approved{" "}
+        {userMentionOrYou(parsedMessage.applicantId, parsedMessage.applicantName)}
+        {"'s"} application. Say hello to them!
       </>
     ) : (
       <>
-        <Mention name={applicant} /> has applied successfully and was added by{" "}
-        <Mention name={approver} />. Say hello to them!
+        {userMentionOrYou(parsedMessage.applicantId, parsedMessage.applicantName, {
+          capitalized: true,
+        })}{" "}
+        has applied successfully and was added by{" "}
+        {userMentionOrYou(parsedMessage.approverId, parsedMessage.approverName)}
+        . Say hello to them!
       </>
     );
 
@@ -2368,8 +2438,11 @@ const MessageDisplay = ({
   const renderRoleApplicationApprovedMessage = (message, parsedMessage) => {
     const messageText = (
       <>
-        <Mention name={parsedMessage.applicantName} />
-        {"'s"} application for{" "}
+        {possessiveUserMentionOrYour(
+          parsedMessage.applicantId,
+          parsedMessage.applicantName,
+        )}{" "}
+        application for{" "}
         <RoleMentionById
           roleId={parsedMessage.roleId}
           name={parsedMessage.roleName}
@@ -2423,20 +2496,12 @@ const MessageDisplay = ({
     const hasKnownApprover =
       parsedMessage.approverName &&
       parsedMessage.approverName.trim().toLowerCase() !== "someone";
-    const applicantMention = hasKnownApplicant ? (
-      <MentionById
-        userId={parsedMessage.applicantId}
-        name={parsedMessage.applicantName}
-      />
-    ) : (
-      "someone"
-    );
-    const approverMention = hasKnownApprover ? (
-      <MentionById
-        userId={parsedMessage.approverId}
-        name={parsedMessage.approverName}
-      />
-    ) : null;
+    const applicantMention = hasKnownApplicant
+      ? userMentionOrYou(parsedMessage.applicantId, parsedMessage.applicantName)
+      : "someone";
+    const approverMention = hasKnownApprover
+      ? userMentionOrYou(parsedMessage.approverId, parsedMessage.approverName)
+      : null;
 
     const messageText = (
       <>
@@ -2472,6 +2537,72 @@ const MessageDisplay = ({
   };
 
   // =============================================================================
+  // renderRoleApplicationDeferredInviteMessage - Orange role theme (approval offer)
+  // =============================================================================
+  const renderRoleApplicationDeferredInviteMessage = (message, parsedMessage) => {
+    const roleMention = (
+      <RoleMentionById
+        roleId={parsedMessage.roleId}
+        name={parsedMessage.roleName}
+      />
+    );
+    const currentRoleMention = (
+      <RoleMentionById
+        roleId={parsedMessage.currentRoleId}
+        name={parsedMessage.currentRoleName}
+        filledUserId={parsedMessage.applicantId}
+        filledUserName={parsedMessage.applicantName}
+      />
+    );
+    const applicantMention = userMentionOrYou(
+      parsedMessage.applicantId,
+      parsedMessage.applicantName,
+      { capitalized: true },
+    );
+    const approverMention = userMentionOrYou(
+      parsedMessage.approverId,
+      parsedMessage.approverName,
+    );
+    const isApplicantCurrentUser = isCurrentViewer(parsedMessage.applicantId);
+
+    const messageText = (
+      <>
+        {isApplicantCurrentUser ? "Your application" : <>{applicantMention}{"'s application"}</>}
+        {" for "}{roleMention}{" was approved by "}
+        {approverMention}
+        {". "}
+        {isApplicantCurrentUser ? "You already fill " : "They already fill "}
+        {currentRoleMention}
+        {", so this is now a role offer "}
+        {isApplicantCurrentUser
+          ? "you can accept once you leave your current role."
+          : "they can accept once they leave their current role."}
+      </>
+    );
+
+    return (
+      <div className="flex flex-col items-center w-full my-4">
+        <div
+          className="event-banner mb-3"
+          style={{
+            backgroundColor: "rgba(245, 158, 11, 0.1)",
+            color: "#f59e0b",
+          }}
+        >
+          <span className="text-sm font-medium event-message-text">
+            <UserSearch size={16} className="event-inline-icon mr-1" />
+            {highlightEventContent(messageText)}
+          </span>
+        </div>
+
+        <div className="text-xs text-base-content/50">
+          {formatLocalTime(message.createdAt)}
+        </div>
+      </div>
+    );
+  };
+
+  // =============================================================================
   // renderRoleInvitationFilledMessage - Orange role theme (invitation accepted + fill)
   // =============================================================================
   const renderRoleInvitationFilledMessage = (message, parsedMessage) => {
@@ -2485,7 +2616,13 @@ const MessageDisplay = ({
       />
     );
 
-    const messageText = parsedMessage.inviteeName &&
+    const isInviteeCurrentUser = isCurrentViewer(parsedMessage.inviteeId);
+    const messageText = isInviteeCurrentUser ? (
+      <>
+        You accepted an invitation to fill the role {roleMention} in this team
+        and are now filling that role.
+      </>
+    ) : parsedMessage.inviteeName &&
       parsedMessage.inviteeName.trim().toLowerCase() !== "someone" ? (
       <>
         <MentionById
@@ -2534,6 +2671,7 @@ const MessageDisplay = ({
     const hasInviter =
       parsedMessage.inviterName &&
       parsedMessage.inviterName.trim().toLowerCase() !== "someone";
+    const isInviteeCurrentUser = isCurrentViewer(parsedMessage.inviteeId);
 
     const roleMention = (
       <RoleMentionById
@@ -2549,31 +2687,41 @@ const MessageDisplay = ({
       <>
         {hasInviter && (
           <>
-            <MentionById userId={parsedMessage.inviterId} name={parsedMessage.inviterName} />
+            {userMentionOrYou(parsedMessage.inviterId, parsedMessage.inviterName, {
+              capitalized: true,
+            })}
             {" invited "}
           </>
         )}
         {hasInvitee ? (
-          <MentionById userId={parsedMessage.inviteeId} name={parsedMessage.inviteeName} />
+          userMentionOrYou(parsedMessage.inviteeId, parsedMessage.inviteeName)
         ) : (
           "Someone"
         )}
-        {" for the role "}{roleMention}{". They accepted and are now filling that role."}
+        {" for the role "}{roleMention}
+        {isInviteeCurrentUser
+          ? ". You accepted and are now filling that role."
+          : ". They accepted and are now filling that role."}
       </>
     ) : (
       <>
         {hasInviter && (
           <>
-            <MentionById userId={parsedMessage.inviterId} name={parsedMessage.inviterName} />
+            {userMentionOrYou(parsedMessage.inviterId, parsedMessage.inviterName, {
+              capitalized: true,
+            })}
             {" invited "}
           </>
         )}
         {hasInvitee ? (
-          <MentionById userId={parsedMessage.inviteeId} name={parsedMessage.inviteeName} />
+          userMentionOrYou(parsedMessage.inviteeId, parsedMessage.inviteeName)
         ) : (
           "Someone"
         )}
-        {" for the role "}{roleMention}{". They accepted the invitation."}
+        {" for the role "}{roleMention}
+        {isInviteeCurrentUser
+          ? ". You accepted the invitation."
+          : ". They accepted the invitation."}
       </>
     );
 
@@ -2643,11 +2791,17 @@ const MessageDisplay = ({
     );
     const messageText = parsedMessage.userName ? (
       <>
-        <MentionById
-          userId={parsedMessage.userId}
-          name={parsedMessage.userName}
-        />{" "}
-        has left the role {roleMention}. The role is open again to be filled.
+        {isCurrentViewer(parsedMessage.userId) ? (
+          <>You have left the role {roleMention}. The role is open again to be filled.</>
+        ) : (
+          <>
+            <MentionById
+              userId={parsedMessage.userId}
+              name={parsedMessage.userName}
+            />{" "}
+            has left the role {roleMention}. The role is open again to be filled.
+          </>
+        )}
       </>
     ) : (
       <>The role {roleMention} is open again to be filled.</>
@@ -2684,8 +2838,14 @@ const MessageDisplay = ({
     );
     const messageText = parsedMessage.userName ? (
       <>
-        <MentionById userId={parsedMessage.userId} name={parsedMessage.userName} />{" "}
-        has reopened the role {roleMention}. It is open again to be filled.
+        {isCurrentViewer(parsedMessage.userId) ? (
+          <>You have reopened the role {roleMention}. It is open again to be filled.</>
+        ) : (
+          <>
+            <MentionById userId={parsedMessage.userId} name={parsedMessage.userName} />{" "}
+            has reopened the role {roleMention}. It is open again to be filled.
+          </>
+        )}
       </>
     ) : (
       <>The role {roleMention} has been reopened and is open to be filled.</>
@@ -2733,18 +2893,12 @@ const MessageDisplay = ({
       />
     );
     const filledByMention = hasKnownFilledBy ? (
-      <MentionById
-        userId={parsedMessage.filledById}
-        name={parsedMessage.filledByName}
-      />
+      userMentionOrYou(parsedMessage.filledById, parsedMessage.filledByName)
     ) : null;
     const messageText = hasKnownFilledUser ? (
       <>
         The role {roleMention} has been filled by{" "}
-        <MentionById
-          userId={parsedMessage.userId}
-          name={parsedMessage.userName}
-        />
+        {userMentionOrYou(parsedMessage.userId, parsedMessage.userName)}
         {filledByMention ? (
           <span>, approved by {filledByMention}.</span>
         ) : (
@@ -2806,7 +2960,7 @@ const MessageDisplay = ({
     const messageText = creatorName ? (
       <>
         The new role {roleMention} has been created by{" "}
-        <MentionById userId={creatorId} name={creatorName} /> in this team. It
+        {userMentionOrYou(creatorId, creatorName)} in this team. It
         is open to be filled.
       </>
     ) : (
@@ -2857,7 +3011,7 @@ const MessageDisplay = ({
     const messageText = closedByName ? (
       <>
         The role {roleMention} has been closed by{" "}
-        <MentionById userId={closedById} name={closedByName} />.
+        {userMentionOrYou(closedById, closedByName)}.
       </>
     ) : (
       <>The role {roleMention} has been closed.</>
@@ -2898,7 +3052,7 @@ const MessageDisplay = ({
     const messageText = updatedByName ? (
       <>
         The role {roleMention} has been updated by{" "}
-        <MentionById userId={updatedById} name={updatedByName} />.
+        {userMentionOrYou(updatedById, updatedByName)}.
       </>
     ) : (
       <>The role {roleMention} has been updated.</>
@@ -2946,7 +3100,7 @@ const MessageDisplay = ({
       <>
         The role <span className="font-medium">{parsedMessage.roleName}</span>{" "}
         has been deleted by{" "}
-        <MentionById userId={deletorId} name={deletorName} /> from this team.
+        {userMentionOrYou(deletorId, deletorName)} from this team.
       </>
     ) : (
       <>
@@ -3032,8 +3186,10 @@ const MessageDisplay = ({
     parsedMessage,
     isCurrentUser,
   ) => {
-    // If the remover is the sender of the system message (likely), they are "current user" here.
-    const text = isCurrentUser ? (
+    const isRemovedMemberCurrentUser = isCurrentViewer(parsedMessage.userId);
+    const text = isRemovedMemberCurrentUser ? (
+      "You were removed from the team."
+    ) : isCurrentUser ? (
       <>
         You removed{" "}
         <MentionById
@@ -3076,7 +3232,9 @@ const MessageDisplay = ({
     parsedMessage,
     isCurrentUser,
   ) => {
-    const messageText = isCurrentUser ? (
+    const isInviteeCurrentUser = isCurrentViewer(parsedMessage.inviteeId);
+    const isInviterCurrentUser = isCurrentViewer(parsedMessage.inviterId);
+    const messageText = isInviteeCurrentUser ? (
       <>
         You accepted <Mention name={parsedMessage.inviterName} />
         {"'s"} invitation for{" "}
@@ -3086,10 +3244,26 @@ const MessageDisplay = ({
         />
         . Welcome to the team!
       </>
+    ) : isInviterCurrentUser ? (
+      <>
+        {userMentionOrYou(parsedMessage.inviteeId, parsedMessage.inviteeName, {
+          capitalized: true,
+        })}{" "}
+        accepted your invitation for{" "}
+        <TeamMentionById
+          teamId={parsedMessage.teamId}
+          name={parsedMessage.teamName}
+        />
+        . Welcome to the team!
+      </>
     ) : (
       <>
-        <Mention name={parsedMessage.inviteeName} /> accepted your invitation
-        for{" "}
+        {userMentionOrYou(parsedMessage.inviteeId, parsedMessage.inviteeName, {
+          capitalized: true,
+        })}{" "}
+        accepted{" "}
+        {userMentionOrYou(parsedMessage.inviterId, parsedMessage.inviterName)}
+        {"'s"} invitation for{" "}
         <TeamMentionById
           teamId={parsedMessage.teamId}
           name={parsedMessage.teamName}
@@ -3665,8 +3839,10 @@ const MessageDisplay = ({
 
     const bannerClass = getRoleBannerClass(newRole);
     const RoleIcon = getRoleIcon(newRole);
+    const isChangerCurrentUser = isCurrentViewer(parsedMessage.changerId);
+    const isMemberCurrentUser = isCurrentViewer(parsedMessage.memberId);
 
-    const messageText = isCurrentUser ? (
+    const messageText = isChangerCurrentUser ? (
       isPromotion ? (
         <>
           You promoted{" "}
@@ -3696,7 +3872,8 @@ const MessageDisplay = ({
           .
         </>
       )
-    ) : isPromotion ? (
+    ) : isMemberCurrentUser ? (
+      isPromotion ? (
       <>
         You were promoted to Admin in{" "}
         <TeamMentionById
@@ -3710,18 +3887,31 @@ const MessageDisplay = ({
         />
         .
       </>
+      ) : (
+        <>
+          Your role in{" "}
+          <TeamMentionById
+            teamId={parsedMessage.teamId}
+            name={parsedMessage.teamName}
+          />{" "}
+          was changed to Member by{" "}
+          {userMentionOrYou(parsedMessage.changerId, parsedMessage.changerName)}
+          .
+        </>
+      )
     ) : (
       <>
-        Your role in{" "}
+        {possessiveUserMentionOrYour(
+          parsedMessage.memberId,
+          parsedMessage.memberName,
+        )}{" "}
+        role in{" "}
         <TeamMentionById
           teamId={parsedMessage.teamId}
           name={parsedMessage.teamName}
         />{" "}
-        was changed to Member by{" "}
-        <MentionById
-          userId={parsedMessage.changerId}
-          name={parsedMessage.changerName}
-        />
+        was {isPromotion ? "changed to Admin" : "changed to Member"} by{" "}
+        {userMentionOrYou(parsedMessage.changerId, parsedMessage.changerName)}
         .
       </>
     );
@@ -3732,7 +3922,7 @@ const MessageDisplay = ({
           <span className="text-sm font-medium event-message-text">
             <RoleIcon size={16} className="event-inline-icon mr-1" />
             {highlightEventContent(messageText)}
-            {isPromotion && !isCurrentUser && (
+            {isPromotion && isMemberCurrentUser && (
               <PartyPopper size={16} className="event-inline-icon ml-1" />
             )}
           </span>
@@ -3749,17 +3939,36 @@ const MessageDisplay = ({
   // renderOwnershipTeamMessage - Pink owner theme (team chat)
   // =============================================================================
   const renderOwnershipTeamMessage = (message, parsedMessage) => {
+    const isPreviousOwnerCurrentUser = isCurrentViewer(parsedMessage.prevOwnerId);
+    const isNewOwnerCurrentUser = isCurrentViewer(parsedMessage.newOwnerId);
+    const messageText = isPreviousOwnerCurrentUser ? (
+      <>
+        You transferred ownership to{" "}
+        {userMentionOrYou(parsedMessage.newOwnerId, parsedMessage.newOwnerName)}
+      </>
+    ) : isNewOwnerCurrentUser ? (
+      <>
+        {userMentionOrYou(parsedMessage.prevOwnerId, parsedMessage.prevOwnerName, {
+          capitalized: true,
+        })}{" "}
+        transferred ownership to you
+      </>
+    ) : (
+      <>
+        {userMentionOrYou(parsedMessage.prevOwnerId, parsedMessage.prevOwnerName, {
+          capitalized: true,
+        })}{" "}
+        transferred ownership to{" "}
+        {userMentionOrYou(parsedMessage.newOwnerId, parsedMessage.newOwnerName)}
+      </>
+    );
+
     return (
       <div className="flex flex-col items-center w-full my-4">
         <div className="event-banner event-banner--owner mb-3">
           <span className="text-sm font-medium event-message-text">
             <Crown size={16} className="event-inline-icon mr-1" />
-            <Mention name={parsedMessage.prevOwnerName} /> transferred ownership
-            to{" "}
-            <MentionById
-              userId={parsedMessage.newOwnerId}
-              name={parsedMessage.newOwnerName}
-            />
+            {highlightEventContent(messageText)}
           </span>
         </div>
 
@@ -4278,7 +4487,11 @@ const MessageDisplay = ({
                     const allLoadedMessages = Array.from(messagesById?.values() ?? []);
                     const hasCombinedMessage = allLoadedMessages.some((m) => {
                       const p = parseSystemMessage(m.content);
-                      if (p?.type !== "role_application_filled") return false;
+                      if (
+                        p?.type !== "role_application_filled" &&
+                        p?.type !== "role_application_deferred_invite"
+                      )
+                        return false;
                       const roleMatch =
                         parsedMessage.roleId != null && p.roleId != null
                           ? String(p.roleId) === String(parsedMessage.roleId)
@@ -4301,6 +4514,10 @@ const MessageDisplay = ({
                   } else if (parsedMessage.type === "role_application_filled") {
                     return renderSystemMessage(
                       renderRoleApplicationFilledMessage(message, parsedMessage),
+                    );
+                  } else if (parsedMessage.type === "role_application_deferred_invite") {
+                    return renderSystemMessage(
+                      renderRoleApplicationDeferredInviteMessage(message, parsedMessage),
                     );
                   } else if (parsedMessage.type === "role_invitation_filled") {
                     return renderSystemMessage(

--- a/src/components/chat/MessageNotifications.jsx
+++ b/src/components/chat/MessageNotifications.jsx
@@ -82,6 +82,7 @@ const NOTIFICATION_TOAST_TYPES = {
   invitation_cancelled: { icon: 'CircleX',      label: 'Invitation Cancelled', color: '#6b7280', senderPrefix: 'Cancelled by ' },
   application_received: { icon: 'Mail',         label: 'New Application',      color: '#ec4899', senderPrefix: 'Applied by ' },
   application_approved: { icon: 'CheckCircle',  label: 'Application Approved', color: '#16a34a', senderColor: '#15803d', senderPrefix: 'Approved by ' },
+  role_application_deferred_invite: { icon: 'UserSearch', label: 'Role Offer', color: '#f59e0b', senderPrefix: 'Approved by ' },
   application_rejected: { icon: 'CircleX',      label: 'Application Declined', color: '#6b7280', senderPrefix: 'Declined by ' },
   member_removed:       { icon: 'UserMinus',    label: 'Removed from Team',    senderPrefix: 'Removed by ' },
   member_removed_public:{ icon: 'UserMinus',    label: 'Removed from Team',    senderPrefix: null },
@@ -111,6 +112,7 @@ const getRoleStatusChangedPreview = (payload) => {
 const NOTIFICATION_VISIBLE_MS = 20000;
 const NOTIFICATION_FADE_MS = 700;
 const TEAM_REMOVAL_SUPPRESS_MS = 15000;
+const COMBINED_APPLICATION_APPROVAL_SUPPRESS_MS = 15000;
 
 const EVENT_CONTENT_KEYS = [
   "content",
@@ -283,7 +285,19 @@ const getFallbackRoleEventPreview = (content) => {
   };
 };
 
-const getRoleEventTypePreview = (message) => {
+const getToastActorLabel = (userId, userName, currentUser) => {
+  if (
+    userId != null &&
+    currentUser?.id != null &&
+    String(userId) === String(currentUser.id)
+  ) {
+    return "you";
+  }
+
+  return userName || null;
+};
+
+const getRoleEventTypePreview = (message, currentUser = null) => {
   const rawType =
     message?.eventType ??
     message?.event_type ??
@@ -310,24 +324,50 @@ const getRoleEventTypePreview = (message) => {
     message?.filledByUser?.name ??
     message?.filled_by_user?.name ??
     null;
+  const filledUserId =
+    message?.filledUserId ??
+    message?.filled_user_id ??
+    message?.filledByUserId ??
+    message?.filled_by_user_id ??
+    message?.userId ??
+    message?.user_id ??
+    message?.filledByUser?.id ??
+    message?.filled_by_user?.id ??
+    null;
   const filledActorName =
     message?.filledByName ??
     message?.filled_by_name ??
     message?.actorName ??
     message?.actor_name ??
     null;
+  const filledActorId =
+    message?.filledById ??
+    message?.filled_by_id ??
+    message?.actorId ??
+    message?.actor_id ??
+    null;
+  const filledUserLabel = getToastActorLabel(
+    filledUserId,
+    filledUserName,
+    currentUser,
+  );
+  const filledActorLabel = getToastActorLabel(
+    filledActorId,
+    filledActorName,
+    currentUser,
+  );
   const labels = {
     role_created: `New role ${roleName} created.`,
     role_updated: `Role edited: ${roleName}`,
     role_deleted: `Role deleted: ${roleName}`,
     role_closed: `Role closed: ${roleName}`,
-    role_filled: filledUserName && filledActorName
-      ? `The role ${roleName} has been filled by ${filledUserName}, approved by ${filledActorName}.`
-      : filledUserName
-        ? `The role ${roleName} has been filled by ${filledUserName}.`
+    role_filled: filledUserLabel && filledActorLabel
+      ? `The role ${roleName} has been filled by ${filledUserLabel}, approved by ${filledActorLabel}.`
+      : filledUserLabel
+        ? `The role ${roleName} has been filled by ${filledUserLabel}.`
         : `The role ${roleName} has been marked filled.`,
-    role_reopened: filledUserName
-      ? `${filledUserName} left the role ${roleName}. It is open again.`
+    role_reopened: filledUserLabel
+      ? `${filledUserLabel === "you" ? "You" : filledUserLabel} left the role ${roleName}. It is open again.`
       : `Role reopened: ${roleName}`,
     role_reopened_admin: `Role reopened: ${roleName}`,
   };
@@ -412,6 +452,37 @@ const getTeamIdFromPayload = (payload) =>
   payload?.metadata?.teamId ??
   payload?.metadata?.team_id ??
   null;
+
+const getRoleIdFromPayload = (payload) =>
+  payload?.roleId ??
+  payload?.role_id ??
+  payload?.role?.id ??
+  payload?.data?.roleId ??
+  payload?.data?.role_id ??
+  payload?.metadata?.roleId ??
+  payload?.metadata?.role_id ??
+  null;
+
+const getRoleNameFromPayload = (payload) =>
+  payload?.roleName ??
+  payload?.role_name ??
+  payload?.role?.roleName ??
+  payload?.role?.role_name ??
+  payload?.data?.roleName ??
+  payload?.data?.role_name ??
+  payload?.metadata?.roleName ??
+  payload?.metadata?.role_name ??
+  null;
+
+const getCombinedApplicationApprovalKey = ({ teamId, roleId, roleName }) => {
+  if (teamId == null) return null;
+
+  const normalizedRole = roleId != null
+    ? `id:${roleId}`
+    : `name:${String(roleName || "").trim().toLowerCase()}`;
+
+  return normalizedRole === "name:" ? null : `${teamId}:${normalizedRole}`;
+};
 
 const getPayloadText = (payload) =>
   [
@@ -591,6 +662,7 @@ const MessageNotifications = () => {
   const { isAuthenticated, user } = useAuth();
   const prevIsAuthenticatedRef = useRef(false);
   const currentUserRemovalSuppressionsRef = useRef(new Map());
+  const combinedApplicationApprovalSuppressionsRef = useRef(new Map());
 
   const isTeamSuppressedForCurrentUserRemoval = useCallback((teamId) => {
     if (teamId == null) return false;
@@ -614,6 +686,41 @@ const MessageNotifications = () => {
       String(teamId),
       Date.now() + TEAM_REMOVAL_SUPPRESS_MS,
     );
+  }, []);
+
+  const markCombinedApplicationApprovalSuppressed = useCallback((payload) => {
+    const key = getCombinedApplicationApprovalKey({
+      teamId: getTeamIdFromPayload(payload),
+      roleId: getRoleIdFromPayload(payload),
+      roleName: getRoleNameFromPayload(payload),
+    });
+
+    if (!key) return;
+
+    combinedApplicationApprovalSuppressionsRef.current.set(
+      key,
+      Date.now() + COMBINED_APPLICATION_APPROVAL_SUPPRESS_MS,
+    );
+  }, []);
+
+  const isCombinedApplicationApprovalSuppressed = useCallback((parsedMessage) => {
+    const key = getCombinedApplicationApprovalKey({
+      teamId: parsedMessage?.teamId,
+      roleId: parsedMessage?.roleId,
+      roleName: parsedMessage?.roleName,
+    });
+
+    if (!key) return false;
+
+    const suppressUntil = combinedApplicationApprovalSuppressionsRef.current.get(key);
+
+    if (!suppressUntil) return false;
+    if (suppressUntil <= Date.now()) {
+      combinedApplicationApprovalSuppressionsRef.current.delete(key);
+      return false;
+    }
+
+    return true;
   }, []);
 
   const upsertCurrentUserRemovalToast = useCallback((payload) => {
@@ -731,6 +838,27 @@ const MessageNotifications = () => {
       return;
     }
 
+    if (
+      parsedMessage?.type === 'role_application_filled' &&
+      (
+        (parsedMessage.applicantId != null && String(parsedMessage.applicantId) === String(user?.id)) ||
+        isCurrentUserName(parsedMessage.applicantName, user)
+      ) &&
+      isCombinedApplicationApprovalSuppressed(parsedMessage)
+    ) {
+      return;
+    }
+
+    if (
+      parsedMessage?.type === 'role_application_deferred_invite' &&
+      (
+        (parsedMessage.applicantId != null && String(parsedMessage.applicantId) === String(user?.id)) ||
+        isCurrentUserName(parsedMessage.applicantName, user)
+      )
+    ) {
+      return;
+    }
+
     if (isMemberRoleChangeForCurrentUser(parsedMessage, user)) {
       return;
     }
@@ -752,7 +880,7 @@ const MessageNotifications = () => {
       if ((message.team_id || message.teamId) && /^[\u{1F44B}\u{1F3AF}]/u.test(eventContent.trim())) return;
 
       const eventPreview =
-        getRoleEventTypePreview(message) ||
+        getRoleEventTypePreview(message, user) ||
         getEventPreview(eventContent, user) ||
         getFallbackRoleEventPreview(eventContent);
       const dedupeKey =
@@ -783,6 +911,7 @@ const MessageNotifications = () => {
     }
   }, [
     isTeamSuppressedForCurrentUserRemoval,
+    isCombinedApplicationApprovalSuppressed,
     upsertCurrentUserRemovalToast,
     user,
   ]);
@@ -880,8 +1009,14 @@ const MessageNotifications = () => {
 
     const config = NOTIFICATION_TOAST_TYPES[payload.type];
     if (!config) return;
+    const isRoleApplicationApproval =
+      payload.type === 'application_approved' && !!getRoleNameFromPayload(payload);
+    if (isRoleApplicationApproval) {
+      markCombinedApplicationApprovalSuppressed(payload);
+    }
     const isRoleInvite = (['invitation_received', 'invitation_cancelled', 'invitation_declined'].includes(payload.type) && !!payload.roleName)
-      || (payload.type === 'invitation_accepted' && !!payload.filledRoleName);
+      || (payload.type === 'invitation_accepted' && !!payload.filledRoleName)
+      || payload.type === 'role_application_deferred_invite';
     const dedupeKey =
       payload.type?.includes?.('member_removed')
         ? `member-removed:${teamId ?? ''}:${getRemovedMemberIdFromPayload(payload) ?? payload.title}`
@@ -893,8 +1028,12 @@ const MessageNotifications = () => {
         dedupeKey,
         isEvent: true,
         headerIconName: config.icon,
-        secondaryHeaderIconName: isRoleInvite ? 'UserSearch' : null,
-        headerLabel: isRoleInvite
+        secondaryHeaderIconName: isRoleInvite || isRoleApplicationApproval ? 'UserSearch' : null,
+        headerLabel: isRoleApplicationApproval
+          ? 'Team & Role Application Approved'
+          : payload.type === 'role_application_deferred_invite'
+            ? 'Role Offer Created'
+          : isRoleInvite
           ? payload.type === 'invitation_cancelled' ? 'Team & Role Invite Cancelled'
             : payload.type === 'invitation_accepted' ? 'Team & Role Invite Accepted'
             : payload.type === 'invitation_declined' ? 'Team & Role Invite Declined'
@@ -914,6 +1053,7 @@ const MessageNotifications = () => {
     ]);
   }, [
     isTeamSuppressedForCurrentUserRemoval,
+    markCombinedApplicationApprovalSuppressed,
     upsertCurrentUserRemovalToast,
     user,
   ]);

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -53,6 +53,7 @@ const yourTeams = (tc) => tc > 1 ? `in ${tc} of your teams` : "one of your teams
 const NOTIFICATION_TYPE_META = [
   { keys: ["invitationReceived", "invitation_received"],             Icon: Mail,          text: (p, n, tc) => `${p(n, "team invitation")} for you${teamSuffix(tc)}` },
   { keys: ["roleInvitation", "role_invitation"],                     Icon: UserSearch,    text: (p, n, tc) => `${p(n, "role invitation")} for you${teamSuffix(tc)}` },
+  { keys: ["roleApplicationDeferredInvite", "role_application_deferred_invite"], Icon: UserSearch, text: (p, n, tc) => `${p(n, "role offer")} created${teamSuffix(tc)}` },
   { keys: ["roleAssigned", "role_assigned"],                         Icon: UserCheck,     text: (p, n, tc) => `${p(n, "role assignment")} ${inYourTeam(tc)}` },
   { keys: ["invitationAccepted", "invitation_accepted"],             Icon: UserCheck,     text: (p, n, tc) => `${p(n, "invitation")} accepted${teamSuffix(tc)}` },
   { keys: ["applicationReceived", "application_received"],           Icon: Mail,          text: (p, n, tc) => `${p(n, "team application")} to review${teamSuffix(tc)}` },

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2160,12 +2160,14 @@ const SearchMapView = ({
     invitationId,
     responseMessage = "",
     fillRole = false,
+    options = {},
   ) => {
     await teamService.respondToInvitation(
       invitationId,
       "accept",
       responseMessage,
       fillRole,
+      options,
     );
     await refreshUserStatusData();
     setSelectedInvitation(null);

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -119,9 +119,12 @@ const TeamApplicationsModal = ({
         }
       }
 
-      await onApplicationAction(applicationId, action, response, fillRole);
+      const actionResult = await onApplicationAction(applicationId, action, response, fillRole);
+      const actionData = actionResult?.data ?? actionResult ?? {};
+      const roleFilled = Boolean(actionData.roleFilled);
+      const roleInvitationCreated = Boolean(actionData.roleInvitationCreated);
 
-      if (action === "approve" && fillRole && teamId && application?.role) {
+      if (action === "approve" && fillRole && roleFilled && teamId && application?.role) {
         try {
           await messageService.sendMessage(
             teamId,
@@ -151,7 +154,17 @@ const TeamApplicationsModal = ({
         }
       }
 
-      if (action === "approve" && fillRole) {
+      if (action === "approve" && roleInvitationCreated) {
+        const roleName =
+          application?.role?.roleName ??
+          application?.role?.role_name ??
+          "the role";
+        const currentRoleName =
+          actionData.deferredByCurrentRoleName ?? "their current role";
+        setSuccess(
+          `Application approved! ${roleName} is now a role offer the member can accept once they leave ${currentRoleName}.`,
+        );
+      } else if (action === "approve" && fillRole && roleFilled) {
         const roleName =
           application?.role?.roleName ??
           application?.role?.role_name ??

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -1519,12 +1519,13 @@ const TeamCard = ({
   };
 
   const handleApplicationAction = async (applicationId, action, response, fillRole = false) => {
-    await teamService.handleTeamApplication(applicationId, action, response, fillRole);
+    const result = await teamService.handleTeamApplication(applicationId, action, response, fillRole);
     await fetchPendingApplications();
     if (onUpdate) {
       const updatedTeam = await teamService.getTeamById(teamData.id);
       onUpdate(updatedTeam.data);
     }
+    return result;
   };
 
   const handleVacantRoleStatusChange = async () => {

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -11,7 +11,6 @@ import TeamEditForm from "./TeamEditForm";
 import { useAuth } from "../../contexts/AuthContext";
 import { teamService } from "../../services/teamService";
 import { userService } from "../../services/userService";
-import { reopenRolesFilledByMember } from "../../services/teamMemberRoleReopenService";
 import Button from "../common/Button";
 import SendMessageButton from "../common/SendMessageButton";
 import ScreenAlert from "../common/ScreenAlert";
@@ -67,6 +66,16 @@ import {
   locationsHaveDifferentKnownParts,
 } from "../../utils/locationUtils";
 import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
+
+const getTeamMemberUserId = (member) =>
+  member?.user_id ??
+  member?.userId ??
+  member?.user?.id ??
+  member?.id ??
+  null;
+
+const idsMatch = (left, right) =>
+  left != null && right != null && String(left) === String(right);
 
 const normalizeTeamTagIds = (team) => {
   const raw = team?.tags ?? team?.tags_json ?? team?.selectedTags ?? [];
@@ -248,7 +257,7 @@ const TeamDetailsModal = ({
         if (isNaN(ownerId) && user && teamData.members) {
           const isCurrentUserOwner = teamData.members.some(
             (member) =>
-              (member.user_id === user.id || member.userId === user.id) &&
+              idsMatch(getTeamMemberUserId(member), user.id) &&
               (member.role === "owner" || member.role === "Owner"),
           );
 
@@ -311,7 +320,7 @@ const TeamDetailsModal = ({
           (isUserAuthenticated &&
             teamData.members?.some(
               (member) =>
-                (member.user_id === user.id || member.userId === user.id) &&
+                idsMatch(getTeamMemberUserId(member), user.id) &&
                 (member.role === "owner" || member.role === "Owner"),
             )) ||
           false;
@@ -324,7 +333,7 @@ const TeamDetailsModal = ({
         // Determine user's role from members list
         if (isUserAuthenticated && teamData.members) {
           const currentUserMember = teamData.members.find(
-            (member) => member.user_id === user.id || member.userId === user.id,
+            (member) => idsMatch(getTeamMemberUserId(member), user.id),
           );
           if (currentUserMember) {
             setInternalUserRole(currentUserMember.role);
@@ -558,7 +567,7 @@ const TeamDetailsModal = ({
     // Show for team members
     if (team && team.members && Array.isArray(team.members)) {
       return team.members.some(
-        (member) => member.user_id === user.id || member.userId === user.id,
+        (member) => idsMatch(getTeamMemberUserId(member), user.id),
       );
     }
 
@@ -837,15 +846,11 @@ const TeamDetailsModal = ({
 
     setLeaveLoading(true);
     try {
-      const reopenedRoles = await reopenRolesFilledByMember({
-        teamId: team.id,
-        teamName: team.name,
-        member: user,
-        memberId: user.id,
-        roles: teamRoles,
-      });
+      const result = await teamService.removeTeamMember(team.id, user.id);
+      const reopenedRoles = Array.isArray(result?.data?.reopenedRoles)
+        ? result.data.reopenedRoles
+        : [];
 
-      await teamService.removeTeamMember(team.id, user.id);
       setNotification({
         type: "success",
         message:
@@ -875,13 +880,19 @@ const TeamDetailsModal = ({
   };
 
   // Invitation response handlers
-  const handleInvitationAccept = async (invitationId, responseMessage = "", fillRole = false) => {
+  const handleInvitationAccept = async (
+    invitationId,
+    responseMessage = "",
+    fillRole = false,
+    options = {},
+  ) => {
     try {
       await teamService.respondToInvitation(
         invitationId,
         "accept",
         responseMessage,
         fillRole,
+        options,
       );
       setNotification({
         type: "success",
@@ -898,7 +909,7 @@ const TeamDetailsModal = ({
       console.error("Error accepting invitation:", error);
       setNotification({
         type: "error",
-        message: "Failed to accept invitation. Please try again.",
+        message: error.message || "Failed to accept invitation. Please try again.",
       });
     }
   };
@@ -936,7 +947,7 @@ const TeamDetailsModal = ({
     if (!user?.id || !team?.members) return false;
 
     const currentMember = team.members.find(
-      (m) => m.user_id === user.id || m.userId === user.id,
+      (m) => idsMatch(getTeamMemberUserId(m), user.id),
     );
 
     if (!currentMember) return false;
@@ -1155,17 +1166,17 @@ const TeamDetailsModal = ({
   const isTeamMember = useMemo(() => {
     if (!team || !user) return false;
     return (
-      team.members?.some((member) => member.user_id === user.id) ||
+      team.members?.some((member) => idsMatch(getTeamMemberUserId(member), user.id)) ||
       isOwner || // Make sure this matches your variable name
-      userRole
+      Boolean(effectiveUserRole)
     );
-  }, [team, user, isOwner, userRole]);
+  }, [team, user, isOwner, effectiveUserRole]);
 
   const renderJoinButton = () => {
     if (!isAuthenticated) return null;
 
     const isMember = team?.members?.some(
-      (m) => m.user_id === user?.id || m.userId === user?.id,
+      (m) => idsMatch(getTeamMemberUserId(m), user?.id),
     );
 
     const isTeamArchived = team?.archived_at || team?.status === "inactive";
@@ -1706,7 +1717,7 @@ const TeamDetailsModal = ({
                   <VacantRolesSection
                     team={team}
                     teamId={effectiveTeamId}
-                    canManage={isOwner || internalUserRole === "admin"}
+                    canManage={isOwner || effectiveUserRole === "admin"}
                     isTeamMember={isTeamMember}
                     isEditing={isEditing}
                     onRolesLoaded={setTeamRoles}

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -9,6 +9,7 @@ import {
   MailOpen,
   UserPlus,
   FlaskConical,
+  ArrowRightLeft,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
@@ -22,6 +23,7 @@ import InlineUserLink from "../users/InlineUserLink";
 import { useHydratedRole } from "../../hooks/useHydratedRole";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
+import { useAuth } from "../../contexts/AuthContext";
 
 const extractRoleMatchData = (roleLike) => {
   const rawScore = roleLike?.matchScore ?? roleLike?.match_score ?? null;
@@ -57,9 +59,12 @@ const TeamInvitationDetailsModal = ({
   onDecline,
   notificationHighlight = false,
 }) => {
+  // ============ Auth ============
+  const { user: currentUser } = useAuth();
+
   // ============ State ============
   const [loading] = useState(false);
-  const [actionLoading, setActionLoading] = useState(null); // "acceptRole" | "acceptTeam" | "decline" | null
+  const [actionLoading, setActionLoading] = useState(null); // "acceptRole" | "switchRole" | "acceptTeam" | "decline" | null
   const [error, setError] = useState(null);
   const [responseMessage, setResponseMessage] = useState("");
   const [selectedUserId, setSelectedUserId] = useState(null);
@@ -91,6 +96,13 @@ const TeamInvitationDetailsModal = ({
   } = useHydratedRole({
     isOpen,
     roleId,
+    teamId,
+  });
+  const currentFilledRoleId =
+    invitation?.current_filled_role_id ?? invitation?.currentFilledRoleId ?? null;
+  const { hydratedRole: hydratedCurrentFilledRole } = useHydratedRole({
+    isOpen,
+    roleId: currentFilledRoleId,
     teamId,
   });
   const invitationRoleMatch = extractRoleMatchData(invitation?.role);
@@ -190,6 +202,20 @@ const TeamInvitationDetailsModal = ({
     }
   };
 
+  const handleSwitchRole = async () => {
+    try {
+      setActionLoading("switchRole");
+      setError(null);
+      await onAccept(invitation.id, responseMessage, true, { switchRoles: true });
+      setResponseMessage("");
+      onClose();
+    } catch (err) {
+      setError(err.message || "Failed to switch roles");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const handleAcceptTeamOnly = async () => {
     try {
       setActionLoading("acceptTeam");
@@ -229,10 +255,11 @@ const TeamInvitationDetailsModal = ({
   const hasRoleInvitation = !!(invitation?.role_id ?? invitation?.roleId ?? invitation?.role?.id);
   const isInternal = invitation?.isInternal ?? invitation?.is_internal ?? false;
   const isAcceptRoleLoading = actionLoading === "acceptRole";
+  const isSwitchRoleLoading = actionLoading === "switchRole";
   const isAcceptTeamLoading = actionLoading === "acceptTeam";
   const isDeclineLoading = actionLoading === "decline";
   const isActionPending =
-    isAcceptRoleLoading || isAcceptTeamLoading || isDeclineLoading;
+    isAcceptRoleLoading || isSwitchRoleLoading || isAcceptTeamLoading || isDeclineLoading;
   const isControlsDisabled = loading || isActionPending;
 
   const headerSubtitle = isInternal
@@ -284,6 +311,55 @@ const TeamInvitationDetailsModal = ({
   const isRoleFilled = hasRoleInvitation && roleStatus === "filled";
   const isRoleClosed = hasRoleInvitation && roleStatus === "closed";
   const isRoleUnavailable = isRoleFilled || isRoleClosed;
+  const currentFilledRole =
+    invitation?.currentFilledRole ??
+    invitation?.current_filled_role ??
+    (invitation?.current_filled_role_id || invitation?.currentFilledRoleId
+      ? {
+          id: invitation.current_filled_role_id ?? invitation.currentFilledRoleId,
+          roleName:
+            invitation.current_filled_role_name ??
+            invitation.currentFilledRoleName ??
+            "your current role",
+          role_name:
+            invitation.current_filled_role_name ??
+            invitation.currentFilledRoleName ??
+            "your current role",
+        }
+      : null);
+  const currentFilledRoleName =
+    currentFilledRole?.roleName ??
+    currentFilledRole?.role_name ??
+    invitation?.current_filled_role_name ??
+    invitation?.currentFilledRoleName ??
+    "your current role";
+  const currentFilledRoleForCard = hydratedCurrentFilledRole
+    ? {
+        ...hydratedCurrentFilledRole,
+        is_synthetic:
+          hydratedCurrentFilledRole.is_synthetic ??
+          hydratedCurrentFilledRole.isSynthetic ??
+          syntheticRoleFlag,
+        isSynthetic:
+          hydratedCurrentFilledRole.isSynthetic ??
+          hydratedCurrentFilledRole.is_synthetic ??
+          syntheticRoleFlag,
+      }
+    : currentFilledRole
+    ? {
+        ...currentFilledRole,
+        status: currentFilledRole.status ?? "filled",
+        filled_by: currentUser?.id ?? null,
+        filled_by_user: currentUser ?? null,
+        is_synthetic: syntheticRoleFlag,
+        isSynthetic: syntheticRoleFlag,
+      }
+    : null;
+  const canSwitchRole =
+    hasRoleInvitation &&
+    isInternal &&
+    !isRoleUnavailable &&
+    Boolean(currentFilledRole?.id ?? invitation?.current_filled_role_id ?? invitation?.currentFilledRoleId);
 
   // Custom header
   const customHeader = (
@@ -298,19 +374,18 @@ const TeamInvitationDetailsModal = ({
     </div>
   );
 
-  // Footer with action buttons + "Sent by" (left)
+  // Footer with action buttons + "Sent by"
   const footer = (
-    <div className="space-y-3">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        {/* Sent by (left) */}
-        <InlineUserLink
-          label="Invite sent by"
-          user={inviter}
-          onOpenUser={handleUserClick}
-        />
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+      {/* Sent by — shares row with buttons when there's space, own row otherwise */}
+      <InlineUserLink
+        label="Invite sent by"
+        user={inviter}
+        onOpenUser={handleUserClick}
+      />
 
-        {/* Buttons (right) */}
-        <div className="flex flex-wrap justify-end gap-2">
+      {/* Buttons — right-aligned, never wrap internally */}
+      <div className="flex flex-nowrap gap-2 ml-auto">
           {isRoleUnavailable && (
             <Tooltip
               content={
@@ -344,15 +419,31 @@ const TeamInvitationDetailsModal = ({
           {hasRoleInvitation && isInternal ? (
             // Internal role invite: user is already a member, just accept/fill the role
             !isRoleUnavailable && (
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleAcceptWithRole}
-                disabled={isControlsDisabled}
-                icon={<Check size={16} />}
-              >
-                {isAcceptRoleLoading ? "Accepting..." : "Accept Role"}
-              </Button>
+              canSwitchRole ? (
+                <Tooltip
+                  content={`Leave ${currentFilledRoleName} and fill this role instead.`}
+                >
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={handleSwitchRole}
+                    disabled={isControlsDisabled}
+                    icon={<ArrowRightLeft size={16} />}
+                  >
+                    {isSwitchRoleLoading ? "Switching..." : "Leave old role to fill new role"}
+                  </Button>
+                </Tooltip>
+              ) : (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleAcceptWithRole}
+                  disabled={isControlsDisabled}
+                  icon={<Check size={16} />}
+                >
+                  {isAcceptRoleLoading ? "Accepting..." : "Accept Role"}
+                </Button>
+              )
             )
           ) : hasRoleInvitation ? (
             // External invite with a role: offer team-only or fill-role options
@@ -391,10 +482,8 @@ const TeamInvitationDetailsModal = ({
             </Button>
           )}
         </div>
-      </div>
     </div>
   );
-
   return (
     <>
       <Modal
@@ -531,11 +620,29 @@ const TeamInvitationDetailsModal = ({
               <MailOpen size={12} className="text-info mr-1" />
               Invitation message:
             </p>
-
-            {/* left-aligned with other content (no extra padding box) */}
             <p className="text-sm text-base-content/90 leading-relaxed">
-              {invitation.message}
+              {(() => {
+                if (isInternal && currentFilledRoleName && currentFilledRoleName !== "your current role") {
+                  const suffix = ` ${currentFilledRoleName}.`;
+                  return invitation.message.endsWith(suffix)
+                    ? invitation.message.slice(0, -suffix.length)
+                    : invitation.message;
+                }
+                return invitation.message;
+              })()}
             </p>
+            {isInternal && currentFilledRoleForCard && (
+              <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <VacantRoleCard
+                  role={currentFilledRoleForCard}
+                  team={team}
+                  matchScore={null}
+                  canManage={false}
+                  isTeamMember={true}
+                  hideActions={true}
+                />
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -974,7 +974,7 @@ const TeamInviteModal = ({
     fillRole = false
   ) => {
     try {
-      await teamService.handleTeamApplication(applicationId, action, response, fillRole);
+      const result = await teamService.handleTeamApplication(applicationId, action, response, fillRole);
 
       // Update local state - remove the processed application
       if (selectedTeamForModal) {
@@ -999,6 +999,7 @@ const TeamInviteModal = ({
           },
         }));
       }
+      return result;
     } catch (err) {
       console.error(`Error ${action}ing application:`, err);
       throw err;

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -6,6 +6,7 @@ import {
   SendHorizontal,
   FlaskConical,
   Trash2,
+  MailOpen,
 } from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
 import Button from "../common/Button";
@@ -916,6 +917,44 @@ const TeamInvitesModal = ({
               </div>
             )}
 
+            {/* Invited role card — shown when invitation targets a specific role */}
+            {(invitation.role || invitation.roleId || invitation.role_id) && (
+              <div className="mb-3">
+                <p className="text-xs text-base-content/60 mb-2 flex items-center">
+                  <MailOpen size={12} className="text-info mr-1" />
+                  Invited for this role:
+                </p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <VacantRoleCard
+                    role={roleForCard}
+                    team={{ id: teamId, name: teamName }}
+                    matchScore={
+                      inviteeRoleMatch?.matchScore ??
+                      selfRoleMatch?.matchScore ??
+                      localInviteeRoleMatch?.matchScore ??
+                      invitation.role?.matchScore ??
+                      invitation.role?.match_score ??
+                      null
+                    }
+                    matchDetails={
+                      inviteeRoleMatch?.matchDetails ??
+                      selfRoleMatch?.matchDetails ??
+                      localInviteeRoleMatch?.matchDetails ??
+                      invitation.role?.matchDetails ??
+                      invitation.role?.match_details ??
+                      null
+                    }
+                    canManage={false}
+                    canManageStatus={false}
+                    isTeamMember={true}
+                    viewAsUserId={invitation.invitee?.id ?? invitation.invitee_id}
+                    viewAsUser={invitation.invitee}
+                    hideActions={true}
+                  />
+                </div>
+              </div>
+            )}
+
             {/* Invitation Message (if any) */}
             {invitation.message && (
               <div className="mb-3">
@@ -924,40 +963,39 @@ const TeamInvitesModal = ({
                   Invitation message:
                 </p>
                 <p className="text-sm text-base-content/90 leading-relaxed">
-                  {invitation.message}
+                  {(() => {
+                    const roleName = invitation.current_filled_role_name ?? invitation.currentFilledRoleName;
+                    if (isInternalInvitation && roleName) {
+                      const suffix = ` ${roleName}.`;
+                      return invitation.message.endsWith(suffix)
+                        ? invitation.message.slice(0, -suffix.length)
+                        : invitation.message;
+                    }
+                    return invitation.message;
+                  })()}
                 </p>
-              </div>
-            )}
-
-            {/* Vacant role card — shown when invitation targets a specific role */}
-            {(invitation.role || invitation.roleId || invitation.role_id) && (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-3">
-                <VacantRoleCard
-                  role={roleForCard}
-                  team={{ id: teamId, name: teamName }}
-                  matchScore={
-                    inviteeRoleMatch?.matchScore ??
-                    selfRoleMatch?.matchScore ??
-                    localInviteeRoleMatch?.matchScore ??
-                    invitation.role?.matchScore ??
-                    invitation.role?.match_score ??
-                    null
-                  }
-                  matchDetails={
-                    inviteeRoleMatch?.matchDetails ??
-                    selfRoleMatch?.matchDetails ??
-                    localInviteeRoleMatch?.matchDetails ??
-                    invitation.role?.matchDetails ??
-                    invitation.role?.match_details ??
-                    null
-                  }
-                  canManage={false}
-                  canManageStatus={false}
-                  isTeamMember={true}
-                  viewAsUserId={invitation.invitee?.id ?? invitation.invitee_id}
-                  viewAsUser={invitation.invitee}
-                  hideActions={true}
-                />
+                {isInternalInvitation && (invitation.current_filled_role_id ?? invitation.currentFilledRoleId) && (
+                  <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <VacantRoleCard
+                      role={{
+                        id: invitation.current_filled_role_id ?? invitation.currentFilledRoleId,
+                        role_name: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
+                        roleName: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
+                        status: "filled",
+                        filled_by: invitation.invitee?.id ?? invitation.invitee_id,
+                        filled_by_user: invitation.invitee ?? null,
+                        is_synthetic: invitation.role_is_synthetic ?? false,
+                        isSynthetic: invitation.role_is_synthetic ?? false,
+                      }}
+                      team={{ id: teamId, name: teamName }}
+                      matchScore={null}
+                      canManage={false}
+                      canManageStatus={false}
+                      isTeamMember={true}
+                      hideActions={true}
+                    />
+                  </div>
+                )}
               </div>
             )}
 

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -11,11 +11,6 @@ import {
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import ScreenAlert from "../common/ScreenAlert";
 import { teamService } from "../../services/teamService";
-import {
-  fetchRolesFilledByMember,
-  getRolesFilledByMember,
-  reopenRolesFilledByMember,
-} from "../../services/teamMemberRoleReopenService";
 import { userService } from "../../services/userService";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import CardMetaItem from "../common/CardMetaItem";
@@ -360,11 +355,6 @@ const TeamMembersSection = ({
                             throw new Error("Could not determine member ID");
                           }
 
-                          const rolesToReopen =
-                            Array.isArray(roles) && roles.length > 0
-                              ? getRolesFilledByMember(roles, resolvedMemberId)
-                              : await fetchRolesFilledByMember(team.id, resolvedMemberId);
-
                           if (member.role === "admin" && isAdmin && !isOwner) {
                             await teamService.updateMemberRole(
                               team.id,
@@ -374,16 +364,15 @@ const TeamMembersSection = ({
                             demotedForRemoval = true;
                           }
 
-                          await teamService.removeTeamMember(team.id, resolvedMemberId);
-
-                          const reopenedRoles = await reopenRolesFilledByMember({
-                            teamId: team.id,
-                            teamName: team.name,
-                            member,
-                            memberId: resolvedMemberId,
-                            roles: rolesToReopen,
-                            useProvidedRoles: true,
-                          });
+                          const result = await teamService.removeTeamMember(
+                            team.id,
+                            resolvedMemberId,
+                          );
+                          const reopenedRoles = Array.isArray(
+                            result?.data?.reopenedRoles,
+                          )
+                            ? result.data.reopenedRoles
+                            : [];
 
                           setNotification({
                             type: "success",

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -1209,7 +1209,7 @@ const VacantRoleDetailsModal = ({
   ]);
 
   const handleApplicationAction = async (applicationId, action, response = "", fillRole = false) => {
-    await teamService.handleTeamApplication(applicationId, action, response, fillRole);
+    const result = await teamService.handleTeamApplication(applicationId, action, response, fillRole);
     try {
       const refreshed = await teamService.getTeamApplications(teamId);
       const apps = refreshed.data || [];
@@ -1224,6 +1224,7 @@ const VacantRoleDetailsModal = ({
     } catch (e) {
       console.warn("Could not refresh applications:", e);
     }
+    return result;
   };
 
   const handleCancelInvitation = async (invitationId) => {
@@ -1282,16 +1283,18 @@ const VacantRoleDetailsModal = ({
     invitationId,
     responseMessage = "",
     fillRole = false,
+    options = {},
   ) => {
     const roleForMessage = viewerRoleInvitationRecord?.role ?? displayRole;
-    await teamService.respondToInvitation(
+    const response = await teamService.respondToInvitation(
       invitationId,
       "accept",
       responseMessage,
       fillRole,
+      options,
     );
 
-    if (teamId) {
+    if (teamId && !response?.data?.roleSwitched) {
       try {
         await messageService.sendMessage(
           teamId,

--- a/src/components/teams/VacantRolesSection.jsx
+++ b/src/components/teams/VacantRolesSection.jsx
@@ -16,6 +16,8 @@ import { vacantRoleService } from "../../services/vacantRoleService";
 import { matchingService } from "../../services/matchingService";
 import { useAuth } from "../../contexts/AuthContext";
 
+const getRoleStatus = (role) => String(role?.status ?? "").toLowerCase();
+
 /**
  * VacantRolesSection Component
  *
@@ -42,7 +44,7 @@ const VacantRolesSection = ({
   className = "",
   onRolesLoaded = null,
 }) => {
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated } = useAuth();
 
   const [roles, setRoles] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -56,9 +58,9 @@ const VacantRolesSection = ({
   const [matchScores, setMatchScores] = useState({});
   const [isExpanded, setIsExpanded] = useState(false);
   const COLLAPSED_COUNT = 4;
-  const shouldShowFilledRoles = canManage || isTeamMember;
+  const shouldShowAllRoleStatuses = canManage || isTeamMember;
   const visibleRoles = roles.filter((role) => {
-    if (canManage || isTeamMember) return true;
+    if (shouldShowAllRoleStatuses) return true;
     return String(role?.status ?? "").toLowerCase() === "open";
   });
 
@@ -78,9 +80,8 @@ const VacantRolesSection = ({
     try {
       setLoading(true);
       setError(null);
-      // Managers see all statuses, team members see open + filled,
-      // and outsiders still see only open roles.
-      const statusFilter = shouldShowFilledRoles ? "all" : "open";
+      // Managers and team members see all statuses; outsiders see only open roles.
+      const statusFilter = shouldShowAllRoleStatuses ? "all" : "open";
       const response = await vacantRoleService.getVacantRoles(
         teamId,
         statusFilter,
@@ -94,7 +95,7 @@ const VacantRolesSection = ({
     } finally {
       setLoading(false);
     }
-  }, [teamId, shouldShowFilledRoles]);
+  }, [teamId, shouldShowAllRoleStatuses, onRolesLoaded]);
 
   useEffect(() => {
     fetchRoles();
@@ -133,23 +134,11 @@ const VacantRolesSection = ({
   // Handle status change
   const handleStatusChange = async (roleId, newStatus) => {
     try {
-      const roleBeforeChange = roles.find(
-        (role) => String(role?.id) === String(roleId),
-      );
-      const updateResponse = await vacantRoleService.updateVacantRoleStatus(
+      await vacantRoleService.updateVacantRoleStatus(
         teamId,
         roleId,
         newStatus,
       );
-      const updatedRole =
-        updateResponse?.data?.data ??
-        updateResponse?.data ??
-        updateResponse?.role ??
-        updateResponse;
-      const eventRole =
-        updatedRole && typeof updatedRole === "object"
-          ? { ...roleBeforeChange, ...updatedRole }
-          : roleBeforeChange;
 
       setNotification({
         type: "success",
@@ -179,7 +168,6 @@ const VacantRolesSection = ({
 
   const confirmDeleteRole = async () => {
     if (!pendingDeleteRoleId) return;
-    const roleSnapshot = pendingDeleteRole;
     try {
       setDeleteRoleLoading(true);
       await vacantRoleService.deleteVacantRole(teamId, pendingDeleteRoleId);
@@ -246,6 +234,18 @@ const VacantRolesSection = ({
 
   // Count open roles for the title
   const openCount = roles.filter((r) => r.status === "open").length;
+  const sortedVisibleRoles = [...visibleRoles].sort((a, b) => {
+    const aIsClosed = getRoleStatus(a) === "closed";
+    const bIsClosed = getRoleStatus(b) === "closed";
+
+    if (aIsClosed !== bIsClosed) {
+      return aIsClosed ? 1 : -1;
+    }
+
+    const scoreA = matchScores[a.id]?.matchScore ?? -1;
+    const scoreB = matchScores[b.id]?.matchScore ?? -1;
+    return scoreB - scoreA;
+  });
 
   return (
     <div className={className}>
@@ -295,12 +295,7 @@ const VacantRolesSection = ({
       {visibleRoles.length > 0 ? (
         <>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {[...visibleRoles]
-              .sort((a, b) => {
-                const scoreA = matchScores[a.id]?.matchScore ?? -1;
-                const scoreB = matchScores[b.id]?.matchScore ?? -1;
-                return scoreB - scoreA;
-              })
+            {sortedVisibleRoles
               .slice(0, isExpanded ? undefined : COLLAPSED_COUNT)
               .map((role) => (
                 <VacantRoleCard

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -20,7 +20,6 @@ import socketService from "../services/socketService";
 import useSocketEvents from "../hooks/useSocketEvents";
 import { userService } from "../services/userService";
 import { teamService } from "../services/teamService";
-import { reopenRolesFilledByMember } from "../services/teamMemberRoleReopenService";
 import ScreenAlert from "../components/common/ScreenAlert";
 import Button from "../components/common/Button";
 import Modal from "../components/common/Modal";
@@ -467,6 +466,7 @@ const NOTIFICATION_EVENT_MESSAGE_MARKERS = {
     "ROLE_APPLICATION_FILLED",
     "ROLE_INVITATION_FILLED",
   ],
+  role_application_deferred_invite: ["ROLE_APPLICATION_DEFERRED_INVITE"],
   role_reopened: ["ROLE_REOPENED"],
   role_reopened_admin: ["ROLE_REOPENED_ADMIN"],
   team_deleted: ["TEAM_DELETED"],
@@ -2423,13 +2423,6 @@ const Chat = () => {
 
   const executeLeaveTeam = async ({ teamId }) => {
     try {
-      await reopenRolesFilledByMember({
-        teamId,
-        teamName: activeConversation?.team?.name,
-        member: user,
-        memberId: user.id,
-      });
-
       // Call the existing leave team API
       await teamService.removeTeamMember(teamId, user.id);
 

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -365,13 +365,19 @@ const MyTeams = () => {
   };
 
   // Invitation handlers
-  const handleInvitationAccept = async (invitationId, responseMessage = "", fillRole = false) => {
+  const handleInvitationAccept = async (
+    invitationId,
+    responseMessage = "",
+    fillRole = false,
+    options = {},
+  ) => {
     try {
       await teamService.respondToInvitation(
         invitationId,
         "accept",
         responseMessage,
         fillRole,
+        options,
       );
 
       // Refresh the data
@@ -1107,8 +1113,8 @@ const MyTeams = () => {
           isOpen={true}
           invitation={notifInvitationModal}
           onClose={() => setNotifInvitationModal(null)}
-          onAccept={async (invitationId, responseMessage, fillRole) => {
-            await handleInvitationAccept(invitationId, responseMessage, fillRole);
+          onAccept={async (invitationId, responseMessage, fillRole, options) => {
+            await handleInvitationAccept(invitationId, responseMessage, fillRole, options);
             setNotifInvitationModal(null);
           }}
           onDecline={async (invitationId, responseMessage) => {

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -115,7 +115,11 @@ export const teamService = {
       return apiResponse.data;
     } catch (error) {
       console.error(`Error handling application ${applicationId}:`, error);
-      throw error;
+      throw new Error(
+        error.response?.data?.message ||
+          error.message ||
+          `Failed to ${action} application`,
+      );
     }
   },
 
@@ -507,17 +511,28 @@ export const teamService = {
     }
   },
 
-  respondToInvitation: async (invitationId, action, responseMessage = "", fillRole = false) => {
+  respondToInvitation: async (
+    invitationId,
+    action,
+    responseMessage = "",
+    fillRole = false,
+    options = {},
+  ) => {
     try {
       const response = await api.put(`/api/teams/invitations/${invitationId}`, {
         action,
         response_message: responseMessage,
         fill_role: fillRole,
+        switch_roles: options.switchRoles || options.switch_roles || undefined,
       });
       return response.data;
     } catch (error) {
       console.error(`Error responding to invitation ${invitationId}:`, error);
-      throw error;
+      throw new Error(
+        error.response?.data?.message ||
+          error.message ||
+          `Failed to ${action} invitation`,
+      );
     }
   },
 

--- a/src/utils/eventPreview.js
+++ b/src/utils/eventPreview.js
@@ -14,6 +14,7 @@ const teamText = (teamName) => (teamName ? ` for "${teamName}"` : "");
 const inTeamText = (teamName) => (teamName ? ` in "${teamName}"` : "");
 
 const possessive = (name) => (name === "You" ? "Your" : `${name}'s`);
+const sentenceObject = (name) => (name === "You" ? "you" : name);
 
 const getActorLabel = (userId, userName, currentUser) => {
   const currentUserName = currentUser ? getDisplayName(currentUser) : null;
@@ -258,12 +259,29 @@ export const getEventPreview = (lastMessage, currentUser = null) => {
 
       return {
         text: approverName
-          ? `The role ${parsedMessage.roleName} has been filled by ${applicantName || "Someone"}, approved by ${approverName}.`
-          : `The role ${parsedMessage.roleName} has been filled by ${applicantName || "Someone"}.`,
+          ? `The role ${parsedMessage.roleName} has been filled by ${sentenceObject(applicantName) || "Someone"}, approved by ${sentenceObject(approverName)}.`
+          : `The role ${parsedMessage.roleName} has been filled by ${sentenceObject(applicantName) || "Someone"}.`,
         icon: "UserCheck",
         bannerClass: null,
         color: EVENT_PREVIEW_TEXT_COLORS.role,
         senderName: approverName || parsedMessage.approverName || null,
+        senderPrefix: "by ",
+      };
+    }
+
+    case "role_application_deferred_invite": {
+      const applicantName = getActorLabel(
+        parsedMessage.applicantId,
+        parsedMessage.applicantName,
+        currentUser,
+      );
+
+      return {
+        text: `${possessive(applicantName || "Applicant")} application for ${parsedMessage.roleName} was approved as a role offer`,
+        icon: "UserSearch",
+        bannerClass: null,
+        color: EVENT_PREVIEW_TEXT_COLORS.role,
+        senderName: parsedMessage.approverName || null,
         senderPrefix: "by ",
       };
     }
@@ -394,7 +412,9 @@ export const getEventPreview = (lastMessage, currentUser = null) => {
 
       return {
         text: userName
-          ? `${userName} left the role ${parsedMessage.roleName || "Vacant Role"}. It is open again.`
+          ? userName === "You"
+            ? `You left the role ${parsedMessage.roleName || "Vacant Role"}. It is open again.`
+            : `${userName} left the role ${parsedMessage.roleName || "Vacant Role"}. It is open again.`
           : `Role reopened: ${parsedMessage.roleName || "Vacant Role"}`,
         icon: "UserSearch",
         bannerClass: null,
@@ -417,9 +437,9 @@ export const getEventPreview = (lastMessage, currentUser = null) => {
 
       return {
         text: filledUserName && filledByName
-          ? `The role ${parsedMessage.roleName} has been filled by ${filledUserName}, approved by ${filledByName}.`
+          ? `The role ${parsedMessage.roleName} has been filled by ${sentenceObject(filledUserName)}, approved by ${sentenceObject(filledByName)}.`
           : filledUserName
-            ? `The role ${parsedMessage.roleName} has been filled by ${filledUserName}.`
+            ? `The role ${parsedMessage.roleName} has been filled by ${sentenceObject(filledUserName)}.`
             : `The role ${parsedMessage.roleName} has been marked filled.`,
         icon: "UserCheck",
         bannerClass: null,

--- a/src/utils/roleEventMessages.js
+++ b/src/utils/roleEventMessages.js
@@ -176,3 +176,26 @@ export const buildRoleApplicationFilledMessage = ({
     ? `${baseMessage} | ${formatIdNameToken(approverId, approverName || "Someone")}`
     : baseMessage;
 };
+
+export const buildRoleApplicationDeferredInviteMessage = ({
+  teamId,
+  teamName,
+  role,
+  applicant = null,
+  approver = null,
+  currentRole = null,
+}) => {
+  const roleId = role?.id ?? role?.roleId ?? role?.role_id ?? null;
+  const roleName = getRoleEventName(role);
+  const applicantId = getUserEventId(applicant);
+  const applicantName = getUserEventName(applicant) ?? "Someone";
+  const approverId = getUserEventId(approver);
+  const approverName = getUserEventName(approver) ?? "Someone";
+  const currentRoleId =
+    currentRole?.id ?? currentRole?.roleId ?? currentRole?.role_id ?? null;
+  const currentRoleName = currentRole
+    ? getRoleEventName(currentRole)
+    : "their current role";
+
+  return `📬 ROLE_APPLICATION_DEFERRED_INVITE: ${formatIdNameToken(teamId, teamName)} | ${formatIdNameToken(roleId, roleName)} | ${formatIdNameToken(applicantId, applicantName)} | ${formatIdNameToken(approverId, approverName)} | ${formatIdNameToken(currentRoleId, currentRoleName)}`;
+};


### PR DESCRIPTION
## Summary

This PR completes the frontend flow for deferred role invitations when a team member is approved for a new role while already filling another one. It updates invitation displays, role-offer actions, chat system messages, notification previews, and role/member state handling so the UI clearly shows what role is being offered and what current role blocks immediate filling.

## Changes

- Added support for accepting internal role invitations with a `switch_roles` option, including a dedicated “Leave old role to fill new role” action.
- Updated invitation detail and team invite modals to show:
  - the role the user was invited for
  - the invitee’s currently filled role when relevant
  - cleaner deferred-invite message text without duplicated legacy role names
- Added frontend parsing/rendering for `ROLE_APPLICATION_DEFERRED_INVITE` chat events.
- Improved chat and toast copy so current-user actions use “you/your” instead of awkward name references.
- Added notification/nav support for role-offer events.
- Updated application approval handling to distinguish between:
  - role filled immediately
  - role offer created because the applicant already fills another role
- Switched leave-team/member-removal UI flows to use reopened-role data returned by the API.
- Improved role visibility and sorting in team details so members/managers can see all role statuses while outsiders still see open roles only.
- Tightened error handling for invitation/application responses so backend messages surface in the UI.

## Verification

- Ran `git diff --check`
- Ran `npm run build` successfully

Build completed with existing Vite warnings about bundle size and `VacantRoleDetailsModal.jsx` being both statically and dynamically imported.