### PR TITLE
UI: Polish pending invites & applications modals

### DIFF
--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -138,7 +138,7 @@ const Modal = ({
       >
         {/* Header */}
         {(title || showCloseButton) && (
-          <div className="flex items-start justify-between p-4 border-b border-base-200">
+          <div className="flex items-start justify-between p-6 border-b border-base-200">
             <div className="flex-1 min-w-0">
               {typeof title === "string" ? (
                 <h2 className="text-lg font-semibold text-primary truncate">
@@ -170,7 +170,7 @@ const Modal = ({
 
         {/* Footer (optional) */}
         {footer && (
-          <div className="p-4 border-t border-base-200 bg-base-100/80">
+          <div className="p-6 border-t border-base-200 bg-base-100/80">
             <ModalLayerProvider zIndex={childLayerZIndex}>
               {footer}
             </ModalLayerProvider>

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -284,7 +284,7 @@ const PersonRequestCard = ({
       {extraContent}
 
       {/* Footer with optional left content and actions */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between mt-8 -mx-4 -mb-4 px-4 pb-4 pt-3 border-t border-base-200 bg-base-100/80 rounded-b-lg">
         {/* Left side (e.g., inviter info) */}
         {footerLeft || <div />}
 

--- a/src/components/common/RequestListModal.jsx
+++ b/src/components/common/RequestListModal.jsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { User } from "lucide-react";
+import { User, X } from "lucide-react";
 import Modal from "./Modal";
 import ScreenAlert from "./ScreenAlert";
+import Button from "./Button";
 
 /**
  * RequestListModal Component
@@ -68,7 +69,7 @@ const RequestListModal = ({
   // Custom header with count
   const customHeader = (
     <div>
-      <h2 className="text-xl font-medium text-primary leading-[120%] mb-[0.2em]">
+      <h2 className="text-xl font-medium text-primary leading-[100%] mb-[0.2em]">
         {subtitle ? `${title} ${subtitle}` : title}
       </h2>
       <p className="text-sm text-base-content/70 mt-1">
@@ -80,11 +81,11 @@ const RequestListModal = ({
   // Footer with summary
   const footer =
     itemCount > 0 ? (
-      <div className="flex justify-between items-center text-sm text-base-content/70">
-        <span>{footerText}</span>
-        <span>
-          Total: {itemCount} {pluralItemName}
-        </span>
+      <div className="flex flex-wrap justify-between items-center gap-y-1 text-sm text-base-content/70">
+        <span className="leading-[1.2]">{footerText}</span>
+        <Button variant="ghost" size="sm" onClick={onClose} icon={<X size={16} />} className="ml-auto w-full sm:w-auto">
+          Close
+        </Button>
       </div>
     ) : null;
 

--- a/src/components/common/RequestListModal.jsx
+++ b/src/components/common/RequestListModal.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { User, X } from "lucide-react";
+import { User, X, Mail } from "lucide-react";
 import Modal from "./Modal";
 import ScreenAlert from "./ScreenAlert";
 import Button from "./Button";
@@ -55,6 +55,9 @@ const RequestListModal = ({
   emptyTitle,
   emptyMessage,
 
+  // Header byline icon (defaults to pink Mail)
+  bylineIcon,
+
   // Content
   children,
 
@@ -70,9 +73,10 @@ const RequestListModal = ({
   const customHeader = (
     <div>
       <h2 className="text-xl font-medium text-primary leading-[100%] mb-[0.2em]">
-        {subtitle ? `${title} ${subtitle}` : title}
+        {typeof title === "string" && subtitle ? `${title} ${subtitle}` : title}
       </h2>
-      <p className="text-sm text-base-content/70 mt-1">
+      <p className="text-sm text-base-content/70 mt-1 flex items-center gap-1.5">
+        {bylineIcon ?? <Mail size={14} className="text-pink-500 shrink-0" />}
         {itemCount} pending {pluralItemName}
       </p>
     </div>

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -6,6 +6,8 @@ import {
   X,
   SendHorizontal,
   FlaskConical,
+  MapPin,
+  Globe,
   Trash2,
 } from "lucide-react";
 import Modal from "../common/Modal";
@@ -37,6 +39,19 @@ const extractRoleMatchData = (roleLike) => {
       roleLike?.scoreBreakdown ??
       null,
   };
+};
+
+const normalizeBoolean = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+
+  if (typeof value === "string") {
+    const normalizedValue = value.trim().toLowerCase();
+    if (["true", "1", "yes"].includes(normalizedValue)) return true;
+    if (["false", "0", "no"].includes(normalizedValue)) return false;
+  }
+
+  return null;
 };
 
 /**
@@ -166,6 +181,25 @@ const TeamApplicationDetailsModal = ({
     return max === null || max === undefined ? "∞" : max;
   };
 
+  const getTeamLocationDetails = () => {
+    const isRemote =
+      normalizeBoolean(team.isRemote ?? team.is_remote) === true;
+    const locationParts = [team.city, team.country].filter(Boolean);
+    const fallbackLocation =
+      typeof team.location === "string"
+        ? team.location
+        : team.postal_code ?? team.postalCode ?? null;
+
+    return {
+      isRemote,
+      locationText: isRemote
+        ? "Remote"
+        : locationParts.length > 0
+          ? locationParts.join(", ")
+          : fallbackLocation,
+    };
+  };
+
   const handleTeamClick = () => {
     if (team?.id) setIsTeamDetailsOpen(true);
   };
@@ -222,6 +256,7 @@ const TeamApplicationDetailsModal = ({
 
   const isInternalRoleApplication =
     application?.isInternalRoleApplication ?? application?.is_internal_role_application ?? false;
+  const teamLocationDetails = getTeamLocationDetails();
   const roleName =
     application?.role?.roleName ?? application?.role?.role_name ?? null;
   const syntheticRoleFlag =
@@ -348,7 +383,7 @@ const TeamApplicationDetailsModal = ({
             className="flex items-start space-x-3 cursor-pointer hover:opacity-80 transition-opacity"
             onClick={handleTeamClick}
           >
-            <Tooltip content="View team details" wrapperClassName="avatar">
+            <Tooltip content="Click to view team details" wrapperClassName="avatar">
               <div className="w-14 h-14 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
@@ -387,7 +422,12 @@ const TeamApplicationDetailsModal = ({
 
             <div className="flex-1 min-w-0">
               <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
-                {team.name || "Unknown Team"}
+                <Tooltip
+                  content="Click to view team details"
+                  wrapperClassName="inline-flex max-w-full min-w-0 align-top"
+                >
+                  <span className="truncate">{team.name || "Unknown Team"}</span>
+                </Tooltip>
               </h4>
               <div className="mt-0.5 flex max-h-[2.75em] flex-wrap items-center gap-x-1.5 gap-y-px overflow-hidden text-sm text-base-content/70">
                 <Tooltip
@@ -399,6 +439,21 @@ const TeamApplicationDetailsModal = ({
                     {getMemberCount()}/{getMaxMembers()}
                   </span>
                 </Tooltip>
+                {teamLocationDetails.locationText && (
+                  <Tooltip
+                    content={teamLocationDetails.locationText}
+                    wrapperClassName="flex min-w-0 max-w-full items-center gap-1 overflow-hidden text-base-content/60 text-sm"
+                  >
+                    {teamLocationDetails.isRemote ? (
+                      <Globe size={14} className="flex-shrink-0" />
+                    ) : (
+                      <MapPin size={14} className="flex-shrink-0" />
+                    )}
+                    <span className="min-w-0 truncate">
+                      {teamLocationDetails.locationText}
+                    </span>
+                  </Tooltip>
+                )}
                 {isInternalRoleApplication && (
                   <Tooltip
                     content="You are already a member of this team"

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -3,6 +3,7 @@ import {
   Calendar,
   Users,
   User,
+  UserSearch,
   X,
   SendHorizontal,
   FlaskConical,
@@ -256,6 +257,11 @@ const TeamApplicationDetailsModal = ({
 
   const isInternalRoleApplication =
     application?.isInternalRoleApplication ?? application?.is_internal_role_application ?? false;
+  const hasRoleApplication = !!(
+    application?.role ||
+    application?.roleId ||
+    application?.role_id
+  );
   const teamLocationDetails = getTeamLocationDetails();
   const roleName =
     application?.role?.roleName ?? application?.role?.role_name ?? null;
@@ -303,15 +309,51 @@ const TeamApplicationDetailsModal = ({
   const customHeader = (
     <div>
       <h2 className="text-xl font-medium text-primary leading-[120%] mb-[0.2em]">
-        {isInternalRoleApplication && roleName
-          ? `Role Application: ${roleName}`
-          : team.name || "Unknown Team"}
+        {isInternalRoleApplication && roleName ? (
+          <span className="flex min-w-0 items-center gap-1.5">
+            <UserSearch size={20} className="shrink-0 text-primary" />
+            <span className="min-w-0 truncate">{roleName}</span>
+          </span>
+        ) : hasRoleApplication ? (
+          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <Users size={20} className="shrink-0 text-primary" />
+              <span>Team</span>
+            </span>
+            <span>and</span>
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <UserSearch size={20} className="shrink-0 text-primary" />
+              <span>Role Application</span>
+            </span>
+          </span>
+        ) : !hasRoleApplication ? (
+          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            <span>Your Application to join</span>
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <Users size={20} className="shrink-0 text-primary" />
+              <span className="min-w-0 truncate">
+                {team.name || "Unknown Team"}
+              </span>
+            </span>
+          </span>
+        ) : (
+          team.name || "Unknown Team"
+        )}
       </h2>
       <p className="text-sm text-base-content/70 flex items-center">
-        <SendHorizontal size={14} className="mr-1.5" />
+        <SendHorizontal
+          size={14}
+          className={`mr-1.5 ${
+            isInternalRoleApplication
+              ? "text-orange-500"
+              : "text-violet-500"
+          }`}
+        />
         {isInternalRoleApplication
-          ? "Role application within your team"
-          : "You applied"}
+          ? "You applied to fill this role within your team"
+          : hasRoleApplication
+            ? "You applied to join a new Team and fill a Role"
+          : "You applied to join"}
       </p>
     </div>
   );
@@ -501,7 +543,7 @@ const TeamApplicationDetailsModal = ({
               <p className="text-sm text-base-content/90 leading-relaxed">
                 {application.message}
               </p>
-              {(application?.role || application?.roleId) && (
+              {hasRoleApplication && (
                 <div className="mt-3 max-w-[300px]">
                   <VacantRoleCard
                     role={roleForCard}
@@ -519,7 +561,7 @@ const TeamApplicationDetailsModal = ({
         )}
 
         {/* Role card bare — shown when no message but role exists */}
-        {!application?.message && (application?.role || application?.roleId) && (
+        {!application?.message && hasRoleApplication && (
           <div className="mb-5 max-w-[300px]">
             <VacantRoleCard
               role={roleForCard}
@@ -534,7 +576,7 @@ const TeamApplicationDetailsModal = ({
         )}
 
         {/* No message fallback — only when no role either */}
-        {!application?.message && !(application?.role || application?.roleId) && (
+        {!application?.message && !hasRoleApplication && (
           <div className="mb-5">
             <p className="text-xs text-base-content/60 mb-0.5 flex items-center">
               <SendHorizontal size={12} className="text-info mr-1" />

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -380,7 +380,7 @@ const TeamApplicationDetailsModal = ({
               : "text-violet-500"
           }`}
         />
-        <span>
+        <span className="leading-[1.2]">
           {isInternalRoleApplication
             ? "You applied to fill this role within your team"
             : hasRoleApplication
@@ -394,16 +394,17 @@ const TeamApplicationDetailsModal = ({
   // Footer with "Received by" (left) and buttons (right)
   // Owner display now matches the inviter display pattern in TeamInvitationDetailsModal
   const footer = (
-    <div className="flex items-center justify-between gap-3">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
       {/* Received by (left) */}
       <InlineUserLink
         label="Received by"
         user={owner}
         onOpenUser={handleUserClick}
+        className="min-w-0 flex-[1_1_12rem] overflow-hidden"
       />
 
       {/* Buttons (right) */}
-      <div className="flex justify-end gap-2">
+      <div className="ml-auto flex flex-wrap justify-end gap-2">
         <Button
           variant="successOutline"
           size="sm"

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -339,33 +339,28 @@ const TeamApplicationDetailsModal = ({
   // Custom header
   const customHeader = (
     <div>
-      <h2 className="text-xl font-medium text-primary leading-[120%] mb-[0.2em]">
+      <h2 className="text-xl font-medium text-primary leading-[100%] mb-[0.2em]">
         {isInternalRoleApplication && roleName ? (
           <span className="flex min-w-0 items-center gap-1.5">
             <UserSearch size={20} className="shrink-0 text-primary" />
             <span className="min-w-0 truncate">{roleName}</span>
           </span>
         ) : hasRoleApplication ? (
-          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
+          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0 leading-[100%] mb-2">
             <span className="inline-flex min-w-0 items-center gap-1.5">
               <Users size={20} className="shrink-0 text-primary" />
               <span>Team</span>
             </span>
-            <span>and</span>
+            <span>{"&"}</span>
             <span className="inline-flex min-w-0 items-center gap-1.5">
               <UserSearch size={20} className="shrink-0 text-primary" />
               <span>Role Application</span>
             </span>
           </span>
         ) : !hasRoleApplication ? (
-          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
-            <span>Your Application to join</span>
-            <span className="inline-flex min-w-0 items-center gap-1.5">
-              <Users size={20} className="shrink-0 text-primary" />
-              <span className="min-w-0 truncate">
-                {teamName}
-              </span>
-            </span>
+          <span className="inline-flex min-w-0 items-center gap-1.5">
+            <Users size={20} className="shrink-0 text-primary" />
+            <span>Team Application</span>
           </span>
         ) : (
           teamName

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useLayoutEffect, useRef, useState } from "react";
 import {
   Calendar,
   Users,
@@ -76,6 +76,12 @@ const TeamApplicationDetailsModal = ({
   const [isTeamDetailsOpen, setIsTeamDetailsOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+  const teamNameContainerRef = useRef(null);
+  const teamNameProbeRef = useRef(null);
+  const teamDateRef = useRef(null);
+  const [teamDateIsNarrow, setTeamDateIsNarrow] = useState(false);
+  const teamDateIsNarrowRef = useRef(false);
+  teamDateIsNarrowRef.current = teamDateIsNarrow;
 
   // ============ Helpers ============
 
@@ -93,6 +99,31 @@ const TeamApplicationDetailsModal = ({
     isSynthetic:
       baseTeam?.isSynthetic ?? baseTeam?.is_synthetic ?? syntheticTeamFlag,
   };
+  const teamName = team.name || "Unknown Team";
+
+  useLayoutEffect(() => {
+    const container = teamNameContainerRef.current;
+    const probe = teamNameProbeRef.current;
+    if (!container || !probe) return;
+
+    const update = () => {
+      const dateEl = teamDateRef.current;
+      const reservedWidth =
+        teamDateIsNarrowRef.current && dateEl ? dateEl.offsetWidth + 16 : 0;
+
+      probe.textContent = teamName;
+      setTeamDateIsNarrow(
+        probe.scrollWidth > container.clientWidth - reservedWidth,
+      );
+    };
+
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(container);
+    if (teamDateRef.current) resizeObserver.observe(teamDateRef.current);
+    update();
+
+    return () => resizeObserver.disconnect();
+  }, [teamName]);
   const roleId = application?.role?.id ?? application?.roleId ?? null;
   const teamId = team?.id ?? null;
   const {
@@ -332,28 +363,30 @@ const TeamApplicationDetailsModal = ({
             <span className="inline-flex min-w-0 items-center gap-1.5">
               <Users size={20} className="shrink-0 text-primary" />
               <span className="min-w-0 truncate">
-                {team.name || "Unknown Team"}
+                {teamName}
               </span>
             </span>
           </span>
         ) : (
-          team.name || "Unknown Team"
+          teamName
         )}
       </h2>
-      <p className="text-sm text-base-content/70 flex items-center">
+      <p className="text-sm text-base-content/70 flex items-start">
         <SendHorizontal
           size={14}
-          className={`mr-1.5 ${
+          className={`mr-1.5 mt-[0.15em] shrink-0 ${
             isInternalRoleApplication
               ? "text-orange-500"
               : "text-violet-500"
           }`}
         />
-        {isInternalRoleApplication
-          ? "You applied to fill this role within your team"
-          : hasRoleApplication
-            ? "You applied to join a new Team and fill a Role"
-          : "You applied to join"}
+        <span>
+          {isInternalRoleApplication
+            ? "You applied to fill this role within your team"
+            : hasRoleApplication
+              ? "You applied to join a new Team and fill a Role"
+            : "You applied to join"}
+        </span>
       </p>
     </div>
   );
@@ -419,14 +452,14 @@ const TeamApplicationDetailsModal = ({
         )}
 
         {/* Top row: Team info (left, clickable) + Date (right) */}
-        <div className="flex items-start justify-between gap-4 mb-5">
+        <div className="relative flex items-start justify-between gap-4 mb-5">
           {/* Team info */}
           <div
-            className="flex items-start space-x-3 cursor-pointer hover:opacity-80 transition-opacity"
+            className="flex min-w-0 flex-1 items-start space-x-4 cursor-pointer hover:opacity-80 transition-opacity"
             onClick={handleTeamClick}
           >
             <Tooltip content="Click to view team details" wrapperClassName="avatar">
-              <div className="w-14 h-14 rounded-full relative overflow-hidden">
+              <div className="w-12 h-12 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
                     src={getTeamAvatar()}
@@ -455,43 +488,64 @@ const TeamApplicationDetailsModal = ({
 
                 {isSyntheticTeam(team) && (
                   <DemoAvatarOverlay
-                    textClassName="text-[7px]"
-                    textTranslateClassName="-translate-y-[3px]"
+                    textClassName="text-[8px]"
+                    textTranslateClassName="-translate-y-[2px]"
                   />
                 )}
               </div>
             </Tooltip>
 
             <div className="flex-1 min-w-0">
-              <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
+              <h4
+                ref={teamNameContainerRef}
+                className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative"
+              >
                 <Tooltip
                   content="Click to view team details"
-                  wrapperClassName="inline-flex max-w-full min-w-0 align-top"
+                  wrapperClassName="cursor-pointer hover:text-primary transition-colors"
                 >
-                  <span className="truncate">{team.name || "Unknown Team"}</span>
+                  <span>{teamName}</span>
                 </Tooltip>
+                <span
+                  ref={teamNameProbeRef}
+                  className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium"
+                  aria-hidden="true"
+                >
+                  {teamName}
+                </span>
               </h4>
-              <div className="mt-0.5 flex max-h-[2.75em] flex-wrap items-center gap-x-1.5 gap-y-px overflow-hidden text-sm text-base-content/70">
+              <div
+                className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs"
+                style={{ maxHeight: "2.1em" }}
+              >
+                {teamDateIsNarrow && (
+                  <div className="flex shrink-0 items-center gap-1 text-base-content/60">
+                    <Calendar size={10} className="shrink-0" />
+                    <span className="leading-[1.05] whitespace-nowrap">
+                      {getApplicationDate()}
+                    </span>
+                  </div>
+                )}
                 <Tooltip
                   content="Team members"
-                  wrapperClassName="flex items-center gap-1 text-base-content/70 text-sm"
+                  wrapperClassName="flex shrink-0 items-center gap-1 text-base-content/70"
                 >
-                  <Users size={14} className="text-primary" />
-                  <span>
+                  <Users size={10} className="shrink-0 text-primary" />
+                  <span className="leading-[1.05] whitespace-nowrap">
                     {getMemberCount()}/{getMaxMembers()}
                   </span>
                 </Tooltip>
                 {teamLocationDetails.locationText && (
                   <Tooltip
                     content={teamLocationDetails.locationText}
-                    wrapperClassName="flex min-w-0 max-w-full items-center gap-1 overflow-hidden text-base-content/60 text-sm"
+                    wrapperClassName="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden"
                   >
                     {teamLocationDetails.isRemote ? (
-                      <Globe size={14} className="flex-shrink-0" />
+                      <Globe size={10} className="shrink-0 text-base-content/60" />
                     ) : (
-                      <MapPin size={14} className="flex-shrink-0" />
+                      <MapPin size={10} className="shrink-0 text-base-content/60" />
                     )}
-                    <span className="min-w-0 truncate">
+                    <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">
                       {teamLocationDetails.locationText}
                     </span>
                   </Tooltip>
@@ -499,19 +553,18 @@ const TeamApplicationDetailsModal = ({
                 {isInternalRoleApplication && (
                   <Tooltip
                     content="You are already a member of this team"
-                    wrapperClassName="flex items-center gap-1 text-base-content/70 text-sm"
+                    wrapperClassName="flex min-w-0 overflow-hidden items-center gap-0.5 text-base-content/70"
                   >
-                    <User size={14} className="flex-shrink-0 text-success" />
-                    <span>You are a member</span>
+                    <User size={10} className="flex-shrink-0 text-success" />
+                    <span className="leading-[1.05] whitespace-nowrap">Team Member</span>
                   </Tooltip>
                 )}
                 {isSyntheticTeam(team) && (
                   <Tooltip
                     content={DEMO_TEAM_TOOLTIP}
-                    wrapperClassName="flex items-center gap-1 text-base-content/50 text-sm"
+                    wrapperClassName="flex shrink-0 items-center gap-0.5 text-base-content/50"
                   >
-                    <FlaskConical size={14} className="flex-shrink-0" />
-                    <span>Demo Team</span>
+                    <FlaskConical size={10} className="flex-shrink-0" />
                   </Tooltip>
                 )}
               </div>
@@ -519,7 +572,10 @@ const TeamApplicationDetailsModal = ({
           </div>
 
           {/* Date - top right */}
-          <div className="flex items-center text-xs text-base-content/60 whitespace-nowrap">
+          <div
+            ref={teamDateRef}
+            className={`flex items-center text-xs text-base-content/60 whitespace-nowrap flex-shrink-0${teamDateIsNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
+          >
             <Calendar size={12} className="mr-1" />
             <span>{getApplicationDate()}</span>
           </div>

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Check, UserCheck, X as Decline, User, Mail, MessageSquare, AlertTriangle, ChevronDown, ChevronUp, Pencil } from "lucide-react";
+import { Check, CheckCheck, UserCheck, X as Decline, User, Mail, MessageSquare, AlertTriangle, ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
 import PersonRequestCard from "../common/PersonRequestCard";
 import Button from "../common/Button";
@@ -876,37 +876,74 @@ const TeamApplicationsModal = ({
                   </div>
                 ) : (
                   <div className="flex flex-wrap justify-end gap-2">
-                    {isRoleUnavailable && (isExternalRoleApplication || isInternalRoleApplication) && (
-                      <Tooltip content={unavailableTooltip}>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          disabled={true}
-                          className="border border-base-content/30 text-base-content/40"
-                          icon={<UserCheck size={16} />}
-                        >
-                          {isInternalRoleApplication ? "Accept & Fill Role" : "Fill Role & Add to Team"}
-                        </Button>
-                      </Tooltip>
-                    )}
-                    <Button
-                      variant="errorOutline"
-                      size="sm"
-                      onClick={() =>
-                        handleApplicationAction(
-                          application.id,
-                          "decline",
-                          responses[application.id] || ""
-                        )
-                      }
-                      disabled={loading}
-                      icon={<Decline size={16} />}
-                    >
-                      Decline
-                    </Button>
                     {isExternalRoleApplication ? (
                       <>
-                        {!isRoleUnavailable && (
+                        {isRoleUnavailable ? (
+                          <Tooltip content={unavailableTooltip}>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={true}
+                              className="border border-base-content/30 text-base-content/40"
+                              icon={<UserCheck size={16} />}
+                            >
+                              Fill Role + Add to Team
+                            </Button>
+                          </Tooltip>
+                        ) : (
+                          <Tooltip content="Accept application, add to team and fill the role">
+                            <Button
+                              variant="successOutline"
+                              size="sm"
+                              onClick={() =>
+                                handleApplicationAction(
+                                  application.id,
+                                  "approve",
+                                  responses[application.id] || "",
+                                  true
+                                )
+                              }
+                              disabled={loading}
+                              icon={<CheckCheck size={16} />}
+                            >
+                              Fill Role + Add to Team
+                            </Button>
+                          </Tooltip>
+                        )}
+                        <Tooltip content="Accept application and add to team without filling the role">
+                          <Button
+                            variant="successOutline"
+                            size="sm"
+                            onClick={() =>
+                              handleApplicationAction(
+                                application.id,
+                                "approve",
+                                responses[application.id] || "",
+                                false
+                              )
+                            }
+                            disabled={loading}
+                            icon={<Check size={16} />}
+                          >
+                            Add to Team
+                          </Button>
+                        </Tooltip>
+                      </>
+                    ) : isInternalRoleApplication ? (
+                      isRoleUnavailable ? (
+                        <Tooltip content={unavailableTooltip}>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            disabled={true}
+                            className="border border-base-content/30 text-base-content/40"
+                            icon={<UserCheck size={16} />}
+                          >
+                            Fill Role
+                          </Button>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip content="Accept application and assign this team member to the role">
                           <Button
                             variant="successOutline"
                             size="sm"
@@ -921,9 +958,12 @@ const TeamApplicationsModal = ({
                             disabled={loading}
                             icon={<Check size={16} />}
                           >
-                            Fill Role & Add to Team
+                            Fill Role
                           </Button>
-                        )}
+                        </Tooltip>
+                      )
+                    ) : (
+                      <Tooltip content="Accept application and add to team">
                         <Button
                           variant="successOutline"
                           size="sm"
@@ -938,27 +978,27 @@ const TeamApplicationsModal = ({
                           disabled={loading}
                           icon={<Check size={16} />}
                         >
-                          Add to Team Only
+                          Add to Team
                         </Button>
-                      </>
-                    ) : isInternalRoleApplication && isRoleUnavailable ? null : (
+                      </Tooltip>
+                    )}
+                    <Tooltip content="Decline this application">
                       <Button
-                        variant="successOutline"
+                        variant="errorOutline"
                         size="sm"
                         onClick={() =>
                           handleApplicationAction(
                             application.id,
-                            "approve",
-                            responses[application.id] || "",
-                            isInternalRoleApplication
+                            "decline",
+                            responses[application.id] || ""
                           )
                         }
                         disabled={loading}
-                        icon={<Check size={16} />}
+                        icon={<Decline size={16} />}
                       >
-                        {isInternalRoleApplication ? "Accept & Fill Role" : "Accept & Add to Team"}
+                        Decline
                       </Button>
-                    )}
+                    </Tooltip>
                   </div>
                 )
               }

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Check, CheckCheck, UserCheck, X as Decline, User, Mail, MessageSquare, AlertTriangle, ChevronDown, ChevronUp, Pencil } from "lucide-react";
+import { Check, CheckCheck, UserCheck, X as Decline, User, Users, Mail, MessageSquare, AlertTriangle, ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
 import PersonRequestCard from "../common/PersonRequestCard";
 import Button from "../common/Button";
@@ -12,6 +12,7 @@ import { matchingService } from "../../services/matchingService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { messageService } from "../../services/messageService";
 import { useAuth } from "../../contexts/AuthContext";
+import { useTeamModal } from "../../contexts/TeamModalContext";
 import { buildRoleApplicationFilledMessage } from "../../utils/roleEventMessages";
 
 const ROLE_CANDIDATE_FETCH_MIN_LIMIT = 20;
@@ -62,6 +63,7 @@ const TeamApplicationsModal = ({
 }) => {
   // ============ Auth ============
   const { user: currentUser } = useAuth();
+  const { openTeamModal } = useTeamModal();
 
   // ============ State ============
   const [loading, setLoading] = useState(false);
@@ -539,8 +541,18 @@ const TeamApplicationsModal = ({
     <RequestListModal
       isOpen={isOpen}
       onClose={handleClose}
-      title="Applications received for"
-      subtitle={teamName}
+      title={
+        <span className="leading-[100%]">
+          <Users size={20} className="inline-block align-middle mr-1.5 shrink-0 text-primary" />
+          <Tooltip content="View team" wrapperClassName="inline">
+            <span
+              className="font-semibold text-success cursor-pointer hover:text-success/70 transition-colors"
+              onClick={() => teamId && openTeamModal(teamId, teamName)}
+            >{teamName}</span>
+          </Tooltip>
+          <span>'s Applications</span>
+        </span>
+      }
       itemCount={applications.length}
       itemName="application"
       footerText="Review each application carefully before making decisions."

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useLayoutEffect, useRef, useState } from "react";
 import {
   Calendar,
   MessageSquare,
@@ -219,6 +219,12 @@ const TeamInvitationDetailsModal = ({
   const [responseExpanded, setResponseExpanded] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [isTeamDetailsOpen, setIsTeamDetailsOpen] = useState(false);
+  const teamNameContainerRef = useRef(null);
+  const teamNameProbeRef = useRef(null);
+  const teamDateRef = useRef(null);
+  const [teamDateIsNarrow, setTeamDateIsNarrow] = useState(false);
+  const teamDateIsNarrowRef = useRef(false);
+  teamDateIsNarrowRef.current = teamDateIsNarrow;
 
   // ============ Helpers ============
 
@@ -236,6 +242,31 @@ const TeamInvitationDetailsModal = ({
     isSynthetic:
       baseTeam?.isSynthetic ?? baseTeam?.is_synthetic ?? syntheticTeamFlag,
   };
+  const teamName = team.name || "Unknown Team";
+
+  useLayoutEffect(() => {
+    const container = teamNameContainerRef.current;
+    const probe = teamNameProbeRef.current;
+    if (!container || !probe) return;
+
+    const update = () => {
+      const dateEl = teamDateRef.current;
+      const reservedWidth =
+        teamDateIsNarrowRef.current && dateEl ? dateEl.offsetWidth + 16 : 0;
+
+      probe.textContent = teamName;
+      setTeamDateIsNarrow(
+        probe.scrollWidth > container.clientWidth - reservedWidth,
+      );
+    };
+
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(container);
+    if (teamDateRef.current) resizeObserver.observe(teamDateRef.current);
+    update();
+
+    return () => resizeObserver.disconnect();
+  }, [teamName]);
   const roleId =
     invitation?.role?.id ?? invitation?.roleId ?? invitation?.role_id ?? null;
   const teamId = team?.id ?? null;
@@ -573,22 +604,22 @@ const TeamInvitationDetailsModal = ({
             <span className="inline-flex min-w-0 items-center gap-1.5">
               <Users size={20} className="shrink-0 text-primary" />
               <span className="min-w-0 truncate">
-                {team.name || "Unknown Team"}
+                {teamName}
               </span>
             </span>
           </span>
         ) : (
-          team.name || "Unknown Team"
+          teamName
         )}
       </h2>
-      <p className="text-sm text-base-content/70 flex items-center">
+      <p className="text-sm text-base-content/70 flex items-start">
         <MailOpen
           size={14}
-          className={`mr-1.5 ${
+          className={`mr-1.5 mt-[0.15em] shrink-0 ${
             inviteeAlreadyTeamMember ? "text-orange-500" : "text-pink-500"
           }`}
         />
-        {headerSubtitle}
+        <span>{headerSubtitle}</span>
       </p>
     </div>
   );
@@ -728,14 +759,14 @@ const TeamInvitationDetailsModal = ({
         )}
 
         {/* Top row: Team info (left, clickable) + Date (right) */}
-        <div className="flex items-start justify-between gap-4 mb-5">
+        <div className="relative flex items-start justify-between gap-4 mb-5">
           {/* Team info (hover + onClick like in TeamInvitesModal) */}
           <div
-            className="flex items-start space-x-3 cursor-pointer hover:opacity-80 transition-opacity"
+            className="flex min-w-0 flex-1 items-start space-x-4 cursor-pointer hover:opacity-80 transition-opacity"
             onClick={handleTeamClick}
           >
             <Tooltip content="Click to view team details" wrapperClassName="avatar">
-              <div className="w-14 h-14 rounded-full relative overflow-hidden">
+              <div className="w-12 h-12 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
                     src={getTeamAvatar()}
@@ -764,43 +795,64 @@ const TeamInvitationDetailsModal = ({
 
                 {isSyntheticTeam(team) && (
                   <DemoAvatarOverlay
-                    textClassName="text-[7px]"
-                    textTranslateClassName="-translate-y-[3px]"
+                    textClassName="text-[8px]"
+                    textTranslateClassName="-translate-y-[2px]"
                   />
                 )}
               </div>
             </Tooltip>
 
             <div className="flex-1 min-w-0">
-              <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
+              <h4
+                ref={teamNameContainerRef}
+                className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative"
+              >
                 <Tooltip
                   content="Click to view team details"
-                  wrapperClassName="inline-flex max-w-full min-w-0 align-top"
+                  wrapperClassName="cursor-pointer hover:text-primary transition-colors"
                 >
-                  <span className="truncate">{team.name || "Unknown Team"}</span>
+                  <span>{teamName}</span>
                 </Tooltip>
+                <span
+                  ref={teamNameProbeRef}
+                  className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium"
+                  aria-hidden="true"
+                >
+                  {teamName}
+                </span>
               </h4>
-              <div className="mt-0.5 flex max-h-[2.75em] flex-wrap items-center gap-x-1.5 gap-y-px overflow-hidden text-sm text-base-content/70">
+              <div
+                className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs"
+                style={{ maxHeight: "2.1em" }}
+              >
+                {teamDateIsNarrow && (
+                  <div className="flex shrink-0 items-center gap-1 text-base-content/60">
+                    <Calendar size={10} className="shrink-0" />
+                    <span className="leading-[1.05] whitespace-nowrap">
+                      {getInvitationDate()}
+                    </span>
+                  </div>
+                )}
                 <Tooltip
                   content="Team members"
-                  wrapperClassName="flex items-center gap-1 text-base-content/70 text-sm"
+                  wrapperClassName="flex shrink-0 items-center gap-1 text-base-content/70"
                 >
-                  <Users size={14} className="text-primary" />
-                  <span>
+                  <Users size={10} className="shrink-0 text-primary" />
+                  <span className="leading-[1.05] whitespace-nowrap">
                     {getMemberCount()}/{getMaxMembers()}
                   </span>
                 </Tooltip>
                 {teamLocationDetails.locationText && (
                   <Tooltip
                     content={teamLocationDetails.locationText}
-                    wrapperClassName="flex min-w-0 max-w-full items-center gap-1 overflow-hidden text-base-content/60 text-sm"
+                    wrapperClassName="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden"
                   >
                     {teamLocationDetails.isRemote ? (
-                      <Globe size={14} className="flex-shrink-0" />
+                      <Globe size={10} className="shrink-0 text-base-content/60" />
                     ) : (
-                      <MapPin size={14} className="flex-shrink-0" />
+                      <MapPin size={10} className="shrink-0 text-base-content/60" />
                     )}
-                    <span className="min-w-0 truncate">
+                    <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">
                       {teamLocationDetails.locationText}
                     </span>
                   </Tooltip>
@@ -808,19 +860,18 @@ const TeamInvitationDetailsModal = ({
                 {inviteeAlreadyTeamMember && (
                   <Tooltip
                     content="You are already a member of this team"
-                    wrapperClassName="flex items-center gap-1 text-base-content/70 text-sm"
+                    wrapperClassName="flex min-w-0 overflow-hidden items-center gap-0.5 text-base-content/70"
                   >
-                    <User size={14} className="flex-shrink-0 text-success" />
-                    <span>You are a member</span>
+                    <User size={10} className="flex-shrink-0 text-success" />
+                    <span className="leading-[1.05] whitespace-nowrap">Team Member</span>
                   </Tooltip>
                 )}
                 {isSyntheticTeam(team) && (
                   <Tooltip
                     content={DEMO_TEAM_TOOLTIP}
-                    wrapperClassName="flex items-center gap-1 text-base-content/50 text-sm"
+                    wrapperClassName="flex shrink-0 items-center gap-0.5 text-base-content/50"
                   >
-                    <FlaskConical size={14} className="flex-shrink-0" />
-                    <span>Demo Team</span>
+                    <FlaskConical size={10} className="flex-shrink-0" />
                   </Tooltip>
                 )}
               </div>
@@ -828,7 +879,10 @@ const TeamInvitationDetailsModal = ({
           </div>
 
           {/* Date - top right */}
-          <div className="flex items-center text-xs text-base-content/60 whitespace-nowrap">
+          <div
+            ref={teamDateRef}
+            className={`flex items-center text-xs text-base-content/60 whitespace-nowrap flex-shrink-0${teamDateIsNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
+          >
             <Calendar size={12} className="mr-1" />
             <span>{getInvitationDate()}</span>
           </div>

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -4,6 +4,7 @@ import {
   MessageSquare,
   Users,
   Check,
+  CheckCheck,
   User,
   UserCheck,
   UserSearch,
@@ -580,7 +581,7 @@ const TeamInvitationDetailsModal = ({
   // Custom header
   const customHeader = (
     <div>
-      <h2 className="text-xl font-medium text-primary leading-[120%] mb-[0.2em]">
+      <h2 className="text-xl font-medium text-primary leading-[100%] mb-[0.2em]">
         {inviteeAlreadyTeamMember && hasRoleInvitation && invitationRoleName ? (
           <span className="flex min-w-0 items-center gap-1.5">
             <UserSearch size={20} className="shrink-0 text-primary" />
@@ -592,21 +593,16 @@ const TeamInvitationDetailsModal = ({
               <Users size={20} className="shrink-0 text-primary" />
               <span>Team</span>
             </span>
-            <span>and</span>
+            <span>{"&"}</span>
             <span className="inline-flex min-w-0 items-center gap-1.5">
               <UserSearch size={20} className="shrink-0 text-primary" />
               <span>Role Invitation</span>
             </span>
           </span>
         ) : !hasRoleInvitation ? (
-          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
-            <span>Invitation to join</span>
-            <span className="inline-flex min-w-0 items-center gap-1.5">
-              <Users size={20} className="shrink-0 text-primary" />
-              <span className="min-w-0 truncate">
-                {teamName}
-              </span>
-            </span>
+          <span className="inline-flex min-w-0 items-center gap-1.5">
+            <Users size={20} className="shrink-0 text-primary" />
+            <span>Team Invitation</span>
           </span>
         ) : (
           teamName
@@ -637,101 +633,110 @@ const TeamInvitationDetailsModal = ({
 
       {/* Buttons — right-aligned and allowed to wrap on narrow screens */}
       <div className="ml-auto flex flex-wrap justify-end gap-2">
-          {isRoleUnavailable && (
-            <Tooltip
-              content={
-                inviteeAlreadyTeamMember
-                  ? (isRoleFilled ? "This role is already filled" : "This role is closed")
-                  : (isRoleFilled
-                      ? "This role is already filled — you can still join the team"
-                      : "This role is closed — you can still join the team")
-              }
-            >
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={true}
-                className="border border-base-content/30 text-base-content/40"
-                icon={<UserCheck size={16} />}
-              >
-                {inviteeAlreadyTeamMember ? "Accept Role" : "Accept & Fill Role"}
-              </Button>
-            </Tooltip>
-          )}
-          <Button
-            variant="errorOutline"
-            size="sm"
-            onClick={handleDecline}
-            disabled={isControlsDisabled}
-            icon={<X size={16} />}
-          >
-            {isDeclineLoading ? "Declining..." : "Decline"}
-          </Button>
           {hasRoleInvitation && inviteeAlreadyTeamMember ? (
-            // Internal role invite: user is already a member, just accept/fill the role
-            !isRoleUnavailable && (
-              canSwitchRole ? (
-                <Tooltip
-                  content={`Leave ${currentFilledRoleName} and fill this role instead.`}
-                >
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    onClick={handleSwitchRole}
-                    disabled={isControlsDisabled}
-                    icon={<ArrowRightLeft size={16} />}
-                  >
-                    {isSwitchRoleLoading ? "Switching..." : "Leave old role to fill new role"}
-                  </Button>
-                </Tooltip>
-              ) : (
+            // Internal role invite: user is already a member, just fill the role
+            isRoleUnavailable ? (
+              <Tooltip content={isRoleFilled ? "This role is already filled" : "This role is closed"}>
                 <Button
-                  variant="primary"
+                  variant="ghost"
+                  size="sm"
+                  disabled={true}
+                  className="border border-base-content/30 text-base-content/40"
+                  icon={<UserCheck size={16} />}
+                >
+                  Fill Role
+                </Button>
+              </Tooltip>
+            ) : canSwitchRole ? (
+              <Tooltip content={`Leave ${currentFilledRoleName} and fill this role instead.`}>
+                <Button
+                  variant="successOutline"
+                  size="sm"
+                  onClick={handleSwitchRole}
+                  disabled={isControlsDisabled}
+                  icon={<ArrowRightLeft size={16} />}
+                >
+                  {isSwitchRoleLoading ? "Switching..." : "Switch Role"}
+                </Button>
+              </Tooltip>
+            ) : (
+              <Tooltip content="Accept this role invitation">
+                <Button
+                  variant="successOutline"
                   size="sm"
                   onClick={handleAcceptWithRole}
                   disabled={isControlsDisabled}
                   icon={<Check size={16} />}
                 >
-                  {isAcceptRoleLoading ? "Accepting..." : "Accept Role"}
+                  {isAcceptRoleLoading ? "Accepting..." : "Fill Role"}
                 </Button>
-              )
+              </Tooltip>
             )
           ) : hasRoleInvitation ? (
             // External invite with a role: offer team-only or fill-role options
             <>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleAcceptTeamOnly}
-                disabled={isControlsDisabled}
-                icon={<UserPlus size={16} />}
-              >
-                {isAcceptTeamLoading ? "Joining..." : "Join Team Only"}
-              </Button>
-              {!isRoleUnavailable && (
+              {isRoleUnavailable ? (
+                <Tooltip content={isRoleFilled ? "This role is already filled — you can still join the team" : "This role is closed — you can still join the team"}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={true}
+                    className="border border-base-content/30 text-base-content/40"
+                    icon={<UserCheck size={16} />}
+                  >
+                    Fill Role + Join Team
+                  </Button>
+                </Tooltip>
+              ) : (
+                <Tooltip content="Join the team and fill the role">
+                  <Button
+                    variant="successOutline"
+                    size="sm"
+                    onClick={handleAcceptWithRole}
+                    disabled={isControlsDisabled}
+                    icon={<CheckCheck size={16} />}
+                  >
+                    {isAcceptRoleLoading ? "Joining..." : "Fill Role + Join Team"}
+                  </Button>
+                </Tooltip>
+              )}
+              <Tooltip content="Join the team without filling the role">
                 <Button
-                  variant="primary"
+                  variant="successOutline"
                   size="sm"
-                  onClick={handleAcceptWithRole}
+                  onClick={handleAcceptTeamOnly}
                   disabled={isControlsDisabled}
                   icon={<Check size={16} />}
                 >
-                  {isAcceptRoleLoading ? "Joining..." : "Accept & Fill Role"}
+                  {isAcceptTeamLoading ? "Joining..." : "Join Team"}
                 </Button>
-              )}
+              </Tooltip>
             </>
           ) : (
             // No role: simple accept
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={handleAcceptTeamOnly}
-              disabled={isControlsDisabled}
-              icon={<Check size={16} />}
-            >
-              {isAcceptTeamLoading ? "Joining..." : "Accept"}
-            </Button>
+            <Tooltip content="Accept this team invitation">
+              <Button
+                variant="successOutline"
+                size="sm"
+                onClick={handleAcceptTeamOnly}
+                disabled={isControlsDisabled}
+                icon={<Check size={16} />}
+              >
+                {isAcceptTeamLoading ? "Joining..." : "Join Team"}
+              </Button>
+            </Tooltip>
           )}
+          <Tooltip content="Decline this invitation">
+            <Button
+              variant="errorOutline"
+              size="sm"
+              onClick={handleDecline}
+              disabled={isControlsDisabled}
+              icon={<X size={16} />}
+            >
+              {isDeclineLoading ? "Declining..." : "Decline"}
+            </Button>
+          </Tooltip>
         </div>
     </div>
   );

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -10,6 +10,8 @@ import {
   MailOpen,
   UserPlus,
   FlaskConical,
+  MapPin,
+  Globe,
   ArrowRightLeft,
   ChevronDown,
   ChevronUp,
@@ -41,6 +43,148 @@ const extractRoleMatchData = (roleLike) => {
       roleLike?.scoreBreakdown ??
       null,
   };
+};
+
+const normalizeBoolean = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+
+  if (typeof value === "string") {
+    const normalizedValue = value.trim().toLowerCase();
+    if (["true", "1", "yes"].includes(normalizedValue)) return true;
+    if (["false", "0", "no"].includes(normalizedValue)) return false;
+  }
+
+  return null;
+};
+
+const idsMatch = (left, right) => {
+  if (left === null || left === undefined || right === null || right === undefined) {
+    return false;
+  }
+
+  return String(left) === String(right);
+};
+
+const isExistingMemberStatus = (value) => {
+  if (typeof value !== "string") return false;
+
+  const normalizedValue = value.trim().toLowerCase();
+  return (
+    normalizedValue === "member" ||
+    normalizedValue === "existing-member" ||
+    normalizedValue === "existing_member"
+  );
+};
+
+const getMemberUserId = (member) => {
+  const memberUser = member?.user || member;
+
+  return (
+    member?.userId ??
+    member?.user_id ??
+    member?.memberId ??
+    member?.member_id ??
+    memberUser?.userId ??
+    memberUser?.user_id ??
+    memberUser?.id ??
+    member?.id ??
+    null
+  );
+};
+
+const isInviteeExistingTeamMember = ({ invitation, team, currentUser }) => {
+  const inviteeId =
+    invitation?.invitee?.id ??
+    invitation?.inviteeId ??
+    invitation?.invitee_id ??
+    currentUser?.id ??
+    null;
+
+  if (!team || inviteeId === null || inviteeId === undefined) return false;
+
+  const directFlags = [
+    invitation?.isInternal,
+    invitation?.is_internal,
+    invitation?.isInviteeMember,
+    invitation?.is_invitee_member,
+    invitation?.inviteeIsMember,
+    invitation?.invitee_is_member,
+    invitation?.alreadyMember,
+    invitation?.already_member,
+    invitation?.isExistingMember,
+    invitation?.is_existing_member,
+    invitation?.existingMember,
+    invitation?.existing_member,
+    invitation?.currentUserIsMember,
+    invitation?.current_user_is_member,
+    team?.isInviteeMember,
+    team?.is_invitee_member,
+    team?.inviteeIsMember,
+    team?.invitee_is_member,
+    team?.alreadyMember,
+    team?.already_member,
+    team?.isExistingMember,
+    team?.is_existing_member,
+    team?.existingMember,
+    team?.existing_member,
+    team?.currentUserIsMember,
+    team?.current_user_is_member,
+  ];
+
+  if (directFlags.some((flag) => normalizeBoolean(flag) === true)) {
+    return true;
+  }
+
+  const membershipStatuses = [
+    invitation?.inviteeMembershipStatus,
+    invitation?.invitee_membership_status,
+    invitation?.membershipStatus,
+    invitation?.membership_status,
+    invitation?.inviteeStatus,
+    invitation?.invitee_status,
+    team?.inviteeMembershipStatus,
+    team?.invitee_membership_status,
+    team?.membershipStatus,
+    team?.membership_status,
+    team?.inviteeStatus,
+    team?.invitee_status,
+  ];
+
+  if (membershipStatuses.some(isExistingMemberStatus)) {
+    return true;
+  }
+
+  if (idsMatch(team?.owner_id ?? team?.ownerId, inviteeId)) {
+    return true;
+  }
+
+  const memberCollections = [
+    team?.members,
+    team?.teamMembers,
+    team?.team_members,
+  ].filter(Array.isArray);
+
+  if (
+    memberCollections.some((members) =>
+      members.some((member) => idsMatch(getMemberUserId(member), inviteeId)),
+    )
+  ) {
+    return true;
+  }
+
+  const memberIdLists = [
+    team?.memberIds,
+    team?.member_ids,
+    team?.memberUserIds,
+    team?.member_user_ids,
+    team?.teamMemberIds,
+    team?.team_member_ids,
+  ].filter(Array.isArray);
+
+  return memberIdLists.some((memberIds) =>
+    memberIds.some((memberId) => idsMatch(memberId, inviteeId)),
+  );
 };
 
 /**
@@ -187,6 +331,25 @@ const TeamInvitationDetailsModal = ({
     return max === null || max === undefined ? "∞" : max;
   };
 
+  const getTeamLocationDetails = () => {
+    const isRemote =
+      normalizeBoolean(team.isRemote ?? team.is_remote) === true;
+    const locationParts = [team.city, team.country].filter(Boolean);
+    const fallbackLocation =
+      typeof team.location === "string"
+        ? team.location
+        : team.postal_code ?? team.postalCode ?? null;
+
+    return {
+      isRemote,
+      locationText: isRemote
+        ? "Remote"
+        : locationParts.length > 0
+          ? locationParts.join(", ")
+          : fallbackLocation,
+    };
+  };
+
   const handleTeamClick = () => {
     if (team?.id) setIsTeamDetailsOpen(true);
   };
@@ -258,7 +421,11 @@ const TeamInvitationDetailsModal = ({
   // ============ Render ============
 
   const hasRoleInvitation = !!(invitation?.role_id ?? invitation?.roleId ?? invitation?.role?.id);
-  const isInternal = invitation?.isInternal ?? invitation?.is_internal ?? false;
+  const isInternal =
+    normalizeBoolean(invitation?.isInternal ?? invitation?.is_internal) === true;
+  const inviteeAlreadyTeamMember =
+    isInternal ||
+    isInviteeExistingTeamMember({ invitation, team, currentUser });
   const isAcceptRoleLoading = actionLoading === "acceptRole";
   const isSwitchRoleLoading = actionLoading === "switchRole";
   const isAcceptTeamLoading = actionLoading === "acceptTeam";
@@ -266,10 +433,13 @@ const TeamInvitationDetailsModal = ({
   const isActionPending =
     isAcceptRoleLoading || isSwitchRoleLoading || isAcceptTeamLoading || isDeclineLoading;
   const isControlsDisabled = loading || isActionPending;
+  const teamLocationDetails = getTeamLocationDetails();
 
   const headerSubtitle = isInternal
     ? "You've been invited to fill a role!"
-    : hasRoleInvitation
+    : inviteeAlreadyTeamMember && hasRoleInvitation
+      ? "You've been invited to fill a role!"
+      : hasRoleInvitation
       ? "You are invited for a role!"
       : "You are invited!";
   const syntheticRoleFlag =
@@ -362,7 +532,7 @@ const TeamInvitationDetailsModal = ({
     : null;
   const canSwitchRole =
     hasRoleInvitation &&
-    isInternal &&
+    inviteeAlreadyTeamMember &&
     !isRoleUnavailable &&
     Boolean(currentFilledRole?.id ?? invitation?.current_filled_role_id ?? invitation?.currentFilledRoleId);
 
@@ -373,7 +543,7 @@ const TeamInvitationDetailsModal = ({
         {team.name || "Unknown Team"}
       </h2>
       <p className="text-sm text-base-content/70 flex items-center">
-        <MailOpen size={14} className={`mr-1.5 ${isInternal ? "text-orange-500" : ""}`} />
+        <MailOpen size={14} className={`mr-1.5 ${inviteeAlreadyTeamMember ? "text-orange-500" : ""}`} />
         {headerSubtitle}
       </p>
     </div>
@@ -394,7 +564,7 @@ const TeamInvitationDetailsModal = ({
           {isRoleUnavailable && (
             <Tooltip
               content={
-                isInternal
+                inviteeAlreadyTeamMember
                   ? (isRoleFilled ? "This role is already filled" : "This role is closed")
                   : (isRoleFilled
                       ? "This role is already filled — you can still join the team"
@@ -408,7 +578,7 @@ const TeamInvitationDetailsModal = ({
                 className="border border-base-content/30 text-base-content/40"
                 icon={<UserCheck size={16} />}
               >
-                {isInternal ? "Accept Role" : "Accept & Fill Role"}
+                {inviteeAlreadyTeamMember ? "Accept Role" : "Accept & Fill Role"}
               </Button>
             </Tooltip>
           )}
@@ -421,7 +591,7 @@ const TeamInvitationDetailsModal = ({
           >
             {isDeclineLoading ? "Declining..." : "Decline"}
           </Button>
-          {hasRoleInvitation && isInternal ? (
+          {hasRoleInvitation && inviteeAlreadyTeamMember ? (
             // Internal role invite: user is already a member, just accept/fill the role
             !isRoleUnavailable && (
               canSwitchRole ? (
@@ -520,7 +690,7 @@ const TeamInvitationDetailsModal = ({
             className="flex items-start space-x-3 cursor-pointer hover:opacity-80 transition-opacity"
             onClick={handleTeamClick}
           >
-            <Tooltip content="View team details" wrapperClassName="avatar">
+            <Tooltip content="Click to view team details" wrapperClassName="avatar">
               <div className="w-14 h-14 rounded-full relative overflow-hidden">
                 {getTeamAvatar() ? (
                   <img
@@ -559,7 +729,12 @@ const TeamInvitationDetailsModal = ({
 
             <div className="flex-1 min-w-0">
               <h4 className="font-medium text-base-content hover:text-primary transition-colors leading-[120%] mb-[0.2em]">
-                {team.name || "Unknown Team"}
+                <Tooltip
+                  content="Click to view team details"
+                  wrapperClassName="inline-flex max-w-full min-w-0 align-top"
+                >
+                  <span className="truncate">{team.name || "Unknown Team"}</span>
+                </Tooltip>
               </h4>
               <div className="mt-0.5 flex max-h-[2.75em] flex-wrap items-center gap-x-1.5 gap-y-px overflow-hidden text-sm text-base-content/70">
                 <Tooltip
@@ -571,7 +746,22 @@ const TeamInvitationDetailsModal = ({
                     {getMemberCount()}/{getMaxMembers()}
                   </span>
                 </Tooltip>
-                {isInternal && (
+                {teamLocationDetails.locationText && (
+                  <Tooltip
+                    content={teamLocationDetails.locationText}
+                    wrapperClassName="flex min-w-0 max-w-full items-center gap-1 overflow-hidden text-base-content/60 text-sm"
+                  >
+                    {teamLocationDetails.isRemote ? (
+                      <Globe size={14} className="flex-shrink-0" />
+                    ) : (
+                      <MapPin size={14} className="flex-shrink-0" />
+                    )}
+                    <span className="min-w-0 truncate">
+                      {teamLocationDetails.locationText}
+                    </span>
+                  </Tooltip>
+                )}
+                {inviteeAlreadyTeamMember && (
                   <Tooltip
                     content="You are already a member of this team"
                     wrapperClassName="flex items-center gap-1 text-base-content/70 text-sm"
@@ -617,7 +807,7 @@ const TeamInvitationDetailsModal = ({
             <div className="w-fit max-w-full bg-base-200 rounded-lg rounded-bl-none p-3">
               <p className="text-sm text-base-content/90 leading-relaxed">
                 {(() => {
-                  if (isInternal && currentFilledRoleName && currentFilledRoleName !== "your current role") {
+                  if (inviteeAlreadyTeamMember && currentFilledRoleName && currentFilledRoleName !== "your current role") {
                     const suffix = ` ${currentFilledRoleName}.`;
                     return invitation.message.endsWith(suffix)
                       ? invitation.message.slice(0, -suffix.length)
@@ -634,13 +824,13 @@ const TeamInvitationDetailsModal = ({
                     matchScore={roleMatchScore}
                     matchDetails={roleMatchDetails}
                     canManage={false}
-                    isTeamMember={false}
+                    isTeamMember={inviteeAlreadyTeamMember}
                     hideActions={true}
                     notificationHighlight={notificationHighlight}
                   />
                 </div>
               )}
-              {isInternal && currentFilledRoleForCard && (
+              {inviteeAlreadyTeamMember && currentFilledRoleForCard && (
                 <div className="mt-3 max-w-[300px]">
                   <VacantRoleCard
                     role={currentFilledRoleForCard}
@@ -665,7 +855,7 @@ const TeamInvitationDetailsModal = ({
               matchScore={roleMatchScore}
               matchDetails={roleMatchDetails}
               canManage={false}
-              isTeamMember={false}
+              isTeamMember={inviteeAlreadyTeamMember}
               hideActions={true}
               notificationHighlight={notificationHighlight}
             />

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -619,7 +619,7 @@ const TeamInvitationDetailsModal = ({
             inviteeAlreadyTeamMember ? "text-orange-500" : "text-pink-500"
           }`}
         />
-        <span>{headerSubtitle}</span>
+        <span className="leading-[1.2]">{headerSubtitle}</span>
       </p>
     </div>
   );
@@ -632,10 +632,11 @@ const TeamInvitationDetailsModal = ({
         label="Invite sent by"
         user={inviter}
         onOpenUser={handleUserClick}
+        className="min-w-0 flex-[1_1_12rem] overflow-hidden"
       />
 
-      {/* Buttons — right-aligned, never wrap internally */}
-      <div className="flex flex-nowrap gap-2 ml-auto">
+      {/* Buttons — right-aligned and allowed to wrap on narrow screens */}
+      <div className="ml-auto flex flex-wrap justify-end gap-2">
           {isRoleUnavailable && (
             <Tooltip
               content={

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -6,6 +6,7 @@ import {
   Check,
   User,
   UserCheck,
+  UserSearch,
   X,
   MailOpen,
   UserPlus,
@@ -434,11 +435,14 @@ const TeamInvitationDetailsModal = ({
     isAcceptRoleLoading || isSwitchRoleLoading || isAcceptTeamLoading || isDeclineLoading;
   const isControlsDisabled = loading || isActionPending;
   const teamLocationDetails = getTeamLocationDetails();
+  const isCombinedRoleInvitation = hasRoleInvitation && !inviteeAlreadyTeamMember;
 
   const headerSubtitle = isInternal
-    ? "You've been invited to fill a role!"
+    ? "You've been invited to fill this role!"
     : inviteeAlreadyTeamMember && hasRoleInvitation
-      ? "You've been invited to fill a role!"
+      ? "You've been invited to fill this role!"
+      : isCombinedRoleInvitation
+      ? "You've been invited to join a new Team and fill a Role"
       : hasRoleInvitation
       ? "You are invited for a role!"
       : "You are invited!";
@@ -535,15 +539,55 @@ const TeamInvitationDetailsModal = ({
     inviteeAlreadyTeamMember &&
     !isRoleUnavailable &&
     Boolean(currentFilledRole?.id ?? invitation?.current_filled_role_id ?? invitation?.currentFilledRoleId);
+  const invitationRoleName =
+    roleForCard?.roleName ??
+    roleForCard?.role_name ??
+    invitation?.roleName ??
+    invitation?.role_name ??
+    null;
 
   // Custom header
   const customHeader = (
     <div>
       <h2 className="text-xl font-medium text-primary leading-[120%] mb-[0.2em]">
-        {team.name || "Unknown Team"}
+        {inviteeAlreadyTeamMember && hasRoleInvitation && invitationRoleName ? (
+          <span className="flex min-w-0 items-center gap-1.5">
+            <UserSearch size={20} className="shrink-0 text-primary" />
+            <span className="min-w-0 truncate">{invitationRoleName}</span>
+          </span>
+        ) : isCombinedRoleInvitation ? (
+          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <Users size={20} className="shrink-0 text-primary" />
+              <span>Team</span>
+            </span>
+            <span>and</span>
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <UserSearch size={20} className="shrink-0 text-primary" />
+              <span>Role Invitation</span>
+            </span>
+          </span>
+        ) : !hasRoleInvitation ? (
+          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            <span>Invitation to join</span>
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <Users size={20} className="shrink-0 text-primary" />
+              <span className="min-w-0 truncate">
+                {team.name || "Unknown Team"}
+              </span>
+            </span>
+          </span>
+        ) : (
+          team.name || "Unknown Team"
+        )}
       </h2>
       <p className="text-sm text-base-content/70 flex items-center">
-        <MailOpen size={14} className={`mr-1.5 ${inviteeAlreadyTeamMember ? "text-orange-500" : ""}`} />
+        <MailOpen
+          size={14}
+          className={`mr-1.5 ${
+            inviteeAlreadyTeamMember ? "text-orange-500" : "text-pink-500"
+          }`}
+        />
         {headerSubtitle}
       </p>
     </div>

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -7,6 +7,7 @@ import {
   FlaskConical,
   Trash2,
   MailOpen,
+  XCircle,
 } from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
 import Button from "../common/Button";
@@ -733,6 +734,13 @@ const TeamInvitesModal = ({
       ? getDisplayName(pendingCancelInvitation.invitee)
       : "this user";
   const pendingCancelIsRole = pendingCancelType === "role";
+  const pendingCancelHasRole =
+    !pendingCancelIsRole &&
+    Boolean(
+      pendingCancelInvitation?.role?.id ??
+        pendingCancelInvitation?.roleId ??
+        pendingCancelInvitation?.role_id,
+    );
   const pendingCancelTitle = pendingCancelIsRole
     ? "Cancel Role Invitation"
     : "Cancel Team Invitation";
@@ -791,6 +799,11 @@ const TeamInvitesModal = ({
             {pendingCancelIsRole
               ? `Cancel the role invitation for ${pendingInviteeName}?`
               : `Cancel the team invitation for ${pendingInviteeName}? They will no longer be able to respond to it.`}
+            {pendingCancelHasRole && (
+              <span className="block mt-2 text-warning text-xs">
+                This will also cancel the associated role invitation.
+              </span>
+            )}
           </p>
         </Modal>
       }
@@ -1108,39 +1121,48 @@ const TeamInvitesModal = ({
 
 
             {/* Bottom row: Inviter info (left) + Action Button (right) */}
-            <div className="flex items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 mt-8 -mx-4 -mb-4 px-4 pb-4 pt-3 border-t border-base-200 bg-base-100/80 rounded-b-lg">
               {/* Inviter info (left) - Using InlineUserLink */}
               {invitation.inviter ? (
-                <InvitedByLink user={invitation.inviter} />
+                <InvitedByLink
+                  user={invitation.inviter}
+                  className="min-w-0 flex-[1_1_12rem] overflow-hidden"
+                />
               ) : invitation.inviter_username ? (
-                <span className="text-xs text-base-content/50">
+                <span className="min-w-0 flex-[1_1_12rem] overflow-hidden truncate text-xs text-base-content/50">
                   Invited by {invitation.inviter_username}
                 </span>
               ) : (
-                <div />
+                <div className="min-w-0 flex-[1_1_12rem] overflow-hidden" />
               )}
 
               {/* Action Button (right) */}
-              <div className="flex flex-wrap justify-end gap-2">
+              <div className="ml-auto flex flex-wrap justify-end gap-2">
                 {hasRoleInvitation && (
-                  <Button
-                    variant="errorOutline"
-                    size="sm"
-                    onClick={() => handleCancelInvitation(invitation.id, "role")}
-                    disabled={loading}
-                  >
-                    {loading ? "Canceling..." : "Cancel Role Invitation"}
-                  </Button>
+                  <Tooltip content="Cancel role invitation only">
+                    <Button
+                      variant="errorOutline"
+                      size="sm"
+                      onClick={() => handleCancelInvitation(invitation.id, "role")}
+                      disabled={loading}
+                      icon={<XCircle size={14} />}
+                    >
+                      {loading ? "Canceling..." : "Cancel Role Invite"}
+                    </Button>
+                  </Tooltip>
                 )}
                 {(!hasRoleInvitation || !isInternalInvitation) && (
-                  <Button
-                    variant="errorOutline"
-                    size="sm"
-                    onClick={() => handleCancelInvitation(invitation.id, "team")}
-                    disabled={loading}
-                  >
-                    {loading ? "Canceling..." : "Cancel Team Invitation"}
-                  </Button>
+                  <Tooltip content={hasRoleInvitation ? "Cancel team & role invitation" : "Cancel team invitation"}>
+                    <Button
+                      variant="errorOutline"
+                      size="sm"
+                      onClick={() => handleCancelInvitation(invitation.id, "team")}
+                      disabled={loading}
+                      icon={<XCircle size={14} />}
+                    >
+                      {loading ? "Canceling..." : hasRoleInvitation ? "Cancel Role + Team Invite" : "Cancel Invite"}
+                    </Button>
+                  </Tooltip>
                 )}
               </div>
             </div>

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
 import {
   User,
+  Users,
   MapPin,
   Calendar,
   SendHorizontal,
@@ -22,6 +23,7 @@ import { vacantRoleService } from "../../services/vacantRoleService";
 import teamService from "../../services/teamService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
+import { useTeamModal } from "../../contexts/TeamModalContext";
 import {
   DEMO_PROFILE_TOOLTIP,
   getUserInitials,
@@ -276,8 +278,8 @@ const TeamInvitesModal = ({
 
   // ============ Context ============
   const { user: currentUser } = useAuth();
-  // Get global user modal opener (for clicking on invitee avatar/name)
   const { openUserModal } = useUserModal();
+  const { openTeamModal } = useTeamModal();
 
   // ============ Scroll to highlighted invitation ============
   useEffect(() => {
@@ -752,10 +754,21 @@ const TeamInvitesModal = ({
     <RequestListModal
       isOpen={isOpen}
       onClose={onClose}
-      title="Invitations sent out to"
-      subtitle={teamName}
+      title={
+        <span className="leading-[100%]">
+          <Users size={20} className="inline-block align-middle mr-1.5 shrink-0 text-primary" />
+          <Tooltip content="View team" wrapperClassName="inline">
+            <span
+              className="font-semibold text-success cursor-pointer hover:text-success/70 transition-colors"
+              onClick={() => teamId && openTeamModal(teamId, teamName)}
+            >{teamName}</span>
+          </Tooltip>
+          <span>'s Invitations</span>
+        </span>
+      }
       itemCount={invitations.length}
       itemName="invitation"
+      bylineIcon={<SendHorizontal size={14} className="text-violet-500 shrink-0" />}
       footerText="You can cancel invitations that haven't been responded to."
       error={error}
       onErrorClose={() => setError(null)}


### PR DESCRIPTION
Summary
This branch overhauls the invitations and applications flow end-to-end — from real-time socket notifications through to the visual design of every modal involved.

Notification & socket infrastructure
Extracted team notification socket subscriptions into a dedicated useSocketEvents hook
Added toast notifications for invitations, applications, role-status changes, and member removal events
Color-coded toasts (success green, pink/violet accents) and deduplicated repeat events
Suppressed unread-message toast on page refresh; fixed unread-toast flag to fire only on real logout
Fixed 401 vs 403 logout logic — only log out on 401
Card & layout unification
Unified card shadows, padding, and border radius across team, role, and user cards
Added a full-bleed footer strip to PersonRequestCard with a subtle top border and muted background
Aligned date placement and subline wrapping responsively across list items
Invite modal redesign
Redesigned invite modal with collapsible message section and consistent card styling
Added deferred role invite flow: team invite first, role invite queued until the user joins
Cancel buttons clearly distinguish "Cancel Role Invite" from "Cancel Role & Team Invite" (XCircle icons + tooltips)
Application modal overhaul
Three-action layout for role applications: Fill Role + Add to Team / Add to Team / Decline — always in that order, Decline last
Internal role applicants get a single Fill Role button; simple team applications get Add to Team
All buttons use successOutline / errorOutline variants with Lucide icons
Invitation & Application detail modals
Standardised button order: positive actions first, Decline always last (errorOutline)
Button labels: "Fill Role + Join Team", "Join Team", "Switch Role", "Fill Role", "Decline"
Header titles: Team & Role Invitation/Application and (Users icon) Team Invitation/Application
Line height normalised to leading-[100%] across all modal titles
List modal headers (shared RequestListModal)
Header format: (Users icon) [Team Name]'s Invitations / Applications
Team name is clickable (font-semibold text-success) with hover fade, opening the team details modal
Added bylineIcon prop — defaults to pink Mail, invitations list uses violet SendHorizontal
Footer now includes a Close button; modal header/footer padding increased p-4 → p-6
Role UX
Disabled fill buttons for already-filled or closed roles with real-time status polling
Hidden apply button and filtered member list for current role holders in VacantRoleDetailsModal
Roles automatically reopen when a member leaves or is removed
Chat integration
Styled chat event messages for role-related actions (assignment, removal, role changes)
role_updated events render with styled preview; fixed duplicate shadow on event cards
@mention chips in reply previews styled to match message text
Test plan
 Invite with role: "Cancel Role & Team Invite" cancels both; without role: "Cancel Invite"
 Deferred role invite flow and cancel label accuracy
 Accept invitation — external user: Fill Role + Join Team / Join Team / Switch Role paths
 Accept invitation — internal member: Fill Role path
 Accept simple team invitation: Join Team path
 Decline any invitation: always last button, errorOutline
 Role application: three-button layout in correct order
 Internal role application: single Fill Role button
 Simple team application: Add to Team button
 Invitations/Applications list headers: team name clickable, opens team modal
 Toast notifications fire correctly; no duplicates on rapid events
 Role status updates in real time when a role is filled or closed