### PR TITLE
broad overhaul of the application, invitation, and role management flows

### DIFF
--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -368,6 +368,8 @@ const VacantRoleDetailsModal = ({
     useState(null);
   const [viewerRoleStatusLoading, setViewerRoleStatusLoading] =
     useState(false);
+  const [filledRoleUserIds, setFilledRoleUserIds] = useState(new Set());
+  const [viewerTeamRoleLoading, setViewerTeamRoleLoading] = useState(false);
   const [isViewerApplicationDetailsOpen, setIsViewerApplicationDetailsOpen] =
     useState(false);
   const [isViewerInvitationDetailsOpen, setIsViewerInvitationDetailsOpen] =
@@ -468,6 +470,8 @@ const VacantRoleDetailsModal = ({
       setViewerRoleApplicationRecord(null);
       setViewerRoleInvitationRecord(null);
       setViewerRoleStatusLoading(false);
+      setFilledRoleUserIds(new Set());
+      setViewerTeamRoleLoading(false);
       setIsViewerApplicationDetailsOpen(false);
       setIsViewerInvitationDetailsOpen(false);
     }
@@ -694,6 +698,42 @@ const VacantRoleDetailsModal = ({
     team,
     teamId,
   ]);
+
+  useEffect(() => {
+    if (!isOpen || !isAuthenticated || !viewerIsTeamMember || !teamId || !currentUser?.id) {
+      setFilledRoleUserIds(new Set());
+      setViewerTeamRoleLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setViewerTeamRoleLoading(true);
+
+    const checkViewerHoldsRole = async () => {
+      try {
+        const response = await vacantRoleService.getVacantRoles(teamId, "filled");
+        if (cancelled) return;
+        const filledRoles = Array.isArray(response?.data) ? response.data : [];
+        const ids = new Set(
+          filledRoles
+            .map((r) => r.filledBy ?? r.filled_by ?? r.filledByUser?.id ?? r.filled_by_user?.id ?? null)
+            .filter((id) => id != null)
+            .map(String),
+        );
+        setFilledRoleUserIds(ids);
+      } catch {
+        setFilledRoleUserIds(new Set());
+      } finally {
+        if (!cancelled) setViewerTeamRoleLoading(false);
+      }
+    };
+
+    checkViewerHoldsRole();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, isAuthenticated, viewerIsTeamMember, teamId, currentUser?.id]);
 
   useEffect(() => {
     if (!isOpen || !isAuthenticated || !comparisonUserId) {
@@ -1795,9 +1835,21 @@ const VacantRoleDetailsModal = ({
   const effectiveViewerRoleApplication =
     viewerRoleApplicationRecord ?? currentUserRoleApplication;
   const effectiveViewerRoleInvitation = viewerRoleInvitationRecord;
+  const viewerHoldsTeamRole =
+    currentUser?.id != null && filledRoleUserIds.has(String(currentUser.id));
+  const availableRoleTeamMembers = roleTeamMembers.filter((memberRow) => {
+    const memberId = String(
+      memberRow.memberId ??
+        memberRow.member?.id ??
+        memberRow.member?.userId ??
+        memberRow.member?.user_id ??
+        "",
+    );
+    return !filledRoleUserIds.has(memberId);
+  });
   const visibleRoleTeamMembers = isTeamMembersExpanded
-    ? roleTeamMembers
-    : roleTeamMembers.slice(0, COLLAPSED_COUNT);
+    ? availableRoleTeamMembers
+    : availableRoleTeamMembers.slice(0, COLLAPSED_COUNT);
   const modalTitle = (
     <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex min-w-0 items-center gap-2">
@@ -2861,15 +2913,15 @@ const VacantRoleDetailsModal = ({
             <div className="flex justify-center py-3">
               <span className="loading loading-spinner loading-sm text-primary"></span>
             </div>
-          ) : roleTeamMembers.length > 0 ? (
+          ) : availableRoleTeamMembers.length > 0 ? (
             <div>
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center">
                   <Users size={18} className="mr-2 text-primary flex-shrink-0" />
-                  <h3 className="font-medium">Existing team members</h3>
+                  <h3 className="font-medium">Available team members</h3>
                 </div>
                 <span className="text-sm text-base-content/50">
-                  ({roleTeamMembers.length})
+                  ({availableRoleTeamMembers.length})
                 </span>
               </div>
 
@@ -3005,7 +3057,7 @@ const VacantRoleDetailsModal = ({
                 })}
               </div>
 
-              {roleTeamMembers.length > COLLAPSED_COUNT && (
+              {availableRoleTeamMembers.length > COLLAPSED_COUNT && (
                 <button
                   type="button"
                   className="flex items-center gap-1 mt-3 text-sm text-base-content/50 hover:text-base-content/80 transition-colors"
@@ -3100,7 +3152,9 @@ const VacantRoleDetailsModal = ({
 
                 {isAuthenticated &&
                   !viewerRoleStatusLoading &&
+                  !viewerTeamRoleLoading &&
                   viewerIsTeamMember &&
+                  !viewerHoldsTeamRole &&
                   isRoleOpen &&
                   !applicationsLoading && (
                   <div className="mt-6 border-t border-base-200 pt-4">


### PR DESCRIPTION
Summary
This branch delivers a broad overhaul of the application, invitation, and role management flows across team modals, chat, and notification systems.

Application flow guardrails
Team members who already fill a vacant role in a team no longer see the "Apply to fill this role" button on other open roles in that team
The "Existing team members" section in a role's detail modal is renamed to "Available team members" and filters out any member who already holds a filled role
Invite modal overhaul
Team and role sections auto-collapse/expand as the user makes selections, reducing visual noise
Message section is collapsible with a preview of draft text when folded
Team cards in the invite modal show larger avatars, open role count, location, and a status badge; list is filtered to owner/admin teams only
Card layout unified across invite modal, team details, and role modals
Deferred role invite flow
Fixed SQL syntax error (LATERAL alias current_role is a PostgreSQL reserved word)
Invitation APIs now return the invitee's currently-filled role so modals can show it contextually
TeamInvitationDetailsModal and TeamInvitesModal display the invitee's current role and use a consistent section order and footer layout
Role lifecycle
Filled roles are automatically reopened when the filling member leaves or is removed from the team, preventing permanent role lock
Team chat switches to read-only for non-members; access is revoked immediately on removal
"Fill Role" and "Accept & Fill Role" buttons are greyed out with a tooltip when the target role is already filled or closed
Role status is polled every 20 s in all modals showing a VacantRoleCard so UI stays in sync across concurrent users
Notification & toast system
Toast notifications wired for: invitation received/accepted/declined/cancelled, role invitation, application received/approved/rejected, role status changed, badge awarded
Duplicate toasts eliminated: 403 no longer triggers logout (was causing spurious session ends for removed members); system-message socket events suppressed when a notification:new event already covers the same action
Clicking a role-status toast deep-links directly into the relevant application or invitation details modal
Unread-message toast suppressed on page refresh within the same session
Chat event messages
Structured event banners in team chat for: application approved + role filled (combined), invitation accepted, legacy backend assignment messages (parsed and deduplicated)
@mention tokens in reply previews styled consistently with message bubbles
Refactoring & optimisation
Dropdown and context menus rendered via createPortal to escape modal/card stacking contexts
Socket subscription logic extracted into a reusable useSocketEvents hook
Tag service lookups cached to avoid redundant API calls
Duplicate invitation service code and dead search service code removed
Auth user object normalised to camelCase at a single point
Test plan
 As a team member with a filled role, open a different open role in the same team — "Apply to fill this role" button should not appear
 As a team member without a filled role, confirm the button does appear and "Available team members" excludes role holders
 Open the invite modal, select a team with open roles — role section should auto-expand; select a role — role section should collapse
 Trigger an invitation/application action and verify the correct colour-coded toast appears once (not twice)
 Leave a team or be removed — confirm any filled role reopens and chat becomes read-only
 Open an application or invitation modal while another user changes the role status — card should update within ~20 s
 Verify page refresh does not show the unread-message toast; fresh login does