### PR TITLE
UI/invite modal roles

### DIFF
--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -10,16 +10,31 @@ import {
   UserSearch,
   MapPin,
   Globe,
+  FlaskConical,
+  ChevronRight,
+  ChevronUp,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
 import ScreenAlert from "../common/ScreenAlert";
+import CardMetaItem from "../common/CardMetaItem";
+import CardMetaRow from "../common/CardMetaRow";
 import RoleBadgePill from "../common/RoleBadgePill";
+import Tooltip from "../common/Tooltip";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import UserDetailsModal from "../users/UserDetailsModal";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import TeamInvitesModal from "../teams/TeamInvitesModal";
 import TeamApplicationsModal from "../teams/TeamApplicationsModal";
-import { getUserInitials } from "../../utils/userHelpers";
+import {
+  DEMO_PROFILE_TOOLTIP,
+  DEMO_ROLE_TOOLTIP,
+  DEMO_TEAM_TOOLTIP,
+  getUserInitials,
+  isSyntheticUser,
+  isSyntheticRole,
+  isSyntheticTeam,
+} from "../../utils/userHelpers";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import useSocketEvents from "../../hooks/useSocketEvents";
@@ -137,6 +152,67 @@ const isInviteeExistingTeamMember = (team, inviteeId) => {
   );
 };
 
