### PR TITLE
Invitations & Applications Modals — UI Polish

### DIFF
--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -27,6 +27,7 @@ import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
  * @param {Function} props.onUserClick - Callback when user avatar/name is clicked
  * @param {React.ReactNode} props.actions - Action buttons to render at the bottom
  * @param {React.ReactNode} props.extraContent - Additional content (e.g., response textarea, tags)
+ * @param {React.ReactNode} props.messageBubbleExtra - Extra content rendered inside the speech bubble, after the message text (e.g., a role card)
  * @param {React.ReactNode} props.footerLeft - Content for the left side of the footer (e.g., inviter info)
  * @param {boolean} props.clickable - Whether user elements are clickable (default: true)
  * @param {boolean} props.showLocation - Whether to show location info (default: true)
@@ -40,6 +41,7 @@ const PersonRequestCard = ({
   onUserClick,
   actions,
   extraContent,
+  messageBubbleExtra,
   footerLeft,
   clickable = true,
   showLocation = true,
@@ -204,14 +206,25 @@ const PersonRequestCard = ({
         </div>
       )}
 
-      {/* Message if provided */}
-      {message && (
+      {/* Message bubble */}
+      {(message || messageBubbleExtra) && (
         <div className="mb-5">
-          <p className="text-xs text-base-content/60 mb-1 flex items-center">
-            {messageIcon}
-            {messageLabel}
-          </p>
-          <p className="text-sm text-base-content/90">{message}</p>
+          {message && (
+            <p className="text-xs text-base-content/60 mb-1 flex items-center">
+              {messageIcon}
+              {messageLabel}
+            </p>
+          )}
+          <div className="w-fit max-w-full bg-base-200 rounded-lg rounded-bl-none p-3">
+            {message && (
+              <p className="text-sm text-base-content/90">{message}</p>
+            )}
+            {messageBubbleExtra && (
+              <div className={`max-w-[300px] ${message ? "mt-3" : ""}`}>
+                {messageBubbleExtra}
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import React, { useRef, useLayoutEffect, useState, useEffect } from "react";
 import { Calendar, MapPin, FlaskConical } from "lucide-react";
 import { format } from "date-fns";
-import LocationDisplay from "./LocationDisplay";
 import Tooltip from "./Tooltip";
 import {
   DEMO_PROFILE_TOOLTIP,
@@ -9,6 +8,7 @@ import {
   isSyntheticUser,
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import { formatDisplayName } from "../../utils/nameFormatters";
 
 /**
  * PersonRequestCard Component
@@ -28,6 +28,7 @@ import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
  * @param {React.ReactNode} props.actions - Action buttons to render at the bottom
  * @param {React.ReactNode} props.extraContent - Additional content (e.g., response textarea, tags)
  * @param {React.ReactNode} props.messageBubbleExtra - Extra content rendered inside the speech bubble, after the message text (e.g., a role card)
+ * @param {React.ReactNode} props.sublineExtra - Extra content rendered in the subline row, before the demo badge (e.g., a "Team member" badge)
  * @param {React.ReactNode} props.footerLeft - Content for the left side of the footer (e.g., inviter info)
  * @param {boolean} props.clickable - Whether user elements are clickable (default: true)
  * @param {boolean} props.showLocation - Whether to show location info (default: true)
@@ -42,9 +43,12 @@ const PersonRequestCard = ({
   actions,
   extraContent,
   messageBubbleExtra,
+  sublineExtra,
   footerLeft,
   clickable = true,
   showLocation = true,
+  onNarrowChange,
+  forceNarrow = false,
 }) => {
   // ============ Helper Functions ============
 
@@ -103,19 +107,57 @@ const PersonRequestCard = ({
     (getDisplayName() !== user.username || isSyntheticUser(user));
   const showDemoProfile = isSyntheticUser(user);
 
+  // ============ Adaptive name (full → abbreviated → CSS truncate) ============
+  const nameContainerRef = useRef(null);
+  const probeRef = useRef(null);
+  const dateRef = useRef(null);
+  const fullName = getDisplayName();
+  const abbrevName = user ? formatDisplayName(user) : fullName;
+  const [displayedName, setDisplayedName] = useState(fullName);
+  const displayedNameRef = useRef(fullName);
+  displayedNameRef.current = displayedName;
+  const forceNarrowRef = useRef(forceNarrow);
+  forceNarrowRef.current = forceNarrow;
+
+  useLayoutEffect(() => {
+    if (fullName === abbrevName) { setDisplayedName(fullName); return; }
+    const container = nameContainerRef.current;
+    const probe = probeRef.current;
+    if (!container || !probe) return;
+    const update = () => {
+      // Date is absolute (out of flow) when either this card or any sibling card is narrow.
+      // Subtract its width + gap back so the measurement is always against the same
+      // effective width, preventing oscillation.
+      const isDateAbsolute = displayedNameRef.current !== fullName || forceNarrowRef.current;
+      const dateEl = dateRef.current;
+      const dateReservedWidth = isDateAbsolute && dateEl ? dateEl.offsetWidth + 16 : 0; // 16 = space-x-4 gap
+      probe.textContent = fullName;
+      setDisplayedName(probe.scrollWidth <= container.clientWidth - dateReservedWidth ? fullName : abbrevName);
+    };
+    const ro = new ResizeObserver(update);
+    ro.observe(container);
+    update();
+    return () => ro.disconnect();
+  }, [fullName, abbrevName]);
+
+  const isNarrow = displayedName !== fullName;
+  const dateIsNarrow = isNarrow || forceNarrow;
+
+  // Report narrow state to parent for cross-card sync
+  useEffect(() => { onNarrowChange?.(isNarrow); }, [isNarrow]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // ============ Render ============
 
   return (
     <div className="bg-base-200/30 rounded-lg border border-base-300 p-4">
       {/* User Info Header */}
-      <div className="flex items-start space-x-4 mb-4">
+      <div className="flex items-start space-x-4 mb-4 relative">
         {/* Avatar */}
-        <div
-          className={`avatar ${clickableStyles}`}
-          onClick={handleUserClick}
-          title={clickable ? "View profile" : undefined}
+        <Tooltip
+          content={clickable ? "View profile" : undefined}
+          wrapperClassName={`avatar ${clickableStyles}`}
         >
-          <div className="w-14 h-14 rounded-full relative overflow-hidden">
+          <div className="w-12 h-12 rounded-full relative overflow-hidden" onClick={handleUserClick}>
             {getAvatarUrl() ? (
               <img
                 src={getAvatarUrl()}
@@ -142,58 +184,68 @@ const PersonRequestCard = ({
             </div>
             {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[8px]" />}
           </div>
-        </div>
+        </Tooltip>
 
         {/* Name and Details */}
         <div className="flex-1 min-w-0">
-          <h4
-            className={`font-medium text-base-content leading-[120%] mb-[0.2em] ${clickableTextStyles}`}
-            onClick={handleUserClick}
-            title={clickable ? "View profile" : undefined}
-          >
-            {getDisplayName()}
+          <h4 ref={nameContainerRef} className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative">
+            {clickable ? (
+              <Tooltip content="View profile" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
+                <span onClick={handleUserClick}>{displayedName}</span>
+              </Tooltip>
+            ) : (
+              displayedName
+            )}
+            <span ref={probeRef} className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium" aria-hidden="true" />
           </h4>
 
-          {(showUsername || showDemoProfile) && (
-            <div className="flex max-h-[2.1em] flex-wrap items-center gap-x-2 gap-y-0.5 overflow-hidden">
-              {showUsername && (
-                <p
-                  className={`text-xs text-base-content/70 ${clickableTextStyles}`}
-                  onClick={handleUserClick}
-                  title={clickable ? "View profile" : undefined}
-                >
-                  @{user.username}
-                </p>
+          {(dateIsNarrow || showUsername || (showLocation && (user?.city || user?.country || getPostalCode())) || sublineExtra || showDemoProfile) && (
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs" style={{ maxHeight: "2.1em" }}>
+              {dateIsNarrow ? (
+                <div className="flex shrink-0 items-center gap-1 text-base-content/60">
+                  <Calendar size={10} className="shrink-0" />
+                  <span className="leading-[1.05] whitespace-nowrap">{formatDate()}</span>
+                </div>
+              ) : showUsername && (
+                clickable ? (
+                  <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
+                    <Tooltip content="View profile" wrapperClassName="block truncate leading-[1.05] text-base-content/70 cursor-pointer hover:text-primary transition-colors">
+                      <span onClick={handleUserClick}>@{user.username}</span>
+                    </Tooltip>
+                  </div>
+                ) : (
+                  <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
+                    <span className="block truncate leading-[1.05] text-base-content/70">@{user.username}</span>
+                  </div>
+                )
               )}
+              {showLocation && (user?.city || user?.country || getPostalCode()) && (
+                <div className="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden">
+                  <MapPin size={10} className="text-base-content/60 shrink-0" />
+                  <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">
+                    {[user?.city, user?.country].filter(Boolean).join(", ") || getPostalCode()}
+                  </span>
+                </div>
+              )}
+              {sublineExtra}
               {showDemoProfile && (
                 <Tooltip
                   content={DEMO_PROFILE_TOOLTIP}
-                  wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+                  wrapperClassName="flex shrink-0 items-center gap-0.5 text-base-content/50"
                 >
-                  <FlaskConical size={12} className="flex-shrink-0" />
+                  <FlaskConical size={10} className="flex-shrink-0" />
                 </Tooltip>
               )}
             </div>
           )}
-
-          {/* Location if available and showLocation is true */}
-          {showLocation && getPostalCode() && (
-            <div className="flex items-center text-sm text-base-content/60 mt-1">
-              <MapPin size={14} className="mr-1" />
-              <LocationDisplay
-                postalCode={getPostalCode()}
-                city={user?.city}
-                state={user?.state}
-                country={user?.country}
-                showIcon={false}
-                displayType="short"
-              />
-            </div>
-          )}
         </div>
 
-        {/* Date - top right */}
-        <div className="flex items-center text-xs text-base-content/60 flex-shrink-0">
+        {/* Date - top right; absolute (out of flow) when narrow so subline gets full width,
+            but still rendered so its width can be measured for stable name-fit calculation */}
+        <div
+          ref={dateRef}
+          className={`flex items-center text-xs text-base-content/60 flex-shrink-0${dateIsNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
+        >
           <Calendar size={12} className="mr-1" />
           <span>{formatDate()}</span>
         </div>

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -2,15 +2,16 @@ import React, { useState } from "react";
 import {
   Calendar,
   Users,
+  User,
   X,
   SendHorizontal,
   FlaskConical,
   Trash2,
 } from "lucide-react";
 import Modal from "../common/Modal";
+import Tooltip from "../common/Tooltip";
 import Button from "../common/Button";
 import ConfirmModal from "../common/ConfirmModal";
-import Tooltip from "../common/Tooltip";
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import InlineUserLink from "../users/InlineUserLink";
@@ -346,9 +347,8 @@ const TeamApplicationDetailsModal = ({
           <div
             className="flex items-start space-x-3 cursor-pointer hover:opacity-80 transition-opacity"
             onClick={handleTeamClick}
-            title="View team details"
           >
-            <div className="avatar">
+            <Tooltip content="View team details" wrapperClassName="avatar">
               <div className="w-14 h-14 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
@@ -383,19 +383,31 @@ const TeamApplicationDetailsModal = ({
                   />
                 )}
               </div>
-            </div>
+            </Tooltip>
 
             <div className="flex-1 min-w-0">
               <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
                 {team.name || "Unknown Team"}
               </h4>
               <div className="mt-0.5 flex max-h-[2.75em] flex-wrap items-center gap-x-1.5 gap-y-px overflow-hidden text-sm text-base-content/70">
-                <span className="flex items-center">
-                  <Users size={14} className="mr-1 text-primary" />
+                <Tooltip
+                  content="Team members"
+                  wrapperClassName="flex items-center gap-1 text-base-content/70 text-sm"
+                >
+                  <Users size={14} className="text-primary" />
                   <span>
                     {getMemberCount()}/{getMaxMembers()}
                   </span>
-                </span>
+                </Tooltip>
+                {isInternalRoleApplication && (
+                  <Tooltip
+                    content="You are already a member of this team"
+                    wrapperClassName="flex items-center gap-1 text-base-content/70 text-sm"
+                  >
+                    <User size={14} className="flex-shrink-0 text-success" />
+                    <span>You are a member</span>
+                  </Tooltip>
+                )}
                 {isSyntheticTeam(team) && (
                   <Tooltip
                     content={DEMO_TEAM_TOOLTIP}
@@ -423,9 +435,37 @@ const TeamApplicationDetailsModal = ({
           </p>
         )}
 
-        {/* Vacant role card — shown when application targets a specific role */}
-        {(application?.role || application?.roleId) && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
+        {/* Application message + role card in speech bubble (when message exists) */}
+        {application?.message && (
+          <div className="mb-5">
+            <p className="text-xs text-base-content/60 mb-1 flex items-center">
+              <SendHorizontal size={12} className="text-info mr-1" />
+              Your application message:
+            </p>
+            <div className="w-fit max-w-full bg-base-200 rounded-lg rounded-bl-none p-3">
+              <p className="text-sm text-base-content/90 leading-relaxed">
+                {application.message}
+              </p>
+              {(application?.role || application?.roleId) && (
+                <div className="mt-3 max-w-[300px]">
+                  <VacantRoleCard
+                    role={roleForCard}
+                    team={team}
+                    matchScore={roleMatchScore}
+                    matchDetails={roleMatchDetails}
+                    canManage={false}
+                    isTeamMember={false}
+                    notificationHighlight={notificationHighlight}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Role card bare — shown when no message but role exists */}
+        {!application?.message && (application?.role || application?.roleId) && (
+          <div className="mb-5 max-w-[300px]">
             <VacantRoleCard
               role={roleForCard}
               team={team}
@@ -438,22 +478,9 @@ const TeamApplicationDetailsModal = ({
           </div>
         )}
 
-        {/* Application Message */}
-        {application?.message && (
-          <div className="mb-4">
-            <p className="text-xs text-base-content/60 mb-0.5 flex items-center">
-              <SendHorizontal size={12} className="text-info mr-1" />
-              Your application message:
-            </p>
-            <p className="text-sm text-base-content/90 leading-relaxed">
-              {application.message}
-            </p>
-          </div>
-        )}
-
-        {/* No message fallback */}
-        {!application?.message && (
-          <div className="mb-4">
+        {/* No message fallback — only when no role either */}
+        {!application?.message && !(application?.role || application?.roleId) && (
+          <div className="mb-5">
             <p className="text-xs text-base-content/60 mb-0.5 flex items-center">
               <SendHorizontal size={12} className="text-info mr-1" />
               Your application message:

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Check, UserCheck, X as Decline, User, Mail, MessageSquare, AlertTriangle } from "lucide-react";
+import { Check, UserCheck, X as Decline, User, Mail, MessageSquare, AlertTriangle, ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
 import PersonRequestCard from "../common/PersonRequestCard";
 import Button from "../common/Button";
@@ -68,6 +68,7 @@ const TeamApplicationsModal = ({
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
   const [responses, setResponses] = useState({});
+  const [responseExpanded, setResponseExpanded] = useState({});
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [roleStatusOverrides, setRoleStatusOverrides] = useState({});
   const [statusUpdatingRoleId, setStatusUpdatingRoleId] = useState(null);
@@ -730,55 +731,53 @@ const TeamApplicationsModal = ({
               user={application.applicant}
               date={getApplicationDate(application)}
               message={application.message || "No message provided."}
-              messageLabel="Application message:"
+              messageLabel={`${application.applicant?.first_name || application.applicant?.firstName || application.applicant?.username || "Their"}'s application message:`}
               messageIcon={<Mail size={12} className="text-pink-500 mr-1" />}
               onUserClick={handleUserClick}
               showLocation={false}
+              messageBubbleExtra={
+                role ? (
+                  <VacantRoleCard
+                      role={role}
+                      team={{ id: teamId, name: teamName }}
+                      matchScore={
+                        applicantRoleMatch?.matchScore ??
+                        selfRoleMatch?.matchScore ??
+                        role.matchScore ??
+                        role.match_score ??
+                        null
+                      }
+                      matchDetails={
+                        applicantRoleMatch?.matchDetails ??
+                        selfRoleMatch?.matchDetails ??
+                        role.matchDetails ??
+                        role.match_details ??
+                        null
+                      }
+                      canManage={false}
+                      canManageStatus={canManageStatusForRole}
+                      onViewApplicationDetails={
+                        isSelfApplication
+                          ? () => setApplicationDetailsFor(application)
+                          : null
+                      }
+                      isTeamMember={true}
+                      onStatusChange={(currentRoleId, newStatus) =>
+                        handleRoleStatusChange(
+                          currentRoleId,
+                          newStatus,
+                          application.applicant ?? null,
+                        )
+                      }
+                      allowedStatusActions={["filled", "open"]}
+                      statusActionLoading={statusUpdatingRoleId === roleId}
+                      viewAsUserId={application.applicant?.id}
+                      viewAsUser={application.applicant}
+                    />
+                ) : null
+              }
               extraContent={
                 <>
-                  {/* Vacant role card — shown when application targets a specific role */}
-                  {role && (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
-                      <VacantRoleCard
-                        role={role}
-                        team={{ id: teamId, name: teamName }}
-                        matchScore={
-                          applicantRoleMatch?.matchScore ??
-                          selfRoleMatch?.matchScore ??
-                          role.matchScore ??
-                          role.match_score ??
-                          null
-                        }
-                        matchDetails={
-                          applicantRoleMatch?.matchDetails ??
-                          selfRoleMatch?.matchDetails ??
-                          role.matchDetails ??
-                          role.match_details ??
-                          null
-                        }
-                        canManage={false}
-                        canManageStatus={canManageStatusForRole}
-                        onViewApplicationDetails={
-                          isSelfApplication
-                            ? () => setApplicationDetailsFor(application)
-                            : null
-                        }
-                        isTeamMember={true}
-                        onStatusChange={(currentRoleId, newStatus) =>
-                          handleRoleStatusChange(
-                            currentRoleId,
-                            newStatus,
-                            application.applicant ?? null,
-                          )
-                        }
-                        allowedStatusActions={["filled", "open"]}
-                        statusActionLoading={statusUpdatingRoleId === roleId}
-                        viewAsUserId={application.applicant?.id}
-                        viewAsUser={application.applicant}
-                      />
-                    </div>
-                  )}
-
                   {/* User Tags/Skills if available */}
                   {application.applicant?.tags &&
                     application.applicant.tags.length > 0 && (
@@ -807,19 +806,45 @@ const TeamApplicationsModal = ({
                   {/* Response Textarea */}
                   {!isSelfApplication && (
                     <div className="mb-5">
-                      <p className="text-xs text-base-content/60 mb-1 flex items-center">
-                        <MessageSquare size={12} className="text-primary mr-1" />
-                        Your response message (optional):
-                      </p>
-                      <textarea
-                        value={responses[application.id] || ""}
-                        onChange={(e) =>
-                          handleResponseChange(application.id, e.target.value)
+                      <div className="flex mb-1">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setResponseExpanded((prev) => ({
+                            ...prev,
+                            [application.id]: !prev[application.id],
+                          }))
                         }
-                        className="textarea textarea-bordered textarea-sm w-full h-20 resize-none text-sm"
-                        placeholder="Add a personal message to your decision..."
-                        disabled={loading}
-                      />
+                        className={`text-xs text-base-content/60 flex items-center text-left cursor-pointer hover:text-base-content/80 transition-colors ${responseExpanded[application.id] ? "w-full" : "ml-auto"}`}
+                      >
+                        {responseExpanded[application.id] || responses[application.id]
+                          ? <MessageSquare size={12} className="text-primary mr-1" />
+                          : <Pencil size={12} className="text-primary mr-1" />
+                        }
+                        {responseExpanded[application.id]
+                          ? "Your response message (optional):"
+                          : "Add a personal response message (optional)"
+                        }
+                        <span className="ml-auto pl-3 text-base-content/40">
+                          {responseExpanded[application.id] ? (
+                            <ChevronUp size={12} />
+                          ) : (
+                            <ChevronDown size={12} />
+                          )}
+                        </span>
+                      </button>
+                      </div>
+                      {responseExpanded[application.id] && (
+                        <textarea
+                          value={responses[application.id] || ""}
+                          onChange={(e) =>
+                            handleResponseChange(application.id, e.target.value)
+                          }
+                          className="textarea textarea-bordered textarea-sm w-full h-20 resize-none text-sm"
+                          placeholder="Add a personal message to your decision..."
+                          disabled={loading}
+                        />
+                      )}
                     </div>
                   )}
                 </>

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -77,6 +77,7 @@ const TeamApplicationsModal = ({
   const [roleCandidateMatchMap, setRoleCandidateMatchMap] = useState({});
   const [selfRoleMatchMap, setSelfRoleMatchMap] = useState({});
   const [polledRoleStatusMap, setPolledRoleStatusMap] = useState({});
+  const [narrowMap, setNarrowMap] = useState({});
 
   // ============ Refs ============
   const highlightedRef = useRef(null);
@@ -532,6 +533,8 @@ const TeamApplicationsModal = ({
   }, [isOpen, teamId, applications]);
 
   // ============ Render ============
+  const anyNarrow = Object.values(narrowMap).some(Boolean);
+
   return (
     <RequestListModal
       isOpen={isOpen}
@@ -730,11 +733,27 @@ const TeamApplicationsModal = ({
             <PersonRequestCard
               user={application.applicant}
               date={getApplicationDate(application)}
+              onNarrowChange={(narrow) => setNarrowMap((prev) => {
+                if ((prev[String(application.id)] ?? false) === narrow) return prev;
+                return { ...prev, [String(application.id)]: narrow };
+              })}
+              forceNarrow={anyNarrow}
               message={application.message || "No message provided."}
               messageLabel={`${application.applicant?.first_name || application.applicant?.firstName || application.applicant?.username || "Their"}'s application message:`}
               messageIcon={<Mail size={12} className="text-pink-500 mr-1" />}
               onUserClick={handleUserClick}
-              showLocation={false}
+              showLocation={true}
+              sublineExtra={
+                isInternalRoleApplication ? (
+                  <Tooltip
+                    content="Already a member of this team"
+                    wrapperClassName="flex min-w-0 overflow-hidden items-center gap-0.5 text-base-content/70"
+                  >
+                    <User size={10} className="flex-shrink-0 text-success" />
+                    <span className="leading-[1.05] whitespace-nowrap">Team Member</span>
+                  </Tooltip>
+                ) : null
+              }
               messageBubbleExtra={
                 role ? (
                   <VacantRoleCard

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -4,12 +4,16 @@ import {
   MessageSquare,
   Users,
   Check,
+  User,
   UserCheck,
   X,
   MailOpen,
   UserPlus,
   FlaskConical,
   ArrowRightLeft,
+  ChevronDown,
+  ChevronUp,
+  Pencil,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
@@ -67,6 +71,7 @@ const TeamInvitationDetailsModal = ({
   const [actionLoading, setActionLoading] = useState(null); // "acceptRole" | "switchRole" | "acceptTeam" | "decline" | null
   const [error, setError] = useState(null);
   const [responseMessage, setResponseMessage] = useState("");
+  const [responseExpanded, setResponseExpanded] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [isTeamDetailsOpen, setIsTeamDetailsOpen] = useState(false);
 
@@ -514,9 +519,8 @@ const TeamInvitationDetailsModal = ({
           <div
             className="flex items-start space-x-3 cursor-pointer hover:opacity-80 transition-opacity"
             onClick={handleTeamClick}
-            title="View team details"
           >
-            <div className="avatar">
+            <Tooltip content="View team details" wrapperClassName="avatar">
               <div className="w-14 h-14 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
@@ -551,19 +555,31 @@ const TeamInvitationDetailsModal = ({
                   />
                 )}
               </div>
-            </div>
+            </Tooltip>
 
             <div className="flex-1 min-w-0">
               <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
                 {team.name || "Unknown Team"}
               </h4>
               <div className="mt-0.5 flex max-h-[2.75em] flex-wrap items-center gap-x-1.5 gap-y-px overflow-hidden text-sm text-base-content/70">
-                <span className="flex items-center">
-                  <Users size={14} className="mr-1 text-primary" />
+                <Tooltip
+                  content="Team members"
+                  wrapperClassName="flex items-center gap-1 text-base-content/70 text-sm"
+                >
+                  <Users size={14} className="text-primary" />
                   <span>
                     {getMemberCount()}/{getMaxMembers()}
                   </span>
-                </span>
+                </Tooltip>
+                {isInternal && (
+                  <Tooltip
+                    content="You are already a member of this team"
+                    wrapperClassName="flex items-center gap-1 text-base-content/70 text-sm"
+                  >
+                    <User size={14} className="flex-shrink-0 text-success" />
+                    <span>You are a member</span>
+                  </Tooltip>
+                )}
                 {isSyntheticTeam(team) && (
                   <Tooltip
                     content={DEMO_TEAM_TOOLTIP}
@@ -591,74 +607,102 @@ const TeamInvitationDetailsModal = ({
           </p>
         )}
 
-        {/* Vacant role card — shown when invitation targets a specific role */}
-        {(hydratedRole || invitation?.role || invitation?.roleId || invitation?.role_id) && (
+        {/* Invitation message + role card in speech bubble (when message exists) */}
+        {invitation?.message && (
           <div className="mb-5">
-            <p className="text-xs text-base-content/60 mb-2 flex items-center">
+            <p className="text-xs text-base-content/60 mb-1 flex items-center">
               <MailOpen size={12} className="text-info mr-1" />
-              Invited for this role:
+              {`Invitation message from ${inviter?.first_name || inviter?.firstName || inviter?.username || "them"}:`}
             </p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <VacantRoleCard
-                role={roleForCard}
-                team={team}
-                matchScore={roleMatchScore}
-                matchDetails={roleMatchDetails}
-                canManage={false}
-                isTeamMember={false}
-                hideActions={true}
-                notificationHighlight={notificationHighlight}
-              />
+            <div className="w-fit max-w-full bg-base-200 rounded-lg rounded-bl-none p-3">
+              <p className="text-sm text-base-content/90 leading-relaxed">
+                {(() => {
+                  if (isInternal && currentFilledRoleName && currentFilledRoleName !== "your current role") {
+                    const suffix = ` ${currentFilledRoleName}.`;
+                    return invitation.message.endsWith(suffix)
+                      ? invitation.message.slice(0, -suffix.length)
+                      : invitation.message;
+                  }
+                  return invitation.message;
+                })()}
+              </p>
+              {(hydratedRole || invitation?.role || invitation?.roleId || invitation?.role_id) && (
+                <div className="mt-3 max-w-[300px]">
+                  <VacantRoleCard
+                    role={roleForCard}
+                    team={team}
+                    matchScore={roleMatchScore}
+                    matchDetails={roleMatchDetails}
+                    canManage={false}
+                    isTeamMember={false}
+                    hideActions={true}
+                    notificationHighlight={notificationHighlight}
+                  />
+                </div>
+              )}
+              {isInternal && currentFilledRoleForCard && (
+                <div className="mt-3 max-w-[300px]">
+                  <VacantRoleCard
+                    role={currentFilledRoleForCard}
+                    team={team}
+                    matchScore={null}
+                    canManage={false}
+                    isTeamMember={true}
+                    hideActions={true}
+                  />
+                </div>
+              )}
             </div>
           </div>
         )}
 
-        {/* Invitation Message */}
-        {invitation?.message && (
-          <div className="mb-4">
-            <p className="text-xs text-base-content/60 mb-0.5 flex items-center">
-              <MailOpen size={12} className="text-info mr-1" />
-              Invitation message:
-            </p>
-            <p className="text-sm text-base-content/90 leading-relaxed">
-              {(() => {
-                if (isInternal && currentFilledRoleName && currentFilledRoleName !== "your current role") {
-                  const suffix = ` ${currentFilledRoleName}.`;
-                  return invitation.message.endsWith(suffix)
-                    ? invitation.message.slice(0, -suffix.length)
-                    : invitation.message;
-                }
-                return invitation.message;
-              })()}
-            </p>
-            {isInternal && currentFilledRoleForCard && (
-              <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <VacantRoleCard
-                  role={currentFilledRoleForCard}
-                  team={team}
-                  matchScore={null}
-                  canManage={false}
-                  isTeamMember={true}
-                  hideActions={true}
-                />
-              </div>
-            )}
+        {/* Role card bare — shown when invitation has no message */}
+        {!invitation?.message && (hydratedRole || invitation?.role || invitation?.roleId || invitation?.role_id) && (
+          <div className="mb-5 max-w-[300px]">
+            <VacantRoleCard
+              role={roleForCard}
+              team={team}
+              matchScore={roleMatchScore}
+              matchDetails={roleMatchDetails}
+              canManage={false}
+              isTeamMember={false}
+              hideActions={true}
+              notificationHighlight={notificationHighlight}
+            />
           </div>
         )}
 
-        {/* Response Textarea */}
+        {/* Response Textarea — collapsible */}
         <div className="mt-2">
-          <p className="text-xs text-base-content/60 mb-1 flex items-center">
-            <MessageSquare size={12} className="text-primary mr-1" />
-            Your response message (optional):
-          </p>
-          <textarea
-            value={responseMessage}
-            onChange={(e) => setResponseMessage(e.target.value)}
-            className="textarea textarea-bordered textarea-sm w-full h-20 resize-none text-sm"
-            placeholder="Add a personal message to your decision. Decline messages will be sent as DM to the inviter only. Acceptance messages will be sent to the team chat."
-            disabled={isControlsDisabled}
-          />
+          <div className="flex mb-1">
+            <button
+              type="button"
+              onClick={() => setResponseExpanded((prev) => !prev)}
+              className={`text-xs text-base-content/60 flex items-center text-left cursor-pointer hover:text-base-content/80 transition-colors ${responseExpanded ? "w-full" : "ml-auto"}`}
+              disabled={isControlsDisabled}
+            >
+              {responseExpanded || responseMessage
+                ? <MessageSquare size={12} className="text-primary mr-1" />
+                : <Pencil size={12} className="text-primary mr-1" />
+              }
+              {responseExpanded
+                ? "Your response message (optional):"
+                : "Add a personal response message (optional)"
+              }
+              <span className="ml-auto pl-3 text-base-content/40">
+                {responseExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+              </span>
+            </button>
+          </div>
+          {responseExpanded && (
+            <textarea
+              value={responseMessage}
+              onChange={(e) => setResponseMessage(e.target.value)}
+              className="textarea textarea-bordered textarea-sm w-full h-20 resize-none text-sm"
+              placeholder="Add a personal message to your decision. Decline messages will be sent as DM to the inviter only. Acceptance messages will be sent to the team chat."
+              disabled={isControlsDisabled}
+            />
+          )}
         </div>
       </Modal>
 

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
 import {
   User,
   MapPin,
@@ -28,6 +28,7 @@ import {
   isSyntheticUser,
 } from "../../utils/userHelpers";
 import { calculateDistanceKm } from "../../utils/locationUtils";
+import { formatDisplayName } from "../../utils/nameFormatters";
 import { format } from "date-fns";
 
 const MATCH_WEIGHTS = {
@@ -188,6 +189,47 @@ const computeRoleUserMatch = ({
   };
 };
 
+const FitInviteeName = ({ invitee, onUserClick, onNarrowChange, getDateEl, forceNarrow = false }) => {
+  const containerRef = useRef(null);
+  const probeRef = useRef(null);
+  const fullName = getDisplayName(invitee);
+  const abbrevName = invitee ? formatDisplayName(invitee) : fullName;
+  const [displayedName, setDisplayedName] = useState(fullName);
+  const displayedNameRef = useRef(fullName);
+  displayedNameRef.current = displayedName;
+  const forceNarrowRef = useRef(forceNarrow);
+  forceNarrowRef.current = forceNarrow;
+
+  useLayoutEffect(() => {
+    if (fullName === abbrevName) { setDisplayedName(fullName); onNarrowChange?.(false); return; }
+    const container = containerRef.current;
+    const probe = probeRef.current;
+    if (!container || !probe) return;
+    const update = () => {
+      const isDateAbsolute = displayedNameRef.current !== fullName || forceNarrowRef.current;
+      const dateEl = getDateEl?.();
+      const dateReservedWidth = isDateAbsolute && dateEl ? dateEl.offsetWidth + 12 : 0; // 12 = gap-3
+      probe.textContent = fullName;
+      const fits = probe.scrollWidth <= container.clientWidth - dateReservedWidth;
+      setDisplayedName(fits ? fullName : abbrevName);
+      onNarrowChange?.(!fits);
+    };
+    const ro = new ResizeObserver(update);
+    ro.observe(container);
+    update();
+    return () => ro.disconnect();
+  }, [fullName, abbrevName]);
+
+  return (
+    <h4 ref={containerRef} className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative">
+      <Tooltip content="View profile" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
+        <span onClick={onUserClick}>{displayedName}</span>
+      </Tooltip>
+      <span ref={probeRef} className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium" aria-hidden="true" />
+    </h4>
+  );
+};
+
 /**
  * TeamInvitesModal Component
  *
@@ -225,6 +267,8 @@ const TeamInvitesModal = ({
     useState(null);
   const [pendingCancelType, setPendingCancelType] = useState("team");
   const [hydratedRoleMap, setHydratedRoleMap] = useState({});
+  const [narrowMap, setNarrowMap] = useState({});
+  const dateElsRef = useRef({});
 
   // ============ Refs ============
   const highlightedRef = useRef(null);
@@ -680,6 +724,7 @@ const TeamInvitesModal = ({
   };
 
   // ============ Render ============
+  const anyNarrow = Object.values(narrowMap).some(Boolean);
   const pendingCancelInvitation = invitations.find(
     (invitation) => String(invitation.id) === String(pendingCancelInvitationId),
   );
@@ -819,7 +864,6 @@ const TeamInvitesModal = ({
           (getDisplayName(invitation.invitee) !== invitation.invitee?.username ||
             isSyntheticUser(invitation.invitee));
         const showInviteeDemoProfile = isSyntheticUser(invitation.invitee);
-
         return (
           <div
             key={invitation.id}
@@ -831,14 +875,16 @@ const TeamInvitesModal = ({
             }`}
           >
             {/* Top row: Avatar + Name/Username + Date */}
-            <div className="flex items-start gap-3 mb-3">
+            <div className="flex items-start gap-3 mb-3 relative">
               {/* Invitee Avatar - Clickable */}
-              <div
-                className="avatar cursor-pointer hover:opacity-80 transition-opacity flex-shrink-0"
-                onClick={() => handleInviteeClick(invitation.invitee?.id)}
-                title="View profile"
+              <Tooltip
+                content="View profile"
+                wrapperClassName="avatar cursor-pointer hover:opacity-80 transition-opacity flex-shrink-0"
               >
-                <div className="w-10 h-10 rounded-full relative overflow-hidden">
+                <div
+                  className="w-12 h-12 rounded-full relative overflow-hidden"
+                  onClick={() => handleInviteeClick(invitation.invitee?.id)}
+                >
                   {getAvatarUrl(invitation.invitee) ? (
                     <img
                       src={getAvatarUrl(invitation.invitee)}
@@ -863,47 +909,83 @@ const TeamInvitesModal = ({
                         : "flex",
                     }}
                   >
-                    <span className="text-sm font-medium">
+                    <span className="text-xl font-medium">
                       {getUserInitials(invitation.invitee)}
                     </span>
                   </div>
                   {isSyntheticUser(invitation.invitee) && (
-                    <DemoAvatarOverlay textClassName="text-[7px]" />
+                    <DemoAvatarOverlay textClassName="text-[8px]" />
                   )}
                 </div>
-              </div>
+              </Tooltip>
 
               {/* User Info */}
               <div className="flex-1 min-w-0">
                 {/* Name - Clickable */}
-                <h4
-                  className="font-medium text-base-content cursor-pointer hover:text-primary transition-colors leading-[120%] mb-[0.2em]"
-                  onClick={() => handleInviteeClick(invitation.invitee?.id)}
-                  title="View profile"
-                >
-                  {getDisplayName(invitation.invitee)}
-                </h4>
-                {(showInviteeUsername || showInviteeDemoProfile) && (
-                  <div className="flex max-h-[2.1em] flex-wrap items-center gap-x-2 gap-y-0.5 overflow-hidden">
-                    {showInviteeUsername && (
-                      <p className="text-xs text-base-content/70">
-                        @{invitation.invitee.username}
-                      </p>
+                <FitInviteeName
+                  invitee={invitation.invitee}
+                  onUserClick={() => handleInviteeClick(invitation.invitee?.id)}
+                  onNarrowChange={(narrow) => setNarrowMap((prev) => {
+                    if ((prev[String(invitation.id)] ?? false) === narrow) return prev;
+                    return { ...prev, [String(invitation.id)]: narrow };
+                  })}
+                  getDateEl={() => dateElsRef.current[String(invitation.id)]}
+                  forceNarrow={anyNarrow}
+                />
+                {(anyNarrow || showInviteeUsername || invitation.invitee?.city || invitation.invitee?.country || invitation.invitee?.postal_code || invitation.invitee?.location || isInternalInvitation || showInviteeDemoProfile) && (
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs" style={{ maxHeight: "2.1em" }}>
+                    {anyNarrow ? (
+                      <div className="flex shrink-0 items-center gap-1 text-base-content/60">
+                        <Calendar size={10} className="shrink-0" />
+                        <span className="leading-[1.05] whitespace-nowrap">{getInvitationDate(invitation)}</span>
+                      </div>
+                    ) : showInviteeUsername && (
+                      <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
+                        <Tooltip content="View profile" wrapperClassName="block truncate leading-[1.05] text-base-content/70 cursor-pointer hover:text-primary transition-colors">
+                          <span onClick={() => handleInviteeClick(invitation.invitee?.id)}>
+                            @{invitation.invitee.username}
+                          </span>
+                        </Tooltip>
+                      </div>
+                    )}
+                    {(invitation.invitee?.city || invitation.invitee?.country || invitation.invitee?.postal_code || invitation.invitee?.location) && (
+                      <div className="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden">
+                        <MapPin size={10} className="text-base-content/60 shrink-0" />
+                        <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">
+                          {[invitation.invitee?.city, invitation.invitee?.country].filter(Boolean).join(", ") || invitation.invitee?.location || invitation.invitee?.postal_code}
+                        </span>
+                      </div>
+                    )}
+                    {isInternalInvitation && (
+                      <Tooltip
+                        content="Already a member of this team"
+                        wrapperClassName="flex min-w-0 overflow-hidden items-center gap-0.5 text-base-content/70"
+                      >
+                        <User size={10} className="flex-shrink-0 text-success" />
+                        <span className="leading-[1.05] whitespace-nowrap">Team Member</span>
+                      </Tooltip>
                     )}
                     {showInviteeDemoProfile && (
                       <Tooltip
                         content={DEMO_PROFILE_TOOLTIP}
-                        wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+                        wrapperClassName="flex shrink-0 items-center gap-0.5 text-base-content/50"
                       >
-                        <FlaskConical size={12} className="flex-shrink-0" />
+                        <FlaskConical size={10} className="flex-shrink-0" />
                       </Tooltip>
                     )}
                   </div>
                 )}
               </div>
 
-              {/* Date - top right */}
-              <div className="flex items-center text-xs text-base-content/60 whitespace-nowrap">
+              {/* Date - top right; absolute (out of flow) when narrow so subline gets full width,
+                  but still rendered so its width can be measured for stable name-fit calculation */}
+              <div
+                ref={(el) => {
+                  if (el) dateElsRef.current[String(invitation.id)] = el;
+                  else delete dateElsRef.current[String(invitation.id)];
+                }}
+                className={`flex items-center text-xs text-base-content/60 whitespace-nowrap${anyNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
+              >
                 <Calendar size={12} className="mr-1" />
                 <span>{getInvitationDate(invitation)}</span>
               </div>
@@ -1024,17 +1106,6 @@ const TeamInvitesModal = ({
               </div>
             )}
 
-            {/* Location (if available) */}
-            {(invitation.invitee?.location ||
-              invitation.invitee?.postal_code) && (
-              <div className="flex items-center text-xs text-base-content/60 mb-3">
-                <MapPin size={12} className="mr-1" />
-                <span>
-                  {invitation.invitee?.location ||
-                    invitation.invitee?.postal_code}
-                </span>
-              </div>
-            )}
 
             {/* Bottom row: Inviter info (left) + Action Button (right) */}
             <div className="flex items-center justify-between gap-3">

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -916,85 +916,111 @@ const TeamInvitesModal = ({
               </div>
             )}
 
-            {/* Invited role card — shown when invitation targets a specific role */}
-            {(invitation.role || invitation.roleId || invitation.role_id) && (
+            {/* Invitation message — speech bubble (only when a message exists) */}
+            {invitation.message && (
               <div className="mb-3">
-                <p className="text-xs text-base-content/60 mb-2 flex items-center">
-                  <MailOpen size={12} className="text-info mr-1" />
-                  Invited for this role:
+                <p className="text-xs text-base-content/60 mb-1 flex items-center">
+                  <SendHorizontal size={12} className="text-info mr-1" />
+                  {`Invitation message sent to ${invitation.invitee?.first_name || invitation.invitee?.firstName || invitation.invitee?.username || "recipient"}:`}
                 </p>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <VacantRoleCard
-                    role={roleForCard}
-                    team={{ id: teamId, name: teamName }}
-                    matchScore={
-                      inviteeRoleMatch?.matchScore ??
-                      selfRoleMatch?.matchScore ??
-                      localInviteeRoleMatch?.matchScore ??
-                      invitation.role?.matchScore ??
-                      invitation.role?.match_score ??
-                      null
-                    }
-                    matchDetails={
-                      inviteeRoleMatch?.matchDetails ??
-                      selfRoleMatch?.matchDetails ??
-                      localInviteeRoleMatch?.matchDetails ??
-                      invitation.role?.matchDetails ??
-                      invitation.role?.match_details ??
-                      null
-                    }
-                    canManage={false}
-                    canManageStatus={false}
-                    isTeamMember={true}
-                    viewAsUserId={invitation.invitee?.id ?? invitation.invitee_id}
-                    viewAsUser={invitation.invitee}
-                    hideActions={true}
-                  />
+                <div className="w-fit max-w-full bg-base-200 rounded-lg rounded-bl-none p-3">
+                  <p className="text-sm text-base-content/90 leading-relaxed">
+                    {(() => {
+                      const roleName = invitation.current_filled_role_name ?? invitation.currentFilledRoleName;
+                      if (isInternalInvitation && roleName) {
+                        const suffix = ` ${roleName}.`;
+                        return invitation.message.endsWith(suffix)
+                          ? invitation.message.slice(0, -suffix.length)
+                          : invitation.message;
+                      }
+                      return invitation.message;
+                    })()}
+                  </p>
+                  {(invitation.role || invitation.roleId || invitation.role_id) && (
+                    <div className="mt-3 max-w-[300px]">
+                      <VacantRoleCard
+                        role={roleForCard}
+                        team={{ id: teamId, name: teamName }}
+                        matchScore={
+                          inviteeRoleMatch?.matchScore ??
+                          selfRoleMatch?.matchScore ??
+                          localInviteeRoleMatch?.matchScore ??
+                          invitation.role?.matchScore ??
+                          invitation.role?.match_score ??
+                          null
+                        }
+                        matchDetails={
+                          inviteeRoleMatch?.matchDetails ??
+                          selfRoleMatch?.matchDetails ??
+                          localInviteeRoleMatch?.matchDetails ??
+                          invitation.role?.matchDetails ??
+                          invitation.role?.match_details ??
+                          null
+                        }
+                        canManage={false}
+                        canManageStatus={false}
+                        isTeamMember={true}
+                        viewAsUserId={invitation.invitee?.id ?? invitation.invitee_id}
+                        viewAsUser={invitation.invitee}
+                        hideActions={true}
+                      />
+                    </div>
+                  )}
+                  {isInternalInvitation && (invitation.current_filled_role_id ?? invitation.currentFilledRoleId) && (
+                    <div className="mt-3 max-w-[300px]">
+                      <VacantRoleCard
+                        role={{
+                          id: invitation.current_filled_role_id ?? invitation.currentFilledRoleId,
+                          role_name: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
+                          roleName: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
+                          status: "filled",
+                          filled_by: invitation.invitee?.id ?? invitation.invitee_id,
+                          filled_by_user: invitation.invitee ?? null,
+                          is_synthetic: invitation.role_is_synthetic ?? false,
+                          isSynthetic: invitation.role_is_synthetic ?? false,
+                        }}
+                        team={{ id: teamId, name: teamName }}
+                        matchScore={null}
+                        canManage={false}
+                        canManageStatus={false}
+                        isTeamMember={true}
+                        hideActions={true}
+                      />
+                    </div>
+                  )}
                 </div>
               </div>
             )}
 
-            {/* Invitation Message (if any) */}
-            {invitation.message && (
-              <div className="mb-3">
-                <p className="text-xs text-base-content/60 mb-0.5 flex items-center">
-                  <SendHorizontal size={12} className="text-info mr-1" />
-                  Invitation message:
-                </p>
-                <p className="text-sm text-base-content/90 leading-relaxed">
-                  {(() => {
-                    const roleName = invitation.current_filled_role_name ?? invitation.currentFilledRoleName;
-                    if (isInternalInvitation && roleName) {
-                      const suffix = ` ${roleName}.`;
-                      return invitation.message.endsWith(suffix)
-                        ? invitation.message.slice(0, -suffix.length)
-                        : invitation.message;
-                    }
-                    return invitation.message;
-                  })()}
-                </p>
-                {isInternalInvitation && (invitation.current_filled_role_id ?? invitation.currentFilledRoleId) && (
-                  <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <VacantRoleCard
-                      role={{
-                        id: invitation.current_filled_role_id ?? invitation.currentFilledRoleId,
-                        role_name: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
-                        roleName: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
-                        status: "filled",
-                        filled_by: invitation.invitee?.id ?? invitation.invitee_id,
-                        filled_by_user: invitation.invitee ?? null,
-                        is_synthetic: invitation.role_is_synthetic ?? false,
-                        isSynthetic: invitation.role_is_synthetic ?? false,
-                      }}
-                      team={{ id: teamId, name: teamName }}
-                      matchScore={null}
-                      canManage={false}
-                      canManageStatus={false}
-                      isTeamMember={true}
-                      hideActions={true}
-                    />
-                  </div>
-                )}
+            {/* Role card — shown bare (no bubble) when there's a role but no message */}
+            {!invitation.message && (invitation.role || invitation.roleId || invitation.role_id) && (
+              <div className="mb-3 max-w-[300px]">
+                <VacantRoleCard
+                  role={roleForCard}
+                  team={{ id: teamId, name: teamName }}
+                  matchScore={
+                    inviteeRoleMatch?.matchScore ??
+                    selfRoleMatch?.matchScore ??
+                    localInviteeRoleMatch?.matchScore ??
+                    invitation.role?.matchScore ??
+                    invitation.role?.match_score ??
+                    null
+                  }
+                  matchDetails={
+                    inviteeRoleMatch?.matchDetails ??
+                    selfRoleMatch?.matchDetails ??
+                    localInviteeRoleMatch?.matchDetails ??
+                    invitation.role?.matchDetails ??
+                    invitation.role?.match_details ??
+                    null
+                  }
+                  canManage={false}
+                  canManageStatus={false}
+                  isTeamMember={true}
+                  viewAsUserId={invitation.invitee?.id ?? invitation.invitee_id}
+                  viewAsUser={invitation.invitee}
+                  hideActions={true}
+                />
               </div>
             )}
 


### PR DESCRIPTION
What changed
Responsive date placement
The application/invitation date previously stayed in the top-right corner of each card regardless of viewport width. It now moves into the subline (replacing the username) whenever the name needs to be abbreviated to fit. The transition is synchronised across all cards in a modal — if any card goes narrow, all dates shift together so the layout feels intentional rather than per-card jitter.

The implementation uses a ResizeObserver + a hidden probe span to measure whether the full name fits. When the date is pulled out of the flex flow (position: absolute), the measurement compensates for the freed-up space to prevent oscillation feedback loops. A narrowMap / forceNarrow pattern propagates the narrow state from individual cards up to the modal and back down.

Subline wrapping
The subline (username, location, "Team Member" badge, demo badge) now wraps to a second row instead of clipping items, matching the CardMetaRow behaviour used on team member cards (flex-wrap, gap-y-0, maxHeight: 2.1em).

Unified avatar size
The invitee avatar in TeamInvitesModal was w-10 h-10; both modals are now w-12 h-12, sized to bottom-align with the two-row subline.

Message speech bubbles in detail modals
TeamApplicationDetailsModal and TeamInvitationDetailsModal now display the application/invitation message in a speech bubble with the role card nested inside it (consistent with the list modals). When there is no message, the role card is shown bare. A "You are a member" badge is added to the team card subline for internal applications/invitations.

Collapsible response textarea
The response message field in the invitation and application detail modals is now collapsed by default, matching the pattern in TeamApplicationsModal. It expands on demand with a chevron toggle.

Files changed
src/components/common/PersonRequestCard.jsx — responsive date, forceNarrow sync, subline wrapping, avatar size
src/components/teams/TeamApplicationsModal.jsx — narrowMap state, passes forceNarrow / onNarrowChange to cards
src/components/teams/TeamInvitesModal.jsx — FitInviteeName with forceNarrow, anyNarrow sync, avatar size, subline wrapping
src/components/teams/TeamApplicationDetailsModal.jsx — speech bubble layout, "You are a member" badge
src/components/teams/TeamInvitationDetailsModal.jsx — speech bubble layout, collapsible response textarea, "You are a member" badge