+const getRoleFilledById = (role) =>
+  role?.filledByUser?.id ??
+  role?.filled_by_user?.id ??
+  role?.filledByUserId ??
+  role?.filled_by_user_id ??
+  role?.filledBy ??
+  role?.filled_by ??
+  null;
+
+const isRoleFilledByInvitee = (role, inviteeId) => {
+  if (!role || inviteeId === null || inviteeId === undefined) return false;
+
+  const filledById = getRoleFilledById(role);
+  return filledById !== null && filledById !== undefined && idsMatch(filledById, inviteeId);
+};
+
+const hasInviteeFilledRole = (team, inviteeId) => {
+  if (!team || inviteeId === null || inviteeId === undefined) return false;
+
+  const directFlags = [
+    team?.inviteeHasFilledRole,
+    team?.invitee_has_filled_role,
+    team?.hasInviteeFilledRole,
+    team?.has_invitee_filled_role,
+    team?.inviteeHasRole,
+    team?.invitee_has_role,
+  ];
+
+  if (directFlags.some((flag) => normalizeBoolean(flag) === true)) {
+    return true;
+  }
+
+  const roleCollections = [
+    team?.roles,
+    team?.teamRoles,
+    team?.team_roles,
+    team?.vacantRoles,
+    team?.vacant_roles,
+  ].filter(Array.isArray);
+
+  return roleCollections.some((roles) =>
+    roles.some((role) => isRoleFilledByInvitee(role, inviteeId)),
+  );
+};
+
+const isInviteModalDemoTeam = (team) => {
+  if (!team) return false;
+
+  return (
+    isSyntheticTeam(team) ||
+    [
+      team?.team_is_synthetic,
+      team?.teamIsSynthetic,
+      team?.is_demo,
+      team?.isDemo,
+      team?.team_is_demo,
+      team?.teamIsDemo,
+    ].some((flag) => normalizeBoolean(flag) === true)
+  );
+};
+
 const unwrapTeamPayload = (payload) => {
   if (!payload || typeof payload !== "object") return null;
 
@@ -163,6 +239,7 @@ const unwrapTeamPayload = (payload) => {
  * @param {string} inviteeUsername - Username of the invitee
  * @param {string} inviteeAvatar - Avatar URL of the invitee
  * @param {string} inviteeBio - Bio/description of the invitee
+ * @param {boolean|string|number} inviteeIsSynthetic - Whether the invitee is demo data
  * @param {string|number|null} prefillTeamId - Team ID to preselect when available
  * @param {string|number|null} prefillRoleId - Vacant role ID to preselect when available
  * @param {string|null} prefillTeamName - Team name for prefill context
@@ -178,6 +255,7 @@ const TeamInviteModal = ({
   inviteeUsername,
   inviteeAvatar,
   inviteeBio,
+  inviteeIsSynthetic = false,
   prefillTeamId = null,
   prefillRoleId = null,
   prefillTeamName = null,
@@ -187,8 +265,10 @@ const TeamInviteModal = ({
   const normalizedPrefillRoleId = normalizeId(prefillRoleId);
   const [teams, setTeams] = useState([]);
   const [selectedTeamId, setSelectedTeamId] = useState(null);
+  const [isTeamSectionExpanded, setIsTeamSectionExpanded] = useState(true);
   const [vacantRoles, setVacantRoles] = useState([]);
   const [selectedRoleId, setSelectedRoleId] = useState(null);
+  const [isRoleSectionExpanded, setIsRoleSectionExpanded] = useState(false);
   const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const [loadingRoles, setLoadingRoles] = useState(false);
@@ -276,17 +356,44 @@ const TeamInviteModal = ({
                 isInviteeExistingTeamMember(team, inviteeId);
 
               let openRoleCount = 0;
+              let hasFilledRoleForInvitee = hasInviteeFilledRole(team, inviteeId);
+              let isDemoTeam = isInviteModalDemoTeam(team);
+
+              if (!isDemoTeam) {
+                try {
+                  const teamDetailsResponse = await teamService.getTeamById(team.id);
+                  const teamDetails = unwrapTeamPayload(teamDetailsResponse);
+                  isDemoTeam = isInviteModalDemoTeam(teamDetails);
+                } catch {
+                  isDemoTeam = false;
+                }
+              }
+
               try {
-                const rolesResponse = await vacantRoleService.getVacantRoles(team.id, "open");
-                openRoleCount = (rolesResponse.data || []).length;
+                const rolesResponse = await vacantRoleService.getVacantRoles(team.id, "all");
+                const allRoles = rolesResponse.data || [];
+                openRoleCount = allRoles.filter((role) => {
+                  const status = String(role?.status ?? "open").toLowerCase();
+                  return status === "open";
+                }).length;
+                hasFilledRoleForInvitee =
+                  hasFilledRoleForInvitee ||
+                  allRoles.some((role) => isRoleFilledByInvitee(role, inviteeId));
               } catch {
-                openRoleCount = 0;
+                try {
+                  const rolesResponse = await vacantRoleService.getVacantRoles(team.id, "open");
+                  openRoleCount = (rolesResponse.data || []).length;
+                } catch {
+                  openRoleCount = 0;
+                }
               }
 
               statusData[team.id] = {
                 hasInviteForUser,
                 hasApplicationFromUser,
                 isExistingMember,
+                hasFilledRoleForInvitee,
+                isDemoTeam,
                 allInvitations,
                 allApplications,
                 openRoleCount,
@@ -297,6 +404,8 @@ const TeamInviteModal = ({
                 hasInviteForUser: false,
                 hasApplicationFromUser: false,
                 isExistingMember: false,
+                hasFilledRoleForInvitee: false,
+                isDemoTeam: isInviteModalDemoTeam(team),
                 allInvitations: [],
                 allApplications: [],
                 openRoleCount: 0,
@@ -321,8 +430,10 @@ const TeamInviteModal = ({
   useEffect(() => {
     if (isOpen) {
       setSelectedTeamId(normalizedPrefillTeamId);
+      setIsTeamSectionExpanded(true);
       setVacantRoles([]);
       setSelectedRoleId(normalizedPrefillRoleId);
+      setIsRoleSectionExpanded(Boolean(normalizedPrefillRoleId));
       setMessage("");
       setLoadingRoles(false);
       setError(null);
@@ -352,6 +463,7 @@ const TeamInviteModal = ({
         return (
           !status.hasInviteForUser &&
           !status.hasApplicationFromUser &&
+          status.hasFilledRoleForInvitee !== true &&
           (hasOpenSlot || isExistingMember)
         );
       };
@@ -378,11 +490,16 @@ const TeamInviteModal = ({
     if (!isOpen || !selectedTeamId) {
       setVacantRoles([]);
       setSelectedRoleId(null);
+      setIsRoleSectionExpanded(false);
       setLoadingRoles(false);
       return;
     }
 
     let cancelled = false;
+    setIsRoleSectionExpanded(
+      idsMatch(selectedTeamId, normalizedPrefillTeamId) &&
+        normalizedPrefillRoleId != null,
+    );
 
     const fetchVacantRoles = async () => {
       try {
@@ -417,7 +534,12 @@ const TeamInviteModal = ({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, selectedTeamId]);
+  }, [
+    isOpen,
+    selectedTeamId,
+    normalizedPrefillTeamId,
+    normalizedPrefillRoleId,
+  ]);
 
   useEffect(() => {
     if (!isOpen || !selectedTeamId || loadingRoles) return;
@@ -487,6 +609,8 @@ const TeamInviteModal = ({
       first_name: inviteeFirstName,
       last_name: inviteeLastName,
       username: inviteeUsername || inviteeName,
+      is_synthetic: inviteeIsSynthetic,
+      isSynthetic: inviteeIsSynthetic,
     };
   };
 
@@ -554,6 +678,18 @@ const TeamInviteModal = ({
 
     const parts = [role.city, role.country].filter(Boolean);
     return parts.length > 0 ? parts.join(", ") : null;
+  };
+
+  const getTeamLocationDetails = (team) => {
+    const isRemote = team.isRemote ?? team.is_remote;
+    const locationParts = [team.city, team.country].filter(Boolean);
+    const locationText = isRemote
+      ? "Remote"
+      : locationParts.length > 0
+        ? locationParts.join(", ")
+        : null;
+
+    return { isRemote, locationText };
   };
 
   // Get the status badge for a team
@@ -644,6 +780,7 @@ const TeamInviteModal = ({
     return (
       !status.hasInviteForUser &&
       !status.hasApplicationFromUser &&
+      status.hasFilledRoleForInvitee !== true &&
       (hasCapacity(team) || status.isExistingMember === true)
     );
   };
@@ -654,6 +791,10 @@ const TeamInviteModal = ({
       if (userRole && !['owner', 'admin'].includes(userRole)) return false;
 
       const status = teamStatusData[team.id];
+      if (status?.isExistingMember === true && status?.hasFilledRoleForInvitee === true) {
+        return false;
+      }
+
       if (status?.isExistingMember === true && (status?.openRoleCount ?? 0) === 0) {
         return false;
       }
@@ -681,6 +822,49 @@ const TeamInviteModal = ({
   const selectedTeamStatus =
     (selectedTeam && teamStatusData[selectedTeam.id]) || {};
   const selectedTeamRequiresRole = selectedTeamStatus.isExistingMember === true;
+  const shouldShowRolePicker =
+    !!selectedTeamId &&
+    (loadingRoles ||
+      vacantRoles.length > 0 ||
+      selectedTeamRequiresRole ||
+      isRoleSectionExpanded);
+  const roleAvailabilityLabel =
+    vacantRoles.length === 1
+      ? "1 open role available"
+      : `${vacantRoles.length} open roles available`;
+  const otherAvailableTeamCount = selectedTeam
+    ? orderedTeams.filter((team) => !idsMatch(team.id, selectedTeam.id)).length
+    : orderedTeams.length;
+  const otherAvailableTeamLabel =
+    otherAvailableTeamCount === 1
+      ? "1 other team available"
+      : `${otherAvailableTeamCount} other teams available`;
+  const selectedRole =
+    vacantRoles.find((role) => idsMatch(role.id, selectedRoleId)) ?? null;
+  const isRoleSelectionRequired =
+    selectedTeamRequiresRole && selectedRoleId === null;
+
+  useEffect(() => {
+    if (isOpen && isRoleSelectionRequired) {
+      setIsRoleSectionExpanded(true);
+    }
+  }, [isOpen, isRoleSelectionRequired]);
+
+  useEffect(() => {
+    if (isOpen && selectedRoleId !== null) {
+      setIsTeamSectionExpanded(false);
+    }
+  }, [isOpen, selectedRoleId]);
+
+  useEffect(() => {
+    if (!isOpen || loadingRoles || !selectedTeamId) return;
+    if (vacantRoles.length > 0) {
+      setIsTeamSectionExpanded(false);
+      setIsRoleSectionExpanded(true);
+    } else {
+      setIsTeamSectionExpanded(false);
+    }
+  }, [isOpen, selectedTeamId, vacantRoles, loadingRoles]);
 
   const prefillContextNote = useMemo(() => {
     if (!idsMatch(selectedTeamId, normalizedPrefillTeamId)) return null;
@@ -775,6 +959,7 @@ const TeamInviteModal = ({
       if (isTeamSelectable(teamId, team)) {
         const nextTeamId = idsMatch(selectedTeamId, teamId) ? null : teamId;
         setSelectedTeamId(nextTeamId);
+        setIsTeamSectionExpanded(true);
         setSelectedRoleId(null);
         setVacantRoles([]);
         setError(null);
@@ -807,9 +992,14 @@ const TeamInviteModal = ({
   };
 
   const handleRoleCardClick = (roleId) => {
-    setSelectedRoleId((currentRoleId) =>
-      idsMatch(currentRoleId, roleId) ? null : roleId,
-    );
+    setSelectedRoleId((currentRoleId) => {
+      const nextRoleId = idsMatch(currentRoleId, roleId) ? null : roleId;
+      if (nextRoleId !== null) {
+        setIsTeamSectionExpanded(false);
+        setIsRoleSectionExpanded(false);
+      }
+      return nextRoleId;
+    });
   };
 
   const refreshSelectedTeamRequests = useCallback(async () => {
@@ -1041,6 +1231,184 @@ const TeamInviteModal = ({
     !sending &&
     !success &&
     (!selectedTeamRequiresRole || selectedRoleId !== null);
+  const inviteeUser = getInviteeUserObject();
+  const showInviteeDemoProfile = isSyntheticUser(inviteeUser);
+  const handleRoleSectionToggle = () => {
+    setIsRoleSectionExpanded((isExpanded) => {
+      if (isExpanded && isRoleSelectionRequired) {
+        return true;
+      }
+
+      return !isExpanded;
+    });
+  };
+  const handleTeamSectionToggle = () => {
+    setIsTeamSectionExpanded((isExpanded) => !isExpanded);
+  };
+
+  const renderTeamSelectionCard = (
+    team,
+    { isCollapsedSummary = false } = {},
+  ) => {
+    const statusBadge = getTeamStatusBadge(team.id, team);
+    const BadgeIcon = statusBadge?.icon;
+    const showDemoTeam =
+      isInviteModalDemoTeam(team) ||
+      teamStatusData[team.id]?.isDemoTeam === true;
+    const isMember = teamStatusData[team.id]?.isExistingMember === true;
+    const { isRemote, locationText } = getTeamLocationDetails(team);
+    const cardClasses = idsMatch(selectedTeamId, team.id)
+      ? "bg-green-100 ring-2 ring-primary shadow-md"
+      : isMember
+        ? "bg-green-50 hover:bg-green-100 hover:shadow-md"
+        : "bg-base-200 hover:bg-base-300 hover:shadow-md";
+
+    const activateCard = () => {
+      if (isCollapsedSummary) {
+        setIsTeamSectionExpanded(true);
+        return;
+      }
+
+      handleCardClick(team);
+    };
+
+    return (
+      <div
+        key={team.id}
+        role={isCollapsedSummary ? "button" : undefined}
+        tabIndex={isCollapsedSummary ? 0 : undefined}
+        onClick={activateCard}
+        onKeyDown={(event) => {
+          if (!isCollapsedSummary) return;
+
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setIsTeamSectionExpanded(true);
+          }
+        }}
+        className={`flex items-start gap-4 p-4 rounded-xl shadow cursor-pointer transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${cardClasses}`}
+      >
+        <div className="avatar">
+          <div className="w-12 h-12 rounded-full relative overflow-hidden">
+            {getTeamAvatarUrl(team) ? (
+              <img
+                src={getTeamAvatarUrl(team)}
+                alt={team.name}
+                className="object-cover w-full h-full rounded-full"
+                onError={(e) => {
+                  e.target.style.display = "none";
+                  const fallback =
+                    e.target.parentElement.querySelector(".avatar-fallback");
+                  if (fallback) fallback.style.display = "flex";
+                }}
+              />
+            ) : null}
+            <div
+              className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+              style={{
+                display: getTeamAvatarUrl(team) ? "none" : "flex",
+              }}
+            >
+              <span className="text-lg">
+                {getTeamInitials(team.name)}
+              </span>
+            </div>
+            {showDemoTeam && (
+              <DemoAvatarOverlay
+                textClassName="text-[7px]"
+                textTranslateClassName="-translate-y-[3px]"
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="flex-1 min-w-0 pt-[1px]">
+          <div className="flex flex-col">
+            <div className="flex items-center justify-between">
+              <h3 className="font-medium text-base truncate leading-[120%] min-w-0">
+                {team.name}
+              </h3>
+              {statusBadge && (
+                <div
+                  className="shrink-0 ml-1"
+                  onClick={(event) => {
+                    if (isCollapsedSummary) {
+                      event.stopPropagation();
+                      setIsTeamSectionExpanded(true);
+                      return;
+                    }
+
+                    handleBadgeClick(event, team.id, team, statusBadge);
+                  }}
+                >
+                  <RoleBadgePill
+                    icon={BadgeIcon}
+                    label={statusBadge.label}
+                    badgeColorClass={statusBadge.badgeClass || ""}
+                    interactive={statusBadge.clickable}
+                    style={statusBadge.customStyle}
+                  />
+                </div>
+              )}
+            </div>
+          <div className="flex flex-wrap gap-x-1.5 text-xs">
+              <div className="flex items-start gap-0.5 min-w-0">
+                <Users size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                <span className="text-base-content/60 leading-tight break-words">
+                  {getMemberCount(team)}/{getMaxMembers(team)}
+                </span>
+              </div>
+              {(teamStatusData[team.id]?.openRoleCount ?? 0) > 0 && (
+                <div className="flex items-start gap-0.5 min-w-0">
+                  <UserSearch size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                  <span className="text-base-content/60 leading-tight break-words">
+                    {teamStatusData[team.id].openRoleCount}
+                  </span>
+                </div>
+              )}
+              {locationText && (
+                <div className="flex items-start gap-0.5 min-w-0">
+                  {isRemote ? (
+                    <Globe size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                  ) : (
+                    <MapPin size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                  )}
+                  <span className="text-base-content/60 leading-tight break-words">
+                    {locationText}
+                  </span>
+                </div>
+              )}
+              {showDemoTeam && (
+                <Tooltip
+                  content={DEMO_TEAM_TOOLTIP}
+                  wrapperClassName="flex items-center gap-0.5 min-w-0 text-base-content/50"
+                >
+                  <FlaskConical
+                    size={10}
+                    className="text-base-content/50 shrink-0 mt-[1px]"
+                  />
+                  <span className="text-base-content/50 leading-tight break-words">
+                    Demo
+                  </span>
+                </Tooltip>
+              )}
+              {(statusBadge?.type === "existing-member-selected" ||
+                ((statusBadge?.type === "pending-invite" ||
+                  statusBadge?.type === "pending-application") &&
+                  teamStatusData[team.id]?.isExistingMember === true)) && (
+                <div className="flex items-start gap-0.5 min-w-0">
+                  <Users size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
+                  <span className="text-base-content/60 leading-tight break-words">
+                    Member
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
 
   const footer = (
     <div className="flex justify-end gap-3">
@@ -1094,7 +1462,7 @@ const TeamInviteModal = ({
               onClick={() => handleUserClick(inviteeId)}
               title="View profile"
             >
-              <div className="w-12 h-12 rounded-full relative">
+              <div className="w-12 h-12 rounded-full relative overflow-hidden">
                 {inviteeAvatar ? (
                   <img
                     src={inviteeAvatar}
@@ -1117,9 +1485,15 @@ const TeamInviteModal = ({
                   }}
                 >
                   <span className="text-lg font-medium">
-                    {getUserInitials(getInviteeUserObject())}
+                    {getUserInitials(inviteeUser)}
                   </span>
                 </div>
+                {showInviteeDemoProfile && (
+                  <DemoAvatarOverlay
+                    textClassName="text-[8px]"
+                    textTranslateClassName="-translate-y-[3px]"
+                  />
+                )}
               </div>
             </div>
 
@@ -1132,13 +1506,24 @@ const TeamInviteModal = ({
                 {getInviteeDisplayName()}
               </h4>
 
-              <p
-                className="text-sm text-base-content/70 cursor-pointer hover:text-primary transition-colors"
-                onClick={() => handleUserClick(inviteeId)}
-                title="View profile"
-              >
-                @{getUsername()}
-              </p>
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                <p
+                  className="text-sm text-base-content/70 cursor-pointer hover:text-primary transition-colors"
+                  onClick={() => handleUserClick(inviteeId)}
+                  title="View profile"
+                >
+                  @{getUsername()}
+                </p>
+                {showInviteeDemoProfile && (
+                  <Tooltip
+                    content={DEMO_PROFILE_TOOLTIP}
+                    wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+                  >
+                    <FlaskConical size={12} className="flex-shrink-0" />
+                    <span>Demo Profile</span>
+                  </Tooltip>
+                )}
+              </div>
             </div>
           </div>
 
@@ -1151,10 +1536,29 @@ const TeamInviteModal = ({
 
           {/* Team selection */}
           <div>
-            <p className="text-xs text-base-content/60 mb-2 flex items-center">
-              <Users size={12} className="text-primary mr-1" />
-              Select a team to invite them to:
-            </p>
+            <button
+              type="button"
+              className="flex w-full items-center justify-between text-xs text-base-content/60 mb-2 hover:text-base-content/80 transition-colors"
+              onClick={handleTeamSectionToggle}
+              aria-expanded={isTeamSectionExpanded}
+            >
+              <span className="flex min-w-0 items-center">
+                <Users size={12} className="text-primary mr-1" />
+                <span className="truncate">Select a team to invite them to:</span>
+              </span>
+              <span className="ml-2 flex min-w-0 items-center gap-1 text-base-content/40">
+                {!isTeamSectionExpanded && selectedTeam && (
+                  <span className="truncate whitespace-nowrap">
+                    {otherAvailableTeamLabel}
+                  </span>
+                )}
+                {isTeamSectionExpanded ? (
+                  <ChevronUp size={14} className="shrink-0" />
+                ) : (
+                  <ChevronRight size={14} className="shrink-0" />
+                )}
+              </span>
+            </button>
 
             {loading ? (
               <div className="flex justify-center py-6">
@@ -1170,133 +1574,53 @@ const TeamInviteModal = ({
                   Create a team or become an admin to send invitations.
                 </p>
               </div>
-            ) : (
+            ) : isTeamSectionExpanded ? (
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-64 overflow-y-auto p-1">
-                {orderedTeams.map((team) => {
-                  const statusBadge = getTeamStatusBadge(team.id, team);
-                  const BadgeIcon = statusBadge?.icon;
-
-                  return (
-                    <div
-                      key={team.id}
-                      onClick={() => handleCardClick(team)}
-                      className={`flex items-start gap-4 p-4 rounded-xl shadow cursor-pointer transition-all duration-200
-                        ${(() => {
-                          const isMember = teamStatusData[team.id]?.isExistingMember === true;
-                          if (idsMatch(selectedTeamId, team.id)) {
-                            return "bg-green-100 ring-2 ring-primary shadow-md";
-                          }
-                          return isMember
-                            ? "bg-green-50 hover:bg-green-100 hover:shadow-md"
-                            : "bg-base-200 hover:bg-base-300 hover:shadow-md";
-                        })()}`}
-                    >
-                      {/* Team avatar */}
-                      <div className="avatar">
-                        <div className="w-12 h-12 rounded-full relative overflow-hidden">
-                          {getTeamAvatarUrl(team) ? (
-                            <img
-                              src={getTeamAvatarUrl(team)}
-                              alt={team.name}
-                              className="object-cover w-full h-full rounded-full"
-                              onError={(e) => {
-                                e.target.style.display = "none";
-                                const fallback =
-                                  e.target.parentElement.querySelector(
-                                    ".avatar-fallback"
-                                  );
-                                if (fallback) fallback.style.display = "flex";
-                              }}
-                            />
-                          ) : null}
-                          <div
-                            className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                            style={{
-                              display: getTeamAvatarUrl(team) ? "none" : "flex",
-                            }}
-                          >
-                            <span className="text-lg">
-                              {getTeamInitials(team.name)}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* Team info */}
-                      <div className="flex-1 min-w-0 pt-[1px]">
-                        <div className="flex flex-col">
-                          <div className="flex items-center justify-between">
-                            <h3 className="font-medium text-base truncate leading-[120%] min-w-0">
-                              {team.name}
-                            </h3>
-                            {statusBadge && (
-                              <div
-                                className="shrink-0 ml-1"
-                                onClick={(e) =>
-                                  handleBadgeClick(e, team.id, team, statusBadge)
-                                }
-                              >
-                                <RoleBadgePill
-                                  icon={BadgeIcon}
-                                  label={statusBadge.label}
-                                  badgeColorClass={statusBadge.badgeClass || ""}
-                                  interactive={statusBadge.clickable}
-                                  style={statusBadge.customStyle}
-                                />
-                              </div>
-                            )}
-                          </div>
-                          <div className="flex flex-wrap gap-x-1.5 text-xs">
-                            <div className="flex items-start gap-0.5 min-w-0">
-                              <Users size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
-                              <span className="text-base-content/60 leading-tight break-words">{getMemberCount(team)}/{getMaxMembers(team)}</span>
-                            </div>
-                            {(teamStatusData[team.id]?.openRoleCount ?? 0) > 0 && (
-                              <div className="flex items-start gap-0.5 min-w-0">
-                                <UserSearch size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
-                                <span className="text-base-content/60 leading-tight break-words">{teamStatusData[team.id].openRoleCount}</span>
-                              </div>
-                            )}
-                            {(() => {
-                              const isRemote = team.isRemote ?? team.is_remote;
-                              const locationParts = [team.city, team.country].filter(Boolean);
-                              const locationText = isRemote ? "Remote" : locationParts.length > 0 ? locationParts.join(", ") : null;
-                              if (!locationText) return null;
-                              return (
-                                <div className="flex items-start gap-0.5 min-w-0">
-                                  {isRemote
-                                    ? <Globe size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
-                                    : <MapPin size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
-                                  }
-                                  <span className="text-base-content/60 leading-tight break-words">{locationText}</span>
-                                </div>
-                              );
-                            })()}
-                            {(statusBadge?.type === "existing-member-selected" ||
-                              ((statusBadge?.type === "pending-invite" || statusBadge?.type === "pending-application") &&
-                                teamStatusData[team.id]?.isExistingMember === true)) && (
-                              <div className="flex items-start gap-0.5 min-w-0">
-                                <Users size={10} className="text-base-content/60 shrink-0 mt-[3px]" />
-                                <span className="text-base-content/60 leading-tight break-words">Member</span>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  );
+                {orderedTeams.map((team) => renderTeamSelectionCard(team))}
+              </div>
+            ) : selectedTeam ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-1">
+                {renderTeamSelectionCard(selectedTeam, {
+                  isCollapsedSummary: true,
                 })}
               </div>
-            )}
+            ) : null}
           </div>
 
           {/* Vacant role selection */}
-          {selectedTeamId && (loadingRoles || vacantRoles.length > 0 || selectedTeamRequiresRole) && (
+          {shouldShowRolePicker && (
             <div className="pt-2">
-              <p className="text-xs text-base-content/60 mb-2 flex items-center">
-                <UserSearch size={12} className="text-orange-500 mr-1" />
-                Select a role you want to fill in this team:
-              </p>
+              <button
+                type="button"
+                className="flex w-full items-center justify-between text-xs text-base-content/60 mb-2 hover:text-base-content/80 transition-colors"
+                onClick={handleRoleSectionToggle}
+                aria-expanded={isRoleSectionExpanded}
+                aria-disabled={isRoleSelectionRequired && isRoleSectionExpanded}
+                title={
+                  isRoleSelectionRequired && isRoleSectionExpanded
+                    ? "Select a role before collapsing this section"
+                    : undefined
+                }
+              >
+                <span className="flex min-w-0 items-center">
+                  <UserSearch size={12} className="text-orange-500 mr-1" />
+                  <span className="truncate">
+                    Select a role you want to fill in this team:
+                  </span>
+                </span>
+                <span className="ml-2 flex items-center gap-1 text-base-content/40">
+                  {!isRoleSectionExpanded && vacantRoles.length > 0 && (
+                    <span className="whitespace-nowrap">
+                      {roleAvailabilityLabel}
+                    </span>
+                  )}
+                  {isRoleSectionExpanded ? (
+                    <ChevronUp size={14} />
+                  ) : (
+                    <ChevronRight size={14} />
+                  )}
+                </span>
+              </button>
 
               {prefillContextNote && (
                 <p className="text-xs text-base-content/40 mb-2">
@@ -1304,7 +1628,98 @@ const TeamInviteModal = ({
                 </p>
               )}
 
-              {loadingRoles ? (
+              {!isRoleSectionExpanded ? (
+                selectedRole ? (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-1">
+                    <div
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setIsRoleSectionExpanded(true)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          setIsRoleSectionExpanded(true);
+                        }
+                      }}
+                      className="flex items-start gap-4 p-4 rounded-xl bg-amber-100 text-left shadow ring-2 ring-amber-400 transition-all duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                    >
+                      <div className="avatar placeholder">
+                        <div className="bg-amber-500 text-white w-12 h-12 rounded-full relative flex items-center justify-center overflow-hidden">
+                          <span className="text-lg">
+                            {getRoleInitials(
+                              selectedRole.roleName ??
+                                selectedRole.role_name ??
+                                "Vacant Role",
+                            )}
+                          </span>
+                          {isSyntheticRole(selectedRole) && (
+                            <DemoAvatarOverlay
+                              textClassName="text-[7px]"
+                              textTranslateClassName="-translate-y-[3px]"
+                            />
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="flex-1 min-w-0 pt-[1px]">
+                        <div className="flex flex-col">
+                          <div className="flex items-center justify-between">
+                            <h3 className="font-medium text-base truncate leading-[120%] min-w-0">
+                              {selectedRole.roleName ??
+                                selectedRole.role_name ??
+                                "Vacant Role"}
+                            </h3>
+                            <div className="shrink-0 ml-1">
+                              <RoleBadgePill
+                                icon={Check}
+                                label="Selected"
+                                badgeColorClass="bg-amber-800 text-white"
+                                interactive
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  handleRoleCardClick(selectedRole.id);
+                                }}
+                              />
+                            </div>
+                          </div>
+
+                        {(getRoleLocation(selectedRole) ||
+                          isSyntheticRole(selectedRole)) && (
+                          <CardMetaRow>
+                            {getRoleLocation(selectedRole) && (
+                              <CardMetaItem
+                                icon={
+                                  (selectedRole.isRemote ??
+                                    selectedRole.is_remote)
+                                    ? Globe
+                                    : MapPin
+                                }
+                              >
+                                {getRoleLocation(selectedRole)}
+                              </CardMetaItem>
+                            )}
+                            {isSyntheticRole(selectedRole) && (
+                              <Tooltip
+                                content={DEMO_ROLE_TOOLTIP}
+                                wrapperClassName="flex items-center gap-0.5 min-w-0 text-base-content/50"
+                              >
+                                <FlaskConical
+                                  size={10}
+                                  className="text-base-content/50 shrink-0 mt-[1px]"
+                                />
+                                <span className="text-base-content/50 leading-tight break-words">
+                                  Demo
+                                </span>
+                              </Tooltip>
+                            )}
+                          </CardMetaRow>
+                        )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ) : null
+              ) : loadingRoles ? (
                 <div className="flex justify-center py-6">
                   <div className="loading loading-spinner loading-md text-primary"></div>
                 </div>
@@ -1324,71 +1739,96 @@ const TeamInviteModal = ({
                   </p>
                 </div>
               ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-h-64 overflow-y-auto p-1">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-64 overflow-y-auto p-1">
                   {vacantRoles.map((role) => {
                     const roleName =
                       role.roleName ?? role.role_name ?? "Vacant Role";
                     const isSelected = idsMatch(selectedRoleId, role.id);
                     const locationText = getRoleLocation(role);
                     const isRemote = role.isRemote ?? role.is_remote;
+                    const showDemoRole = isSyntheticRole(role);
 
                     return (
                       <div
+                        role="button"
+                        tabIndex={0}
                         key={role.id}
                         onClick={() => handleRoleCardClick(role.id)}
-                        className={`relative flex items-center gap-3 p-3 rounded-xl shadow cursor-pointer transition-all duration-200
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            handleRoleCardClick(role.id);
+                          }
+                        }}
+                        className={`flex items-start gap-4 p-4 rounded-xl text-left shadow cursor-pointer transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400
                           ${
                             isSelected
                               ? "bg-amber-100 ring-2 ring-amber-400 shadow-md"
-                              : "bg-amber-50 hover:bg-amber-100 hover:shadow-md"
+                              : "bg-amber-50 hover:bg-amber-100/70 hover:shadow-md"
                           }`}
                       >
-                        <div className="absolute top-2 right-2">
-                          <span
-                            className={`badge badge-sm gap-1 ${
-                              isSelected ? "" : "badge-role-member"
-                            }`}
-                            style={
-                              isSelected
-                                ? {
-                                    backgroundColor:
-                                      "var(--color-warning, #F59E0B)",
-                                    color: "#ffffff",
-                                  }
-                                : {}
-                            }
-                          >
-                            {isSelected ? (
-                              <Check className="w-3 h-3" />
-                            ) : (
-                              <UserSearch className="w-3 h-3" />
-                            )}
-                            {isSelected ? "Selected" : "Select"}
-                          </span>
-                        </div>
-
-                        <div className="avatar placeholder flex-shrink-0">
-                          <div className="bg-amber-200 text-amber-800 rounded-full w-10 h-10 flex items-center justify-center">
-                            <span className="text-sm font-medium">
+                        <div className="avatar placeholder">
+                          <div className="bg-amber-500 text-white w-12 h-12 rounded-full relative flex items-center justify-center overflow-hidden">
+                            <span className="text-lg">
                               {getRoleInitials(roleName)}
                             </span>
+                            {showDemoRole && (
+                              <DemoAvatarOverlay
+                                textClassName="text-[7px]"
+                                textTranslateClassName="-translate-y-[3px]"
+                              />
+                            )}
                           </div>
                         </div>
 
-                        <div className="flex-1 min-w-0 pr-16">
-                          <h4 className="font-medium text-sm text-base-content leading-tight truncate">
-                            {roleName}
-                          </h4>
-                          {locationText && (
-                            <p className="text-xs text-base-content/60 flex items-center mt-0.5">
-                              {isRemote ? (
-                                <Globe size={10} className="mr-1 flex-shrink-0" />
-                              ) : (
-                                <MapPin size={10} className="mr-1 flex-shrink-0" />
+                        <div className="flex-1 min-w-0 pt-[1px]">
+                          <div className="flex flex-col">
+                            <div className="flex items-center justify-between">
+                              <h3 className="font-medium text-base truncate leading-[120%] min-w-0">
+                                {roleName}
+                              </h3>
+                              <div className="shrink-0 ml-1">
+                                <RoleBadgePill
+                                  icon={isSelected ? Check : UserSearch}
+                                  label={isSelected ? "Selected" : "Select"}
+                                  badgeColorClass={
+                                    isSelected
+                                      ? "bg-amber-800 text-white"
+                                      : "badge-role-vacant"
+                                  }
+                                  interactive
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    handleRoleCardClick(role.id);
+                                  }}
+                                />
+                              </div>
+                            </div>
+
+                          {(locationText || showDemoRole) && (
+                            <CardMetaRow>
+                              {locationText && (
+                                <CardMetaItem icon={isRemote ? Globe : MapPin}>
+                                  {locationText}
+                                </CardMetaItem>
                               )}
-                              <span className="truncate">{locationText}</span>
-                            </p>
+                              {showDemoRole && (
+                                <Tooltip
+                                  content={DEMO_ROLE_TOOLTIP}
+                                  wrapperClassName="flex items-center gap-0.5 min-w-0 text-base-content/50"
+                                >
+                                  <FlaskConical
+                                    size={10}
+                                    className="text-base-content/50 shrink-0 mt-[1px]"
+                                  />
+                                  <span className="text-base-content/50 leading-tight break-words">
+                                    Demo
+                                  </span>
+                                </Tooltip>
+                              )}
+                            </CardMetaRow>
                           )}
+                          </div>
                         </div>
                       </div>
                     );
@@ -1397,6 +1837,7 @@ const TeamInviteModal = ({
               )}
 
               {!loadingRoles &&
+                isRoleSectionExpanded &&
                 vacantRoles.length > 0 &&
                 selectedRoleId === null &&
                 selectedTeamRequiresRole && (
@@ -1407,6 +1848,7 @@ const TeamInviteModal = ({
                 )}
 
               {!loadingRoles &&
+                isRoleSectionExpanded &&
                 vacantRoles.length > 0 &&
                 selectedRoleId === null &&
                 !selectedTeamRequiresRole && (

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -269,6 +269,7 @@ const TeamInviteModal = ({
   const [vacantRoles, setVacantRoles] = useState([]);
   const [selectedRoleId, setSelectedRoleId] = useState(null);
   const [isRoleSectionExpanded, setIsRoleSectionExpanded] = useState(false);
+  const [isMessageSectionExpanded, setIsMessageSectionExpanded] = useState(false);
   const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const [loadingRoles, setLoadingRoles] = useState(false);
@@ -1641,7 +1642,7 @@ const TeamInviteModal = ({
                           setIsRoleSectionExpanded(true);
                         }
                       }}
-                      className="flex items-start gap-4 p-4 rounded-xl bg-amber-100 text-left shadow ring-2 ring-amber-400 transition-all duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                      className="flex items-start gap-4 p-4 rounded-xl bg-amber-100 text-left shadow shadow-md ring-2 ring-amber-400 transition-all duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
                     >
                       <div className="avatar placeholder">
                         <div className="bg-amber-500 text-white w-12 h-12 rounded-full relative flex items-center justify-center overflow-hidden">
@@ -1863,22 +1864,43 @@ const TeamInviteModal = ({
           {/* Optional message */}
           {orderedTeams.length > 0 && (
             <div>
-              <p className="text-xs text-base-content/60 mb-1 flex items-center">
-                <Send size={12} className="text-info mr-1" />
-                Add a message (optional):
-              </p>
-              <div className="relative">
-                <textarea
-                  value={message}
-                  onChange={(e) => setMessage(e.target.value)}
-                  placeholder={`Hi ${getInviteeDisplayName()}, I'd like to invite you to join our team...`}
-                  className="textarea textarea-bordered w-full h-24 resize-none text-sm pb-6"
-                  maxLength={500}
-                />
-                <span className="absolute bottom-2 left-3 text-xs text-base-content/40 pointer-events-none">
-                  {message.length}/500 characters
+              <button
+                type="button"
+                className="flex w-full items-center justify-between text-xs text-base-content/60 mb-2 hover:text-base-content/80 transition-colors"
+                onClick={() => setIsMessageSectionExpanded((v) => !v)}
+                aria-expanded={isMessageSectionExpanded}
+              >
+                <span className="flex min-w-0 items-center">
+                  <Send size={12} className="text-info mr-1" />
+                  <span className="truncate">Add a message (optional){isMessageSectionExpanded ? ":" : ""}</span>
                 </span>
-              </div>
+                <span className="ml-2 flex min-w-0 items-center gap-1 text-base-content/40">
+                  {!isMessageSectionExpanded && message && (
+                    <span className="truncate max-w-[160px] whitespace-nowrap">
+                      {message}
+                    </span>
+                  )}
+                  {isMessageSectionExpanded ? (
+                    <ChevronUp size={14} className="shrink-0" />
+                  ) : (
+                    <ChevronRight size={14} className="shrink-0" />
+                  )}
+                </span>
+              </button>
+              {isMessageSectionExpanded && (
+                <div className="relative">
+                  <textarea
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    placeholder={`Hi ${getInviteeDisplayName()}, I'd like to invite you to join our team...`}
+                    className="textarea textarea-bordered w-full h-24 resize-none text-sm pb-6"
+                    maxLength={500}
+                  />
+                  <span className="absolute bottom-2 left-3 text-xs text-base-content/40 pointer-events-none">
+                    {message.length}/500 characters
+                  </span>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -735,11 +735,11 @@ const VacantRoleCard = ({
   const avatarSizeClass = isMiniView ? "w-10 h-10" : "w-12 h-12";
   const avatarTextClass = isMiniView ? "text-sm" : "text-lg";
   const matchIconSize = isMiniView ? 32 : 40;
-  const wrapperPaddingClass = isMiniView ? "p-3 sm:p-4" : "p-4 sm:p-5";
+  const wrapperPaddingClass = isMiniView ? "p-3" : "p-4";
   const titleLeadingClass = isMiniView ? "leading-[110%]" : "leading-[120%]";
   const roleNameClass = isMiniView
-    ? "text-sm font-semibold"
-    : "text-base font-semibold";
+    ? "text-sm font-medium"
+    : "text-base font-medium";
   const roleBadges =
     role.badges ?? role.requiredBadges ?? role.required_badges ?? [];
   const badgeNames = Array.isArray(roleBadges)
@@ -1243,8 +1243,7 @@ const VacantRoleCard = ({
           status !== "open" ? "opacity-70" : ""
         } ${notificationHighlight ? "role-card-highlight" : ""}`}
       >
-        <div className="flex-shrink-0">
-          {isFilled && filledUser ? (
+        {isFilled && filledUser ? (
             <div className="avatar">
               <div className={`${avatarSizeClass} rounded-full relative overflow-hidden`}>
                 {filledUserAvatarUrl ? (
@@ -1299,29 +1298,14 @@ const VacantRoleCard = ({
               </div>
             </div>
           )}
-        </div>
 
         <div className={`flex-1 min-w-0 pt-[1px] ${isMiniView ? "space-y-1" : ""}`}>
-          <div className="flex items-center justify-between gap-2 min-w-0">
-            <div className="flex-1 min-w-0 overflow-hidden">
-              <Tooltip
-                content={role_name || "Vacant Role"}
-                wrapperClassName="block w-full min-w-0 overflow-hidden"
-              >
-                <div
-                  className={`block w-full min-w-0 truncate ${roleNameClass} ${titleLeadingClass} text-[var(--color-primary-focus)] transition-colors`}
-                >
-                  {role_name || "Vacant Role"}
-                </div>
-              </Tooltip>
-              {teamContext?.name && viewMode === "card" && (
-                <p className="text-xs text-base-content/50 mt-0.5 truncate">
-                  {teamContext.name}
-                </p>
-              )}
-            </div>
-
-            <div ref={menuTriggerRef} className="relative flex-shrink-0" data-dropdown-menu>
+          <div className="flex flex-col">
+            <div className="flex items-center justify-between">
+              <h3 className={`${roleNameClass} ${titleLeadingClass} truncate min-w-0`}>
+                {role_name || "Vacant Role"}
+              </h3>
+              <div ref={menuTriggerRef} className="shrink-0 ml-1" data-dropdown-menu>
               <RoleBadgePill
                 icon={badgeConfig.icon}
                 label={badgeConfig.label}
@@ -1344,9 +1328,8 @@ const VacantRoleCard = ({
                     : undefined
                 }
               />
-            </div>
-
-            {canOpenBadgeMenu && showMenu && menuPosition && createPortal(
+              </div>
+              {canOpenBadgeMenu && showMenu && menuPosition && createPortal(
               <>
                 <div
                   className="fixed inset-0"
@@ -1443,6 +1426,12 @@ const VacantRoleCard = ({
                 </div>
               </>,
               document.body
+            )}
+            </div>
+            {teamContext?.name && viewMode === "card" && (
+              <p className="text-xs text-base-content/50 mt-0.5 truncate">
+                {teamContext.name}
+              </p>
             )}
           </div>
 

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -836,6 +836,7 @@ const UserDetailsModal = ({
           inviteeUsername={user.username}
           inviteeAvatar={user.avatar_url || user.avatarUrl}
           inviteeBio={user.bio}
+          inviteeIsSynthetic={user.is_synthetic ?? user.isSynthetic}
           prefillTeamId={invitationPrefillTeamId}
           prefillRoleId={invitationPrefillRoleId}
           prefillTeamName={invitationPrefillTeamName}


### PR DESCRIPTION
Summary
Collapsible invite modal sections — Team, role, and message sections now all collapse/expand with a chevron toggle. Selecting a team with vacant roles auto-collapses the team section and opens the role section; selecting a role auto-collapses the role section. The message section starts collapsed and shows a preview of any typed message in the header.
Unified card design — Team cards, role cards (expanded and collapsed), and the selected role card in the invite modal now all follow the same layout as member cards on team detail modals: p-4, flex-col structure, font-medium title, and consistent shadow-md on selected state.
VacantRoleCard alignment — Card view mode updated to match member card design (padding, font weight, avatar wrapper, title/badge row layout).
inviteeIsSynthetic prop forwarding — UserDetailsModal now passes the synthetic user flag through to TeamInviteModal.
Test plan
 Open invite modal from a user's profile — team section is expanded by default
 Select a team that has vacant roles — team section collapses, role section opens automatically
 Select a team with no vacant roles — team section collapses
 Select a role — role section collapses, showing the selected role as a collapsed card
 Click collapsed role card to re-expand role section
 Open/close message section with chevron; verify colon only appears when expanded
 Type a message, collapse the section — preview text appears in the header
 Verify selected team card and selected role card have the same shadow depth
 Check vacant role cards on team detail modals match member card layout