### PR TITLE
Refactor: eliminate N+1 fetches, unify request modals, clean up axios

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Contact the project owner for a demo login, or register a new account with a val
 | Styling | Tailwind CSS 3 + DaisyUI 5 |
 | Routing | React Router 7 |
 | HTTP Client | Axios |
+| Server State | TanStack React Query 5 |
 | Real-time | Socket.IO Client |
 | Maps | Leaflet + React Leaflet |
 | Icons | Lucide React, React Icons |
@@ -167,7 +168,9 @@ Lomir-frontend/
 │   │   ├── TeamModalContext.jsx    # Global team detail modal state
 │   │   └── ModalLayerContext.jsx   # Modal z-index stacking
 │   ├── services/
-│   │   ├── api.js                  # Axios instance with interceptors (camelCase ↔ snake_case)
+│   │   ├── api.js                  # Axios instance with default camelCase ↔ snake_case interceptors;
+│   │   │                           #   call sites can opt out via skipRequestCaseTransform /
+│   │   │                           #   skipResponseCaseTransform for explicit per-call data contracts
 │   │   ├── authService.js
 │   │   ├── userService.js          # Includes deletionPreview + deleteUser
 │   │   ├── teamService.js
@@ -181,10 +184,23 @@ Lomir-frontend/
 │   │   ├── socketService.js        # Socket.IO client wrapper
 │   │   └── geocodingService.js
 │   ├── hooks/
+│   │   ├── useUserQueries.js       # React Query hooks for user profile/tags/badges (useUserProfile, useUserTags, useUserBadges) + unwrap helpers
+│   │   ├── useTagQueries.js        # React Query hooks for structured tags
+│   │   ├── useBadgeQueries.js      # React Query hooks for badge catalog and shared-teams lookups
+│   │   ├── useViewerMatchProfile.js # Viewer's tags/badges/location for client-side scoring
+│   │   ├── useViewerPendingRequests.js # Shared cache of viewer's pending invitations + applications, consumed by MyTeams and modals
+│   │   ├── useViewerTeamMemberships.js # Viewer's team memberships for "already in team" gates
+│   │   ├── useTeamRequestLists.js  # Shared list state for TeamApplicationsModal / TeamInvitesModal
+│   │   ├── usePolledRequestRoles.js # Bulk-poll vacant role status every 20s via /vacant-roles?ids=
+│   │   ├── useSelfRoleMatchMap.js  # Viewer's match scores against a set of roles
 │   │   ├── useHydratedRole.js      # Fetch full role details + match score for modals; polls role status every 20 s
 │   │   ├── useLocationAutoFill.js  # Geocoding-based city/country auto-fill from postal code
+│   │   ├── useLocation.js          # Reverse-geocode current device location
+│   │   ├── useMyTeamsSort.js       # Sort state for MyTeams page
+│   │   ├── useClientPagination.js  # Client-side pagination state for lists
+│   │   ├── useSocketEvents.js      # Subscribe to a set of Socket.IO events with React-safe cleanup
 │   │   ├── useAwardModals.js       # Badge award modal state management
-│   │   └── useViewerMatchProfile.js # Viewer's tags/badges/location for client-side scoring
+│   │   └── useTheme.js             # Theme toggle state
 │   ├── utils/
 │   │   ├── deletedUser.js          # "Former Lomir User" display utilities + FormerUserAvatar
 │   │   ├── userHelpers.js          # Initials, display names, isSynthetic* helpers, demo tooltips

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lomir_frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.100.14",
         "axios": "^1.8.4",
         "date-fns": "^4.1.0",
         "downshift": "^9.0.10",
@@ -1426,6 +1427,32 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.100.14",
     "axios": "^1.8.4",
     "date-fns": "^4.1.0",
     "downshift": "^9.0.10",

--- a/src/components/badges/AwardCard.jsx
+++ b/src/components/badges/AwardCard.jsx
@@ -29,6 +29,8 @@ import {
   getDisplayName as getDeletedUserDisplayName,
   isDeletedUser,
 } from "../../utils/deletedUser";
+import { formatDisplayName } from "../../utils/nameFormatters";
+import { getDisplayName } from "../../utils/userHelpers";
 
 /**
  * AwardCard
@@ -167,6 +169,8 @@ const AwardCard = ({
     award?.awardedByUsername || award?.awarded_by_username;
   const awardedByAvatarUrl =
     award?.awardedByAvatarUrl || award?.awarded_by_avatar_url;
+  const awardedByIsSynthetic =
+    award?.awardedByIsSynthetic ?? award?.awarded_by_is_synthetic ?? false;
 
   const awardedByUser = {
     id: awardedByUserId,
@@ -174,6 +178,7 @@ const AwardCard = ({
     last_name: awardedByLastName,
     username: awardedByUsername,
     avatar_url: awardedByAvatarUrl,
+    is_synthetic: awardedByIsSynthetic,
   };
 
   // --- Awarded TO / Awardee (title row — team context) ---
@@ -187,6 +192,8 @@ const AwardCard = ({
     award?.awardedToUsername || award?.awarded_to_username || null;
   const awardedToAvatarUrl =
     award?.awardedToAvatarUrl || award?.awarded_to_avatar_url || null;
+  const awardedToIsSynthetic =
+    award?.awardedToIsSynthetic ?? award?.awarded_to_is_synthetic ?? false;
 
   const hasAwardeeInfo = Boolean(awardedToUserId);
 
@@ -606,20 +613,57 @@ const AwardCard = ({
       <div className="flex items-end justify-between mt-auto pt-3 gap-2">
         {hasAwardeeInfo ? (
           <InlineUserLink
-            label="Awarded to"
+            label={
+              <>
+                <span className="hidden sm:inline">Awarded </span>to
+              </>
+            }
             user={{
               id: awardedToUserId,
               first_name: awardedToFirstName,
               last_name: awardedToLastName,
               username: awardedToUsername,
               avatar_url: awardedToAvatarUrl,
+              is_synthetic: awardedToIsSynthetic,
             }}
+            displayName={
+              <>
+                <span className="hidden sm:inline">
+                  {getDisplayName({
+                    first_name: awardedToFirstName,
+                    last_name: awardedToLastName,
+                    username: awardedToUsername,
+                  })}
+                </span>
+                <span className="sm:hidden">
+                  {formatDisplayName({
+                    first_name: awardedToFirstName,
+                    last_name: awardedToLastName,
+                    username: awardedToUsername,
+                  })}
+                </span>
+              </>
+            }
             onOpenUser={openUser}
           />
         ) : (
           <InlineUserLink
-            label="Awarded by"
+            label={
+              <>
+                <span className="hidden sm:inline">Awarded </span>by
+              </>
+            }
             user={awardedByUser}
+            displayName={
+              <>
+                <span className="hidden sm:inline">
+                  {getDisplayName(awardedByUser)}
+                </span>
+                <span className="sm:hidden">
+                  {formatDisplayName(awardedByUser)}
+                </span>
+              </>
+            }
             onOpenUser={openUser}
           />
         )}
@@ -627,11 +671,18 @@ const AwardCard = ({
         <div className="flex flex-col items-end gap-1">
           <div className="flex items-center gap-1 text-xs text-base-content/60 leading-tight">
             <Calendar size={12} className="flex-shrink-0" />
-            <span>
-              {awardedAt
-                ? format(new Date(awardedAt), "MMM d, yyyy")
-                : "Unknown"}
-            </span>
+            {awardedAt ? (
+              <>
+                <span className="hidden sm:inline">
+                  {format(new Date(awardedAt), "MMM d, yyyy")}
+                </span>
+                <span className="sm:hidden">
+                  {format(new Date(awardedAt), "MM/dd/yy")}
+                </span>
+              </>
+            ) : (
+              <span>Unknown</span>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/badges/BadgeAwardModal.jsx
+++ b/src/components/badges/BadgeAwardModal.jsx
@@ -35,6 +35,7 @@ import Tooltip from "../common/Tooltip";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { badgeService } from "../../services/badgeService";
 import { tagService } from "../../services/tagService";
+import { useBadges, useSharedTeamsForAward } from "../../hooks/useBadgeQueries";
 import { useUserTags } from "../../hooks/useUserQueries";
 import {
   getUserInitials,
@@ -97,8 +98,6 @@ const BadgeAwardModal = ({
   onUserClick,
   onAwardComplete,
 }) => {
-  const [badges, setBadges] = useState([]);
-  const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
@@ -114,10 +113,6 @@ const BadgeAwardModal = ({
   const [selectedTag, setSelectedTag] = useState(null);
   const [reason, setReason] = useState("");
 
-  // Shared teams state
-  const [sharedTeams, setSharedTeams] = useState([]);
-  const [teamsLoading, setTeamsLoading] = useState(false);
-
   // Tag picker state
   const [awardeeTags, setAwardeeTags] = useState([]);
   const [tagSearchQuery, setTagSearchQuery] = useState("");
@@ -126,6 +121,20 @@ const BadgeAwardModal = ({
   const [showTagSearch, setShowTagSearch] = useState(false);
   const tagSearchRef = useRef(null);
   const tagSearchTimerRef = useRef(null);
+  const {
+    data: badges = [],
+    error: badgesError,
+    isLoading: loading,
+  } = useBadges({
+    enabled: Boolean(isOpen),
+  });
+  const {
+    data: sharedTeams = [],
+    error: sharedTeamsError,
+    isLoading: teamsLoading,
+  } = useSharedTeamsForAward(awardeeId, {
+    enabled: Boolean(isOpen && awardeeId),
+  });
   const {
     data: fetchedAwardeeTags = [],
     error: awardeeTagsError,
@@ -152,52 +161,22 @@ const BadgeAwardModal = ({
     return (awardeeFirstName || "").split(" ")[0] || awardeeUsername || "User";
   };
 
-  // Fetch all badges on open
-  useEffect(() => {
-    const fetchBadges = async () => {
-      if (!isOpen) return;
-
-      try {
-        setLoading(true);
-        setError(null);
-
-        const response = await badgeService.getAllBadges();
-        const badgeData = response?.data || [];
-        setBadges(badgeData);
-      } catch (err) {
-        console.error("Error fetching badges:", err);
-        setError("Failed to load badges. Please try again.");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchBadges();
-  }, [isOpen]);
-
-  // Fetch shared teams when modal opens
-  useEffect(() => {
-    const fetchSharedTeams = async () => {
-      if (!isOpen || !awardeeId) return;
-
-      try {
-        setTeamsLoading(true);
-        const response = await badgeService.getSharedTeams(awardeeId);
-        setSharedTeams(response?.data || []);
-      } catch (err) {
-        console.error("Error fetching shared teams:", err);
-        setSharedTeams([]);
-      } finally {
-        setTeamsLoading(false);
-      }
-    };
-
-    fetchSharedTeams();
-  }, [isOpen, awardeeId]);
-
   useEffect(() => {
     setAwardeeTags(fetchedAwardeeTags);
   }, [fetchedAwardeeTags]);
+
+  useEffect(() => {
+    if (!badgesError) return;
+
+    console.error("Error fetching badges:", badgesError);
+    setError("Failed to load badges. Please try again.");
+  }, [badgesError]);
+
+  useEffect(() => {
+    if (!sharedTeamsError) return;
+
+    console.error("Error fetching shared teams:", sharedTeamsError);
+  }, [sharedTeamsError]);
 
   useEffect(() => {
     if (!awardeeTagsError) return;

--- a/src/components/badges/BadgeAwardModal.jsx
+++ b/src/components/badges/BadgeAwardModal.jsx
@@ -85,6 +85,8 @@ const CONTEXT_OPTIONS = [
   },
 ];
 
+const EMPTY_QUERY_ARRAY = [];
+
 const BadgeAwardModal = ({
   isOpen,
   onClose,
@@ -122,21 +124,21 @@ const BadgeAwardModal = ({
   const tagSearchRef = useRef(null);
   const tagSearchTimerRef = useRef(null);
   const {
-    data: badges = [],
+    data: badges = EMPTY_QUERY_ARRAY,
     error: badgesError,
     isLoading: loading,
   } = useBadges({
     enabled: Boolean(isOpen),
   });
   const {
-    data: sharedTeams = [],
+    data: sharedTeams = EMPTY_QUERY_ARRAY,
     error: sharedTeamsError,
     isLoading: teamsLoading,
   } = useSharedTeamsForAward(awardeeId, {
     enabled: Boolean(isOpen && awardeeId),
   });
   const {
-    data: fetchedAwardeeTags = [],
+    data: fetchedAwardeeTags = EMPTY_QUERY_ARRAY,
     error: awardeeTagsError,
     isLoading: tagsLoading,
   } = useUserTags(awardeeId, {

--- a/src/components/badges/BadgeAwardModal.jsx
+++ b/src/components/badges/BadgeAwardModal.jsx
@@ -34,8 +34,8 @@ import Alert from "../common/Alert";
 import Tooltip from "../common/Tooltip";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { badgeService } from "../../services/badgeService";
-import { userService } from "../../services/userService";
 import { tagService } from "../../services/tagService";
+import { useUserTags } from "../../hooks/useUserQueries";
 import {
   getUserInitials,
   DEMO_PROFILE_TOOLTIP,
@@ -120,13 +120,19 @@ const BadgeAwardModal = ({
 
   // Tag picker state
   const [awardeeTags, setAwardeeTags] = useState([]);
-  const [tagsLoading, setTagsLoading] = useState(false);
   const [tagSearchQuery, setTagSearchQuery] = useState("");
   const [tagSearchResults, setTagSearchResults] = useState([]);
   const [tagSearching, setTagSearching] = useState(false);
   const [showTagSearch, setShowTagSearch] = useState(false);
   const tagSearchRef = useRef(null);
   const tagSearchTimerRef = useRef(null);
+  const {
+    data: fetchedAwardeeTags = [],
+    error: awardeeTagsError,
+    isLoading: tagsLoading,
+  } = useUserTags(awardeeId, {
+    enabled: Boolean(isOpen && awardeeId),
+  });
 
   // Get display name
   const getDisplayName = () => {
@@ -189,26 +195,16 @@ const BadgeAwardModal = ({
     fetchSharedTeams();
   }, [isOpen, awardeeId]);
 
-  // Fetch awardee's tags when modal opens
   useEffect(() => {
-    const fetchAwardeeTags = async () => {
-      if (!isOpen || !awardeeId) return;
+    setAwardeeTags(fetchedAwardeeTags);
+  }, [fetchedAwardeeTags]);
 
-      try {
-        setTagsLoading(true);
-        const response = await userService.getUserTags(awardeeId);
-        const tags = response?.data || [];
-        setAwardeeTags(tags);
-      } catch (err) {
-        console.error("Error fetching awardee tags:", err);
-        setAwardeeTags([]);
-      } finally {
-        setTagsLoading(false);
-      }
-    };
+  useEffect(() => {
+    if (!awardeeTagsError) return;
 
-    fetchAwardeeTags();
-  }, [isOpen, awardeeId]);
+    console.error("Error fetching awardee tags:", awardeeTagsError);
+    setAwardeeTags([]);
+  }, [awardeeTagsError]);
 
   // Reset form on close
   useEffect(() => {
@@ -392,7 +388,11 @@ const BadgeAwardModal = ({
 
       // Notify parent to refresh badge data
       if (onAwardComplete) {
-        onAwardComplete();
+        try {
+          await onAwardComplete();
+        } catch (refreshError) {
+          console.warn("Badge awarded, but refreshing badge data failed:", refreshError);
+        }
       }
 
       // Close after a brief delay

--- a/src/components/badges/BadgeCategoryModal.jsx
+++ b/src/components/badges/BadgeCategoryModal.jsx
@@ -121,20 +121,35 @@ const BadgeCategoryModal = ({
   ).size;
 
   const titleNode = (
-    <div className="min-w-0">
-      {/* Line 1: icon + title */}
-      <div className="flex items-center gap-2 min-w-0">
-        <span className="flex-shrink-0">
-          {getCategoryIcon(category, color, 20)}
-        </span>
-
-        <span className="text-xl font-medium truncate" style={{ color }}>
-          {focusedBadgeName
-            ? category || "Badge Category"
-            : `Earned badges for ${category || "this category"}`}
-        </span>
-      </div>
-    </div>
+    <h2
+      className="text-xl font-medium leading-[110%] mb-[0.2em]"
+      style={{ color }}
+    >
+      <span className="leading-[100%]">
+        {focusedBadgeName ? (
+          <>
+            <span className="inline-block align-middle mr-1.5 shrink-0">
+              {getCategoryIcon(category, color, 20)}
+            </span>
+            <span className="font-semibold">
+              {category || "Badge Category"}
+            </span>
+          </>
+        ) : (
+          <>
+            <span>Earned badges for </span>
+            <span className="block md:inline">
+              <span className="inline-block align-middle mr-1.5 shrink-0">
+                {getCategoryIcon(category, color, 20)}
+              </span>
+              <span className="font-semibold">
+                {category || "this category"}
+              </span>
+            </span>
+          </>
+        )}
+      </span>
+    </h2>
   );
 
   return (

--- a/src/components/badges/SupercategoryAwardsModal.jsx
+++ b/src/components/badges/SupercategoryAwardsModal.jsx
@@ -102,17 +102,23 @@ const SupercategoryAwardsModal = ({
   const totalTagCount = tags.length;
 
   const titleNode = (
-    <div className="min-w-0">
-      <div className="flex items-center gap-2 min-w-0">
-        {getSupercategoryIcon(supercategory, 20)}
-        <span
-          className="text-xl font-medium truncate"
-          style={{ color: FOCUS_GREEN }}
-        >
-          Earned badges in the focus area of {supercategory}
+    <h2
+      className="text-xl font-medium leading-[110%] mb-[0.2em]"
+      style={{ color: FOCUS_GREEN }}
+    >
+      <span className="leading-[100%]">
+        <span className="hidden md:inline">
+          Earned badges in the focus area of{" "}
         </span>
-      </div>
-    </div>
+        <span className="md:hidden">Earned Badges in </span>
+        <span className="block md:inline">
+          <span className="inline-block align-middle mr-1.5 shrink-0">
+            {getSupercategoryIcon(supercategory, 20)}
+          </span>
+          <span className="font-semibold">{supercategory}</span>
+        </span>
+      </span>
+    </h2>
   );
 
   return (

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -1951,6 +1951,10 @@ const MessageDisplay = ({
           firstName: member.first_name || member.firstName,
           lastName: member.last_name || member.lastName,
           avatarUrl: member.avatar_url || member.avatarUrl,
+          isSynthetic:
+            member.isSynthetic ?? member.is_synthetic ?? undefined,
+          is_synthetic:
+            member.is_synthetic ?? member.isSynthetic ?? undefined,
           isCurrentMember: true,
           isDeletedUser: false,
           },

--- a/src/components/chat/MessageInput.jsx
+++ b/src/components/chat/MessageInput.jsx
@@ -5,6 +5,7 @@ import {
   Crown,
   FileText,
   LogOut,
+  Pencil,
   Reply,
   Send,
   Shield,
@@ -26,6 +27,7 @@ const EVENT_PREVIEW_ICONS = {
   Crown,
   FileText,
   LogOut,
+  Pencil,
   Shield,
   User,
   UserCheck,
@@ -278,12 +280,14 @@ const MessageInput = ({
                   )}
                 </div>
               </div>
-            ) : replyEventPreview && ReplyEventIcon ? (
+            ) : replyEventPreview ? (
               <p
                 className="flex min-w-0 items-center gap-1 text-xs font-medium truncate"
                 style={{ color: replyEventPreview.color }}
               >
-                <ReplyEventIcon size={13} className="shrink-0" />
+                {ReplyEventIcon && (
+                  <ReplyEventIcon size={13} className="shrink-0" />
+                )}
                 <span className="truncate">{replyEventPreview.text}</span>
               </p>
             ) : (

--- a/src/components/common/ImageUploader.jsx
+++ b/src/components/common/ImageUploader.jsx
@@ -233,7 +233,7 @@ const ImageUploader = ({
         </label>
       )}
 
-      <div className="flex items-center gap-6">
+      <div className="flex flex-col items-center text-center gap-4 sm:flex-row sm:items-center sm:text-left sm:gap-6">
         {/* Drop Zone / Preview */}
         <div
           role="button"
@@ -337,7 +337,7 @@ const ImageUploader = ({
         </div>
 
         {/* Right Side: Instructions & Remove Button */}
-        <div className="flex-1 space-y-2">
+        <div className="flex-1 space-y-2 flex flex-col items-center sm:items-stretch">
           {/* Upload Instructions */}
           <div className="text-sm text-base-content/70">
             {isDragging ? (

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -275,12 +275,12 @@ const PersonRequestCard = ({
       {extraContent}
 
       {/* Footer with optional left content and actions */}
-      <div className="flex items-center justify-between mt-8 -mx-4 -mb-4 px-4 pb-4 pt-3 border-t border-base-200 bg-base-100/80 rounded-b-lg">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 mt-8 -mx-4 -mb-4 px-4 pb-4 pt-3 border-t border-base-200 bg-base-100/80 rounded-b-lg">
         {/* Left side (e.g., inviter info) */}
-        {footerLeft || <div />}
+        {footerLeft}
 
         {/* Right side - action buttons */}
-        {actions}
+        {actions && <div className="ml-auto">{actions}</div>}
       </div>
     </div>
   );

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -4,6 +4,8 @@ import { format } from "date-fns";
 import Tooltip from "./Tooltip";
 import {
   DEMO_PROFILE_TOOLTIP,
+  getDisplayName as getUserDisplayName,
+  getUserAvatarUrl,
   getUserInitials,
   isSyntheticUser,
 } from "../../utils/userHelpers";
@@ -52,22 +54,10 @@ const PersonRequestCard = ({
 }) => {
   // ============ Helper Functions ============
 
-  // Get avatar URL - handles both snake_case and camelCase
-  const getAvatarUrl = () => {
-    if (!user) return null;
-    return user.avatar_url || user.avatarUrl || null;
-  };
-
   // Get display name
   const getDisplayName = () => {
-    if (!user) return "Unknown User";
-
-    const firstName = user.first_name || user.firstName || "";
-    const lastName = user.last_name || user.lastName || "";
-    const fullName = `${firstName} ${lastName}`.trim();
-
-    if (fullName.length > 0) return fullName;
-    return user.username || "Unknown User";
+    const displayName = getUserDisplayName(user);
+    return displayName === "Unknown" ? "Unknown User" : displayName;
   };
 
   // Format date
@@ -106,6 +96,7 @@ const PersonRequestCard = ({
     user?.username &&
     (getDisplayName() !== user.username || isSyntheticUser(user));
   const showDemoProfile = isSyntheticUser(user);
+  const avatarUrl = getUserAvatarUrl(user);
 
   // ============ Adaptive name (full → abbreviated → CSS truncate) ============
   const nameContainerRef = useRef(null);
@@ -158,9 +149,9 @@ const PersonRequestCard = ({
           wrapperClassName={`avatar ${clickableStyles}`}
         >
           <div className="w-12 h-12 rounded-full relative overflow-hidden" onClick={handleUserClick}>
-            {getAvatarUrl() ? (
+            {avatarUrl ? (
               <img
-                src={getAvatarUrl()}
+                src={avatarUrl}
                 alt={user?.username || "User"}
                 className="object-cover w-full h-full rounded-full"
                 onError={(e) => {
@@ -175,7 +166,7 @@ const PersonRequestCard = ({
             <div
               className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
               style={{
-                display: getAvatarUrl() ? "none" : "flex",
+                display: avatarUrl ? "none" : "flex",
               }}
             >
               <span className="text-xl font-medium">

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -37,6 +37,8 @@ import { useUserModalSafe } from "../../contexts/UserModalContext";
 import { useAuth } from "../../contexts/AuthContext";
 import { teamService } from "../../services/teamService";
 import { userService } from "../../services/userService";
+import useViewerPendingRequests from "../../hooks/useViewerPendingRequests";
+import useViewerTeamMemberships from "../../hooks/useViewerTeamMemberships";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import {
@@ -1951,10 +1953,17 @@ const SearchMapView = ({
   const authUserId = authContext?.user?.id ?? null;
   const [selectedRolePoint, setSelectedRolePoint] = useState(null);
   const [activeStatusTooltipPointId, setActiveStatusTooltipPointId] = useState(null);
-  const [fetchedTeamRoles, setFetchedTeamRoles] = useState({});
-  const [fetchedApplications, setFetchedApplications] = useState([]);
-  const [fetchedInvitations, setFetchedInvitations] = useState([]);
-  const [fetchedUserTeamIds, setFetchedUserTeamIds] = useState(() => new Set());
+  const {
+    data: viewerPendingRequests,
+    refetch: refetchViewerPendingRequests,
+  } = useViewerPendingRequests(authUserId, { enabled: Boolean(authUserId) });
+  const {
+    teamIdSet: fetchedUserTeamIds,
+    teamRoles: fetchedTeamRoles,
+    refetch: refetchViewerTeamMemberships,
+  } = useViewerTeamMemberships(authUserId, { enabled: Boolean(authUserId) });
+  const fetchedApplications = viewerPendingRequests?.applications ?? [];
+  const fetchedInvitations = viewerPendingRequests?.invitations ?? [];
   const [selectedInvitation, setSelectedInvitation] = useState(null);
   const [selectedApplication, setSelectedApplication] = useState(null);
   const [mapInstance, setMapInstance] = useState(null);
@@ -1979,134 +1988,12 @@ const SearchMapView = ({
     };
   }, []);
 
-  const fetchUserRequestData = useCallback(async () => {
-    if (!authUserId) {
-      return { applications: [], invitations: [] };
-    }
-
-    const [appsResponse, invResponse] = await Promise.all([
-      teamService.getUserPendingApplications(),
-      teamService.getUserReceivedInvitations(),
-    ]);
-
-    return {
-      applications: Array.isArray(appsResponse?.data) ? appsResponse.data : [],
-      invitations: Array.isArray(invResponse?.data) ? invResponse.data : [],
-    };
-  }, [authUserId]);
-
-  const fetchUserTeamMemberships = useCallback(async () => {
-    if (!authUserId) {
-      return { teamIds: new Set(), teamRoles: {} };
-    }
-
-    const teamIds = new Set();
-    const teamRoles = {};
-    const limit = 100;
-    let page = 1;
-    let totalPages = 1;
-
-    while (page <= totalPages) {
-      const response = await teamService.getUserTeams(authUserId, { page, limit });
-      const teams = Array.isArray(response?.data) ? response.data : [];
-
-      teams.forEach((team) => {
-        const teamId = firstPresent(team?.id, team?.teamId, team?.team_id);
-        if (teamId == null) return;
-
-        const teamKey = String(teamId);
-        teamIds.add(teamKey);
-        teamRoles[teamKey] = getTeamViewerRole(team, { id: authUserId });
-      });
-
-      const pagination = response?.pagination ?? {};
-      const nextTotalPages = Number(
-        pagination.totalPages ?? pagination.total_pages ?? 1,
-      );
-      totalPages =
-        Number.isFinite(nextTotalPages) && nextTotalPages > 0
-          ? nextTotalPages
-          : 1;
-
-      const hasNextPage = Boolean(
-        pagination.hasNextPage ??
-          pagination.has_next_page ??
-          page < totalPages,
-      );
-
-      if (!hasNextPage) break;
-      page += 1;
-    }
-
-    return { teamIds, teamRoles };
-  }, [authUserId]);
-
-  useEffect(() => {
-    if (!authUserId) {
-      setFetchedApplications([]);
-      setFetchedInvitations([]);
-      return;
-    }
-
-    let isActive = true;
-
-    const fetchUserRoleData = async () => {
-      try {
-        const { applications, invitations } = await fetchUserRequestData();
-        if (!isActive) return;
-        setFetchedApplications(applications);
-        setFetchedInvitations(invitations);
-      } catch {
-        // silent fail — icon simply won't show if fetch fails
-      }
-    };
-
-    fetchUserRoleData();
-
-    return () => { isActive = false; };
-  }, [authUserId, fetchUserRequestData]);
-
-  useEffect(() => {
-    if (!authUserId) {
-      setFetchedUserTeamIds(new Set());
-      return;
-    }
-
-    let isActive = true;
-
-    const loadUserTeamMemberships = async () => {
-      try {
-        const { teamIds, teamRoles } = await fetchUserTeamMemberships();
-        if (isActive) {
-          setFetchedUserTeamIds(teamIds);
-          setFetchedTeamRoles(teamRoles);
-        }
-      } catch {
-        if (isActive) {
-          setFetchedUserTeamIds(new Set());
-          setFetchedTeamRoles({});
-        }
-      }
-    };
-
-    loadUserTeamMemberships();
-
-    return () => {
-      isActive = false;
-    };
-  }, [authUserId, fetchUserTeamMemberships]);
-
   const refreshUserStatusData = useCallback(async () => {
-    const [{ applications, invitations }, { teamIds, teamRoles }] = await Promise.all([
-      fetchUserRequestData(),
-      fetchUserTeamMemberships(),
+    await Promise.all([
+      refetchViewerPendingRequests(),
+      refetchViewerTeamMemberships(),
     ]);
-
-    setFetchedApplications(applications);
-    setFetchedInvitations(invitations);
-    setFetchedUserTeamIds(teamIds);
-    setFetchedTeamRoles(teamRoles);
-  }, [fetchUserRequestData, fetchUserTeamMemberships]);
+  }, [refetchViewerPendingRequests, refetchViewerTeamMemberships]);
 
   const openInvitationDetails = useCallback((invitation) => {
     if (!invitation) return;

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -1995,10 +1995,13 @@ const SearchMapView = ({
     };
   }, [authUserId]);
 
-  const fetchUserTeamIds = useCallback(async () => {
-    if (!authUserId) return new Set();
+  const fetchUserTeamMemberships = useCallback(async () => {
+    if (!authUserId) {
+      return { teamIds: new Set(), teamRoles: {} };
+    }
 
     const teamIds = new Set();
+    const teamRoles = {};
     const limit = 100;
     let page = 1;
     let totalPages = 1;
@@ -2009,7 +2012,11 @@ const SearchMapView = ({
 
       teams.forEach((team) => {
         const teamId = firstPresent(team?.id, team?.teamId, team?.team_id);
-        if (teamId != null) teamIds.add(String(teamId));
+        if (teamId == null) return;
+
+        const teamKey = String(teamId);
+        teamIds.add(teamKey);
+        teamRoles[teamKey] = getTeamViewerRole(team, { id: authUserId });
       });
 
       const pagination = response?.pagination ?? {};
@@ -2031,7 +2038,7 @@ const SearchMapView = ({
       page += 1;
     }
 
-    return teamIds;
+    return { teamIds, teamRoles };
   }, [authUserId]);
 
   useEffect(() => {
@@ -2067,87 +2074,39 @@ const SearchMapView = ({
 
     let isActive = true;
 
-    const loadUserTeamIds = async () => {
+    const loadUserTeamMemberships = async () => {
       try {
-        const teamIds = await fetchUserTeamIds();
+        const { teamIds, teamRoles } = await fetchUserTeamMemberships();
         if (isActive) {
           setFetchedUserTeamIds(teamIds);
+          setFetchedTeamRoles(teamRoles);
         }
       } catch {
         if (isActive) {
           setFetchedUserTeamIds(new Set());
+          setFetchedTeamRoles({});
         }
       }
     };
 
-    loadUserTeamIds();
+    loadUserTeamMemberships();
 
     return () => {
       isActive = false;
     };
-  }, [authUserId, fetchUserTeamIds]);
-
-  useEffect(() => {
-    if (!authUserId) return;
-
-    const seenTeamIds = new Set();
-
-    const teamItemsNeedingRole = items.filter((item) => {
-      if (getMapPointType(item) !== "team") return false;
-      const teamId = getTeamItemId(item);
-      if (teamId === null) return false;
-      const teamKey = String(teamId);
-      if (seenTeamIds.has(teamKey)) return false;
-      seenTeamIds.add(teamKey);
-      if (Object.prototype.hasOwnProperty.call(fetchedTeamRoles, teamKey)) return false;
-      return !getTeamViewerRole(item, { id: authUserId });
-    });
-
-    if (teamItemsNeedingRole.length === 0) return;
-
-    let isActive = true;
-
-    const fetchTeamRoles = async () => {
-      const entries = await Promise.all(
-        teamItemsNeedingRole.map(async (teamItem) => {
-          const teamId = getTeamItemId(teamItem);
-          const response = await teamService.getUserRoleInTeam(teamId, authUserId);
-          const payload = response?.data ?? response;
-          const data = payload?.data ?? payload;
-
-          return [String(teamId), normalizeRoleValue(data?.role ?? payload?.role)];
-        }),
-      );
-
-      if (!isActive) return;
-
-      setFetchedTeamRoles((previousRoles) => {
-        const nextRoles = { ...previousRoles };
-        entries.forEach(([teamId, role]) => {
-          nextRoles[teamId] = role;
-        });
-        return nextRoles;
-      });
-    };
-
-    fetchTeamRoles();
-
-    return () => {
-      isActive = false;
-    };
-  }, [authUserId, fetchedTeamRoles, items]);
+  }, [authUserId, fetchUserTeamMemberships]);
 
   const refreshUserStatusData = useCallback(async () => {
-    const [{ applications, invitations }, teamIds] = await Promise.all([
+    const [{ applications, invitations }, { teamIds, teamRoles }] = await Promise.all([
       fetchUserRequestData(),
-      fetchUserTeamIds(),
+      fetchUserTeamMemberships(),
     ]);
 
     setFetchedApplications(applications);
     setFetchedInvitations(invitations);
     setFetchedUserTeamIds(teamIds);
-    setFetchedTeamRoles({});
-  }, [fetchUserRequestData, fetchUserTeamIds]);
+    setFetchedTeamRoles(teamRoles);
+  }, [fetchUserRequestData, fetchUserTeamMemberships]);
 
   const openInvitationDetails = useCallback((invitation) => {
     if (!invitation) return;

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
 import { createPortal } from "react-dom";
 import {
   AttributionControl,
@@ -36,9 +37,12 @@ import { useTeamModalSafe } from "../../contexts/TeamModalContext";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
 import { useAuth } from "../../contexts/AuthContext";
 import { teamService } from "../../services/teamService";
-import { userService } from "../../services/userService";
 import useViewerPendingRequests from "../../hooks/useViewerPendingRequests";
 import useViewerTeamMemberships from "../../hooks/useViewerTeamMemberships";
+import {
+  fetchUserProfile,
+  userProfileQueryKey,
+} from "../../hooks/useUserQueries";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import {
@@ -531,19 +535,6 @@ const getCityCoordinateFallback = (item) =>
   getCanonicalDemoLocation(item) ??
   CITY_COORDINATE_FALLBACKS[normalizeLocationKey(getItemCity(item))] ??
   null;
-
-const unwrapUserDetailsResponse = (response) => {
-  const payload = response?.data ?? response;
-  return firstObject(
-    payload?.data?.user,
-    payload?.data?.profile,
-    payload?.data?.data,
-    payload?.data,
-    payload?.user,
-    payload?.profile,
-    payload,
-  ) ?? null;
-};
 
 const mergeUserLocationDetails = (item, userDetails) => {
   if (!item || !userDetails) return item;
@@ -1978,15 +1969,6 @@ const SearchMapView = ({
   const [userLocationDetailsById, setUserLocationDetailsById] = useState({});
   const popupRef = useRef(null);
   const markerTooltipRef = useRef(null);
-  const userLocationFetchesRef = useRef(new Set());
-  const isMountedRef = useRef(false);
-
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
 
   const refreshUserStatusData = useCallback(async () => {
     await Promise.all([
@@ -2094,7 +2076,6 @@ const SearchMapView = ({
       const userId = String(point.rawId);
       if (seenIds.has(userId)) return;
       if (Object.prototype.hasOwnProperty.call(userLocationDetailsById, userId)) return;
-      if (userLocationFetchesRef.current.has(userId)) return;
 
       seenIds.add(userId);
       ids.push(userId);
@@ -2102,43 +2083,48 @@ const SearchMapView = ({
 
     return ids;
   }, [normalizedPoints, userLocationDetailsById]);
+  const userLocationDetailQueries = useQueries({
+    queries: userIdsNeedingLocationDetails.map((userId) => ({
+      queryKey: userProfileQueryKey(userId),
+      queryFn: () => fetchUserProfile(userId),
+      staleTime: 30_000,
+    })),
+  });
+  const userLocationDetailQuerySignature = userLocationDetailQueries
+    .map(
+      (query) =>
+        `${query.status}:${query.dataUpdatedAt ?? 0}:${query.errorUpdatedAt ?? 0}`,
+    )
+    .join("|");
 
   useEffect(() => {
     if (userIdsNeedingLocationDetails.length === 0) return;
 
-    userIdsNeedingLocationDetails.forEach((userId) => {
-      userLocationFetchesRef.current.add(userId);
-    });
+    const entries = userIdsNeedingLocationDetails
+      .map((userId, index) => {
+        const query = userLocationDetailQueries[index];
+        if (query?.isSuccess) return [userId, query.data ?? null];
+        if (query?.isError) return [userId, null];
+        return null;
+      })
+      .filter(Boolean);
 
-    const fetchUserLocationDetails = async () => {
-      const entries = await Promise.all(
-        userIdsNeedingLocationDetails.map(async (userId) => {
-          try {
-            const response = await userService.getUserById(userId);
-            return [userId, unwrapUserDetailsResponse(response)];
-          } catch {
-            return [userId, null];
-          }
-        }),
-      );
+    if (entries.length === 0) return;
 
-      userIdsNeedingLocationDetails.forEach((userId) => {
-        userLocationFetchesRef.current.delete(userId);
-      });
-
-      if (!isMountedRef.current) return;
-
-      setUserLocationDetailsById((previousDetails) => {
-        const nextDetails = { ...previousDetails };
-        entries.forEach(([userId, details]) => {
+    setUserLocationDetailsById((previousDetails) => {
+      const nextDetails = { ...previousDetails };
+      entries.forEach(([userId, details]) => {
+        if (!Object.prototype.hasOwnProperty.call(nextDetails, userId)) {
           nextDetails[userId] = details;
-        });
-        return nextDetails;
+        }
       });
-    };
-
-    fetchUserLocationDetails();
-  }, [userIdsNeedingLocationDetails]);
+      return nextDetails;
+    });
+  }, [
+    userIdsNeedingLocationDetails,
+    userLocationDetailQueries,
+    userLocationDetailQuerySignature,
+  ]);
 
   const markerPoints = useMemo(
     () => normalizedPoints.filter((point) => point.hasCoordinates),

--- a/src/components/tags/TagInput.jsx
+++ b/src/components/tags/TagInput.jsx
@@ -23,6 +23,7 @@ const EDGE_MARGIN = 8; // keep within viewport edges
 const GAP = 16;
 const MIN_MENU_HEIGHT = 140;
 const MAX_MENU_HEIGHT = 360;
+const EMPTY_QUERY_ARRAY = [];
 
 const TagInput = ({
   selectedTags = [],
@@ -60,11 +61,11 @@ const TagInput = ({
   });
   const [menuPlacement, setMenuPlacement] = useState("bottom"); // "top" | "bottom"
   const {
-    data: structuredTags = [],
+    data: structuredTags = EMPTY_QUERY_ARRAY,
     error: structuredTagsError,
   } = useStructuredTags();
   const {
-    data: fetchedPopularTags = [],
+    data: fetchedPopularTags = EMPTY_QUERY_ARRAY,
     error: popularTagsError,
   } = usePopularTags(5, null, {
     enabled: showPopularTags,
@@ -97,6 +98,8 @@ const TagInput = ({
   );
 
   const updateTagMap = useCallback((tags) => {
+    if (!tags?.length) return;
+
     setTagMap((prev) => {
       const next = new Map(prev);
       (tags || []).forEach((t) => {

--- a/src/components/tags/TagInput.jsx
+++ b/src/components/tags/TagInput.jsx
@@ -498,81 +498,90 @@ const TagInput = ({
       )}
 
       {typeof document !== "undefined" &&
-        shouldShowDropdown &&
         createPortal(
           <ul
             {...getMenuProps({
               ref: dropdownRef,
             })}
-            style={menuStyle}
-            className="menu bg-base-100 border border-base-300 rounded-box p-2 shadow-xl overflow-y-auto"
+            style={shouldShowDropdown ? menuStyle : { display: "none" }}
+            className={
+              shouldShowDropdown
+                ? "menu bg-base-100 border border-base-300 rounded-box p-2 shadow-xl overflow-y-auto"
+                : ""
+            }
           >
-            <li className="menu-title flex items-center gap-2 px-3 py-2">
-              {React.createElement(currentSuggestions.icon, {
-                size: 16,
-                className:
-                  currentSuggestions.type === "popular"
-                    ? "text-warning"
-                    : currentSuggestions.type === "related"
-                      ? "text-secondary"
-                      : "text-primary",
-              })}
-              <span className="font-semibold">{getSuggestionTitle()}</span>
+            {shouldShowDropdown && (
+              <>
+                <li className="menu-title flex items-center gap-2 px-3 py-2">
+                  {React.createElement(currentSuggestions.icon, {
+                    size: 16,
+                    className:
+                      currentSuggestions.type === "popular"
+                        ? "text-warning"
+                        : currentSuggestions.type === "related"
+                          ? "text-secondary"
+                          : "text-primary",
+                  })}
+                  <span className="font-semibold">{getSuggestionTitle()}</span>
 
-              {loading && (
-                <span className="ml-auto text-xs opacity-70 flex items-center gap-2">
-                  <span className="loading loading-spinner loading-xs"></span>
-                  Loading…
-                </span>
-              )}
-            </li>
-
-            {currentSuggestions.tags.map((tag, index) => {
-              const alreadyAdded = selectedTagIdSet.has(getTagId(tag));
-              return (
-                <li key={tag.id} {...getItemProps({ item: tag, index })}>
-                  <button
-                    type="button"
-                    onMouseDown={(e) => e.preventDefault()}
-                    disabled={alreadyAdded}
-                    title={
-                      alreadyAdded ? UI_TEXT.focusAreas.alreadyAdded : undefined
-                    }
-                    className={`flex items-center justify-between w-full ${
-                      alreadyAdded
-                        ? "opacity-40 cursor-not-allowed"
-                        : highlightedIndex === index
-                          ? "active"
-                          : ""
-                    }`}
-                  >
-                    <div className="flex items-center gap-2">
-                      <TagIcon size={14} />
-                      <span className="font-medium">{tag.name}</span>
-                    </div>
-                    <div className="flex items-center gap-2 text-xs">
-                      {alreadyAdded ? (
-                        <span className="badge badge-sm badge-ghost opacity-60">
-                          added
-                        </span>
-                      ) : (
-                        <>
-                          <span className="badge badge-sm badge-ghost">
-                            {tag.category}
-                          </span>
-                          {tag.usage_count !== undefined &&
-                            tag.usage_count > 0 && (
-                              <span className="badge badge-sm badge-primary">
-                                {tag.usage_count}
-                              </span>
-                            )}
-                        </>
-                      )}
-                    </div>
-                  </button>
+                  {loading && (
+                    <span className="ml-auto text-xs opacity-70 flex items-center gap-2">
+                      <span className="loading loading-spinner loading-xs"></span>
+                      Loading…
+                    </span>
+                  )}
                 </li>
-              );
-            })}
+
+                {currentSuggestions.tags.map((tag, index) => {
+                  const alreadyAdded = selectedTagIdSet.has(getTagId(tag));
+                  return (
+                    <li key={tag.id} {...getItemProps({ item: tag, index })}>
+                      <button
+                        type="button"
+                        onMouseDown={(e) => e.preventDefault()}
+                        disabled={alreadyAdded}
+                        title={
+                          alreadyAdded
+                            ? UI_TEXT.focusAreas.alreadyAdded
+                            : undefined
+                        }
+                        className={`flex items-center justify-between w-full ${
+                          alreadyAdded
+                            ? "opacity-40 cursor-not-allowed"
+                            : highlightedIndex === index
+                              ? "active"
+                              : ""
+                        }`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <TagIcon size={14} />
+                          <span className="font-medium">{tag.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2 text-xs">
+                          {alreadyAdded ? (
+                            <span className="badge badge-sm badge-ghost opacity-60">
+                              added
+                            </span>
+                          ) : (
+                            <>
+                              <span className="badge badge-sm badge-ghost">
+                                {tag.category}
+                              </span>
+                              {tag.usage_count !== undefined &&
+                                tag.usage_count > 0 && (
+                                  <span className="badge badge-sm badge-primary">
+                                    {tag.usage_count}
+                                  </span>
+                                )}
+                            </>
+                          )}
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </>
+            )}
           </ul>,
           document.body,
         )}

--- a/src/components/tags/TagInput.jsx
+++ b/src/components/tags/TagInput.jsx
@@ -9,6 +9,11 @@ import { createPortal } from "react-dom";
 import { useCombobox } from "downshift";
 import { X, Tag as TagIcon, TrendingUp, Sparkles } from "lucide-react";
 import { tagService } from "../../services/tagService";
+import {
+  flattenStructuredTags,
+  usePopularTags,
+  useStructuredTags,
+} from "../../hooks/useTagQueries";
 import { UI_TEXT } from "../../constants/uiText";
 import { debounce } from "lodash";
 
@@ -54,6 +59,16 @@ const TagInput = ({
     zIndex: 10000,
   });
   const [menuPlacement, setMenuPlacement] = useState("bottom"); // "top" | "bottom"
+  const {
+    data: structuredTags = [],
+    error: structuredTagsError,
+  } = useStructuredTags();
+  const {
+    data: fetchedPopularTags = [],
+    error: popularTagsError,
+  } = usePopularTags(5, null, {
+    enabled: showPopularTags,
+  });
 
   const getTagId = (t) => {
     if (t == null) return null;
@@ -100,34 +115,27 @@ const TagInput = ({
   }, []);
 
   useEffect(() => {
-    let alive = true;
+    const flat = flattenStructuredTags(structuredTags);
+    updateTagMap(flat);
+  }, [structuredTags, updateTagMap]);
 
-    const fetchInitial = async () => {
-      try {
-        if (showPopularTags) {
-          const tags = await tagService.getPopularTags(5);
-          if (!alive) return;
-          setPopularTags(tags || []);
-          updateTagMap(tags || []);
-        }
+  useEffect(() => {
+    const tags = showPopularTags ? fetchedPopularTags || [] : [];
+    setPopularTags(tags);
+    updateTagMap(tags);
+  }, [fetchedPopularTags, showPopularTags, updateTagMap]);
 
-        const allTags = await tagService.getStructuredTags();
-        if (!alive) return;
+  useEffect(() => {
+    if (structuredTagsError) {
+      console.error("Error fetching tags:", structuredTagsError);
+    }
+  }, [structuredTagsError]);
 
-        const flat = (allTags || [])
-          .flatMap((supercat) => supercat.categories || [])
-          .flatMap((cat) => cat.tags || []);
-        updateTagMap(flat);
-      } catch (err) {
-        console.error("Error fetching tags:", err);
-      }
-    };
-
-    fetchInitial();
-    return () => {
-      alive = false;
-    };
-  }, [showPopularTags, updateTagMap]);
+  useEffect(() => {
+    if (popularTagsError) {
+      console.error("Error fetching popular tags:", popularTagsError);
+    }
+  }, [popularTagsError]);
 
   const debouncedSearch = useCallback(
     debounce(async (query) => {

--- a/src/components/teams/RequestRoleCard.jsx
+++ b/src/components/teams/RequestRoleCard.jsx
@@ -1,0 +1,44 @@
+import VacantRoleCard from "./VacantRoleCard";
+
+const getMatchScore = (...sources) => {
+  for (const source of sources) {
+    const score = source?.matchScore ?? source?.match_score ?? null;
+    if (score !== null && score !== undefined) return score;
+  }
+
+  return null;
+};
+
+const getMatchDetails = (...sources) => {
+  for (const source of sources) {
+    const details = source?.matchDetails ?? source?.match_details ?? null;
+    if (details !== null && details !== undefined) return details;
+  }
+
+  return null;
+};
+
+const RequestRoleCard = ({
+  role,
+  teamId,
+  teamName,
+  primaryMatch = null,
+  secondaryMatch = null,
+  viewAsUserId = null,
+  viewAsUser = null,
+  ...props
+}) => (
+  <VacantRoleCard
+    role={role}
+    team={{ id: teamId, name: teamName }}
+    matchScore={getMatchScore(primaryMatch, secondaryMatch, role)}
+    matchDetails={getMatchDetails(primaryMatch, secondaryMatch, role)}
+    canManage={false}
+    isTeamMember={true}
+    viewAsUserId={viewAsUserId}
+    viewAsUser={viewAsUser}
+    {...props}
+  />
+);
+
+export default RequestRoleCard;

--- a/src/components/teams/RoleBadgeDropdown.jsx
+++ b/src/components/teams/RoleBadgeDropdown.jsx
@@ -177,8 +177,6 @@ const RoleBadgeDropdown = ({
       <Dropdown
         trigger={triggerBadge}
         position="bottom-right"
-        openOnHover={true}
-        hoverDelay={150}
         dropdownClassName="min-w-48"
       >
         {/* Promote to Admin - shown for members (NOT for archived teams) */}

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -27,33 +27,10 @@ import {
 import Alert from "../common/Alert";
 import { format } from "date-fns";
 import { useHydratedRole } from "../../hooks/useHydratedRole";
-
-const extractRoleMatchData = (roleLike) => {
-  const rawScore = roleLike?.matchScore ?? roleLike?.match_score ?? null;
-  const numericScore = Number(rawScore);
-
-  return {
-    matchScore: Number.isFinite(numericScore) ? numericScore : null,
-    matchDetails:
-      roleLike?.matchDetails ??
-      roleLike?.match_details ??
-      roleLike?.scoreBreakdown ??
-      null,
-  };
-};
-
-const normalizeBoolean = (value) => {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value === 1;
-
-  if (typeof value === "string") {
-    const normalizedValue = value.trim().toLowerCase();
-    if (["true", "1", "yes"].includes(normalizedValue)) return true;
-    if (["false", "0", "no"].includes(normalizedValue)) return false;
-  }
-
-  return null;
-};
+import {
+  extractRoleMatchData,
+  normalizeBoolean,
+} from "../../utils/teamRequestUtils";
 
 /**
  * TeamApplicationDetailsModal Component

--- a/src/components/teams/TeamApplicationModal.jsx
+++ b/src/components/teams/TeamApplicationModal.jsx
@@ -28,11 +28,9 @@ import {
   isSyntheticRole,
   isSyntheticTeam,
 } from "../../utils/userHelpers";
+import { idsMatch } from "../../utils/teamRequestUtils";
 
 const VacantRoleDetailsModal = lazy(() => import("./VacantRoleDetailsModal"));
-
-const idsMatch = (left, right) =>
-  left != null && right != null && String(left) === String(right);
 
 /**
  * TeamApplicationModal Component

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -14,6 +14,10 @@ import { messageService } from "../../services/messageService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
 import { buildRoleApplicationFilledMessage } from "../../utils/roleEventMessages";
+import {
+  buildApplicationRoleForCard,
+  getRequestRoleId,
+} from "../../utils/teamRequestUtils";
 
 const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
 
@@ -502,67 +506,14 @@ const TeamApplicationsModal = ({
       {applications.map((application) => {
         const applicantId =
           application?.applicant?.id ?? application?.applicant_id ?? null;
-        const roleId =
-          application?.role?.id ??
-          application?.roleId ??
-          application?.role_id ??
-          null;
-        const syntheticRoleFlag =
-          application?.role?.is_synthetic ??
-          application?.role?.isSynthetic ??
-          application?.role_is_synthetic ??
-          application?.roleIsSynthetic ??
-          application?.is_synthetic ??
-          application?.isSynthetic;
+        const roleId = getRequestRoleId(application);
         const roleOverride = roleId ? roleStatusOverrides[roleId] : null;
         const polledRole = roleId ? polledRoleStatusMap[String(roleId)] : null;
-        const role =
-          application?.role && roleId
-            ? {
-                ...application.role,
-                ...(polledRole ?? {}),
-                is_synthetic:
-                  application.role.is_synthetic ??
-                  application.role.isSynthetic ??
-                  syntheticRoleFlag,
-                isSynthetic:
-                  application.role.isSynthetic ??
-                  application.role.is_synthetic ??
-                  syntheticRoleFlag,
-                status:
-                  roleOverride?.status ??
-                  polledRole?.status ??
-                  application.role.status ??
-                  "open",
-                filledBy:
-                  roleOverride?.filledBy ??
-                  polledRole?.filledBy ??
-                  polledRole?.filled_by ??
-                  application.role.filledBy ??
-                  application.role.filled_by ??
-                  null,
-                filledByUser:
-                  roleOverride?.filledByUser ??
-                  polledRole?.filledByUser ??
-                  polledRole?.filled_by_user ??
-                  application.role.filledByUser ??
-                  application.role.filled_by_user ??
-                  null,
-              }
-            : application?.role
-              ? {
-                  ...application.role,
-                  ...(polledRole ?? {}),
-                  is_synthetic:
-                    application.role.is_synthetic ??
-                    application.role.isSynthetic ??
-                    syntheticRoleFlag,
-                  isSynthetic:
-                    application.role.isSynthetic ??
-                    application.role.is_synthetic ??
-                    syntheticRoleFlag,
-                }
-              : null;
+        const role = buildApplicationRoleForCard(
+          application,
+          polledRole,
+          roleOverride,
+        );
         const isSelfApplication =
           currentUser?.id === (application.applicant?.id ?? application.applicant_id);
         const isInternalRoleApplication = Boolean(

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -17,7 +17,10 @@ import usePolledRequestRoles from "../../hooks/usePolledRequestRoles";
 import useSelfRoleMatchMap from "../../hooks/useSelfRoleMatchMap";
 import {
   buildApplicationRoleForCard,
+  getRequestDateValue,
+  getRequestUserId,
   getRequestRoleId,
+  isRequestForUser,
 } from "../../utils/teamRequestUtils";
 
 /**
@@ -276,16 +279,6 @@ const TeamApplicationsModal = ({
     }
   };
 
-  // ============ Helper Functions ============
-  const getApplicationDate = (application) => {
-    return (
-      application?.created_at ||
-      application?.createdAt ||
-      application?.date ||
-      application?.applied_at
-    );
-  };
-
   // ============ Effects ============
   useEffect(() => {
     if (!isOpen || (!highlightApplicationId && !highlightUserId)) return;
@@ -387,8 +380,7 @@ const TeamApplicationsModal = ({
       }
     >
       {applications.map((application) => {
-        const applicantId =
-          application?.applicant?.id ?? application?.applicant_id ?? null;
+        const applicantId = getRequestUserId(application, "applicant");
         const roleId = getRequestRoleId(application);
         const roleOverride = roleId ? roleStatusOverrides[roleId] : null;
         const polledRole = roleId ? polledRoleStatusMap[String(roleId)] : null;
@@ -397,8 +389,11 @@ const TeamApplicationsModal = ({
           polledRole,
           roleOverride,
         );
-        const isSelfApplication =
-          currentUser?.id === (application.applicant?.id ?? application.applicant_id);
+        const isSelfApplication = isRequestForUser(
+          application,
+          "applicant",
+          currentUser?.id,
+        );
         const isInternalRoleApplication = Boolean(
           application?.isInternalRoleApplication ??
             application?.is_internal_role_application ??
@@ -466,7 +461,7 @@ const TeamApplicationsModal = ({
           >
             <PersonRequestCard
               user={application.applicant}
-              date={getApplicationDate(application)}
+              date={getRequestDateValue(application)}
               onNarrowChange={(narrow) => setNarrowMap((prev) => {
                 if ((prev[String(application.id)] ?? false) === narrow) return prev;
                 return { ...prev, [String(application.id)]: narrow };

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -18,6 +18,7 @@ import useSelfRoleMatchMap from "../../hooks/useSelfRoleMatchMap";
 import {
   buildApplicationRoleForCard,
   getRequestDateValue,
+  getRequestUserLabel,
   getRequestUserId,
   getRequestRoleId,
   isRequestForUser,
@@ -468,7 +469,7 @@ const TeamApplicationsModal = ({
               })}
               forceNarrow={anyNarrow}
               message={application.message || "No message provided."}
-              messageLabel={`${application.applicant?.first_name || application.applicant?.firstName || application.applicant?.username || "Their"}'s application message:`}
+              messageLabel={`${getRequestUserLabel(application, "applicant")}'s application message:`}
               messageIcon={<Mail size={12} className="text-pink-500 mr-1" />}
               onUserClick={handleUserClick}
               showLocation={true}

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -8,19 +8,17 @@ import Tooltip from "../common/Tooltip";
 import UserDetailsModal from "../users/UserDetailsModal";
 import VacantRoleCard from "./VacantRoleCard";
 import TeamApplicationDetailsModal from "./TeamApplicationDetailsModal";
-import { matchingService } from "../../services/matchingService";
 import { messageService } from "../../services/messageService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
 import { buildRoleApplicationFilledMessage } from "../../utils/roleEventMessages";
 import usePolledRequestRoles from "../../hooks/usePolledRequestRoles";
+import useSelfRoleMatchMap from "../../hooks/useSelfRoleMatchMap";
 import {
   buildApplicationRoleForCard,
   getRequestRoleId,
 } from "../../utils/teamRequestUtils";
-
-const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
 
 /**
  * TeamApplicationsModal Component
@@ -62,11 +60,17 @@ const TeamApplicationsModal = ({
   const [statusUpdatingRoleId, setStatusUpdatingRoleId] = useState(null);
   const [showCloseGuard, setShowCloseGuard] = useState(false);
   const [applicationDetailsFor, setApplicationDetailsFor] = useState(null);
-  const [selfRoleMatchMap, setSelfRoleMatchMap] = useState({});
   const [narrowMap, setNarrowMap] = useState({});
   const polledRoleStatusMap = usePolledRequestRoles(applications, {
     isOpen,
     teamId,
+  });
+  const selfRoleMatchMap = useSelfRoleMatchMap(applications, {
+    isOpen,
+    teamId,
+    currentUserId: currentUser?.id,
+    userKey: "applicant",
+    warningLabel: "application",
   });
 
   // ============ Refs ============
@@ -308,77 +312,6 @@ const TeamApplicationsModal = ({
       setRoleStatusOverrides({});
     }
   }, [isOpen]);
-
-  useEffect(() => {
-    const selfRoleIds = [
-      ...new Set(
-        applications
-          .filter((application) => {
-            const applicantId =
-              application?.applicant?.id ??
-              application?.applicant_id ??
-              null;
-            return applicantId != null && String(applicantId) === String(currentUser?.id);
-          })
-          .map((application) =>
-            application?.role?.id ??
-            application?.roleId ??
-            application?.role_id ??
-            null,
-          )
-          .filter((roleId) => roleId != null)
-          .map(String),
-      ),
-    ];
-
-    if (!isOpen || !teamId || !currentUser?.id || selfRoleIds.length === 0) {
-      setSelfRoleMatchMap({});
-      return;
-    }
-
-    let cancelled = false;
-
-    const fetchSelfRoleMatches = async () => {
-      try {
-        const response = await matchingService.getMatchingRolesForTeam(teamId, {
-          limit: SELF_ROLE_MATCH_FETCH_LIMIT,
-        });
-
-        if (cancelled) return;
-
-        const nextMatchMap = {};
-
-        (response?.data || []).forEach((role) => {
-          const roleId = role?.id;
-          if (roleId == null || !selfRoleIds.includes(String(roleId))) return;
-
-          nextMatchMap[String(roleId)] = {
-            matchScore:
-              role?.matchScore ??
-              role?.match_score ??
-              null,
-            matchDetails:
-              role?.matchDetails ??
-              role?.match_details ??
-              null,
-          };
-        });
-
-        setSelfRoleMatchMap(nextMatchMap);
-      } catch (error) {
-        if (!cancelled) {
-          console.warn("Could not fetch self-application role match scores:", error);
-          setSelfRoleMatchMap({});
-        }
-      }
-    };
-
-    fetchSelfRoleMatches();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, teamId, currentUser?.id, applications]);
 
   // ============ Render ============
   const anyNarrow = Object.values(narrowMap).some(Boolean);

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -9,11 +9,12 @@ import UserDetailsModal from "../users/UserDetailsModal";
 import VacantRoleCard from "./VacantRoleCard";
 import TeamApplicationDetailsModal from "./TeamApplicationDetailsModal";
 import { matchingService } from "../../services/matchingService";
-import { vacantRoleService } from "../../services/vacantRoleService";
 import { messageService } from "../../services/messageService";
+import { vacantRoleService } from "../../services/vacantRoleService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
 import { buildRoleApplicationFilledMessage } from "../../utils/roleEventMessages";
+import usePolledRequestRoles from "../../hooks/usePolledRequestRoles";
 import {
   buildApplicationRoleForCard,
   getRequestRoleId,
@@ -62,8 +63,11 @@ const TeamApplicationsModal = ({
   const [showCloseGuard, setShowCloseGuard] = useState(false);
   const [applicationDetailsFor, setApplicationDetailsFor] = useState(null);
   const [selfRoleMatchMap, setSelfRoleMatchMap] = useState({});
-  const [polledRoleStatusMap, setPolledRoleStatusMap] = useState({});
   const [narrowMap, setNarrowMap] = useState({});
+  const polledRoleStatusMap = usePolledRequestRoles(applications, {
+    isOpen,
+    teamId,
+  });
 
   // ============ Refs ============
   const highlightedRef = useRef(null);
@@ -375,60 +379,6 @@ const TeamApplicationsModal = ({
       cancelled = true;
     };
   }, [isOpen, teamId, currentUser?.id, applications]);
-
-  // Poll role status every 20s so VacantRoleCard reflects changes made by others
-  useEffect(() => {
-    if (!isOpen || !teamId) return;
-
-    const roleIds = [
-      ...new Set(
-        applications
-          .map(
-            (app) =>
-              app?.role?.id ?? app?.roleId ?? app?.role_id ?? null,
-          )
-          .filter(Boolean)
-          .map(String),
-      ),
-    ];
-
-    if (roleIds.length === 0) return;
-
-    let isCancelled = false;
-
-    const pollRoles = async () => {
-      try {
-        const results = await Promise.allSettled(
-          roleIds.map((id) =>
-            vacantRoleService.getVacantRoleById(teamId, id),
-          ),
-        );
-        if (isCancelled) return;
-        const nextMap = {};
-        results.forEach((result, i) => {
-          if (result.status === "fulfilled") {
-            const payload = result.value?.data ?? result.value;
-            const roleData =
-              payload?.success !== undefined
-                ? payload?.data ?? null
-                : payload?.data?.data ?? payload?.data ?? payload;
-            if (roleData) nextMap[roleIds[i]] = roleData;
-          }
-        });
-        setPolledRoleStatusMap((prev) => ({ ...prev, ...nextMap }));
-      } catch {
-        // silent — keep showing last known state
-      }
-    };
-
-    pollRoles();
-    const intervalId = setInterval(pollRoles, 20_000);
-
-    return () => {
-      isCancelled = true;
-      clearInterval(intervalId);
-    };
-  }, [isOpen, teamId, applications]);
 
   // ============ Render ============
   const anyNarrow = Object.values(narrowMap).some(Boolean);

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -14,9 +14,7 @@ import { messageService } from "../../services/messageService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
 import { buildRoleApplicationFilledMessage } from "../../utils/roleEventMessages";
-import { extractCandidateMatchData } from "../../utils/matchHelpers";
 
-const ROLE_CANDIDATE_FETCH_MIN_LIMIT = 20;
 const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
 
 /**
@@ -59,7 +57,6 @@ const TeamApplicationsModal = ({
   const [statusUpdatingRoleId, setStatusUpdatingRoleId] = useState(null);
   const [showCloseGuard, setShowCloseGuard] = useState(false);
   const [applicationDetailsFor, setApplicationDetailsFor] = useState(null);
-  const [roleCandidateMatchMap, setRoleCandidateMatchMap] = useState({});
   const [selfRoleMatchMap, setSelfRoleMatchMap] = useState({});
   const [polledRoleStatusMap, setPolledRoleStatusMap] = useState({});
   const [narrowMap, setNarrowMap] = useState({});
@@ -375,94 +372,6 @@ const TeamApplicationsModal = ({
     };
   }, [isOpen, teamId, currentUser?.id, applications]);
 
-  useEffect(() => {
-    if (!isOpen || applications.length === 0) {
-      setRoleCandidateMatchMap({});
-      return;
-    }
-
-    const applicantsByRole = applications.reduce((acc, application) => {
-      const roleId =
-        application?.role?.id ??
-        application?.roleId ??
-        application?.role_id ??
-        null;
-      const applicantId =
-        application?.applicant?.id ??
-        application?.applicant_id ??
-        null;
-
-      if (roleId == null || applicantId == null) {
-        return acc;
-      }
-
-      const roleKey = String(roleId);
-      if (!acc.has(roleKey)) {
-        acc.set(roleKey, new Set());
-      }
-      acc.get(roleKey).add(String(applicantId));
-      return acc;
-    }, new Map());
-
-    if (applicantsByRole.size === 0) {
-      setRoleCandidateMatchMap({});
-      return;
-    }
-
-    let cancelled = false;
-
-    const fetchCandidateMatches = async () => {
-      const roleEntries = [...applicantsByRole.entries()];
-
-      try {
-        const results = await Promise.allSettled(
-          roleEntries.map(([roleId, applicantIds]) =>
-            matchingService.getMatchingCandidates(roleId, {
-              limit: Math.max(applicantIds.size, ROLE_CANDIDATE_FETCH_MIN_LIMIT),
-            }),
-          ),
-        );
-
-        if (cancelled) return;
-
-        const nextMatchMap = {};
-
-        results.forEach((result, index) => {
-          if (result.status !== "fulfilled") return;
-
-          const [roleId] = roleEntries[index];
-          const roleMatches = {};
-
-          (result.value?.data || []).forEach((candidate) => {
-            const candidateId =
-              candidate?.id ??
-              candidate?.userId ??
-              candidate?.user_id ??
-              null;
-            if (candidateId == null) return;
-
-            roleMatches[String(candidateId)] = extractCandidateMatchData(candidate);
-          });
-
-          nextMatchMap[String(roleId)] = roleMatches;
-        });
-
-        setRoleCandidateMatchMap(nextMatchMap);
-      } catch (error) {
-        if (!cancelled) {
-          console.warn("Could not fetch application role match scores:", error);
-          setRoleCandidateMatchMap({});
-        }
-      }
-    };
-
-    fetchCandidateMatches();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, applications]);
-
   // Poll role status every 20s so VacantRoleCard reflects changes made by others
   useEffect(() => {
     if (!isOpen || !teamId) return;
@@ -654,10 +563,6 @@ const TeamApplicationsModal = ({
                     syntheticRoleFlag,
                 }
               : null;
-        const applicantRoleMatch =
-          roleId != null && applicantId != null
-            ? roleCandidateMatchMap[String(roleId)]?.[String(applicantId)] ?? null
-            : null;
         const isSelfApplication =
           currentUser?.id === (application.applicant?.id ?? application.applicant_id);
         const isInternalRoleApplication = Boolean(
@@ -755,17 +660,15 @@ const TeamApplicationsModal = ({
                       role={role}
                       team={{ id: teamId, name: teamName }}
                       matchScore={
-                        applicantRoleMatch?.matchScore ??
                         selfRoleMatch?.matchScore ??
-                        role.matchScore ??
                         role.match_score ??
+                        role.matchScore ??
                         null
                       }
                       matchDetails={
-                        applicantRoleMatch?.matchDetails ??
                         selfRoleMatch?.matchDetails ??
-                        role.matchDetails ??
                         role.match_details ??
+                        role.matchDetails ??
                         null
                       }
                       canManage={false}

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -6,7 +6,7 @@ import Button from "../common/Button";
 import Modal from "../common/Modal";
 import Tooltip from "../common/Tooltip";
 import UserDetailsModal from "../users/UserDetailsModal";
-import VacantRoleCard from "./VacantRoleCard";
+import RequestRoleCard from "./RequestRoleCard";
 import TeamApplicationDetailsModal from "./TeamApplicationDetailsModal";
 import { messageService } from "../../services/messageService";
 import { vacantRoleService } from "../../services/vacantRoleService";
@@ -485,29 +485,17 @@ const TeamApplicationsModal = ({
               }
               messageBubbleExtra={
                 role ? (
-                  <VacantRoleCard
+                  <RequestRoleCard
                       role={role}
-                      team={{ id: teamId, name: teamName }}
-                      matchScore={
-                        selfRoleMatch?.matchScore ??
-                        role.match_score ??
-                        role.matchScore ??
-                        null
-                      }
-                      matchDetails={
-                        selfRoleMatch?.matchDetails ??
-                        role.match_details ??
-                        role.matchDetails ??
-                        null
-                      }
-                      canManage={false}
+                      teamId={teamId}
+                      teamName={teamName}
+                      primaryMatch={selfRoleMatch}
                       canManageStatus={canManageStatusForRole}
                       onViewApplicationDetails={
                         isSelfApplication
                           ? () => setApplicationDetailsFor(application)
                           : null
                       }
-                      isTeamMember={true}
                       onStatusChange={(currentRoleId, newStatus) =>
                         handleRoleStatusChange(
                           currentRoleId,

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -14,27 +14,10 @@ import { messageService } from "../../services/messageService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
 import { buildRoleApplicationFilledMessage } from "../../utils/roleEventMessages";
+import { extractCandidateMatchData } from "../../utils/matchHelpers";
 
 const ROLE_CANDIDATE_FETCH_MIN_LIMIT = 20;
 const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
-
-const extractCandidateMatchData = (candidateLike) => {
-  const rawScore =
-    candidateLike?.matchScore ??
-    candidateLike?.match_score ??
-    candidateLike?.bestMatchScore ??
-    candidateLike?.best_match_score ??
-    null;
-  const numericScore = Number(rawScore);
-
-  return {
-    matchScore: Number.isFinite(numericScore) ? numericScore : null,
-    matchDetails:
-      candidateLike?.matchDetails ??
-      candidateLike?.match_details ??
-      null,
-  };
-};
 
 /**
  * TeamApplicationsModal Component

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -43,6 +43,16 @@ import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import { calculateDistanceKm } from "../../utils/locationUtils";
 import {
+  extractListPayload,
+  extractProfilePayload,
+} from "../../utils/payloadExtractors";
+import {
+  buildBadgeLookup,
+  buildTagLookup,
+  computeRoleUserMatch,
+  extractCandidateMatchData,
+} from "../../utils/matchHelpers";
+import {
   DEMO_ROLE_TOOLTIP,
   DEMO_TEAM_TOOLTIP,
   isSyntheticRole,
@@ -52,149 +62,13 @@ import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
 const teamMemberBadgesCache = new Map();
 const viewerRoleProfileCache = new Map();
-const MATCH_WEIGHTS = {
-  tags: 0.4,
-  badges: 0.3,
-  distance: 0.3,
-};
-const LOCATION_GRACE_KM = 20;
-const LOCATION_GRACE_SCORE = 0.25;
+const EMPTY_ARRAY = [];
 
 const extractBadgeRows = (payload) => {
   if (Array.isArray(payload)) return payload;
   if (Array.isArray(payload?.data)) return payload.data;
   if (Array.isArray(payload?.data?.data)) return payload.data.data;
   return [];
-};
-
-const extractProfilePayload = (response) => {
-  const payload = response?.data ?? response;
-
-  if (!payload) return null;
-  if (payload?.success !== undefined) return payload?.data ?? null;
-
-  return payload?.data?.data ?? payload?.data ?? payload;
-};
-
-const extractListPayload = (response) => {
-  if (Array.isArray(response)) return response;
-  if (Array.isArray(response?.data)) return response.data;
-  if (Array.isArray(response?.data?.data)) return response.data.data;
-  return [];
-};
-
-const buildTagLookup = (tagData) => {
-  const nextMap = new Map();
-
-  for (const tag of tagData) {
-    nextMap.set(Number(tag.id), {
-      badgeCredits: Number(tag.badge_credits ?? tag.badgeCredits ?? 0),
-    });
-  }
-
-  return nextMap;
-};
-
-const buildBadgeLookup = (badgeData) => {
-  const nextMap = new Map();
-
-  for (const badge of badgeData) {
-    const name = (badge.badgeName ?? badge.badge_name ?? badge.name ?? "")
-      .trim()
-      .toLowerCase();
-    const credits = Number(
-      badge.totalCredits ?? badge.total_credits ?? badge.credits ?? 0,
-    );
-    const existing = nextMap.get(name);
-
-    nextMap.set(name, {
-      totalCredits: (existing?.totalCredits || 0) + credits,
-    });
-  }
-
-  return nextMap;
-};
-
-const roundMatchValue = (value) => Math.round(value * 100) / 100;
-
-const computeRoleUserMatch = ({
-  role,
-  tags,
-  badges,
-  user,
-  userTagMap,
-  userBadgeMap,
-}) => {
-  if (!role || !user) return null;
-
-  const requiredTagIds = tags
-    .map((tag) => Number(tag.tagId ?? tag.tag_id ?? tag.id))
-    .filter(Number.isFinite);
-  const requiredBadgeKeys = badges
-    .map((badge) =>
-      (badge.name ?? badge.badgeName ?? badge.badge_name ?? "")
-        .trim()
-        .toLowerCase(),
-    )
-    .filter(Boolean);
-
-  const matchingTags = requiredTagIds.filter((id) => userTagMap.has(id)).length;
-  const matchingBadges = requiredBadgeKeys.filter((key) => userBadgeMap.has(key)).length;
-
-  const tagScore =
-    requiredTagIds.length > 0 ? matchingTags / requiredTagIds.length : 0.5;
-  const badgeScore =
-    requiredBadgeKeys.length > 0
-      ? matchingBadges / requiredBadgeKeys.length
-      : 0.5;
-
-  const isRemote = role.isRemote ?? role.is_remote;
-  const maxDistanceKm = Number(role.maxDistanceKm ?? role.max_distance_km) || 50;
-
-  let distanceScore = 0.5;
-  let distanceKm = null;
-  let isWithinRange = null;
-
-  if (isRemote) {
-    distanceScore = 1;
-    isWithinRange = true;
-  } else {
-    distanceKm = calculateDistanceKm(user, role);
-
-    if (distanceKm !== null) {
-      if (distanceKm <= maxDistanceKm) {
-        distanceScore = 1;
-        isWithinRange = true;
-      } else if (distanceKm <= maxDistanceKm + LOCATION_GRACE_KM) {
-        distanceScore = LOCATION_GRACE_SCORE;
-        isWithinRange = false;
-      } else {
-        distanceScore = 0;
-        isWithinRange = false;
-      }
-    }
-  }
-
-  const matchScore =
-    MATCH_WEIGHTS.tags * tagScore +
-    MATCH_WEIGHTS.badges * badgeScore +
-    MATCH_WEIGHTS.distance * distanceScore;
-
-  return {
-    matchScore: roundMatchValue(matchScore),
-    matchDetails: {
-      tagScore: roundMatchValue(tagScore),
-      badgeScore: roundMatchValue(badgeScore),
-      distanceScore: roundMatchValue(distanceScore),
-      matchingTags,
-      totalRequiredTags: requiredTagIds.length,
-      matchingBadges,
-      totalRequiredBadges: requiredBadgeKeys.length,
-      distanceKm: distanceKm !== null ? Math.round(distanceKm) : null,
-      maxDistanceKm,
-      isWithinRange,
-    },
-  };
 };
 
 const getViewerRoleProfile = async (userId, fallbackUser = null) => {
@@ -255,6 +129,9 @@ const getExplicitMatchScore = (item) => {
 
   return Number.isFinite(score) ? score : null;
 };
+
+const hasRoleMatchDetails = (item) =>
+  item?.matchDetails != null || item?.match_details != null;
 
 const hasDisplayableBadges = (rawBadges) => {
   if (typeof rawBadges === "string") {
@@ -511,8 +388,12 @@ const TeamCard = ({
   const flatRoleBio = roleSource?.bio ?? roleSource?.roleBio ?? null;
   const flatRoleCity = roleSource?.city ?? null;
   const flatRoleCountry = roleSource?.country ?? null;
-  const flatRoleTags = roleSource?.tags ?? [];
-  const flatRoleBadges = roleSource?.badges ?? [];
+  const flatRoleTags = roleSource?.tags ?? EMPTY_ARRAY;
+  const flatRoleBadges = roleSource?.badges ?? EMPTY_ARRAY;
+  const roleHasPreloadedRequirements =
+    (Array.isArray(nestedRoleData?.tags) &&
+      Array.isArray(nestedRoleData?.badges)) ||
+    (Array.isArray(roleSource?.tags) && Array.isArray(roleSource?.badges));
   const flatRoleIsRemote =
     roleSource?.isRemote ?? roleSource?.is_remote ?? undefined;
   const syntheticRoleFlag = isRoleApplicationVariant
@@ -1250,21 +1131,28 @@ const TeamCard = ({
 
     const fetchRoleMatchData = async () => {
       try {
-        const [viewerProfileRes, detailsRes] = await Promise.allSettled([
-          getViewerRoleProfile(user.id, user),
-          vacantRoleService.getVacantRoleById(roleTeamId, roleDataId),
-        ]);
-
-        if (viewerProfileRes.status !== "fulfilled") {
-          throw viewerProfileRes.reason;
+        const preloadedMatchData = extractCandidateMatchData(roleData);
+        if (
+          preloadedMatchData.matchScore != null &&
+          hasRoleMatchDetails(roleData)
+        ) {
+          if (!isCancelled) {
+            setRoleMatchData(preloadedMatchData);
+          }
+          return;
         }
 
-        const viewerProfile = viewerProfileRes.value;
-        const hydratedRole =
-          detailsRes.status === "fulfilled"
-            ? extractProfilePayload(detailsRes.value)
-            : null;
-        const effectiveRole = hydratedRole ?? roleData ?? null;
+        const viewerProfile = await getViewerRoleProfile(user.id, user);
+        let effectiveRole = roleData ?? null;
+
+        if (!roleHasPreloadedRequirements) {
+          const detailsRes = await vacantRoleService.getVacantRoleById(
+            roleTeamId,
+            roleDataId,
+          );
+          effectiveRole = extractProfilePayload(detailsRes) ?? effectiveRole;
+        }
+
         const nextMatchData = effectiveRole
           ? computeRoleUserMatch({
               role: effectiveRole,
@@ -1289,7 +1177,15 @@ const TeamCard = ({
     return () => {
       isCancelled = true;
     };
-  }, [isRoleVariant, showMatchScore, roleDataId, roleTeamId, user?.id]);
+  }, [
+    isRoleVariant,
+    showMatchScore,
+    roleData,
+    roleDataId,
+    roleHasPreloadedRequirements,
+    roleTeamId,
+    user?.id,
+  ]);
 
   // ================= GUARD CLAUSE – AFTER ALL HOOKS =================
 

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -382,6 +382,13 @@ const TeamCard = ({
   highlightApplicationId = null,
   highlightInvitationId = null,
   onApplicationsModalClosed,
+
+  // Preloaded viewer-scoped lists (provided by parent to avoid N+1 fetches).
+  // If the prop is undefined (not provided by parent at all), the card falls
+  // back to fetching on its own. If the prop is null, parent is still loading
+  // and the card should wait — not fall back to fetching.
+  viewerPendingApplications,
+  viewerPendingInvitations,
 }) => {
   const isInternalRoleApplication =
     application?.isInternalRoleApplication ??
@@ -758,6 +765,14 @@ const TeamCard = ({
         return;
       }
 
+      // Use role from list response (getUserTeams) if present — avoids an
+      // extra request per card.
+      const preloadedRole = teamData.userRole ?? teamData.user_role ?? null;
+      if (preloadedRole) {
+        setUserRole(preloadedRole);
+        return;
+      }
+
       try {
         const response = await teamService.getUserRoleInTeam(
           teamData.id,
@@ -787,6 +802,8 @@ const TeamCard = ({
     teamData?.id,
     teamData?.owner_id,
     teamData?.ownerId,
+    teamData?.userRole,
+    teamData?.user_role,
     effectiveVariant,
   ]);
 
@@ -1013,6 +1030,19 @@ const TeamCard = ({
         return;
       }
 
+      // If parent is managing the viewer's pending applications, never fetch.
+      // While the parent's list is still loading (null), wait. Once it's an
+      // array, scan it locally.
+      if (viewerPendingApplications !== undefined) {
+        if (Array.isArray(viewerPendingApplications)) {
+          const found = viewerPendingApplications.find(
+            (app) => app.team?.id === teamData.id || app.team_id === teamData.id,
+          );
+          setPendingApplicationForTeam(found || null);
+        }
+        return;
+      }
+
       try {
         const response = await teamService.getUserPendingApplications();
         const pendingApplications = response.data || [];
@@ -1029,12 +1059,23 @@ const TeamCard = ({
     };
 
     checkPendingApplication();
-  }, [isSearchResult, isAuthenticated, teamData?.id]);
+  }, [isSearchResult, isAuthenticated, teamData?.id, viewerPendingApplications]);
 
   // Check if user has a pending invitation for this team (for search results)
   useEffect(() => {
     const checkPendingInvitation = async () => {
       if (!isSearchResult || !isAuthenticated || !teamData?.id) return;
+
+      // If parent is managing the viewer's pending invitations, never fetch.
+      if (viewerPendingInvitations !== undefined) {
+        if (Array.isArray(viewerPendingInvitations)) {
+          const found = viewerPendingInvitations.find(
+            (inv) => inv.team?.id === teamData.id || inv.team_id === teamData.id,
+          );
+          setPendingInvitationForTeam(found || null);
+        }
+        return;
+      }
 
       try {
         // IMPORTANT: use whatever your actual service method is called
@@ -1054,7 +1095,7 @@ const TeamCard = ({
     };
 
     checkPendingInvitation();
-  }, [isSearchResult, isAuthenticated, teamData?.id]);
+  }, [isSearchResult, isAuthenticated, teamData?.id, viewerPendingInvitations]);
 
   // useEffect(() => {
   //   if (effectiveVariant !== "member") return;

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -846,13 +846,58 @@ const TeamCard = ({
     }
   }, [effectiveVariant, teamData?.id, canManageInvitations]);
 
+  // Counts may be preloaded by the parent's list response (getUserTeams).
+  // When present, we defer the full list fetch until the user actually opens
+  // the corresponding modal.
+  const preloadedApplicationCount =
+    teamData?.pendingApplicationsCount ??
+    teamData?.pending_applications_count;
+  const preloadedSentInvitationCount =
+    teamData?.pendingSentInvitationsCount ??
+    teamData?.pending_sent_invitations_count;
+  const hasPreloadedApplicationCount = Number.isFinite(
+    preloadedApplicationCount,
+  );
+  const hasPreloadedSentInvitationCount = Number.isFinite(
+    preloadedSentInvitationCount,
+  );
+
+  // Once the full list is loaded (after a modal open), state.length is the
+  // source of truth. Otherwise fall back to the count from teamData.
+  const displayedApplicationCount = pendingApplicationsLoaded
+    ? pendingApplications.length
+    : hasPreloadedApplicationCount
+      ? preloadedApplicationCount
+      : 0;
+  const displayedSentInvitationCount = pendingInvitationsLoaded
+    ? pendingSentInvitations.length
+    : hasPreloadedSentInvitationCount
+      ? preloadedSentInvitationCount
+      : 0;
+
+  // Eagerly fetch only when the parent didn't provide a count (older backend).
   useEffect(() => {
+    if (hasPreloadedApplicationCount) return;
     fetchPendingApplications();
-  }, [fetchPendingApplications]);
+  }, [fetchPendingApplications, hasPreloadedApplicationCount]);
 
   useEffect(() => {
+    if (hasPreloadedSentInvitationCount) return;
     fetchSentInvitations();
-  }, [fetchSentInvitations]);
+  }, [fetchSentInvitations, hasPreloadedSentInvitationCount]);
+
+  // Lazy-fetch the full list the first time the relevant modal opens.
+  useEffect(() => {
+    if (isApplicationsModalOpen && !pendingApplicationsLoaded) {
+      fetchPendingApplications();
+    }
+  }, [isApplicationsModalOpen, pendingApplicationsLoaded, fetchPendingApplications]);
+
+  useEffect(() => {
+    if (isInvitesModalOpen && !pendingInvitationsLoaded) {
+      fetchSentInvitations();
+    }
+  }, [isInvitesModalOpen, pendingInvitationsLoaded, fetchSentInvitations]);
 
   const handleTeamRequestEvent = useCallback((payload = {}) => {
     const payloadTeamId = payload.teamId ?? payload.team_id ?? null;
@@ -871,14 +916,24 @@ const TeamCard = ({
       type.includes("invitation") ||
       type.includes("invite");
 
-    if (shouldRefreshApplications) {
+    // Only refresh the per-card list when we already loaded it (i.e. the
+    // modal was opened at least once). Otherwise badge counts update from
+    // the parent's getUserTeams refetch and the list is re-fetched the next
+    // time the modal opens.
+    if (shouldRefreshApplications && pendingApplicationsLoaded) {
       fetchPendingApplications();
     }
 
-    if (shouldRefreshInvitations) {
+    if (shouldRefreshInvitations && pendingInvitationsLoaded) {
       fetchSentInvitations();
     }
-  }, [fetchPendingApplications, fetchSentInvitations, teamData?.id]);
+  }, [
+    fetchPendingApplications,
+    fetchSentInvitations,
+    teamData?.id,
+    pendingApplicationsLoaded,
+    pendingInvitationsLoaded,
+  ]);
 
   useSocketEvents(
     effectiveVariant === "member" && teamData?.id && canManageInvitations
@@ -1927,7 +1982,7 @@ const TeamCard = ({
             {canManageInvitations && (
               <NotificationBadge
                 variant="application"
-                count={pendingApplications.length}
+                count={displayedApplicationCount}
                 onClick={(e) => {
                   e.stopPropagation();
                   setIsApplicationsModalOpen(true);
@@ -1939,7 +1994,7 @@ const TeamCard = ({
             {canManageInvitations && (
               <NotificationBadge
                 variant="invitation"
-                count={pendingSentInvitations.length}
+                count={displayedSentInvitationCount}
                 onClick={(e) => {
                   e.stopPropagation();
                   setIsInvitesModalOpen(true);
@@ -2456,7 +2511,7 @@ const TeamCard = ({
                 <>
                   <NotificationBadge
                     variant="application"
-                    count={pendingApplications.length}
+                    count={displayedApplicationCount}
                     onClick={(e) => {
                       e.stopPropagation();
                       setIsApplicationsModalOpen(true);
@@ -2464,7 +2519,7 @@ const TeamCard = ({
                   />
                   <NotificationBadge
                     variant="invitation"
-                    count={pendingSentInvitations.length}
+                    count={displayedSentInvitationCount}
                     onClick={(e) => {
                       e.stopPropagation();
                       setIsInvitesModalOpen(true);

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -389,6 +389,11 @@ const TeamCard = ({
   // and the card should wait — not fall back to fetching.
   viewerPendingApplications,
   viewerPendingInvitations,
+
+  // Pre-fetched member badges for this team (bulk-fetched by the parent).
+  // Same `!== undefined` sentinel: undefined = parent doesn't manage, null =
+  // parent is loading, array = use directly (skip per-card fetch).
+  teamMemberBadges,
 }) => {
   const isInternalRoleApplication =
     application?.isInternalRoleApplication ??
@@ -848,13 +853,22 @@ const TeamCard = ({
 
   // Counts may be preloaded by the parent's list response (getUserTeams).
   // When present, we defer the full list fetch until the user actually opens
-  // the corresponding modal.
-  const preloadedApplicationCount =
+  // the corresponding modal. Note: postgres returns COUNT(*) as bigint which
+  // the pg driver serializes as a string unless cast, so coerce defensively.
+  const rawPreloadedApplicationCount =
     teamData?.pendingApplicationsCount ??
     teamData?.pending_applications_count;
-  const preloadedSentInvitationCount =
+  const rawPreloadedSentInvitationCount =
     teamData?.pendingSentInvitationsCount ??
     teamData?.pending_sent_invitations_count;
+  const preloadedApplicationCount =
+    rawPreloadedApplicationCount != null
+      ? Number(rawPreloadedApplicationCount)
+      : undefined;
+  const preloadedSentInvitationCount =
+    rawPreloadedSentInvitationCount != null
+      ? Number(rawPreloadedSentInvitationCount)
+      : undefined;
   const hasPreloadedApplicationCount = Number.isFinite(
     preloadedApplicationCount,
   );
@@ -964,11 +978,13 @@ const TeamCard = ({
       // Skip getTeamById when the parent already provided the tags array.
       // The list response from getUserTeams + search responses both include
       // it (empty array means "no tags", which is valid data — no fetch
-      // needed). We still fetch team member badges if those are missing
-      // (separate concern with its own module-level cache).
+      // needed). Skip team member badges when the parent is managing them
+      // via the teamMemberBadges prop (bulk-fetched by MyTeams).
       const parentProvidedTags = Array.isArray(teamData.tags);
+      const parentManagesMemberBadges = teamMemberBadges !== undefined;
       const shouldFetchTeamById = !parentProvidedTags;
-      const shouldFetchMemberBadges = !hasDisplayableBadges(teamData.badges);
+      const shouldFetchMemberBadges =
+        !parentManagesMemberBadges && !hasDisplayableBadges(teamData.badges);
 
       if (!shouldFetchTeamById && !shouldFetchMemberBadges) return;
 
@@ -1059,6 +1075,19 @@ const TeamCard = ({
 
     fetchCompleteTeamData();
   }, [teamData?.id, effectiveVariant, user, viewerDistanceSource]);
+
+  // Sync parent-managed member badges into teamData. When the parent provides
+  // an array (bulk fetch resolved), we use it directly. While the parent is
+  // still loading (prop === null), we leave teamData.badges alone so the card
+  // doesn't flicker between "no badges" and "with badges" mid-load.
+  useEffect(() => {
+    if (Array.isArray(teamMemberBadges)) {
+      setTeamData((prev) => ({
+        ...prev,
+        badges: teamMemberBadges,
+      }));
+    }
+  }, [teamMemberBadges]);
 
   useEffect(() => {
     if (!teamData?.id) return;

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -31,6 +31,7 @@ import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { userService } from "../../services/userService";
 import useSocketEvents from "../../hooks/useSocketEvents";
+import useTeamRequestLists from "../../hooks/useTeamRequestLists";
 import { useAuth } from "../../contexts/AuthContext";
 import Alert from "../common/Alert";
 import ConfirmModal from "../common/ConfirmModal";
@@ -526,12 +527,8 @@ const TeamCard = ({
   const [userRole, setUserRole] = useState(null);
   const [teamData, setTeamData] = useState(normalizedData.team);
   const { user, isAuthenticated } = useAuth();
-  const [pendingApplications, setPendingApplications] = useState([]);
   const [isApplicationsModalOpen, setIsApplicationsModalOpen] = useState(false);
-  const [pendingSentInvitations, setPendingSentInvitations] = useState([]);
   const [isInvitesModalOpen, setIsInvitesModalOpen] = useState(false);
-  const [pendingApplicationsLoaded, setPendingApplicationsLoaded] = useState(false);
-  const [pendingInvitationsLoaded, setPendingInvitationsLoaded] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [responses, setResponses] = useState({});
   const [isInvitationDetailsModalOpen, setIsInvitationDetailsModalOpen] =
@@ -693,45 +690,6 @@ const TeamCard = ({
     effectiveVariant,
   ]);
 
-  // Fetch pending applications (for team owners and admins)
-  const fetchPendingApplications = useCallback(async () => {
-    if (canManageInvitations && teamData?.id && effectiveVariant === "member") {
-      try {
-        const response = await teamService.getTeamApplications(teamData.id);
-        setPendingApplications(response.data || []);
-        setPendingApplicationsLoaded(true);
-      } catch (error) {
-        console.error("Error fetching applications:", error);
-        setPendingApplications([]);
-        setPendingApplicationsLoaded(true);
-      }
-    }
-  }, [canManageInvitations, teamData?.id, effectiveVariant]);
-
-  // Fetch sent invitations (for team owners and admins)
-  const fetchSentInvitations = useCallback(async () => {
-    if (canManageInvitations && teamData?.id && effectiveVariant === "member") {
-      try {
-        const response = await teamService.getTeamSentInvitations(teamData.id);
-        setPendingSentInvitations(response.data || []);
-        setPendingInvitationsLoaded(true);
-      } catch (error) {
-        console.error("Error fetching sent invitations:", error);
-        setPendingSentInvitations([]);
-        setPendingInvitationsLoaded(true);
-      }
-    }
-  }, [canManageInvitations, teamData?.id, effectiveVariant]);
-
-  useEffect(() => {
-    if (effectiveVariant !== "member" || !teamData?.id || !canManageInvitations) {
-      setPendingApplications([]);
-      setPendingSentInvitations([]);
-      setPendingApplicationsLoaded(false);
-      setPendingInvitationsLoaded(false);
-    }
-  }, [effectiveVariant, teamData?.id, canManageInvitations]);
-
   // Counts may be preloaded by the parent's list response (getUserTeams).
   // When present, we defer the full list fetch until the user actually opens
   // the corresponding modal. Note: postgres returns COUNT(*) as bigint which
@@ -756,6 +714,52 @@ const TeamCard = ({
   const hasPreloadedSentInvitationCount = Number.isFinite(
     preloadedSentInvitationCount,
   );
+  const canFetchTeamRequests =
+    canManageInvitations && Boolean(teamData?.id) && effectiveVariant === "member";
+  const shouldFetchApplications =
+    canFetchTeamRequests &&
+    (!hasPreloadedApplicationCount || isApplicationsModalOpen);
+  const shouldFetchInvitations =
+    canFetchTeamRequests &&
+    (!hasPreloadedSentInvitationCount || isInvitesModalOpen);
+  const {
+    applications: pendingApplications,
+    invitations: pendingSentInvitations,
+    applicationsLoaded: rawPendingApplicationsLoaded,
+    invitationsLoaded: rawPendingInvitationsLoaded,
+    refetchApplications,
+    refetchInvitations,
+  } = useTeamRequestLists(teamData?.id, {
+    enabled: canFetchTeamRequests,
+    applicationsEnabled: shouldFetchApplications,
+    invitationsEnabled: shouldFetchInvitations,
+  });
+  const pendingApplicationsLoaded =
+    canFetchTeamRequests && rawPendingApplicationsLoaded;
+  const pendingInvitationsLoaded =
+    canFetchTeamRequests && rawPendingInvitationsLoaded;
+
+  const fetchPendingApplications = useCallback(async () => {
+    if (!canFetchTeamRequests) return [];
+
+    const result = await refetchApplications();
+    if (result.error) {
+      console.error("Error fetching applications:", result.error);
+      return [];
+    }
+    return result.data ?? [];
+  }, [canFetchTeamRequests, refetchApplications]);
+
+  const fetchSentInvitations = useCallback(async () => {
+    if (!canFetchTeamRequests) return [];
+
+    const result = await refetchInvitations();
+    if (result.error) {
+      console.error("Error fetching sent invitations:", result.error);
+      return [];
+    }
+    return result.data ?? [];
+  }, [canFetchTeamRequests, refetchInvitations]);
 
   // Once the full list is loaded (after a modal open), state.length is the
   // source of truth. Otherwise fall back to the count from teamData.
@@ -769,30 +773,6 @@ const TeamCard = ({
     : hasPreloadedSentInvitationCount
       ? preloadedSentInvitationCount
       : 0;
-
-  // Eagerly fetch only when the parent didn't provide a count (older backend).
-  useEffect(() => {
-    if (hasPreloadedApplicationCount) return;
-    fetchPendingApplications();
-  }, [fetchPendingApplications, hasPreloadedApplicationCount]);
-
-  useEffect(() => {
-    if (hasPreloadedSentInvitationCount) return;
-    fetchSentInvitations();
-  }, [fetchSentInvitations, hasPreloadedSentInvitationCount]);
-
-  // Lazy-fetch the full list the first time the relevant modal opens.
-  useEffect(() => {
-    if (isApplicationsModalOpen && !pendingApplicationsLoaded) {
-      fetchPendingApplications();
-    }
-  }, [isApplicationsModalOpen, pendingApplicationsLoaded, fetchPendingApplications]);
-
-  useEffect(() => {
-    if (isInvitesModalOpen && !pendingInvitationsLoaded) {
-      fetchSentInvitations();
-    }
-  }, [isInvitesModalOpen, pendingInvitationsLoaded, fetchSentInvitations]);
 
   const handleTeamRequestEvent = useCallback((payload = {}) => {
     const payloadTeamId = payload.teamId ?? payload.team_id ?? null;

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -2488,6 +2488,7 @@ const TeamCard = ({
           matchScore={teamModalRawScore ?? null}
           matchType={teamModalMatchType}
           matchDetails={teamModalMatchDetails}
+          teamMemberBadges={teamMemberBadges}
         />
 
         {/* Applications Modal (for team owners and admins) */}
@@ -3058,6 +3059,7 @@ const TeamCard = ({
         matchScore={teamModalRawScore ?? null}
         matchType={teamModalMatchType}
         matchDetails={teamModalMatchDetails}
+        teamMemberBadges={teamMemberBadges}
       />
 
       {/* Applications Modal (for team owners and admins) */}

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -899,83 +899,106 @@ const TeamCard = ({
 
   useEffect(() => {
     const fetchCompleteTeamData = async () => {
-      if (
-        teamData &&
-        teamData.id &&
-        (effectiveVariant === "member" ||
-          effectiveVariant === "invitation" ||
-          effectiveVariant === "application")
-      ) {
-        try {
-          const shouldFetchMemberBadges =
-            !hasDisplayableBadges(teamData.badges);
+      if (!teamData?.id) return;
+      const isHydratableVariant =
+        effectiveVariant === "member" ||
+        effectiveVariant === "invitation" ||
+        effectiveVariant === "application";
+      if (!isHydratableVariant) return;
 
-          const [response, memberBadges] = await Promise.all([
-            teamService.getTeamById(teamData.id),
-            shouldFetchMemberBadges
-              ? (() => {
-                  const cached = teamMemberBadgesCache.get(teamData.id);
-                  if (cached) return Promise.resolve(cached);
+      // Skip getTeamById when the parent already provided the tags array.
+      // The list response from getUserTeams + search responses both include
+      // it (empty array means "no tags", which is valid data — no fetch
+      // needed). We still fetch team member badges if those are missing
+      // (separate concern with its own module-level cache).
+      const parentProvidedTags = Array.isArray(teamData.tags);
+      const shouldFetchTeamById = !parentProvidedTags;
+      const shouldFetchMemberBadges = !hasDisplayableBadges(teamData.badges);
 
-                  return teamService
-                    .getTeamMemberBadges(teamData.id)
-                    .then((badgesResponse) => {
-                      const badges = extractBadgeRows(badgesResponse);
-                      teamMemberBadgesCache.set(teamData.id, badges);
-                      return badges;
-                    })
-                    .catch((badgeError) => {
-                      console.warn(
-                        "Could not fetch team member badges for card display:",
-                        badgeError,
-                      );
-                      return [];
-                    });
-                })()
-              : Promise.resolve(
-                  hasDisplayableBadges(teamData.badges) ? teamData.badges : [],
-                ),
-          ]);
-          const fullTeam = response?.data?.data ?? response?.data;
+      if (!shouldFetchTeamById && !shouldFetchMemberBadges) return;
 
-          if (fullTeam) {
-            setTeamData((prev) => {
-              const preservedDistanceKm = resolveDistanceKm({
-                preferredDistance: prev?.distance_km ?? prev?.distanceKm,
-                fallbackDistance: fullTeam.distance_km ?? fullTeam.distanceKm,
-                viewerEntity: viewerDistanceSource ?? user,
-                targetEntity: fullTeam,
-              });
-              const resolvedBadges =
-                memberBadges.length > 0
-                  ? memberBadges
-                  : hasDisplayableBadges(fullTeam.badges)
-                    ? fullTeam.badges
-                    : prev?.badges;
+      try {
+        const teamByIdPromise = shouldFetchTeamById
+          ? teamService.getTeamById(teamData.id)
+          : Promise.resolve(null);
 
-              return {
-                ...prev,
-                ...fullTeam,
-                is_public:
-                  fullTeam.is_public === true || fullTeam.is_public === "true",
-                tags: Array.isArray(fullTeam.tags) ? fullTeam.tags : prev.tags,
-                badges: resolvedBadges,
-                distance_km: preservedDistanceKm,
-                distanceKm: preservedDistanceKm,
-              };
-            });
+        const memberBadgesPromise = shouldFetchMemberBadges
+          ? (() => {
+              const cached = teamMemberBadgesCache.get(teamData.id);
+              if (cached) return Promise.resolve(cached);
 
-            // Compute role from members list
-            if (user?.id && Array.isArray(fullTeam.members)) {
-              const me = fullTeam.members.find(
-                (m) => (m.user_id ?? m.userId) === user.id,
-              );
-              setUserRole(me?.role ?? null);
-            }
+              return teamService
+                .getTeamMemberBadges(teamData.id)
+                .then((badgesResponse) => {
+                  const badges = extractBadgeRows(badgesResponse);
+                  teamMemberBadgesCache.set(teamData.id, badges);
+                  return badges;
+                })
+                .catch((badgeError) => {
+                  console.warn(
+                    "Could not fetch team member badges for card display:",
+                    badgeError,
+                  );
+                  return [];
+                });
+            })()
+          : Promise.resolve(
+              hasDisplayableBadges(teamData.badges) ? teamData.badges : [],
+            );
+
+        const [response, memberBadges] = await Promise.all([
+          teamByIdPromise,
+          memberBadgesPromise,
+        ]);
+
+        const fullTeam = response?.data?.data ?? response?.data ?? null;
+
+        setTeamData((prev) => {
+          const baseTeam = fullTeam ?? prev;
+          const preservedDistanceKm = resolveDistanceKm({
+            preferredDistance: prev?.distance_km ?? prev?.distanceKm,
+            fallbackDistance: baseTeam.distance_km ?? baseTeam.distanceKm,
+            viewerEntity: viewerDistanceSource ?? user,
+            targetEntity: baseTeam,
+          });
+          const resolvedBadges =
+            memberBadges.length > 0
+              ? memberBadges
+              : hasDisplayableBadges(baseTeam.badges)
+                ? baseTeam.badges
+                : prev?.badges;
+
+          if (!fullTeam) {
+            // Only refreshed badges / distance — keep everything else.
+            return {
+              ...prev,
+              badges: resolvedBadges,
+              distance_km: preservedDistanceKm,
+              distanceKm: preservedDistanceKm,
+            };
           }
-        } catch (error) {
-          console.error("Error fetching complete team data:", error);
+
+          return {
+            ...prev,
+            ...fullTeam,
+            is_public:
+              fullTeam.is_public === true || fullTeam.is_public === "true",
+            tags: Array.isArray(fullTeam.tags) ? fullTeam.tags : prev.tags,
+            badges: resolvedBadges,
+            distance_km: preservedDistanceKm,
+            distanceKm: preservedDistanceKm,
+          };
+        });
+
+        // Compute role from members list (only possible if we fetched it)
+        if (fullTeam && user?.id && Array.isArray(fullTeam.members)) {
+          const me = fullTeam.members.find(
+            (m) => (m.user_id ?? m.userId) === user.id,
+          );
+          setUserRole(me?.role ?? null);
         }
+      } catch (error) {
+        console.error("Error fetching complete team data:", error);
       }
     };
 

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -110,6 +110,8 @@ const normalizeTeamTagIds = (team) => {
   return Array.from(new Set(ids));
 };
 
+const EMPTY_QUERY_ARRAY = [];
+
 const TeamDetailsModal = ({
   isOpen = true,
   teamId: propTeamId,
@@ -254,10 +256,12 @@ const TeamDetailsModal = ({
   }, [teamName, isEditing, isModalVisible]);
 
   const showHighlightsForContext = !hideMatchData && (!isFromSearch || showMatchHighlights);
-  const { data: structuredTags = [], error: structuredTagsError } =
-    useStructuredTags({
-      enabled: isModalVisible,
-    });
+  const {
+    data: structuredTags = EMPTY_QUERY_ARRAY,
+    error: structuredTagsError,
+  } = useStructuredTags({
+    enabled: isModalVisible,
+  });
   const currentUserTagsQuery = useUserTags(user?.id, {
     enabled: Boolean(isModalVisible && isAuthenticated && user?.id),
   });

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -134,6 +134,7 @@ const TeamDetailsModal = ({
   membersRefreshKey = 0,
   zIndexStyle = null,
   boxZIndexStyle = null,
+  teamMemberBadges,
 }) => {
   const navigate = useNavigate();
   const { id: urlTeamId } = useParams();
@@ -790,9 +791,25 @@ const TeamDetailsModal = ({
     });
   }, [isEditing, team]); // formData.selectedTags intentionally excluded
 
-  // Fetch aggregated member badges when modal opens
+  // Fetch aggregated member badges when modal opens. If the parent provides
+  // teamMemberBadges, it owns this data: undefined = legacy self-fetch,
+  // null = parent loading, array = parent data ready.
   useEffect(() => {
     if (!isModalVisible || !effectiveTeamId) return;
+
+    if (teamMemberBadges !== undefined) {
+      if (Array.isArray(teamMemberBadges)) {
+        setTeamBadges(teamMemberBadges);
+        setTeamBadgesTotalCredits(
+          teamMemberBadges.reduce(
+            (sum, badge) =>
+              sum + Number(badge?.totalCredits ?? badge?.total_credits ?? 0),
+            0,
+          ),
+        );
+      }
+      return;
+    }
 
     const fetchTeamBadges = async () => {
       try {
@@ -807,7 +824,7 @@ const TeamDetailsModal = ({
     };
 
     fetchTeamBadges();
-  }, [isModalVisible, effectiveTeamId]);
+  }, [isModalVisible, effectiveTeamId, teamMemberBadges]);
 
   // Resolve current user's badge names for match highlighting
   useEffect(() => {

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -43,12 +43,16 @@ import UserDetailsModal from "../users/UserDetailsModal";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import TagsDisplaySection from "../tags/TagsDisplaySection";
 import { UI_TEXT } from "../../constants/uiText";
+import { useQueryClient } from "@tanstack/react-query";
 import { useStructuredTags } from "../../hooks/useTagQueries";
 import {
   useUserBadges,
   useUserProfile,
   useUserTags,
 } from "../../hooks/useUserQueries";
+import useViewerPendingRequests, {
+  viewerPendingRequestsQueryKey,
+} from "../../hooks/useViewerPendingRequests";
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import TeamApplicationButton from "./TeamApplicationButton";
 import TeamApplicationDetailsModal from "./TeamApplicationDetailsModal";
@@ -211,9 +215,6 @@ const TeamDetailsModal = ({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isInvitationModalOpen, setIsInvitationModalOpen] = useState(false);
   const [localPendingApplication, setLocalPendingApplication] = useState(null);
-  // All fetched pending applications for this team (user may have both a team + a role application)
-  const [fetchedPendingApplications, setFetchedPendingApplications] = useState([]);
-  const [fetchedPendingInvitation, setFetchedPendingInvitation] = useState(null);
   const [isApplicationDetailsOpen, setIsApplicationDetailsOpen] =
     useState(false);
   const [selectedPendingApplication, setSelectedPendingApplication] =
@@ -265,10 +266,30 @@ const TeamDetailsModal = ({
   const currentUserProfileQuery = useUserProfile(user?.id, {
     enabled: Boolean(isModalVisible && isAuthenticated && user?.id),
   });
+  const queryClient = useQueryClient();
+  const { data: viewerPendingData } = useViewerPendingRequests(user?.id, {
+    enabled: Boolean(isModalVisible && isAuthenticated && user?.id),
+  });
+  const fetchedPendingApplications = useMemo(() => {
+    const apps = viewerPendingData?.applications ?? [];
+    if (!effectiveTeamId) return [];
+    return apps.filter(
+      (a) =>
+        String(a.team?.id ?? a.teamId ?? a.team_id) === String(effectiveTeamId),
+    );
+  }, [viewerPendingData, effectiveTeamId]);
+  const fetchedPendingInvitation = useMemo(() => {
+    const invs = viewerPendingData?.invitations ?? [];
+    if (!effectiveTeamId) return null;
+    return (
+      invs.find(
+        (i) =>
+          String(i.team?.id ?? i.teamId ?? i.team_id) ===
+          String(effectiveTeamId),
+      ) ?? null
+    );
+  }, [viewerPendingData, effectiveTeamId]);
   const handledMembersRefreshKeyRef = useRef(0);
-  // Tracks which teamId we last fetched application/invitation status for.
-  // Prevents double-firing in React StrictMode (dev) where effects run twice.
-  const statusFetchedForRef = useRef(null);
 
   const fetchTeamDetails = useCallback(
     async (forceRefresh = false) => {
@@ -493,51 +514,9 @@ const TeamDetailsModal = ({
 
   useEffect(() => {
     setLocalPendingApplication(null);
-    setFetchedPendingApplications([]);
-    setFetchedPendingInvitation(null);
     setIsApplicationDetailsOpen(false);
     setSelectedPendingApplication(null);
   }, [effectiveTeamId]);
-
-  // Fetch the user's pending application and invitation for this team when not
-  // supplied via props (e.g. when opened through TeamModalContext).
-  // The ref guard prevents double-firing: React StrictMode (dev) remounts effects
-  // synchronously, but refs survive the remount, so the second invocation is skipped.
-  useEffect(() => {
-    if (!isAuthenticated || !effectiveTeamId || !isModalVisible) return;
-    if (statusFetchedForRef.current === effectiveTeamId) return; // already fetched this open-session
-
-    statusFetchedForRef.current = effectiveTeamId;
-
-    const fetchUserStatus = async () => {
-      try {
-        const [appsRes, invsRes] = await Promise.allSettled([
-          teamService.getUserPendingApplications(),
-          teamService.getUserReceivedInvitations(),
-        ]);
-
-        if (appsRes.status === "fulfilled") {
-          const apps = appsRes.value?.data ?? appsRes.value ?? [];
-          const matches = apps.filter(
-            (a) => String(a.team?.id ?? a.teamId ?? a.team_id) === String(effectiveTeamId),
-          );
-          setFetchedPendingApplications(matches);
-        }
-
-        if (invsRes.status === "fulfilled") {
-          const invs = invsRes.value?.data ?? invsRes.value ?? [];
-          const match = invs.find(
-            (i) => String(i.team?.id ?? i.teamId ?? i.team_id) === String(effectiveTeamId),
-          );
-          setFetchedPendingInvitation(match ?? null);
-        }
-      } catch {
-        // Non-critical — silently ignore
-      }
-    };
-
-    fetchUserStatus();
-  }, [isAuthenticated, effectiveTeamId, isModalVisible]);
 
   useEffect(() => {
     if (isModalVisible && effectiveTeamId) {
@@ -604,8 +583,6 @@ const TeamDetailsModal = ({
     if (!isModalVisible) {
       setNotification({ type: null, message: null });
       setFormErrors({});
-      // Reset the status-fetch guard so the next open re-fetches fresh data
-      statusFetchedForRef.current = null;
     }
   }, [isModalVisible]);
 
@@ -2137,8 +2114,19 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
             await teamService.cancelApplication(applicationId);
             setLocalPendingApplication(null);
             setSelectedPendingApplication(null);
-            setFetchedPendingApplications((prev) =>
-              prev.filter((a) => String(a.id) !== String(applicationId)),
+            // Optimistically drop the cancelled application from the viewer
+            // pending requests cache so the modal reflects it immediately.
+            queryClient.setQueryData(
+              viewerPendingRequestsQueryKey(user?.id),
+              (prev) => {
+                if (!prev) return prev;
+                return {
+                  ...prev,
+                  applications: (prev.applications ?? []).filter(
+                    (a) => String(a.id) !== String(applicationId),
+                  ),
+                };
+              },
             );
             setIsApplicationDetailsOpen(false);
             await fetchTeamDetails(true);

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -43,7 +43,12 @@ import UserDetailsModal from "../users/UserDetailsModal";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import TagsDisplaySection from "../tags/TagsDisplaySection";
 import { UI_TEXT } from "../../constants/uiText";
-import { tagService } from "../../services/tagService";
+import { useStructuredTags } from "../../hooks/useTagQueries";
+import {
+  useUserBadges,
+  useUserProfile,
+  useUserTags,
+} from "../../hooks/useUserQueries";
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import TeamApplicationButton from "./TeamApplicationButton";
 import TeamApplicationDetailsModal from "./TeamApplicationDetailsModal";
@@ -247,6 +252,19 @@ const TeamDetailsModal = ({
   }, [teamName, isEditing, isModalVisible]);
 
   const showHighlightsForContext = !hideMatchData && (!isFromSearch || showMatchHighlights);
+  const { data: structuredTags = [], error: structuredTagsError } =
+    useStructuredTags({
+      enabled: isModalVisible,
+    });
+  const currentUserTagsQuery = useUserTags(user?.id, {
+    enabled: Boolean(isModalVisible && isAuthenticated && user?.id),
+  });
+  const currentUserBadgesQuery = useUserBadges(user?.id, {
+    enabled: Boolean(isModalVisible && isAuthenticated && user?.id),
+  });
+  const currentUserProfileQuery = useUserProfile(user?.id, {
+    enabled: Boolean(isModalVisible && isAuthenticated && user?.id),
+  });
   const handledMembersRefreshKeyRef = useRef(0);
   // Tracks which teamId we last fetched application/invitation status for.
   // Prevents double-firing in React StrictMode (dev) where effects run twice.
@@ -562,27 +580,24 @@ const TeamDetailsModal = ({
   useEffect(() => {
     if (!isModalVisible || !isAuthenticated || !user?.id) return;
 
-    const fetchUserTags = async () => {
-      try {
-        const tagsRes = await userService.getUserTags(user.id);
-        const tagData = Array.isArray(tagsRes?.data)
-          ? tagsRes.data
-          : tagsRes?.data?.data || [];
-        const ids = new Set(
-          tagData
-            .map((t) => Number(t.tagId ?? t.tag_id ?? t.id))
-            .filter(Number.isFinite),
-        );
-        // Set both state vars from one request — avoids a second identical API call
-        setUserTagIds(ids);
-        setCurrentUserTagIds(ids);
-      } catch (err) {
-        console.warn("Could not fetch user tags for matching highlights:", err);
-      }
-    };
+    const ids = new Set(
+      (currentUserTagsQuery.data ?? [])
+        .map((t) => Number(t.tagId ?? t.tag_id ?? t.id))
+        .filter(Number.isFinite),
+    );
+    // Set both state vars from one query result.
+    setUserTagIds(ids);
+    setCurrentUserTagIds(ids);
+  }, [currentUserTagsQuery.data, isAuthenticated, isModalVisible, user?.id]);
 
-    fetchUserTags();
-  }, [isModalVisible, isAuthenticated, user?.id]);
+  useEffect(() => {
+    if (!currentUserTagsQuery.error) return;
+
+    console.warn(
+      "Could not fetch user tags for matching highlights:",
+      currentUserTagsQuery.error,
+    );
+  }, [currentUserTagsQuery.error]);
 
   useEffect(() => {
     // Reset state when modal closes
@@ -817,29 +832,35 @@ const TeamDetailsModal = ({
     fetchTeamBadges();
   }, [isModalVisible, effectiveTeamId]);
 
-  // Fetch current user's badge names for match highlighting
+  // Resolve current user's badge names for match highlighting
   useEffect(() => {
     if (!isModalVisible || !isAuthenticated || !user?.id) {
       return;
     }
 
-    const fetchCurrentUserBadges = async () => {
-      try {
-        const response = await userService.getUserBadges(user.id);
-        const rows = Array.isArray(response?.data) ? response.data : [];
-        const names = new Set(
-          rows
-            .map((r) => (r.badgeName ?? r.badge_name ?? r.name ?? "").trim().toLowerCase())
-            .filter(Boolean),
-        );
-        setCurrentUserBadgeNames(names);
-      } catch (err) {
-        console.warn("Could not fetch user badges for matching highlights:", err);
-      }
-    };
+    const names = new Set(
+      (currentUserBadgesQuery.data ?? [])
+        .map((r) =>
+          (r.badgeName ?? r.badge_name ?? r.name ?? "").trim().toLowerCase(),
+        )
+        .filter(Boolean),
+    );
+    setCurrentUserBadgeNames(names);
+  }, [
+    currentUserBadgesQuery.data,
+    isAuthenticated,
+    isModalVisible,
+    user?.id,
+  ]);
 
-    fetchCurrentUserBadges();
-  }, [isModalVisible, isAuthenticated, user?.id]);
+  useEffect(() => {
+    if (!currentUserBadgesQuery.error) return;
+
+    console.warn(
+      "Could not fetch user badges for matching highlights:",
+      currentUserBadgesQuery.error,
+    );
+  }, [currentUserBadgesQuery.error]);
 
   useEffect(() => {
     if (!isModalVisible || !isAuthenticated || !user?.id) {
@@ -847,36 +868,20 @@ const TeamDetailsModal = ({
       return;
     }
 
-    let cancelled = false;
+    setDistanceViewerUser(currentUserProfileQuery.data ?? user);
+  }, [currentUserProfileQuery.data, isAuthenticated, isModalVisible, user]);
 
-    const fetchDistanceViewerUser = async () => {
-      try {
-        const response = await userService.getUserById(user.id);
-        const payload = response?.data ?? response;
-        const viewerData =
-          payload?.success !== undefined
-            ? payload?.data
-            : (payload?.data?.data ?? payload?.data ?? payload);
+  useEffect(() => {
+    if (!currentUserProfileQuery.error) return;
 
-        if (!cancelled) {
-          setDistanceViewerUser(viewerData ?? user);
-        }
-      } catch (err) {
-        console.warn("Could not fetch current user details for distance fallback:", err);
-        if (!cancelled) {
-          setDistanceViewerUser(user);
-        }
-      }
-    };
+    console.warn(
+      "Could not fetch current user details for distance fallback:",
+      currentUserProfileQuery.error,
+    );
+    setDistanceViewerUser(user);
+  }, [currentUserProfileQuery.error, user]);
 
-    fetchDistanceViewerUser();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuthenticated, isModalVisible, user]);
-
-  // Fetch structured tags when modal opens (needed for display AND edit mode)
+  // Resolve structured tags when modal opens (needed for display AND edit mode)
   useEffect(() => {
     // Only run when the modal is actually visible
     if (!isModalVisible) return;
@@ -884,17 +889,14 @@ const TeamDetailsModal = ({
     // If we already have tags, no need to fetch again
     if (allTags.length > 0) return;
 
-    const fetchTags = async () => {
-      try {
-        const structuredTags = await tagService.getStructuredTags();
-        setAllTags(structuredTags);
-      } catch (error) {
-        console.error("Error fetching tags:", error);
-      }
-    };
+    setAllTags(structuredTags);
+  }, [isModalVisible, allTags.length, structuredTags]);
 
-    fetchTags();
-  }, [isModalVisible, allTags.length]);
+  useEffect(() => {
+    if (structuredTagsError) {
+      console.error("Error fetching tags:", structuredTagsError);
+    }
+  }, [structuredTagsError]);
 
   // Handle team tags update
   const handleTeamTagsUpdate = async (newTagIds) => {

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -32,68 +32,13 @@ import { useHydratedRole } from "../../hooks/useHydratedRole";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
 import { useAuth } from "../../contexts/AuthContext";
-
-const extractRoleMatchData = (roleLike) => {
-  const rawScore = roleLike?.matchScore ?? roleLike?.match_score ?? null;
-  const numericScore = Number(rawScore);
-
-  return {
-    matchScore: Number.isFinite(numericScore) ? numericScore : null,
-    matchDetails:
-      roleLike?.matchDetails ??
-      roleLike?.match_details ??
-      roleLike?.scoreBreakdown ??
-      null,
-  };
-};
-
-const normalizeBoolean = (value) => {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value === 1;
-
-  if (typeof value === "string") {
-    const normalizedValue = value.trim().toLowerCase();
-    if (["true", "1", "yes"].includes(normalizedValue)) return true;
-    if (["false", "0", "no"].includes(normalizedValue)) return false;
-  }
-
-  return null;
-};
-
-const idsMatch = (left, right) => {
-  if (left === null || left === undefined || right === null || right === undefined) {
-    return false;
-  }
-
-  return String(left) === String(right);
-};
-
-const isExistingMemberStatus = (value) => {
-  if (typeof value !== "string") return false;
-
-  const normalizedValue = value.trim().toLowerCase();
-  return (
-    normalizedValue === "member" ||
-    normalizedValue === "existing-member" ||
-    normalizedValue === "existing_member"
-  );
-};
-
-const getMemberUserId = (member) => {
-  const memberUser = member?.user || member;
-
-  return (
-    member?.userId ??
-    member?.user_id ??
-    member?.memberId ??
-    member?.member_id ??
-    memberUser?.userId ??
-    memberUser?.user_id ??
-    memberUser?.id ??
-    member?.id ??
-    null
-  );
-};
+import {
+  extractRoleMatchData,
+  getMemberUserId,
+  idsMatch,
+  isExistingMemberStatus,
+  normalizeBoolean,
+} from "../../utils/teamRequestUtils";
 
 const isInviteeExistingTeamMember = ({ invitation, team, currentUser }) => {
   const inviteeId =

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -39,45 +39,15 @@ import {
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import useSocketEvents from "../../hooks/useSocketEvents";
+import {
+  isExistingMemberStatus,
+  normalizeBoolean,
+  normalizeNumericId,
+  numericIdsMatch,
+} from "../../utils/teamRequestUtils";
 
-const normalizeId = (value) => {
-  if (value === null || value === undefined || value === "") return null;
-
-  const numericValue = Number(value);
-  return Number.isFinite(numericValue) ? numericValue : null;
-};
-
-const idsMatch = (left, right) => {
-  const normalizedLeft = normalizeId(left);
-  const normalizedRight = normalizeId(right);
-
-  if (normalizedLeft === null || normalizedRight === null) return false;
-  return normalizedLeft === normalizedRight;
-};
-
-const normalizeBoolean = (value) => {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value === 1;
-
-  if (typeof value === "string") {
-    const normalizedValue = value.trim().toLowerCase();
-    if (["true", "1", "yes"].includes(normalizedValue)) return true;
-    if (["false", "0", "no"].includes(normalizedValue)) return false;
-  }
-
-  return null;
-};
-
-const isExistingMemberStatus = (value) => {
-  if (typeof value !== "string") return false;
-
-  const normalizedValue = value.trim().toLowerCase();
-  return (
-    normalizedValue === "member" ||
-    normalizedValue === "existing-member" ||
-    normalizedValue === "existing_member"
-  );
-};
+const normalizeId = normalizeNumericId;
+const idsMatch = numericIdsMatch;
 
 const isInviteeExistingTeamMember = (team, inviteeId) => {
   if (!team || inviteeId === null || inviteeId === undefined) return false;

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -17,12 +17,12 @@ import Tooltip from "../common/Tooltip";
 import InlineUserLink, { InvitedByLink } from "../users/InlineUserLink";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import VacantRoleCard from "./VacantRoleCard";
-import { matchingService } from "../../services/matchingService";
 import teamService from "../../services/teamService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
 import usePolledRequestRoles from "../../hooks/usePolledRequestRoles";
+import useSelfRoleMatchMap from "../../hooks/useSelfRoleMatchMap";
 import {
   DEMO_PROFILE_TOOLTIP,
   getUserInitials,
@@ -36,8 +36,6 @@ import {
   extractRoleMatchData,
   getRequestRoleId,
 } from "../../utils/teamRequestUtils";
-
-const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
 
 const FitInviteeName = ({ invitee, onUserClick, onNarrowChange, getDateEl, forceNarrow = false }) => {
   const containerRef = useRef(null);
@@ -110,7 +108,6 @@ const TeamInvitesModal = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
-  const [selfRoleMatchMap, setSelfRoleMatchMap] = useState({});
   const [pendingCancelInvitationId, setPendingCancelInvitationId] =
     useState(null);
   const [pendingCancelType, setPendingCancelType] = useState("team");
@@ -127,6 +124,13 @@ const TeamInvitesModal = ({
   const hydratedRoleMap = usePolledRequestRoles(invitations, {
     isOpen,
     teamId,
+  });
+  const selfRoleMatchMap = useSelfRoleMatchMap(invitations, {
+    isOpen,
+    teamId,
+    currentUserId: currentUser?.id,
+    userKey: "invitee",
+    warningLabel: "invitation",
   });
 
   // ============ Scroll to highlighted invitation ============
@@ -148,77 +152,6 @@ const TeamInvitesModal = ({
       if (frameId != null) window.cancelAnimationFrame(frameId);
     };
   }, [highlightInvitationId, highlightUserId, invitations.length, isOpen]);
-
-  useEffect(() => {
-    const selfRoleIds = [
-      ...new Set(
-        invitations
-          .filter((invitation) => {
-            const inviteeId =
-              invitation?.invitee?.id ??
-              invitation?.invitee_id ??
-              null;
-            return inviteeId != null && String(inviteeId) === String(currentUser?.id);
-          })
-          .map((invitation) =>
-            invitation?.role?.id ??
-            invitation?.roleId ??
-            invitation?.role_id ??
-            null,
-          )
-          .filter((roleId) => roleId != null)
-          .map(String),
-      ),
-    ];
-
-    if (!isOpen || !teamId || !currentUser?.id || selfRoleIds.length === 0) {
-      setSelfRoleMatchMap({});
-      return;
-    }
-
-    let cancelled = false;
-
-    const fetchSelfRoleMatches = async () => {
-      try {
-        const response = await matchingService.getMatchingRolesForTeam(teamId, {
-          limit: SELF_ROLE_MATCH_FETCH_LIMIT,
-        });
-
-        if (cancelled) return;
-
-        const nextMatchMap = {};
-
-        (response?.data || []).forEach((role) => {
-          const roleId = role?.id;
-          if (roleId == null || !selfRoleIds.includes(String(roleId))) return;
-
-          nextMatchMap[String(roleId)] = {
-            matchScore:
-              role?.matchScore ??
-              role?.match_score ??
-              null,
-            matchDetails:
-              role?.matchDetails ??
-              role?.match_details ??
-              null,
-          };
-        });
-
-        setSelfRoleMatchMap(nextMatchMap);
-      } catch (error) {
-        if (!cancelled) {
-          console.warn("Could not fetch self-invitation role match scores:", error);
-          setSelfRoleMatchMap({});
-        }
-      }
-    };
-
-    fetchSelfRoleMatches();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, teamId, currentUser?.id, invitations]);
 
   // ============ Handlers ============
 

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -30,11 +30,13 @@ import {
   isSyntheticUser,
 } from "../../utils/userHelpers";
 import { formatDisplayName } from "../../utils/nameFormatters";
-import { format } from "date-fns";
 import {
   buildInvitationRoleForCard,
   extractRoleMatchData,
+  formatRequestDate,
+  getRequestUserId,
   getRequestRoleId,
+  isRequestForUser,
 } from "../../utils/teamRequestUtils";
 
 const FitInviteeName = ({ invitee, onUserClick, onNarrowChange, getDateEl, forceNarrow = false }) => {
@@ -215,24 +217,6 @@ const TeamInvitesModal = ({
     return user?.avatar_url || user?.avatarUrl || null;
   };
 
-  // Format invitation date
-  const getInvitationDate = (invitation) => {
-    const date =
-      invitation?.created_at ||
-      invitation?.createdAt ||
-      invitation?.date ||
-      invitation?.sent_at;
-
-    if (!date) return "Unknown date";
-
-    try {
-      return format(new Date(date), "MMM d, yyyy");
-    } catch (error) {
-      console.error("Error formatting date:", error);
-      return "Unknown date";
-    }
-  };
-
   // ============ Render ============
   const anyNarrow = Object.values(narrowMap).some(Boolean);
   const pendingCancelInvitation = invitations.find(
@@ -330,13 +314,15 @@ const TeamInvitesModal = ({
     >
       {invitations.map((invitation) => {
         // Get invitee ID for highlighting comparison
-        const inviteeId =
-          invitation?.invitee?.id ?? invitation?.invitee_id ?? null;
+        const inviteeId = getRequestUserId(invitation, "invitee");
         const roleId = getRequestRoleId(invitation);
         const polledRole = roleId ? hydratedRoleMap[String(roleId)] : null;
         const roleForCard = buildInvitationRoleForCard(invitation, polledRole);
-        const isSelfInvitation =
-          currentUser?.id === (invitation.invitee?.id ?? invitation.invitee_id);
+        const isSelfInvitation = isRequestForUser(
+          invitation,
+          "invitee",
+          currentUser?.id,
+        );
         const inviteeRoleMatch =
           roleId != null && invitation?.role
             ? extractRoleMatchData(invitation.role)
@@ -435,7 +421,7 @@ const TeamInvitesModal = ({
                     {anyNarrow ? (
                       <div className="flex shrink-0 items-center gap-1 text-base-content/60">
                         <Calendar size={10} className="shrink-0" />
-                        <span className="leading-[1.05] whitespace-nowrap">{getInvitationDate(invitation)}</span>
+                        <span className="leading-[1.05] whitespace-nowrap">{formatRequestDate(invitation)}</span>
                       </div>
                     ) : showInviteeUsername && (
                       <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
@@ -485,7 +471,7 @@ const TeamInvitesModal = ({
                 className={`flex items-center text-xs text-base-content/60 whitespace-nowrap${anyNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
               >
                 <Calendar size={12} className="mr-1" />
-                <span>{getInvitationDate(invitation)}</span>
+                <span>{formatRequestDate(invitation)}</span>
               </div>
             </div>
 
@@ -534,7 +520,7 @@ const TeamInvitesModal = ({
                         canManage={false}
                         canManageStatus={false}
                         isTeamMember={true}
-                        viewAsUserId={invitation.invitee?.id ?? invitation.invitee_id}
+                        viewAsUserId={getRequestUserId(invitation, "invitee")}
                         viewAsUser={invitation.invitee}
                         hideActions={true}
                       />
@@ -548,7 +534,7 @@ const TeamInvitesModal = ({
                           role_name: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
                           roleName: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
                           status: "filled",
-                          filled_by: invitation.invitee?.id ?? invitation.invitee_id,
+                          filled_by: getRequestUserId(invitation, "invitee"),
                           filled_by_user: invitation.invitee ?? null,
                           is_synthetic: invitation.role_is_synthetic ?? false,
                           isSynthetic: invitation.role_is_synthetic ?? false,
@@ -585,7 +571,7 @@ const TeamInvitesModal = ({
                   canManage={false}
                   canManageStatus={false}
                   isTeamMember={true}
-                  viewAsUserId={invitation.invitee?.id ?? invitation.invitee_id}
+                  viewAsUserId={getRequestUserId(invitation, "invitee")}
                   viewAsUser={invitation.invitee}
                   hideActions={true}
                 />

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -31,6 +31,11 @@ import {
 } from "../../utils/userHelpers";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import { format } from "date-fns";
+import {
+  buildInvitationRoleForCard,
+  extractRoleMatchData,
+  getRequestRoleId,
+} from "../../utils/teamRequestUtils";
 
 const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
 
@@ -445,54 +450,14 @@ const TeamInvitesModal = ({
         // Get invitee ID for highlighting comparison
         const inviteeId =
           invitation?.invitee?.id ?? invitation?.invitee_id ?? null;
-        const roleId =
-          invitation?.role?.id ??
-          invitation?.roleId ??
-          invitation?.role_id ??
-          null;
-        const syntheticRoleFlag =
-          invitation?.role?.is_synthetic ??
-          invitation?.role?.isSynthetic ??
-          invitation?.role_is_synthetic ??
-          invitation?.roleIsSynthetic ??
-          invitation?.is_synthetic ??
-          invitation?.isSynthetic;
+        const roleId = getRequestRoleId(invitation);
         const polledRole = roleId ? hydratedRoleMap[String(roleId)] : null;
-        const roleForCard = invitation?.role
-          ? {
-              ...invitation.role,
-              ...(polledRole ?? {}),
-              is_synthetic:
-                invitation.role.is_synthetic ??
-                invitation.role.isSynthetic ??
-                syntheticRoleFlag,
-              isSynthetic:
-                invitation.role.isSynthetic ??
-                invitation.role.is_synthetic ??
-                syntheticRoleFlag,
-            }
-          : {
-              id: invitation?.roleId ?? invitation?.role_id,
-              roleName: invitation?.roleName ?? invitation?.role_name,
-              role_name: invitation?.role_name ?? invitation?.roleName,
-              is_synthetic: syntheticRoleFlag,
-              isSynthetic: syntheticRoleFlag,
-              ...(polledRole ?? {}),
-            };
+        const roleForCard = buildInvitationRoleForCard(invitation, polledRole);
         const isSelfInvitation =
           currentUser?.id === (invitation.invitee?.id ?? invitation.invitee_id);
         const inviteeRoleMatch =
           roleId != null && invitation?.role
-            ? {
-                matchScore:
-                  invitation.role.match_score ??
-                  invitation.role.matchScore ??
-                  null,
-                matchDetails:
-                  invitation.role.match_details ??
-                  invitation.role.matchDetails ??
-                  null,
-              }
+            ? extractRoleMatchData(invitation.role)
             : null;
         const selfRoleMatch =
           roleId != null && isSelfInvitation

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect, useRef, useLayoutEffect, useMemo } from "react";
-import { useQueries, useQueryClient } from "@tanstack/react-query";
+import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
 import {
   User,
   Users,
@@ -21,14 +20,6 @@ import VacantRoleCard from "./VacantRoleCard";
 import { matchingService } from "../../services/matchingService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import teamService from "../../services/teamService";
-import {
-  fetchUserBadges,
-  fetchUserProfile,
-  fetchUserTags,
-  userBadgesQueryKey,
-  userProfileQueryKey,
-  userTagsQueryKey,
-} from "../../hooks/useUserQueries";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
@@ -38,24 +29,10 @@ import {
   getDisplayName,
   isSyntheticUser,
 } from "../../utils/userHelpers";
-import { extractProfilePayload } from "../../utils/payloadExtractors";
-import {
-  buildBadgeLookup,
-  buildTagLookup,
-  computeRoleUserMatch,
-  extractCandidateMatchData,
-} from "../../utils/matchHelpers";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import { format } from "date-fns";
 
-const ROLE_CANDIDATE_FETCH_MIN_LIMIT = 20;
 const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
-
-const inviteeRoleMatchDataQueryKey = (inviteeId) => [
-  "users",
-  inviteeId ?? null,
-  "roleMatchData",
-];
 
 const FitInviteeName = ({ invitee, onUserClick, onNarrowChange, getDateEl, forceNarrow = false }) => {
   const containerRef = useRef(null);
@@ -128,9 +105,7 @@ const TeamInvitesModal = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
-  const [roleCandidateMatchMap, setRoleCandidateMatchMap] = useState({});
   const [selfRoleMatchMap, setSelfRoleMatchMap] = useState({});
-  const [localInviteeRoleMatchMap, setLocalInviteeRoleMatchMap] = useState({});
   const [pendingCancelInvitationId, setPendingCancelInvitationId] =
     useState(null);
   const [pendingCancelType, setPendingCancelType] = useState("team");
@@ -145,94 +120,6 @@ const TeamInvitesModal = ({
   const { user: currentUser } = useAuth();
   const { openUserModal } = useUserModal();
   const { openTeamModal } = useTeamModal();
-  const queryClient = useQueryClient();
-  const roleInviteePairs = useMemo(
-    () =>
-      invitations
-        .map((invitation) => ({
-          roleId:
-            invitation?.role?.id ??
-            invitation?.roleId ??
-            invitation?.role_id ??
-            null,
-          inviteeId:
-            invitation?.invitee?.id ??
-            invitation?.invitee_id ??
-            null,
-          fallbackRole: invitation?.role ?? null,
-        }))
-        .filter((pair) => pair.roleId != null && pair.inviteeId != null),
-    [invitations],
-  );
-  const uniqueRoleIds = useMemo(
-    () => [...new Set(roleInviteePairs.map((pair) => String(pair.roleId)))],
-    [roleInviteePairs],
-  );
-  const uniqueInviteeIds = useMemo(
-    () => [...new Set(roleInviteePairs.map((pair) => String(pair.inviteeId)))],
-    [roleInviteePairs],
-  );
-  const fallbackRoleMap = useMemo(
-    () =>
-      roleInviteePairs.reduce((acc, pair) => {
-        if (!acc[pair.roleId] && pair.fallbackRole) {
-          acc[pair.roleId] = pair.fallbackRole;
-        }
-        return acc;
-      }, {}),
-    [roleInviteePairs],
-  );
-  const inviteeRoleMatchQueries = useQueries({
-    queries: uniqueInviteeIds.map((inviteeId) => ({
-      queryKey: inviteeRoleMatchDataQueryKey(inviteeId),
-      queryFn: async () => {
-        const [profile, tags, badges] = await Promise.all([
-          queryClient.fetchQuery({
-            queryKey: userProfileQueryKey(inviteeId),
-            queryFn: () => fetchUserProfile(inviteeId),
-            staleTime: 30_000,
-          }),
-          queryClient.fetchQuery({
-            queryKey: userTagsQueryKey(inviteeId),
-            queryFn: () => fetchUserTags(inviteeId),
-            staleTime: 30_000,
-          }),
-          queryClient.fetchQuery({
-            queryKey: userBadgesQueryKey(inviteeId),
-            queryFn: () => fetchUserBadges(inviteeId),
-            staleTime: 30_000,
-          }),
-        ]);
-
-        return {
-          inviteeId,
-          profile,
-          userTagMap: buildTagLookup(tags),
-          userBadgeMap: buildBadgeLookup(badges),
-        };
-      },
-      enabled: Boolean(isOpen && teamId && roleInviteePairs.length > 0),
-      staleTime: 30_000,
-    })),
-  });
-  const inviteeRoleMatchQuerySignature = inviteeRoleMatchQueries
-    .map(
-      (query) =>
-        `${query.status}:${query.dataUpdatedAt ?? 0}:${query.errorUpdatedAt ?? 0}`,
-    )
-    .join("|");
-  const inviteeQueriesPending = inviteeRoleMatchQueries.some(
-    (query) => query.isLoading || query.isFetching,
-  );
-  const inviteeRoleMatchDataById = useMemo(() => {
-    if (inviteeQueriesPending) return null;
-
-    return uniqueInviteeIds.reduce((acc, inviteeId, index) => {
-      const result = inviteeRoleMatchQueries[index];
-      acc[inviteeId] = result?.isSuccess ? result.data : null;
-      return acc;
-    }, {});
-  }, [inviteeQueriesPending, inviteeRoleMatchQuerySignature, uniqueInviteeIds]);
 
   // ============ Scroll to highlighted invitation ============
   useEffect(() => {
@@ -324,177 +211,6 @@ const TeamInvitesModal = ({
       cancelled = true;
     };
   }, [isOpen, teamId, currentUser?.id, invitations]);
-
-  useEffect(() => {
-    if (!isOpen || !teamId || roleInviteePairs.length === 0) {
-      setLocalInviteeRoleMatchMap({});
-      return;
-    }
-
-    if (!inviteeRoleMatchDataById) return;
-
-    let cancelled = false;
-
-    const fetchLocalInviteeMatches = async () => {
-      try {
-        const roleResults = await Promise.allSettled(
-          uniqueRoleIds.map((roleId) =>
-            vacantRoleService.getVacantRoleById(teamId, roleId),
-          ),
-        );
-
-        if (cancelled) return;
-
-        const roleMap = {};
-        uniqueRoleIds.forEach((roleId, index) => {
-          const result = roleResults[index];
-          roleMap[roleId] =
-            result?.status === "fulfilled"
-              ? extractProfilePayload(result.value) ?? fallbackRoleMap[roleId] ?? null
-              : fallbackRoleMap[roleId] ?? null;
-        });
-
-        const inviteeMap = {};
-        uniqueInviteeIds.forEach((inviteeId) => {
-          inviteeMap[inviteeId] = inviteeRoleMatchDataById[inviteeId] ?? null;
-        });
-
-        const nextMatchMap = {};
-
-        roleInviteePairs.forEach(({ roleId, inviteeId }) => {
-          const role = roleMap[String(roleId)];
-          const inviteeData = inviteeMap[String(inviteeId)];
-
-          if (!role || !inviteeData?.profile) return;
-
-          const localMatch = computeRoleUserMatch({
-            role,
-            tags: role.tags ?? role.desiredTags ?? [],
-            badges: role.badges ?? role.desiredBadges ?? [],
-            user: inviteeData.profile,
-            userTagMap: inviteeData.userTagMap,
-            userBadgeMap: inviteeData.userBadgeMap,
-          });
-
-          if (!localMatch) return;
-
-          if (!nextMatchMap[String(roleId)]) {
-            nextMatchMap[String(roleId)] = {};
-          }
-          nextMatchMap[String(roleId)][String(inviteeId)] = localMatch;
-        });
-
-        setLocalInviteeRoleMatchMap(nextMatchMap);
-      } catch (error) {
-        if (!cancelled) {
-          console.warn("Could not compute local invitation role match scores:", error);
-          setLocalInviteeRoleMatchMap({});
-        }
-      }
-    };
-
-    fetchLocalInviteeMatches();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    fallbackRoleMap,
-    inviteeRoleMatchDataById,
-    isOpen,
-    roleInviteePairs,
-    teamId,
-    uniqueInviteeIds,
-    uniqueRoleIds,
-  ]);
-
-  useEffect(() => {
-    if (!isOpen || invitations.length === 0) {
-      setRoleCandidateMatchMap({});
-      return;
-    }
-
-    const inviteesByRole = invitations.reduce((acc, invitation) => {
-      const roleId =
-        invitation?.role?.id ??
-        invitation?.roleId ??
-        invitation?.role_id ??
-        null;
-      const inviteeId =
-        invitation?.invitee?.id ??
-        invitation?.invitee_id ??
-        null;
-
-      if (roleId == null || inviteeId == null) {
-        return acc;
-      }
-
-      const roleKey = String(roleId);
-      if (!acc.has(roleKey)) {
-        acc.set(roleKey, new Set());
-      }
-      acc.get(roleKey).add(String(inviteeId));
-      return acc;
-    }, new Map());
-
-    if (inviteesByRole.size === 0) {
-      setRoleCandidateMatchMap({});
-      return;
-    }
-
-    let cancelled = false;
-
-    const fetchCandidateMatches = async () => {
-      const roleEntries = [...inviteesByRole.entries()];
-
-      try {
-        const results = await Promise.allSettled(
-          roleEntries.map(([roleId, inviteeIds]) =>
-            matchingService.getMatchingCandidates(roleId, {
-              limit: Math.max(inviteeIds.size, ROLE_CANDIDATE_FETCH_MIN_LIMIT),
-            }),
-          ),
-        );
-
-        if (cancelled) return;
-
-        const nextMatchMap = {};
-
-        results.forEach((result, index) => {
-          if (result.status !== "fulfilled") return;
-
-          const [roleId] = roleEntries[index];
-          const roleMatches = {};
-
-          (result.value?.data || []).forEach((candidate) => {
-            const candidateId =
-              candidate?.id ??
-              candidate?.userId ??
-              candidate?.user_id ??
-              null;
-            if (candidateId == null) return;
-
-            roleMatches[String(candidateId)] = extractCandidateMatchData(candidate);
-          });
-
-          nextMatchMap[String(roleId)] = roleMatches;
-        });
-
-        setRoleCandidateMatchMap(nextMatchMap);
-      } catch (error) {
-        if (!cancelled) {
-          console.warn("Could not fetch invitation role match scores:", error);
-          setRoleCandidateMatchMap({});
-        }
-      }
-    };
-
-    fetchCandidateMatches();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, invitations]);
 
   // Poll role status every 20s so VacantRoleCard reflects changes made by others
   useEffect(() => {
@@ -766,16 +482,21 @@ const TeamInvitesModal = ({
         const isSelfInvitation =
           currentUser?.id === (invitation.invitee?.id ?? invitation.invitee_id);
         const inviteeRoleMatch =
-          roleId != null && inviteeId != null
-            ? roleCandidateMatchMap[String(roleId)]?.[String(inviteeId)] ?? null
+          roleId != null && invitation?.role
+            ? {
+                matchScore:
+                  invitation.role.match_score ??
+                  invitation.role.matchScore ??
+                  null,
+                matchDetails:
+                  invitation.role.match_details ??
+                  invitation.role.matchDetails ??
+                  null,
+              }
             : null;
         const selfRoleMatch =
           roleId != null && isSelfInvitation
             ? selfRoleMatchMap[String(roleId)] ?? null
-            : null;
-        const localInviteeRoleMatch =
-          roleId != null && inviteeId != null
-            ? localInviteeRoleMatchMap[String(roleId)]?.[String(inviteeId)] ?? null
             : null;
         const hasRoleInvitation = roleId != null;
         const isInternalInvitation = Boolean(
@@ -956,17 +677,11 @@ const TeamInvitesModal = ({
                         matchScore={
                           inviteeRoleMatch?.matchScore ??
                           selfRoleMatch?.matchScore ??
-                          localInviteeRoleMatch?.matchScore ??
-                          invitation.role?.matchScore ??
-                          invitation.role?.match_score ??
                           null
                         }
                         matchDetails={
                           inviteeRoleMatch?.matchDetails ??
                           selfRoleMatch?.matchDetails ??
-                          localInviteeRoleMatch?.matchDetails ??
-                          invitation.role?.matchDetails ??
-                          invitation.role?.match_details ??
                           null
                         }
                         canManage={false}
@@ -1013,17 +728,11 @@ const TeamInvitesModal = ({
                   matchScore={
                     inviteeRoleMatch?.matchScore ??
                     selfRoleMatch?.matchScore ??
-                    localInviteeRoleMatch?.matchScore ??
-                    invitation.role?.matchScore ??
-                    invitation.role?.match_score ??
                     null
                   }
                   matchDetails={
                     inviteeRoleMatch?.matchDetails ??
                     selfRoleMatch?.matchDetails ??
-                    localInviteeRoleMatch?.matchDetails ??
-                    invitation.role?.matchDetails ??
-                    invitation.role?.match_details ??
                     null
                   }
                   canManage={false}

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
+import React, { useState, useEffect, useRef, useLayoutEffect, useMemo } from "react";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import {
   User,
   Users,
@@ -18,9 +19,16 @@ import InlineUserLink, { InvitedByLink } from "../users/InlineUserLink";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import VacantRoleCard from "./VacantRoleCard";
 import { matchingService } from "../../services/matchingService";
-import { userService } from "../../services/userService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import teamService from "../../services/teamService";
+import {
+  fetchUserBadges,
+  fetchUserProfile,
+  fetchUserTags,
+  userBadgesQueryKey,
+  userProfileQueryKey,
+  userTagsQueryKey,
+} from "../../hooks/useUserQueries";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
@@ -30,10 +38,7 @@ import {
   getDisplayName,
   isSyntheticUser,
 } from "../../utils/userHelpers";
-import {
-  extractListPayload,
-  extractProfilePayload,
-} from "../../utils/payloadExtractors";
+import { extractProfilePayload } from "../../utils/payloadExtractors";
 import {
   buildBadgeLookup,
   buildTagLookup,
@@ -45,6 +50,12 @@ import { format } from "date-fns";
 
 const ROLE_CANDIDATE_FETCH_MIN_LIMIT = 20;
 const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
+
+const inviteeRoleMatchDataQueryKey = (inviteeId) => [
+  "users",
+  inviteeId ?? null,
+  "roleMatchData",
+];
 
 const FitInviteeName = ({ invitee, onUserClick, onNarrowChange, getDateEl, forceNarrow = false }) => {
   const containerRef = useRef(null);
@@ -134,6 +145,94 @@ const TeamInvitesModal = ({
   const { user: currentUser } = useAuth();
   const { openUserModal } = useUserModal();
   const { openTeamModal } = useTeamModal();
+  const queryClient = useQueryClient();
+  const roleInviteePairs = useMemo(
+    () =>
+      invitations
+        .map((invitation) => ({
+          roleId:
+            invitation?.role?.id ??
+            invitation?.roleId ??
+            invitation?.role_id ??
+            null,
+          inviteeId:
+            invitation?.invitee?.id ??
+            invitation?.invitee_id ??
+            null,
+          fallbackRole: invitation?.role ?? null,
+        }))
+        .filter((pair) => pair.roleId != null && pair.inviteeId != null),
+    [invitations],
+  );
+  const uniqueRoleIds = useMemo(
+    () => [...new Set(roleInviteePairs.map((pair) => String(pair.roleId)))],
+    [roleInviteePairs],
+  );
+  const uniqueInviteeIds = useMemo(
+    () => [...new Set(roleInviteePairs.map((pair) => String(pair.inviteeId)))],
+    [roleInviteePairs],
+  );
+  const fallbackRoleMap = useMemo(
+    () =>
+      roleInviteePairs.reduce((acc, pair) => {
+        if (!acc[pair.roleId] && pair.fallbackRole) {
+          acc[pair.roleId] = pair.fallbackRole;
+        }
+        return acc;
+      }, {}),
+    [roleInviteePairs],
+  );
+  const inviteeRoleMatchQueries = useQueries({
+    queries: uniqueInviteeIds.map((inviteeId) => ({
+      queryKey: inviteeRoleMatchDataQueryKey(inviteeId),
+      queryFn: async () => {
+        const [profile, tags, badges] = await Promise.all([
+          queryClient.fetchQuery({
+            queryKey: userProfileQueryKey(inviteeId),
+            queryFn: () => fetchUserProfile(inviteeId),
+            staleTime: 30_000,
+          }),
+          queryClient.fetchQuery({
+            queryKey: userTagsQueryKey(inviteeId),
+            queryFn: () => fetchUserTags(inviteeId),
+            staleTime: 30_000,
+          }),
+          queryClient.fetchQuery({
+            queryKey: userBadgesQueryKey(inviteeId),
+            queryFn: () => fetchUserBadges(inviteeId),
+            staleTime: 30_000,
+          }),
+        ]);
+
+        return {
+          inviteeId,
+          profile,
+          userTagMap: buildTagLookup(tags),
+          userBadgeMap: buildBadgeLookup(badges),
+        };
+      },
+      enabled: Boolean(isOpen && teamId && roleInviteePairs.length > 0),
+      staleTime: 30_000,
+    })),
+  });
+  const inviteeRoleMatchQuerySignature = inviteeRoleMatchQueries
+    .map(
+      (query) =>
+        `${query.status}:${query.dataUpdatedAt ?? 0}:${query.errorUpdatedAt ?? 0}`,
+    )
+    .join("|");
+  const inviteeQueriesPending = inviteeRoleMatchQueries.some(
+    (query) => query.isLoading || query.isFetching,
+  );
+  const inviteeRoleMatchDataById = useMemo(() => {
+    if (inviteeQueriesPending) return null;
+
+    return uniqueInviteeIds.reduce((acc, inviteeId, index) => {
+      const result = inviteeRoleMatchQueries[index];
+      acc[inviteeId] = result?.isSuccess ? result.data : null;
+      return acc;
+    }, {});
+  }, [inviteeQueriesPending, inviteeRoleMatchQuerySignature, uniqueInviteeIds]);
 
   // ============ Scroll to highlighted invitation ============
   useEffect(() => {
@@ -227,75 +326,22 @@ const TeamInvitesModal = ({
   }, [isOpen, teamId, currentUser?.id, invitations]);
 
   useEffect(() => {
-    const roleInviteePairs = invitations
-      .map((invitation) => ({
-        roleId:
-          invitation?.role?.id ??
-          invitation?.roleId ??
-          invitation?.role_id ??
-          null,
-        inviteeId:
-          invitation?.invitee?.id ??
-          invitation?.invitee_id ??
-          null,
-        fallbackRole: invitation?.role ?? null,
-      }))
-      .filter(
-        (pair) => pair.roleId != null && pair.inviteeId != null,
-      );
-
     if (!isOpen || !teamId || roleInviteePairs.length === 0) {
       setLocalInviteeRoleMatchMap({});
       return;
     }
 
+    if (!inviteeRoleMatchDataById) return;
+
     let cancelled = false;
 
     const fetchLocalInviteeMatches = async () => {
-      const uniqueRoleIds = [...new Set(roleInviteePairs.map((pair) => String(pair.roleId)))];
-      const uniqueInviteeIds = [
-        ...new Set(roleInviteePairs.map((pair) => String(pair.inviteeId))),
-      ];
-      const fallbackRoleMap = roleInviteePairs.reduce((acc, pair) => {
-        if (!acc[pair.roleId] && pair.fallbackRole) {
-          acc[pair.roleId] = pair.fallbackRole;
-        }
-        return acc;
-      }, {});
-
       try {
-        const [roleResults, inviteeResults] = await Promise.all([
-          Promise.allSettled(
-            uniqueRoleIds.map((roleId) =>
-              vacantRoleService.getVacantRoleById(teamId, roleId),
-            ),
+        const roleResults = await Promise.allSettled(
+          uniqueRoleIds.map((roleId) =>
+            vacantRoleService.getVacantRoleById(teamId, roleId),
           ),
-          Promise.allSettled(
-            uniqueInviteeIds.map(async (inviteeId) => {
-              const [profileRes, tagsRes, badgesRes] = await Promise.allSettled([
-                userService.getUserById(inviteeId),
-                userService.getUserTags(inviteeId),
-                userService.getUserBadges(inviteeId),
-              ]);
-
-              return {
-                inviteeId,
-                profile:
-                  profileRes.status === "fulfilled"
-                    ? extractProfilePayload(profileRes.value)
-                    : null,
-                userTagMap:
-                  tagsRes.status === "fulfilled"
-                    ? buildTagLookup(extractListPayload(tagsRes.value))
-                    : new Map(),
-                userBadgeMap:
-                  badgesRes.status === "fulfilled"
-                    ? buildBadgeLookup(extractListPayload(badgesRes.value))
-                    : new Map(),
-              };
-            }),
-          ),
-        ]);
+        );
 
         if (cancelled) return;
 
@@ -309,12 +355,8 @@ const TeamInvitesModal = ({
         });
 
         const inviteeMap = {};
-        uniqueInviteeIds.forEach((inviteeId, index) => {
-          const result = inviteeResults[index];
-          inviteeMap[inviteeId] =
-            result?.status === "fulfilled"
-              ? result.value
-              : null;
+        uniqueInviteeIds.forEach((inviteeId) => {
+          inviteeMap[inviteeId] = inviteeRoleMatchDataById[inviteeId] ?? null;
         });
 
         const nextMatchMap = {};
@@ -356,7 +398,15 @@ const TeamInvitesModal = ({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, teamId, invitations]);
+  }, [
+    fallbackRoleMap,
+    inviteeRoleMatchDataById,
+    isOpen,
+    roleInviteePairs,
+    teamId,
+    uniqueInviteeIds,
+    uniqueRoleIds,
+  ]);
 
   useEffect(() => {
     if (!isOpen || invitations.length === 0) {

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -26,14 +26,17 @@ import useSelfRoleMatchMap from "../../hooks/useSelfRoleMatchMap";
 import {
   DEMO_PROFILE_TOOLTIP,
   getUserInitials,
+  getUserAvatarUrl,
   getDisplayName,
   isSyntheticUser,
 } from "../../utils/userHelpers";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import {
+  buildCurrentFilledRoleForCard,
   buildInvitationRoleForCard,
   extractRoleMatchData,
   formatRequestDate,
+  getRequestUserLabel,
   getRequestUserId,
   getRequestRoleId,
   isRequestForUser,
@@ -212,11 +215,6 @@ const TeamInvitesModal = ({
 
   // ============ Helpers ============
 
-  // Helper to get avatar URL
-  const getAvatarUrl = (user) => {
-    return user?.avatar_url || user?.avatarUrl || null;
-  };
-
   // ============ Render ============
   const anyNarrow = Object.values(narrowMap).some(Boolean);
   const pendingCancelInvitation = invitations.find(
@@ -318,6 +316,10 @@ const TeamInvitesModal = ({
         const roleId = getRequestRoleId(invitation);
         const polledRole = roleId ? hydratedRoleMap[String(roleId)] : null;
         const roleForCard = buildInvitationRoleForCard(invitation, polledRole);
+        const currentFilledRoleForCard = buildCurrentFilledRoleForCard(
+          invitation,
+          invitation.invitee ?? null,
+        );
         const isSelfInvitation = isRequestForUser(
           invitation,
           "invitee",
@@ -348,6 +350,7 @@ const TeamInvitesModal = ({
           (getDisplayName(invitation.invitee) !== invitation.invitee?.username ||
             isSyntheticUser(invitation.invitee));
         const showInviteeDemoProfile = isSyntheticUser(invitation.invitee);
+        const inviteeAvatarUrl = getUserAvatarUrl(invitation.invitee);
         return (
           <div
             key={invitation.id}
@@ -369,9 +372,9 @@ const TeamInvitesModal = ({
                   className="w-12 h-12 rounded-full relative overflow-hidden"
                   onClick={() => handleInviteeClick(invitation.invitee?.id)}
                 >
-                  {getAvatarUrl(invitation.invitee) ? (
+                  {inviteeAvatarUrl ? (
                     <img
-                      src={getAvatarUrl(invitation.invitee)}
+                      src={inviteeAvatarUrl}
                       alt={getDisplayName(invitation.invitee)}
                       className="object-cover w-full h-full rounded-full"
                       onError={(e) => {
@@ -388,7 +391,7 @@ const TeamInvitesModal = ({
                   <div
                     className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
                     style={{
-                      display: getAvatarUrl(invitation.invitee)
+                      display: inviteeAvatarUrl
                         ? "none"
                         : "flex",
                     }}
@@ -487,7 +490,7 @@ const TeamInvitesModal = ({
               <div className="mb-3">
                 <p className="text-xs text-base-content/60 mb-1 flex items-center">
                   <SendHorizontal size={12} className="text-info mr-1" />
-                  {`Invitation message sent to ${invitation.invitee?.first_name || invitation.invitee?.firstName || invitation.invitee?.username || "recipient"}:`}
+                  {`Invitation message sent to ${getRequestUserLabel(invitation, "invitee", "recipient")}:`}
                 </p>
                 <div className="w-fit max-w-full bg-base-200 rounded-lg rounded-bl-none p-3">
                   <p className="text-sm text-base-content/90 leading-relaxed">
@@ -517,19 +520,10 @@ const TeamInvitesModal = ({
                       />
                     </div>
                   )}
-                  {isInternalInvitation && (invitation.current_filled_role_id ?? invitation.currentFilledRoleId) && (
+                  {isInternalInvitation && currentFilledRoleForCard && (
                     <div className="mt-3 max-w-[300px]">
                       <RequestRoleCard
-                        role={{
-                          id: invitation.current_filled_role_id ?? invitation.currentFilledRoleId,
-                          role_name: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
-                          roleName: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
-                          status: "filled",
-                          filled_by: getRequestUserId(invitation, "invitee"),
-                          filled_by_user: invitation.invitee ?? null,
-                          is_synthetic: invitation.role_is_synthetic ?? false,
-                          isSynthetic: invitation.role_is_synthetic ?? false,
-                        }}
+                        role={currentFilledRoleForCard}
                         teamId={teamId}
                         teamName={teamName}
                         canManageStatus={false}

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -30,167 +30,21 @@ import {
   getDisplayName,
   isSyntheticUser,
 } from "../../utils/userHelpers";
-import { calculateDistanceKm } from "../../utils/locationUtils";
+import {
+  extractListPayload,
+  extractProfilePayload,
+} from "../../utils/payloadExtractors";
+import {
+  buildBadgeLookup,
+  buildTagLookup,
+  computeRoleUserMatch,
+  extractCandidateMatchData,
+} from "../../utils/matchHelpers";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import { format } from "date-fns";
 
-const MATCH_WEIGHTS = {
-  tags: 0.4,
-  badges: 0.3,
-  distance: 0.3,
-};
 const ROLE_CANDIDATE_FETCH_MIN_LIMIT = 20;
 const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
-const LOCATION_GRACE_KM = 20;
-const LOCATION_GRACE_SCORE = 0.25;
-
-const roundMatchValue = (value) => Math.round(value * 100) / 100;
-
-const extractCandidateMatchData = (candidateLike) => {
-  const rawScore =
-    candidateLike?.matchScore ??
-    candidateLike?.match_score ??
-    candidateLike?.bestMatchScore ??
-    candidateLike?.best_match_score ??
-    null;
-  const numericScore = Number(rawScore);
-
-  return {
-    matchScore: Number.isFinite(numericScore) ? numericScore : null,
-    matchDetails:
-      candidateLike?.matchDetails ??
-      candidateLike?.match_details ??
-      null,
-  };
-};
-
-const extractProfilePayload = (response) => {
-  const payload = response?.data ?? response;
-
-  if (!payload) return null;
-  if (payload?.success !== undefined) return payload?.data ?? null;
-
-  return payload?.data?.data ?? payload?.data ?? payload;
-};
-
-const extractListPayload = (response) => {
-  if (Array.isArray(response)) return response;
-  if (Array.isArray(response?.data)) return response.data;
-  if (Array.isArray(response?.data?.data)) return response.data.data;
-  return [];
-};
-
-const buildTagLookup = (tagData) => {
-  const nextMap = new Map();
-
-  for (const tag of tagData) {
-    nextMap.set(Number(tag.id), {
-      badgeCredits: Number(tag.badge_credits ?? tag.badgeCredits ?? 0),
-    });
-  }
-
-  return nextMap;
-};
-
-const buildBadgeLookup = (badgeData) => {
-  const nextMap = new Map();
-
-  for (const badge of badgeData) {
-    const name = (badge.badgeName ?? badge.badge_name ?? badge.name ?? "")
-      .trim()
-      .toLowerCase();
-    const credits = Number(
-      badge.totalCredits ?? badge.total_credits ?? badge.credits ?? 0,
-    );
-    const existing = nextMap.get(name);
-
-    nextMap.set(name, {
-      totalCredits: (existing?.totalCredits || 0) + credits,
-    });
-  }
-
-  return nextMap;
-};
-
-const computeRoleUserMatch = ({
-  role,
-  tags,
-  badges,
-  user,
-  userTagMap,
-  userBadgeMap,
-}) => {
-  if (!role || !user) return null;
-
-  const requiredTagIds = tags
-    .map((tag) => Number(tag.tagId ?? tag.tag_id ?? tag.id))
-    .filter(Number.isFinite);
-  const requiredBadgeKeys = badges
-    .map((badge) =>
-      (badge.name ?? badge.badgeName ?? badge.badge_name ?? "")
-        .trim()
-        .toLowerCase(),
-    )
-    .filter(Boolean);
-
-  const matchingTags = requiredTagIds.filter((id) => userTagMap.has(id)).length;
-  const matchingBadges = requiredBadgeKeys.filter((key) => userBadgeMap.has(key)).length;
-
-  const tagScore =
-    requiredTagIds.length > 0 ? matchingTags / requiredTagIds.length : 0.5;
-  const badgeScore =
-    requiredBadgeKeys.length > 0
-      ? matchingBadges / requiredBadgeKeys.length
-      : 0.5;
-
-  const isRemote = role.isRemote ?? role.is_remote;
-  const maxDistanceKm = Number(role.maxDistanceKm ?? role.max_distance_km) || 50;
-
-  let distanceScore = 0.5;
-  let distanceKm = null;
-  let isWithinRange = null;
-
-  if (isRemote) {
-    distanceScore = 1;
-    isWithinRange = true;
-  } else {
-    distanceKm = calculateDistanceKm(user, role);
-
-    if (distanceKm !== null) {
-      if (distanceKm <= maxDistanceKm) {
-        distanceScore = 1;
-        isWithinRange = true;
-      } else if (distanceKm <= maxDistanceKm + LOCATION_GRACE_KM) {
-        distanceScore = LOCATION_GRACE_SCORE;
-        isWithinRange = false;
-      } else {
-        distanceScore = 0;
-        isWithinRange = false;
-      }
-    }
-  }
-
-  const matchScore =
-    MATCH_WEIGHTS.tags * tagScore +
-    MATCH_WEIGHTS.badges * badgeScore +
-    MATCH_WEIGHTS.distance * distanceScore;
-
-  return {
-    matchScore: roundMatchValue(matchScore),
-    matchDetails: {
-      tagScore: roundMatchValue(tagScore),
-      badgeScore: roundMatchValue(badgeScore),
-      distanceScore: roundMatchValue(distanceScore),
-      matchingTags,
-      totalRequiredTags: requiredTagIds.length,
-      matchingBadges,
-      totalRequiredBadges: requiredBadgeKeys.length,
-      distanceKm: distanceKm !== null ? Math.round(distanceKm) : null,
-      maxDistanceKm,
-      isWithinRange,
-    },
-  };
-};
 
 const FitInviteeName = ({ invitee, onUserClick, onNarrowChange, getDateEl, forceNarrow = false }) => {
   const containerRef = useRef(null);

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -18,11 +18,11 @@ import InlineUserLink, { InvitedByLink } from "../users/InlineUserLink";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import VacantRoleCard from "./VacantRoleCard";
 import { matchingService } from "../../services/matchingService";
-import { vacantRoleService } from "../../services/vacantRoleService";
 import teamService from "../../services/teamService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
+import usePolledRequestRoles from "../../hooks/usePolledRequestRoles";
 import {
   DEMO_PROFILE_TOOLTIP,
   getUserInitials,
@@ -114,7 +114,6 @@ const TeamInvitesModal = ({
   const [pendingCancelInvitationId, setPendingCancelInvitationId] =
     useState(null);
   const [pendingCancelType, setPendingCancelType] = useState("team");
-  const [hydratedRoleMap, setHydratedRoleMap] = useState({});
   const [narrowMap, setNarrowMap] = useState({});
   const dateElsRef = useRef({});
 
@@ -125,6 +124,10 @@ const TeamInvitesModal = ({
   const { user: currentUser } = useAuth();
   const { openUserModal } = useUserModal();
   const { openTeamModal } = useTeamModal();
+  const hydratedRoleMap = usePolledRequestRoles(invitations, {
+    isOpen,
+    teamId,
+  });
 
   // ============ Scroll to highlighted invitation ============
   useEffect(() => {
@@ -216,60 +219,6 @@ const TeamInvitesModal = ({
       cancelled = true;
     };
   }, [isOpen, teamId, currentUser?.id, invitations]);
-
-  // Poll role status every 20s so VacantRoleCard reflects changes made by others
-  useEffect(() => {
-    if (!isOpen || !teamId) return;
-
-    const roleIds = [
-      ...new Set(
-        invitations
-          .map(
-            (inv) =>
-              inv?.role?.id ?? inv?.roleId ?? inv?.role_id ?? null,
-          )
-          .filter(Boolean)
-          .map(String),
-      ),
-    ];
-
-    if (roleIds.length === 0) return;
-
-    let isCancelled = false;
-
-    const pollRoles = async () => {
-      try {
-        const results = await Promise.allSettled(
-          roleIds.map((id) =>
-            vacantRoleService.getVacantRoleById(teamId, id),
-          ),
-        );
-        if (isCancelled) return;
-        const nextMap = {};
-        results.forEach((result, i) => {
-          if (result.status === "fulfilled") {
-            const payload = result.value?.data ?? result.value;
-            const roleData =
-              payload?.success !== undefined
-                ? payload?.data ?? null
-                : payload?.data?.data ?? payload?.data ?? payload;
-            if (roleData) nextMap[roleIds[i]] = roleData;
-          }
-        });
-        setHydratedRoleMap((prev) => ({ ...prev, ...nextMap }));
-      } catch {
-        // silent — keep showing last known state
-      }
-    };
-
-    pollRoles();
-    const intervalId = setInterval(pollRoles, 20_000);
-
-    return () => {
-      isCancelled = true;
-      clearInterval(intervalId);
-    };
-  }, [isOpen, teamId, invitations]);
 
   // ============ Handlers ============
 

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -1,21 +1,17 @@
-import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   User,
   Users,
-  MapPin,
-  Calendar,
   SendHorizontal,
-  FlaskConical,
   Trash2,
-  MailOpen,
   XCircle,
 } from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
+import PersonRequestCard from "../common/PersonRequestCard";
 import Button from "../common/Button";
 import Modal from "../common/Modal";
 import Tooltip from "../common/Tooltip";
-import InlineUserLink, { InvitedByLink } from "../users/InlineUserLink";
-import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import { InvitedByLink } from "../users/InlineUserLink";
 import RequestRoleCard from "./RequestRoleCard";
 import teamService from "../../services/teamService";
 import { useAuth } from "../../contexts/AuthContext";
@@ -23,65 +19,17 @@ import { useUserModal } from "../../contexts/UserModalContext";
 import { useTeamModal } from "../../contexts/TeamModalContext";
 import usePolledRequestRoles from "../../hooks/usePolledRequestRoles";
 import useSelfRoleMatchMap from "../../hooks/useSelfRoleMatchMap";
-import {
-  DEMO_PROFILE_TOOLTIP,
-  getUserInitials,
-  getUserAvatarUrl,
-  getDisplayName,
-  isSyntheticUser,
-} from "../../utils/userHelpers";
-import { formatDisplayName } from "../../utils/nameFormatters";
+import { getDisplayName } from "../../utils/userHelpers";
 import {
   buildCurrentFilledRoleForCard,
   buildInvitationRoleForCard,
   extractRoleMatchData,
-  formatRequestDate,
+  getRequestDateValue,
   getRequestUserLabel,
   getRequestUserId,
   getRequestRoleId,
   isRequestForUser,
 } from "../../utils/teamRequestUtils";
-
-const FitInviteeName = ({ invitee, onUserClick, onNarrowChange, getDateEl, forceNarrow = false }) => {
-  const containerRef = useRef(null);
-  const probeRef = useRef(null);
-  const fullName = getDisplayName(invitee);
-  const abbrevName = invitee ? formatDisplayName(invitee) : fullName;
-  const [displayedName, setDisplayedName] = useState(fullName);
-  const displayedNameRef = useRef(fullName);
-  displayedNameRef.current = displayedName;
-  const forceNarrowRef = useRef(forceNarrow);
-  forceNarrowRef.current = forceNarrow;
-
-  useLayoutEffect(() => {
-    if (fullName === abbrevName) { setDisplayedName(fullName); onNarrowChange?.(false); return; }
-    const container = containerRef.current;
-    const probe = probeRef.current;
-    if (!container || !probe) return;
-    const update = () => {
-      const isDateAbsolute = displayedNameRef.current !== fullName || forceNarrowRef.current;
-      const dateEl = getDateEl?.();
-      const dateReservedWidth = isDateAbsolute && dateEl ? dateEl.offsetWidth + 12 : 0; // 12 = gap-3
-      probe.textContent = fullName;
-      const fits = probe.scrollWidth <= container.clientWidth - dateReservedWidth;
-      setDisplayedName(fits ? fullName : abbrevName);
-      onNarrowChange?.(!fits);
-    };
-    const ro = new ResizeObserver(update);
-    ro.observe(container);
-    update();
-    return () => ro.disconnect();
-  }, [fullName, abbrevName]);
-
-  return (
-    <h4 ref={containerRef} className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative">
-      <Tooltip content="View profile" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
-        <span onClick={onUserClick}>{displayedName}</span>
-      </Tooltip>
-      <span ref={probeRef} className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium" aria-hidden="true" />
-    </h4>
-  );
-};
 
 /**
  * TeamInvitesModal Component
@@ -117,7 +65,6 @@ const TeamInvitesModal = ({
     useState(null);
   const [pendingCancelType, setPendingCancelType] = useState("team");
   const [narrowMap, setNarrowMap] = useState({});
-  const dateElsRef = useRef({});
 
   // ============ Refs ============
   const highlightedRef = useRef(null);
@@ -338,6 +285,22 @@ const TeamInvitesModal = ({
           invitation?.isInternal ?? invitation?.is_internal ?? false,
         );
 
+        // Strip the " <roleName>." suffix the backend appends to internal invitation messages
+        const displayedMessage = invitation.message
+          ? (() => {
+              const roleName =
+                invitation.current_filled_role_name ??
+                invitation.currentFilledRoleName;
+              if (isInternalInvitation && roleName) {
+                const suffix = ` ${roleName}.`;
+                return invitation.message.endsWith(suffix)
+                  ? invitation.message.slice(0, -suffix.length)
+                  : invitation.message;
+              }
+              return invitation.message;
+            })()
+          : null;
+
         // Normalize types to avoid "1" vs 1 mismatches
         const isHighlighted =
           (highlightInvitationId != null &&
@@ -345,260 +308,137 @@ const TeamInvitesModal = ({
           (highlightUserId != null &&
             inviteeId != null &&
             String(inviteeId) === String(highlightUserId));
-        const showInviteeUsername =
-          invitation.invitee?.username &&
-          (getDisplayName(invitation.invitee) !== invitation.invitee?.username ||
-            isSyntheticUser(invitation.invitee));
-        const showInviteeDemoProfile = isSyntheticUser(invitation.invitee);
-        const inviteeAvatarUrl = getUserAvatarUrl(invitation.invitee);
+
+        const inviteeRoleCard = hasRoleInvitation ? (
+          <RequestRoleCard
+            role={roleForCard}
+            teamId={teamId}
+            teamName={teamName}
+            primaryMatch={inviteeRoleMatch}
+            secondaryMatch={selfRoleMatch}
+            canManageStatus={false}
+            viewAsUserId={inviteeId}
+            viewAsUser={invitation.invitee}
+            hideActions={true}
+          />
+        ) : null;
+        const currentFilledRoleCard =
+          isInternalInvitation && currentFilledRoleForCard ? (
+            <RequestRoleCard
+              role={currentFilledRoleForCard}
+              teamId={teamId}
+              teamName={teamName}
+              canManageStatus={false}
+              hideActions={true}
+            />
+          ) : null;
+
         return (
           <div
             key={invitation.id}
             ref={isHighlighted ? highlightedRef : null}
-            className={`bg-base-200/30 rounded-lg border border-base-300 p-4 transition-all duration-300 ${
+            className={`transition-all duration-300 ${
               isHighlighted
-                ? "ring-2 ring-green-500/70 ring-offset-2 border-green-400 bg-green-50"
+                ? "ring-2 ring-green-500/70 ring-offset-2 rounded-xl bg-green-50"
                 : ""
             }`}
           >
-            {/* Top row: Avatar + Name/Username + Date */}
-            <div className="flex items-start gap-3 mb-3 relative">
-              {/* Invitee Avatar - Clickable */}
-              <Tooltip
-                content="View profile"
-                wrapperClassName="avatar cursor-pointer hover:opacity-80 transition-opacity flex-shrink-0"
-              >
-                <div
-                  className="w-12 h-12 rounded-full relative overflow-hidden"
-                  onClick={() => handleInviteeClick(invitation.invitee?.id)}
-                >
-                  {inviteeAvatarUrl ? (
-                    <img
-                      src={inviteeAvatarUrl}
-                      alt={getDisplayName(invitation.invitee)}
-                      className="object-cover w-full h-full rounded-full"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        const fallback =
-                          e.target.parentElement.querySelector(
-                            ".avatar-fallback"
-                          );
-                        if (fallback) fallback.style.display = "flex";
-                      }}
-                    />
-                  ) : null}
-                  {/* Fallback initials */}
-                  <div
-                    className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                    style={{
-                      display: inviteeAvatarUrl
-                        ? "none"
-                        : "flex",
-                    }}
+            <PersonRequestCard
+              user={invitation.invitee}
+              date={getRequestDateValue(invitation)}
+              onNarrowChange={(narrow) =>
+                setNarrowMap((prev) => {
+                  if ((prev[String(invitation.id)] ?? false) === narrow) return prev;
+                  return { ...prev, [String(invitation.id)]: narrow };
+                })
+              }
+              forceNarrow={anyNarrow}
+              message={displayedMessage || undefined}
+              messageLabel={`Invitation message sent to ${getRequestUserLabel(invitation, "invitee", "recipient")}:`}
+              messageIcon={<SendHorizontal size={12} className="text-info mr-1" />}
+              onUserClick={handleInviteeClick}
+              showLocation={true}
+              sublineExtra={
+                isInternalInvitation ? (
+                  <Tooltip
+                    content="Already a member of this team"
+                    wrapperClassName="flex min-w-0 overflow-hidden items-center gap-0.5 text-base-content/70"
                   >
-                    <span className="text-xl font-medium">
-                      {getUserInitials(invitation.invitee)}
-                    </span>
-                  </div>
-                  {isSyntheticUser(invitation.invitee) && (
-                    <DemoAvatarOverlay textClassName="text-[8px]" />
+                    <User size={10} className="flex-shrink-0 text-success" />
+                    <span className="leading-[1.05] whitespace-nowrap">Team Member</span>
+                  </Tooltip>
+                ) : null
+              }
+              messageBubbleExtra={
+                displayedMessage ? (
+                  <>
+                    {inviteeRoleCard}
+                    {currentFilledRoleCard && (
+                      <div className={inviteeRoleCard ? "mt-3" : ""}>
+                        {currentFilledRoleCard}
+                      </div>
+                    )}
+                  </>
+                ) : null
+              }
+              extraContent={
+                !displayedMessage && inviteeRoleCard ? (
+                  <div className="mb-3 max-w-[300px]">{inviteeRoleCard}</div>
+                ) : null
+              }
+              footerLeft={
+                invitation.inviter ? (
+                  <InvitedByLink
+                    user={invitation.inviter}
+                    className="min-w-0 flex-[1_1_12rem] overflow-hidden"
+                  />
+                ) : invitation.inviter_username ? (
+                  <span className="min-w-0 flex-[1_1_12rem] overflow-hidden truncate text-xs text-base-content/50">
+                    Invited by {invitation.inviter_username}
+                  </span>
+                ) : null
+              }
+              actions={
+                <div className="ml-auto flex flex-wrap justify-end gap-2">
+                  {hasRoleInvitation && (
+                    <Tooltip content="Cancel role invitation only">
+                      <Button
+                        variant="errorOutline"
+                        size="sm"
+                        onClick={() => handleCancelInvitation(invitation.id, "role")}
+                        disabled={loading}
+                        icon={<XCircle size={14} />}
+                      >
+                        {loading ? "Canceling..." : "Cancel Role Invite"}
+                      </Button>
+                    </Tooltip>
                   )}
-                </div>
-              </Tooltip>
-
-              {/* User Info */}
-              <div className="flex-1 min-w-0">
-                {/* Name - Clickable */}
-                <FitInviteeName
-                  invitee={invitation.invitee}
-                  onUserClick={() => handleInviteeClick(invitation.invitee?.id)}
-                  onNarrowChange={(narrow) => setNarrowMap((prev) => {
-                    if ((prev[String(invitation.id)] ?? false) === narrow) return prev;
-                    return { ...prev, [String(invitation.id)]: narrow };
-                  })}
-                  getDateEl={() => dateElsRef.current[String(invitation.id)]}
-                  forceNarrow={anyNarrow}
-                />
-                {(anyNarrow || showInviteeUsername || invitation.invitee?.city || invitation.invitee?.country || invitation.invitee?.postal_code || invitation.invitee?.location || isInternalInvitation || showInviteeDemoProfile) && (
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs" style={{ maxHeight: "2.1em" }}>
-                    {anyNarrow ? (
-                      <div className="flex shrink-0 items-center gap-1 text-base-content/60">
-                        <Calendar size={10} className="shrink-0" />
-                        <span className="leading-[1.05] whitespace-nowrap">{formatRequestDate(invitation)}</span>
-                      </div>
-                    ) : showInviteeUsername && (
-                      <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
-                        <Tooltip content="View profile" wrapperClassName="block truncate leading-[1.05] text-base-content/70 cursor-pointer hover:text-primary transition-colors">
-                          <span onClick={() => handleInviteeClick(invitation.invitee?.id)}>
-                            @{invitation.invitee.username}
-                          </span>
-                        </Tooltip>
-                      </div>
-                    )}
-                    {(invitation.invitee?.city || invitation.invitee?.country || invitation.invitee?.postal_code || invitation.invitee?.location) && (
-                      <div className="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden">
-                        <MapPin size={10} className="text-base-content/60 shrink-0" />
-                        <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">
-                          {[invitation.invitee?.city, invitation.invitee?.country].filter(Boolean).join(", ") || invitation.invitee?.location || invitation.invitee?.postal_code}
-                        </span>
-                      </div>
-                    )}
-                    {isInternalInvitation && (
-                      <Tooltip
-                        content="Already a member of this team"
-                        wrapperClassName="flex min-w-0 overflow-hidden items-center gap-0.5 text-base-content/70"
-                      >
-                        <User size={10} className="flex-shrink-0 text-success" />
-                        <span className="leading-[1.05] whitespace-nowrap">Team Member</span>
-                      </Tooltip>
-                    )}
-                    {showInviteeDemoProfile && (
-                      <Tooltip
-                        content={DEMO_PROFILE_TOOLTIP}
-                        wrapperClassName="flex shrink-0 items-center gap-0.5 text-base-content/50"
-                      >
-                        <FlaskConical size={10} className="flex-shrink-0" />
-                      </Tooltip>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {/* Date - top right; absolute (out of flow) when narrow so subline gets full width,
-                  but still rendered so its width can be measured for stable name-fit calculation */}
-              <div
-                ref={(el) => {
-                  if (el) dateElsRef.current[String(invitation.id)] = el;
-                  else delete dateElsRef.current[String(invitation.id)];
-                }}
-                className={`flex items-center text-xs text-base-content/60 whitespace-nowrap${anyNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
-              >
-                <Calendar size={12} className="mr-1" />
-                <span>{formatRequestDate(invitation)}</span>
-              </div>
-            </div>
-
-            {/* Invitee Bio (if available) */}
-            {invitation.invitee?.bio && (
-              <div className="mb-3 text-sm text-base-content/80">
-                <p className="line-clamp-2">{invitation.invitee.bio}</p>
-              </div>
-            )}
-
-            {/* Invitation message — speech bubble (only when a message exists) */}
-            {invitation.message && (
-              <div className="mb-3">
-                <p className="text-xs text-base-content/60 mb-1 flex items-center">
-                  <SendHorizontal size={12} className="text-info mr-1" />
-                  {`Invitation message sent to ${getRequestUserLabel(invitation, "invitee", "recipient")}:`}
-                </p>
-                <div className="w-fit max-w-full bg-base-200 rounded-lg rounded-bl-none p-3">
-                  <p className="text-sm text-base-content/90 leading-relaxed">
-                    {(() => {
-                      const roleName = invitation.current_filled_role_name ?? invitation.currentFilledRoleName;
-                      if (isInternalInvitation && roleName) {
-                        const suffix = ` ${roleName}.`;
-                        return invitation.message.endsWith(suffix)
-                          ? invitation.message.slice(0, -suffix.length)
-                          : invitation.message;
+                  {(!hasRoleInvitation || !isInternalInvitation) && (
+                    <Tooltip
+                      content={
+                        hasRoleInvitation
+                          ? "Cancel team & role invitation"
+                          : "Cancel team invitation"
                       }
-                      return invitation.message;
-                    })()}
-                  </p>
-                  {(invitation.role || invitation.roleId || invitation.role_id) && (
-                    <div className="mt-3 max-w-[300px]">
-                      <RequestRoleCard
-                        role={roleForCard}
-                        teamId={teamId}
-                        teamName={teamName}
-                        primaryMatch={inviteeRoleMatch}
-                        secondaryMatch={selfRoleMatch}
-                        canManageStatus={false}
-                        viewAsUserId={getRequestUserId(invitation, "invitee")}
-                        viewAsUser={invitation.invitee}
-                        hideActions={true}
-                      />
-                    </div>
-                  )}
-                  {isInternalInvitation && currentFilledRoleForCard && (
-                    <div className="mt-3 max-w-[300px]">
-                      <RequestRoleCard
-                        role={currentFilledRoleForCard}
-                        teamId={teamId}
-                        teamName={teamName}
-                        canManageStatus={false}
-                        hideActions={true}
-                      />
-                    </div>
+                    >
+                      <Button
+                        variant="errorOutline"
+                        size="sm"
+                        onClick={() => handleCancelInvitation(invitation.id, "team")}
+                        disabled={loading}
+                        icon={<XCircle size={14} />}
+                      >
+                        {loading
+                          ? "Canceling..."
+                          : hasRoleInvitation
+                            ? "Cancel Role + Team Invite"
+                            : "Cancel Invite"}
+                      </Button>
+                    </Tooltip>
                   )}
                 </div>
-              </div>
-            )}
-
-            {/* Role card — shown bare (no bubble) when there's a role but no message */}
-            {!invitation.message && (invitation.role || invitation.roleId || invitation.role_id) && (
-              <div className="mb-3 max-w-[300px]">
-                <RequestRoleCard
-                  role={roleForCard}
-                  teamId={teamId}
-                  teamName={teamName}
-                  primaryMatch={inviteeRoleMatch}
-                  secondaryMatch={selfRoleMatch}
-                  canManageStatus={false}
-                  viewAsUserId={getRequestUserId(invitation, "invitee")}
-                  viewAsUser={invitation.invitee}
-                  hideActions={true}
-                />
-              </div>
-            )}
-
-
-            {/* Bottom row: Inviter info (left) + Action Button (right) */}
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 mt-8 -mx-4 -mb-4 px-4 pb-4 pt-3 border-t border-base-200 bg-base-100/80 rounded-b-lg">
-              {/* Inviter info (left) - Using InlineUserLink */}
-              {invitation.inviter ? (
-                <InvitedByLink
-                  user={invitation.inviter}
-                  className="min-w-0 flex-[1_1_12rem] overflow-hidden"
-                />
-              ) : invitation.inviter_username ? (
-                <span className="min-w-0 flex-[1_1_12rem] overflow-hidden truncate text-xs text-base-content/50">
-                  Invited by {invitation.inviter_username}
-                </span>
-              ) : (
-                <div className="min-w-0 flex-[1_1_12rem] overflow-hidden" />
-              )}
-
-              {/* Action Button (right) */}
-              <div className="ml-auto flex flex-wrap justify-end gap-2">
-                {hasRoleInvitation && (
-                  <Tooltip content="Cancel role invitation only">
-                    <Button
-                      variant="errorOutline"
-                      size="sm"
-                      onClick={() => handleCancelInvitation(invitation.id, "role")}
-                      disabled={loading}
-                      icon={<XCircle size={14} />}
-                    >
-                      {loading ? "Canceling..." : "Cancel Role Invite"}
-                    </Button>
-                  </Tooltip>
-                )}
-                {(!hasRoleInvitation || !isInternalInvitation) && (
-                  <Tooltip content={hasRoleInvitation ? "Cancel team & role invitation" : "Cancel team invitation"}>
-                    <Button
-                      variant="errorOutline"
-                      size="sm"
-                      onClick={() => handleCancelInvitation(invitation.id, "team")}
-                      disabled={loading}
-                      icon={<XCircle size={14} />}
-                    >
-                      {loading ? "Canceling..." : hasRoleInvitation ? "Cancel Role + Team Invite" : "Cancel Invite"}
-                    </Button>
-                  </Tooltip>
-                )}
-              </div>
-            </div>
+              }
+            />
           </div>
         );
       })}

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -16,7 +16,7 @@ import Modal from "../common/Modal";
 import Tooltip from "../common/Tooltip";
 import InlineUserLink, { InvitedByLink } from "../users/InlineUserLink";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
-import VacantRoleCard from "./VacantRoleCard";
+import RequestRoleCard from "./RequestRoleCard";
 import teamService from "../../services/teamService";
 import { useAuth } from "../../contexts/AuthContext";
 import { useUserModal } from "../../contexts/UserModalContext";
@@ -504,22 +504,13 @@ const TeamInvitesModal = ({
                   </p>
                   {(invitation.role || invitation.roleId || invitation.role_id) && (
                     <div className="mt-3 max-w-[300px]">
-                      <VacantRoleCard
+                      <RequestRoleCard
                         role={roleForCard}
-                        team={{ id: teamId, name: teamName }}
-                        matchScore={
-                          inviteeRoleMatch?.matchScore ??
-                          selfRoleMatch?.matchScore ??
-                          null
-                        }
-                        matchDetails={
-                          inviteeRoleMatch?.matchDetails ??
-                          selfRoleMatch?.matchDetails ??
-                          null
-                        }
-                        canManage={false}
+                        teamId={teamId}
+                        teamName={teamName}
+                        primaryMatch={inviteeRoleMatch}
+                        secondaryMatch={selfRoleMatch}
                         canManageStatus={false}
-                        isTeamMember={true}
                         viewAsUserId={getRequestUserId(invitation, "invitee")}
                         viewAsUser={invitation.invitee}
                         hideActions={true}
@@ -528,7 +519,7 @@ const TeamInvitesModal = ({
                   )}
                   {isInternalInvitation && (invitation.current_filled_role_id ?? invitation.currentFilledRoleId) && (
                     <div className="mt-3 max-w-[300px]">
-                      <VacantRoleCard
+                      <RequestRoleCard
                         role={{
                           id: invitation.current_filled_role_id ?? invitation.currentFilledRoleId,
                           role_name: invitation.current_filled_role_name ?? invitation.currentFilledRoleName,
@@ -539,11 +530,9 @@ const TeamInvitesModal = ({
                           is_synthetic: invitation.role_is_synthetic ?? false,
                           isSynthetic: invitation.role_is_synthetic ?? false,
                         }}
-                        team={{ id: teamId, name: teamName }}
-                        matchScore={null}
-                        canManage={false}
+                        teamId={teamId}
+                        teamName={teamName}
                         canManageStatus={false}
-                        isTeamMember={true}
                         hideActions={true}
                       />
                     </div>
@@ -555,22 +544,13 @@ const TeamInvitesModal = ({
             {/* Role card — shown bare (no bubble) when there's a role but no message */}
             {!invitation.message && (invitation.role || invitation.roleId || invitation.role_id) && (
               <div className="mb-3 max-w-[300px]">
-                <VacantRoleCard
+                <RequestRoleCard
                   role={roleForCard}
-                  team={{ id: teamId, name: teamName }}
-                  matchScore={
-                    inviteeRoleMatch?.matchScore ??
-                    selfRoleMatch?.matchScore ??
-                    null
-                  }
-                  matchDetails={
-                    inviteeRoleMatch?.matchDetails ??
-                    selfRoleMatch?.matchDetails ??
-                    null
-                  }
-                  canManage={false}
+                  teamId={teamId}
+                  teamName={teamName}
+                  primaryMatch={inviteeRoleMatch}
+                  secondaryMatch={selfRoleMatch}
                   canManageStatus={false}
-                  isTeamMember={true}
                   viewAsUserId={getRequestUserId(invitation, "invitee")}
                   viewAsUser={invitation.invitee}
                   hideActions={true}

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from "react";
-import { useQueries } from "@tanstack/react-query";
 import {
   Users,
   MapPin,
@@ -12,10 +11,6 @@ import {
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import ScreenAlert from "../common/ScreenAlert";
 import { teamService } from "../../services/teamService";
-import {
-  fetchUserProfile,
-  userProfileQueryKey,
-} from "../../hooks/useUserQueries";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
@@ -60,34 +55,10 @@ const TeamMembersSection = ({
     () => (Array.isArray(team?.members) ? team.members : []),
     [team?.members],
   );
-  const memberSyntheticQueryIds = useMemo(() => {
-    const seenIds = new Set();
-    const ids = [];
-
-    members.forEach((member) => {
-      const memberId = getTeamMemberId(member);
-      if (memberId == null) return;
-
-      const hasInlineSyntheticFlag =
-        member?.is_synthetic != null || member?.isSynthetic != null;
-      if (hasInlineSyntheticFlag) return;
-
-      const key = String(memberId);
-      if (seenIds.has(key)) return;
-
-      seenIds.add(key);
-      ids.push(memberId);
-    });
-
-    return ids;
-  }, [members]);
-  const memberSyntheticQueries = useQueries({
-    queries: memberSyntheticQueryIds.map((memberId) => ({
-      queryKey: userProfileQueryKey(memberId),
-      queryFn: () => fetchUserProfile(memberId),
-      staleTime: 30_000,
-    })),
-  });
+  // Only show the synthetic indicator when the parent embeds is_synthetic
+  // in the member object. Fetching profiles per member just to discover this
+  // flag was an N+1 (one round trip per member); the indicator is only
+  // meaningful for demo users, so gracefully degrade when the data is absent.
   const syntheticMemberStatusMap = useMemo(() => {
     const statuses = {};
 
@@ -102,15 +73,8 @@ const TeamMembersSection = ({
       }
     });
 
-    memberSyntheticQueryIds.forEach((memberId, index) => {
-      const profile = memberSyntheticQueries[index]?.data;
-      if (!profile) return;
-
-      statuses[String(memberId)] = isSyntheticUser(profile);
-    });
-
     return statuses;
-  }, [memberSyntheticQueries, memberSyntheticQueryIds, members]);
+  }, [members]);
 
   // Helper function to get member initials (2 letters: "NK" for Nam Khoa)
   const getMemberInitials = (member) => {

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -18,17 +18,9 @@ import CardMetaRow from "../common/CardMetaRow";
 import Tooltip from "../common/Tooltip";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { DEMO_PROFILE_TOOLTIP, isSyntheticUser } from "../../utils/userHelpers";
+import { extractProfilePayload } from "../../utils/payloadExtractors";
 
 const memberSyntheticStatusCache = new Map();
-
-const extractProfilePayload = (response) => {
-  const payload = response?.data ?? response;
-
-  if (!payload) return null;
-  if (payload?.success !== undefined) return payload?.data ?? null;
-
-  return payload?.data?.data ?? payload?.data ?? payload;
-};
 
 const getCachedMemberSyntheticStatus = async (memberId) => {
   const cacheKey = String(memberId);

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useMemo, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
 import {
   Users,
   MapPin,
@@ -11,40 +12,16 @@ import {
 import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import ScreenAlert from "../common/ScreenAlert";
 import { teamService } from "../../services/teamService";
-import { userService } from "../../services/userService";
+import {
+  fetchUserProfile,
+  userProfileQueryKey,
+} from "../../hooks/useUserQueries";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import Tooltip from "../common/Tooltip";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { DEMO_PROFILE_TOOLTIP, isSyntheticUser } from "../../utils/userHelpers";
-import { extractProfilePayload } from "../../utils/payloadExtractors";
-
-const memberSyntheticStatusCache = new Map();
-
-const getCachedMemberSyntheticStatus = async (memberId) => {
-  const cacheKey = String(memberId);
-
-  if (memberSyntheticStatusCache.has(cacheKey)) {
-    return memberSyntheticStatusCache.get(cacheKey);
-  }
-
-  const request = (async () => {
-    const response = await userService.getUserById(memberId);
-    return isSyntheticUser(extractProfilePayload(response));
-  })();
-
-  memberSyntheticStatusCache.set(cacheKey, request);
-
-  try {
-    const result = await request;
-    memberSyntheticStatusCache.set(cacheKey, Promise.resolve(result));
-    return result;
-  } catch (error) {
-    memberSyntheticStatusCache.delete(cacheKey);
-    throw error;
-  }
-};
 
 const getTeamMemberId = (member) =>
   member?.userId ??
@@ -78,8 +55,62 @@ const TeamMembersSection = ({
     message: null,
   });
   const [isExpanded, setIsExpanded] = useState(false);
-  const [syntheticMemberStatusMap, setSyntheticMemberStatusMap] = useState({});
   const COLLAPSED_COUNT = 4;
+  const members = useMemo(
+    () => (Array.isArray(team?.members) ? team.members : []),
+    [team?.members],
+  );
+  const memberSyntheticQueryIds = useMemo(() => {
+    const seenIds = new Set();
+    const ids = [];
+
+    members.forEach((member) => {
+      const memberId = getTeamMemberId(member);
+      if (memberId == null) return;
+
+      const hasInlineSyntheticFlag =
+        member?.is_synthetic != null || member?.isSynthetic != null;
+      if (hasInlineSyntheticFlag) return;
+
+      const key = String(memberId);
+      if (seenIds.has(key)) return;
+
+      seenIds.add(key);
+      ids.push(memberId);
+    });
+
+    return ids;
+  }, [members]);
+  const memberSyntheticQueries = useQueries({
+    queries: memberSyntheticQueryIds.map((memberId) => ({
+      queryKey: userProfileQueryKey(memberId),
+      queryFn: () => fetchUserProfile(memberId),
+      staleTime: 30_000,
+    })),
+  });
+  const syntheticMemberStatusMap = useMemo(() => {
+    const statuses = {};
+
+    members.forEach((member) => {
+      const memberId = getTeamMemberId(member);
+      if (memberId == null) return;
+
+      const hasInlineSyntheticFlag =
+        member?.is_synthetic != null || member?.isSynthetic != null;
+      if (hasInlineSyntheticFlag) {
+        statuses[String(memberId)] = isSyntheticUser(member);
+      }
+    });
+
+    memberSyntheticQueryIds.forEach((memberId, index) => {
+      const profile = memberSyntheticQueries[index]?.data;
+      if (!profile) return;
+
+      statuses[String(memberId)] = isSyntheticUser(profile);
+    });
+
+    return statuses;
+  }, [memberSyntheticQueries, memberSyntheticQueryIds, members]);
 
   // Helper function to get member initials (2 letters: "NK" for Nam Khoa)
   const getMemberInitials = (member) => {
@@ -97,71 +128,6 @@ const TeamMembersSection = ({
     }
     return "?";
   };
-
-  useEffect(() => {
-    const members = Array.isArray(team?.members) ? team.members : [];
-    const nextKnownStatuses = {};
-    const memberIdsToFetch = [];
-
-    members.forEach((member) => {
-      const memberId = getTeamMemberId(member);
-      if (memberId == null) return;
-
-      const cacheKey = String(memberId);
-      const hasInlineSyntheticFlag =
-        member?.is_synthetic != null || member?.isSynthetic != null;
-
-      if (hasInlineSyntheticFlag) {
-        const isDemoMember = isSyntheticUser(member);
-        nextKnownStatuses[cacheKey] = isDemoMember;
-        memberSyntheticStatusCache.set(cacheKey, Promise.resolve(isDemoMember));
-        return;
-      }
-
-      memberIdsToFetch.push(memberId);
-    });
-
-    if (Object.keys(nextKnownStatuses).length > 0) {
-      setSyntheticMemberStatusMap((prev) => ({
-        ...prev,
-        ...nextKnownStatuses,
-      }));
-    }
-
-    if (memberIdsToFetch.length === 0) {
-      return undefined;
-    }
-
-    let cancelled = false;
-
-    Promise.allSettled(
-      [...new Set(memberIdsToFetch)].map(async (memberId) => ({
-        memberId,
-        isSynthetic: await getCachedMemberSyntheticStatus(memberId),
-      })),
-    ).then((results) => {
-      if (cancelled) return;
-
-      const fetchedStatuses = {};
-
-      results.forEach((result) => {
-        if (result.status !== "fulfilled") return;
-
-        fetchedStatuses[String(result.value.memberId)] = result.value.isSynthetic;
-      });
-
-      if (Object.keys(fetchedStatuses).length > 0) {
-        setSyntheticMemberStatusMap((prev) => ({
-          ...prev,
-          ...fetchedStatuses,
-        }));
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [team?.members]);
 
   // Early return if no members
   if (!team?.members || team.members.length === 0) {

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -31,10 +31,12 @@ import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import Tooltip from "../common/Tooltip";
 import {
+  DEMO_PROFILE_TOOLTIP,
   DEMO_ROLE_TOOLTIP,
   getDisplayName,
   getUserInitials,
   isSyntheticRole,
+  isSyntheticUser,
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { resolveFilledRoleUser } from "../../utils/vacantRoleUtils";
@@ -865,9 +867,10 @@ const VacantRoleCard = ({
       </span>
     </Tooltip>
   ) : null;
-  const demoRoleMetaItem = isSyntheticRole(role) ? (
+  const hasDemoRoleMeta = isSyntheticRole(role) || isSyntheticUser(filledUser);
+  const demoRoleMetaItem = hasDemoRoleMeta ? (
     <Tooltip
-      content={DEMO_ROLE_TOOLTIP}
+      content={isSyntheticRole(role) ? DEMO_ROLE_TOOLTIP : DEMO_PROFILE_TOOLTIP}
       wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
     >
       <FlaskConical size={10} className="flex-shrink-0" />
@@ -1001,6 +1004,12 @@ const VacantRoleCard = ({
       textTranslateClassName="-translate-y-[3px]"
     />
   ) : null;
+  const compactFilledUserDemoAvatarOverlay = isSyntheticUser(filledUser) ? (
+    <DemoAvatarOverlay
+      textClassName={isMiniView ? "text-[6px]" : "text-[7px]"}
+      textTranslateClassName="-translate-y-[3px]"
+    />
+  ) : null;
 
   if (viewMode === "list") {
     const roundedDistanceKm = showDistance ? Math.round(rawDistanceKm) : null;
@@ -1022,21 +1031,14 @@ const VacantRoleCard = ({
       teamSubtitleItem ||
       roleInvitationSubtitleItem ||
       roleApplicationSubtitleItem ||
-      isSyntheticRole(role) ? (
+      hasDemoRoleMeta ? (
         <span className="flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden whitespace-nowrap text-base-content/60">
           {scoreSubtitleItem}
           {postedDateSubtitleItem}
           {roleInvitationSubtitleItem}
           {roleApplicationSubtitleItem}
           {teamSubtitleItem}
-          {isSyntheticRole(role) && (
-            <Tooltip
-              content={DEMO_ROLE_TOOLTIP}
-              wrapperClassName="flex items-center whitespace-nowrap text-base-content/50"
-            >
-              <FlaskConical size={9} className="flex-shrink-0" />
-            </Tooltip>
-          )}
+          {demoRoleMetaItem}
         </span>
       ) : null;
 
@@ -1281,7 +1283,7 @@ const VacantRoleCard = ({
                     {getUserInitials(filledUser)}
                   </span>
                 </div>
-                {compactDemoAvatarOverlay}
+                {compactFilledUserDemoAvatarOverlay ?? compactDemoAvatarOverlay}
                 {miniMatchOverlay}
               </div>
             </div>

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useLayoutEffect, useRef } from "react";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import {
   MapPin,
@@ -52,7 +53,17 @@ import TeamApplicationsModal from "./TeamApplicationsModal";
 import TeamInvitationDetailsModal from "./TeamInvitationDetailsModal";
 import TeamInvitesModal from "./TeamInvitesModal";
 import { useAuth } from "../../contexts/AuthContext";
-import { userService } from "../../services/userService";
+import {
+  fetchUserBadges,
+  fetchUserProfile,
+  fetchUserTags,
+  userBadgesQueryKey,
+  useUserBadges,
+  useUserProfile,
+  useUserTags,
+  userProfileQueryKey,
+  userTagsQueryKey,
+} from "../../hooks/useUserQueries";
 import { matchingService } from "../../services/matchingService";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
@@ -72,10 +83,6 @@ import {
   formatLocation,
 } from "../../utils/locationUtils";
 import {
-  extractListPayload,
-  extractProfilePayload,
-} from "../../utils/payloadExtractors";
-import {
   buildBadgeLookup,
   buildTagLookup,
   computeRoleUserMatch,
@@ -88,6 +95,11 @@ import { useChildModalZIndex } from "../../contexts/ModalLayerContext";
 
 const COLLAPSED_COUNT = 4;
 const EMPTY_TEAM_MEMBERS = [];
+const roleMemberMatchDataQueryKey = (memberId) => [
+  "users",
+  memberId ?? null,
+  "roleMemberMatchData",
+];
 
 const toPossessive = (value) =>
   !value ? "your" : value.endsWith("s") ? `${value}'` : `${value}'s`;
@@ -220,6 +232,7 @@ const VacantRoleDetailsModal = ({
   onStatusChange = null,
 }) => {
   const { user: currentUser, isAuthenticated } = useAuth();
+  const queryClient = useQueryClient();
   const userModal = useUserModalSafe();
   const teamModal = useTeamModalSafe();
   const childTeamModalZIndex = useChildModalZIndex();
@@ -309,7 +322,6 @@ const VacantRoleDetailsModal = ({
       ),
     ],
   );
-
   useEffect(() => {
     const fetchFullRole = async () => {
       if (!isOpen || !roleId || !teamId) return;
@@ -395,6 +407,154 @@ const VacantRoleDetailsModal = ({
     ? resolvedFilledUser ?? viewAsUser ?? null
     : viewAsUser ?? currentUser ?? null;
   const comparisonUserSeedJson = JSON.stringify(comparisonUserSeed ?? null);
+  const shouldFetchComparisonData = Boolean(
+    isOpen &&
+      isAuthenticated &&
+      comparisonUserId &&
+      shouldShowRoleMatchScore,
+  );
+  const comparisonUserProfileQuery = useUserProfile(comparisonUserId, {
+    enabled: shouldFetchComparisonData,
+  });
+  const comparisonUserTagsQuery = useUserTags(comparisonUserId, {
+    enabled: shouldFetchComparisonData,
+  });
+  const comparisonUserBadgesQuery = useUserBadges(comparisonUserId, {
+    enabled: shouldFetchComparisonData,
+  });
+  const roleMemberEntries = useMemo(
+    () => [
+      ...new Map(
+        teamMembers
+          .map((member) => {
+            const memberId = member?.userId ?? member?.user_id ?? null;
+            return memberId != null ? [String(memberId), member] : null;
+          })
+          .filter(Boolean),
+      ).entries(),
+    ],
+    [teamMembers],
+  );
+  const roleMatchTags = useMemo(
+    () =>
+      displayRole?.tags?.length > 0
+        ? displayRole.tags
+        : displayRole?.desiredTags || [],
+    [displayRole],
+  );
+  const roleMatchBadges = useMemo(
+    () =>
+      displayRole?.badges?.length > 0
+        ? displayRole.badges
+        : displayRole?.desiredBadges || [],
+    [displayRole],
+  );
+  const shouldFetchRoleMemberMatches = Boolean(
+    isOpen &&
+      displayRole &&
+      canViewTeamMemberMatches &&
+      isRoleOpen &&
+      roleMemberEntries.length > 0,
+  );
+  const roleMemberMatchQueries = useQueries({
+    queries: roleMemberEntries.map(([memberId, member]) => ({
+      queryKey: roleMemberMatchDataQueryKey(memberId),
+      queryFn: async () => {
+        const [profile, tags, badges] = await Promise.all([
+          queryClient.fetchQuery({
+            queryKey: userProfileQueryKey(memberId),
+            queryFn: () => fetchUserProfile(memberId),
+            staleTime: 30_000,
+          }),
+          queryClient.fetchQuery({
+            queryKey: userTagsQueryKey(memberId),
+            queryFn: () => fetchUserTags(memberId),
+            staleTime: 30_000,
+          }),
+          queryClient.fetchQuery({
+            queryKey: userBadgesQueryKey(memberId),
+            queryFn: () => fetchUserBadges(memberId),
+            staleTime: 30_000,
+          }),
+        ]);
+
+        return {
+          memberId,
+          member: {
+            ...(member || {}),
+            ...(profile || {}),
+          },
+          teamRole: member?.role ?? null,
+          userTagMap: buildTagLookup(tags),
+          userBadgeMap: buildBadgeLookup(badges),
+        };
+      },
+      enabled: shouldFetchRoleMemberMatches,
+      staleTime: 30_000,
+    })),
+  });
+  const roleMemberMatchQuerySignature = roleMemberMatchQueries
+    .map(
+      (query) =>
+        `${query.status}:${query.dataUpdatedAt ?? 0}:${query.errorUpdatedAt ?? 0}`,
+    )
+    .join("|");
+  const applicantProfileIds = useMemo(() => {
+    if (!isOpen || !canManage || !isRoleOpen) return [];
+
+    return [
+      ...new Set(
+        roleApplications
+          .map((application) => {
+            const applicant = application?.applicant || {};
+            return applicant.id ?? application.applicant_id ?? null;
+          })
+          .filter((id) => id != null)
+          .map(String),
+      ),
+    ];
+  }, [canManage, isOpen, isRoleOpen, roleApplications]);
+  const inviteeProfileIds = useMemo(() => {
+    if (!isOpen || !canManage || !isRoleOpen) return [];
+
+    return [
+      ...new Set(
+        roleInvitations
+          .map((invitation) => {
+            const invitee = invitation?.invitee || {};
+            return invitee.id ?? invitation.invitee_id ?? null;
+          })
+          .filter((id) => id != null)
+          .map(String),
+      ),
+    ];
+  }, [canManage, isOpen, isRoleOpen, roleInvitations]);
+  const applicantProfileQueries = useQueries({
+    queries: applicantProfileIds.map((applicantId) => ({
+      queryKey: userProfileQueryKey(applicantId),
+      queryFn: () => fetchUserProfile(applicantId),
+      staleTime: 30_000,
+    })),
+  });
+  const inviteeProfileQueries = useQueries({
+    queries: inviteeProfileIds.map((inviteeId) => ({
+      queryKey: userProfileQueryKey(inviteeId),
+      queryFn: () => fetchUserProfile(inviteeId),
+      staleTime: 30_000,
+    })),
+  });
+  const applicantProfileQuerySignature = applicantProfileQueries
+    .map(
+      (query) =>
+        `${query.status}:${query.dataUpdatedAt ?? 0}:${query.errorUpdatedAt ?? 0}`,
+    )
+    .join("|");
+  const inviteeProfileQuerySignature = inviteeProfileQueries
+    .map(
+      (query) =>
+        `${query.status}:${query.dataUpdatedAt ?? 0}:${query.errorUpdatedAt ?? 0}`,
+    )
+    .join("|");
   const roleNameForStatusMatch =
     displayRole?.roleName ??
     displayRole?.role_name ??
@@ -632,12 +792,7 @@ const VacantRoleDetailsModal = ({
   }, [isOpen, isAuthenticated, viewerIsTeamMember, teamId, currentUser?.id]);
 
   useEffect(() => {
-    if (
-      !isOpen ||
-      !isAuthenticated ||
-      !comparisonUserId ||
-      !shouldShowRoleMatchScore
-    ) {
+    if (!shouldFetchComparisonData) {
       setComparisonUserProfile(null);
       setLoadingComparisonData(false);
       setComparisonDataLoaded(false);
@@ -646,88 +801,59 @@ const VacantRoleDetailsModal = ({
       return;
     }
 
-    const fetchComparisonData = async () => {
-      const fallbackComparisonUser = comparisonUserSeedJson
-        ? JSON.parse(comparisonUserSeedJson)
-        : null;
+    const fallbackComparisonUser = comparisonUserSeedJson
+      ? JSON.parse(comparisonUserSeedJson)
+      : null;
+    const queries = [
+      comparisonUserProfileQuery,
+      comparisonUserTagsQuery,
+      comparisonUserBadgesQuery,
+    ];
+    const hasPendingQuery = queries.some(
+      (query) => query.isLoading || query.isFetching,
+    );
 
-      try {
-        setLoadingComparisonData(true);
-        setComparisonDataLoaded(false);
+    setLoadingComparisonData(hasPendingQuery);
 
-        const [profileRes, tagsRes, badgesRes] = await Promise.allSettled([
-          userService.getUserById(comparisonUserId),
-          userService.getUserTags(comparisonUserId),
-          userService.getUserBadges(comparisonUserId),
-        ]);
+    if (hasPendingQuery) {
+      setComparisonDataLoaded(false);
+      return;
+    }
 
-        if (profileRes.status === "fulfilled") {
-          const profileData =
-            profileRes.value?.data?.data ?? profileRes.value?.data ?? null;
-          setComparisonUserProfile({
-            ...(fallbackComparisonUser || {}),
-            ...(profileData || {}),
-          });
-        } else {
-          setComparisonUserProfile(fallbackComparisonUser);
-        }
+    if (queries.some((query) => query.isError)) {
+      console.warn("Could not fetch user data for matching highlights:", {
+        profileError: comparisonUserProfileQuery.error ?? null,
+        tagsError: comparisonUserTagsQuery.error ?? null,
+        badgesError: comparisonUserBadgesQuery.error ?? null,
+      });
+    }
 
-        const tagData =
-          tagsRes.status === "fulfilled"
-            ? Array.isArray(tagsRes.value)
-              ? tagsRes.value
-              : Array.isArray(tagsRes.value?.data)
-                ? tagsRes.value.data
-                : tagsRes.value?.data?.data || []
-            : [];
-        const tMap = new Map();
-        for (const tag of tagData) {
-          tMap.set(Number(tag.id), {
-            badgeCredits: Number(tag.badge_credits ?? tag.badgeCredits ?? 0),
-          });
-        }
-        setUserTagMap(tMap);
-
-        const badgeData =
-          badgesRes.status === "fulfilled"
-            ? Array.isArray(badgesRes.value)
-              ? badgesRes.value
-              : Array.isArray(badgesRes.value?.data)
-                ? badgesRes.value.data
-                : badgesRes.value?.data?.data || []
-            : [];
-        const bMap = new Map();
-        for (const badge of badgeData) {
-          const name = (badge.badgeName ?? badge.badge_name ?? badge.name ?? "")
-            .trim()
-            .toLowerCase();
-          const credits = Number(
-            badge.totalCredits ?? badge.total_credits ?? badge.credits ?? 0,
-          );
-          const existing = bMap.get(name);
-          bMap.set(name, {
-            totalCredits: (existing?.totalCredits || 0) + credits,
-          });
-        }
-        setUserBadgeMap(bMap);
-      } catch (err) {
-        console.warn("Could not fetch user data for matching highlights:", err);
-        setComparisonUserProfile(fallbackComparisonUser);
-        setUserTagMap(new Map());
-        setUserBadgeMap(new Map());
-      } finally {
-        setLoadingComparisonData(false);
-        setComparisonDataLoaded(true);
-      }
-    };
-
-    fetchComparisonData();
+    setComparisonUserProfile({
+      ...(fallbackComparisonUser || {}),
+      ...(comparisonUserProfileQuery.data || {}),
+    });
+    setUserTagMap(buildTagLookup(comparisonUserTagsQuery.data ?? []));
+    setUserBadgeMap(buildBadgeLookup(comparisonUserBadgesQuery.data ?? []));
+    setLoadingComparisonData(false);
+    setComparisonDataLoaded(true);
   }, [
-    isOpen,
-    isAuthenticated,
-    comparisonUserId,
+    comparisonUserBadgesQuery.data,
+    comparisonUserBadgesQuery.error,
+    comparisonUserBadgesQuery.isError,
+    comparisonUserBadgesQuery.isFetching,
+    comparisonUserBadgesQuery.isLoading,
+    comparisonUserProfileQuery.data,
+    comparisonUserProfileQuery.error,
+    comparisonUserProfileQuery.isError,
+    comparisonUserProfileQuery.isFetching,
+    comparisonUserProfileQuery.isLoading,
+    comparisonUserTagsQuery.data,
+    comparisonUserTagsQuery.error,
+    comparisonUserTagsQuery.isError,
+    comparisonUserTagsQuery.isFetching,
+    comparisonUserTagsQuery.isLoading,
     comparisonUserSeedJson,
-    shouldShowRoleMatchScore,
+    shouldFetchComparisonData,
   ]);
 
   useEffect(() => {
@@ -892,268 +1018,134 @@ const VacantRoleDetailsModal = ({
   }, [isOpen, canManage, isRoleOpen, roleApplications, roleInvitations, roleId]);
 
   useEffect(() => {
-    if (!isOpen || !canManage || !isRoleOpen || roleApplications.length === 0) {
+    if (applicantProfileIds.length === 0) {
       setApplicantProfileMap({});
       return;
     }
 
-    let cancelled = false;
+    if (
+      applicantProfileQueries.some(
+        (query) => query.isLoading || query.isFetching,
+      )
+    ) {
+      return;
+    }
 
-    const fetchApplicantProfiles = async () => {
-      const applicantIds = [
-        ...new Set(
-          roleApplications
-            .map((application) => {
-              const applicant = application?.applicant || {};
-              return applicant.id ?? application.applicant_id ?? null;
-            })
-            .filter((id) => id != null),
-        ),
-      ];
+    const nextProfileMap = {};
 
-      if (applicantIds.length === 0) {
-        setApplicantProfileMap({});
+    applicantProfileIds.forEach((applicantId, index) => {
+      const query = applicantProfileQueries[index];
+
+      if (query?.isError) {
+        console.warn("Could not fetch applicant profile details:", query.error);
         return;
       }
 
-      try {
-        const results = await Promise.allSettled(
-          applicantIds.map((id) => userService.getUserById(id)),
-        );
+      if (!query?.data) return;
 
-        if (cancelled) return;
+      nextProfileMap[String(applicantId)] = query.data;
+    });
 
-        const nextProfileMap = {};
-
-        results.forEach((result, index) => {
-          if (result.status !== "fulfilled") return;
-
-          const payload = result.value?.data ?? result.value;
-          const profile =
-            payload?.success !== undefined
-              ? payload?.data
-              : (payload?.data?.data ?? payload?.data ?? payload);
-
-          if (!profile) return;
-
-          nextProfileMap[String(applicantIds[index])] = profile;
-        });
-
-        setApplicantProfileMap(nextProfileMap);
-      } catch (err) {
-        console.warn("Could not fetch applicant profile details:", err);
-        if (!cancelled) {
-          setApplicantProfileMap({});
-        }
-      }
-    };
-
-    fetchApplicantProfiles();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, canManage, isRoleOpen, roleApplications]);
+    setApplicantProfileMap(nextProfileMap);
+  }, [applicantProfileIds, applicantProfileQuerySignature]);
 
   useEffect(() => {
-    if (!isOpen || !canManage || !isRoleOpen || roleInvitations.length === 0) {
+    if (inviteeProfileIds.length === 0) {
       setInviteeProfileMap({});
       return;
     }
 
-    let cancelled = false;
+    if (
+      inviteeProfileQueries.some(
+        (query) => query.isLoading || query.isFetching,
+      )
+    ) {
+      return;
+    }
 
-    const fetchInviteeProfiles = async () => {
-      const inviteeIds = [
-        ...new Set(
-          roleInvitations
-            .map((invitation) => {
-              const invitee = invitation?.invitee || {};
-              return invitee.id ?? invitation.invitee_id ?? null;
-            })
-            .filter((id) => id != null),
-        ),
-      ];
+    const nextProfileMap = {};
 
-      if (inviteeIds.length === 0) {
-        setInviteeProfileMap({});
+    inviteeProfileIds.forEach((inviteeId, index) => {
+      const query = inviteeProfileQueries[index];
+
+      if (query?.isError) {
+        console.warn("Could not fetch invitee profile details:", query.error);
         return;
       }
 
-      try {
-        const results = await Promise.allSettled(
-          inviteeIds.map((id) => userService.getUserById(id)),
-        );
+      if (!query?.data) return;
 
-        if (cancelled) return;
+      nextProfileMap[String(inviteeId)] = query.data;
+    });
 
-        const nextProfileMap = {};
-
-        results.forEach((result, index) => {
-          if (result.status !== "fulfilled") return;
-
-          const payload = result.value?.data ?? result.value;
-          const profile =
-            payload?.success !== undefined
-              ? payload?.data
-              : (payload?.data?.data ?? payload?.data ?? payload);
-
-          if (!profile) return;
-
-          nextProfileMap[String(inviteeIds[index])] = profile;
-        });
-
-        setInviteeProfileMap(nextProfileMap);
-      } catch (err) {
-        console.warn("Could not fetch invitee profile details:", err);
-        if (!cancelled) {
-          setInviteeProfileMap({});
-        }
-      }
-    };
-
-    fetchInviteeProfiles();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, canManage, isRoleOpen, roleInvitations]);
+    setInviteeProfileMap(nextProfileMap);
+  }, [inviteeProfileIds, inviteeProfileQuerySignature]);
 
   useEffect(() => {
-    if (
-      !isOpen ||
-      !displayRole ||
-      !canViewTeamMemberMatches ||
-      !isRoleOpen ||
-      teamMemberIdsKey === "[]"
-    ) {
+    if (!shouldFetchRoleMemberMatches) {
       setRoleTeamMembers((prev) => (prev.length === 0 ? prev : []));
       setTeamMembersLoading(false);
       return;
     }
 
-    let cancelled = false;
+    const hasPendingQuery = roleMemberMatchQueries.some(
+      (query) => query.isLoading || query.isFetching,
+    );
 
-    const fetchTeamMemberMatches = async () => {
-      const roleTags =
-        displayRole?.tags?.length > 0
-          ? displayRole.tags
-          : displayRole?.desiredTags || [];
-      const roleBadges =
-        displayRole?.badges?.length > 0
-          ? displayRole.badges
-          : displayRole?.desiredBadges || [];
-      const uniqueMembers = [
-        ...new Map(
-          teamMembers
-            .map((member) => {
-              const memberId = member?.userId ?? member?.user_id ?? null;
-              return memberId != null ? [String(memberId), member] : null;
-            })
-            .filter(Boolean),
-        ).entries(),
-      ];
+    setTeamMembersLoading(hasPendingQuery);
+    if (hasPendingQuery) return;
 
-      if (uniqueMembers.length === 0) {
-        setRoleTeamMembers([]);
-        setTeamMembersLoading(false);
-        return;
-      }
+    const nextRows = roleMemberMatchQueries
+      .map((query) => {
+        if (query.isError) {
+          console.warn("Could not fetch team member match data for role:", query.error);
+          return null;
+        }
+        if (!query.data) return null;
 
-      try {
-        setTeamMembersLoading(true);
+        const memberMatch = computeRoleUserMatch({
+          role: displayRole,
+          tags: roleMatchTags,
+          badges: roleMatchBadges,
+          user: query.data.member,
+          userTagMap: query.data.userTagMap,
+          userBadgeMap: query.data.userBadgeMap,
+        });
 
-        const results = await Promise.allSettled(
-          uniqueMembers.map(async ([memberKey, member]) => {
-            const memberId = memberKey;
-            const [profileRes, tagsRes, badgesRes] = await Promise.allSettled([
-              userService.getUserById(memberId),
-              userService.getUserTags(memberId),
-              userService.getUserBadges(memberId),
-            ]);
+        return {
+          memberId: query.data.memberId,
+          member: query.data.member,
+          teamRole: query.data.teamRole,
+          matchScore: memberMatch?.matchScore ?? null,
+          matchDetails: memberMatch?.matchDetails ?? null,
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => {
+        const scoreA = Number(a?.matchScore);
+        const scoreB = Number(b?.matchScore);
+        const hasScoreA = Number.isFinite(scoreA);
+        const hasScoreB = Number.isFinite(scoreB);
 
-            const profile =
-              profileRes.status === "fulfilled"
-                ? extractProfilePayload(profileRes.value)
-                : null;
-            const memberProfile = {
-              ...(member || {}),
-              ...(profile || {}),
-            };
-            const memberTagMap =
-              tagsRes.status === "fulfilled"
-                ? buildTagLookup(extractListPayload(tagsRes.value))
-                : new Map();
-            const memberBadgeMap =
-              badgesRes.status === "fulfilled"
-                ? buildBadgeLookup(extractListPayload(badgesRes.value))
-                : new Map();
-            const memberMatch = computeRoleUserMatch({
-              role: displayRole,
-              tags: roleTags,
-              badges: roleBadges,
-              user: memberProfile,
-              userTagMap: memberTagMap,
-              userBadgeMap: memberBadgeMap,
-            });
+        if (hasScoreA && hasScoreB && scoreA !== scoreB) {
+          return scoreB - scoreA;
+        }
+        if (hasScoreA && !hasScoreB) return -1;
+        if (!hasScoreA && hasScoreB) return 1;
 
-            return {
-              memberId,
-              member: memberProfile,
-              teamRole: member?.role ?? null,
-              matchScore: memberMatch?.matchScore ?? null,
-              matchDetails: memberMatch?.matchDetails ?? null,
-            };
-          }),
+        return getDisplayName(a?.member ?? {}).localeCompare(
+          getDisplayName(b?.member ?? {}),
         );
+      });
 
-        if (cancelled) return;
-
-        const nextRows = results
-          .filter((result) => result.status === "fulfilled")
-          .map((result) => result.value)
-          .sort((a, b) => {
-            const scoreA = Number(a?.matchScore);
-            const scoreB = Number(b?.matchScore);
-            const hasScoreA = Number.isFinite(scoreA);
-            const hasScoreB = Number.isFinite(scoreB);
-
-            if (hasScoreA && hasScoreB && scoreA !== scoreB) {
-              return scoreB - scoreA;
-            }
-            if (hasScoreA && !hasScoreB) return -1;
-            if (!hasScoreA && hasScoreB) return 1;
-
-            return getDisplayName(a?.member ?? {}).localeCompare(
-              getDisplayName(b?.member ?? {}),
-            );
-          });
-
-        setRoleTeamMembers(nextRows);
-      } catch (error) {
-        console.warn("Could not fetch team member matches for role:", error);
-        if (!cancelled) {
-          setRoleTeamMembers([]);
-        }
-      } finally {
-        if (!cancelled) {
-          setTeamMembersLoading(false);
-        }
-      }
-    };
-
-    fetchTeamMemberMatches();
-
-    return () => {
-      cancelled = true;
-    };
+    setRoleTeamMembers(nextRows);
+    setTeamMembersLoading(false);
   }, [
-    isOpen,
     displayRole,
-    canViewTeamMemberMatches,
-    isRoleOpen,
-    teamMembers,
-    teamMemberIdsKey,
+    roleMatchBadges,
+    roleMatchTags,
+    roleMemberMatchQuerySignature,
+    shouldFetchRoleMemberMatches,
   ]);
 
   const handleApplicationAction = async (applicationId, action, response = "", fillRole = false) => {

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -68,154 +68,29 @@ import {
   isSyntheticUser,
 } from "../../utils/userHelpers";
 import {
-  calculateDistanceKm,
   normalizeLocationData,
   formatLocation,
 } from "../../utils/locationUtils";
+import {
+  extractListPayload,
+  extractProfilePayload,
+} from "../../utils/payloadExtractors";
+import {
+  buildBadgeLookup,
+  buildTagLookup,
+  computeRoleUserMatch,
+} from "../../utils/matchHelpers";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import { resolveFilledRoleUser } from "../../utils/vacantRoleUtils";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
 import { useTeamModalSafe } from "../../contexts/TeamModalContext";
 import { useChildModalZIndex } from "../../contexts/ModalLayerContext";
 
-const MATCH_WEIGHTS = {
-  tags: 0.4,
-  badges: 0.3,
-  distance: 0.3,
-};
-
-const LOCATION_GRACE_KM = 20;
-const LOCATION_GRACE_SCORE = 0.25;
 const COLLAPSED_COUNT = 4;
 const EMPTY_TEAM_MEMBERS = [];
 
-const roundMatchValue = (value) => Math.round(value * 100) / 100;
 const toPossessive = (value) =>
   !value ? "your" : value.endsWith("s") ? `${value}'` : `${value}'s`;
-
-const computeRoleUserMatch = ({
-  role,
-  tags,
-  badges,
-  user,
-  userTagMap,
-  userBadgeMap,
-}) => {
-  if (!role || !user) return null;
-
-  const requiredTagIds = tags
-    .map((tag) => Number(tag.tagId ?? tag.tag_id ?? tag.id))
-    .filter(Number.isFinite);
-  const requiredBadgeKeys = badges
-    .map((badge) => (badge.name ?? badge.badgeName ?? badge.badge_name ?? "").trim().toLowerCase())
-    .filter(Boolean);
-
-  const matchingTags = requiredTagIds.filter((id) => userTagMap.has(id)).length;
-  const matchingBadges = requiredBadgeKeys.filter((key) => userBadgeMap.has(key)).length;
-
-  const tagScore =
-    requiredTagIds.length > 0 ? matchingTags / requiredTagIds.length : 0.5;
-  const badgeScore =
-    requiredBadgeKeys.length > 0
-      ? matchingBadges / requiredBadgeKeys.length
-      : 0.5;
-
-  const isRemote = role.isRemote ?? role.is_remote;
-  const maxDistanceKm = Number(role.maxDistanceKm ?? role.max_distance_km) || 50;
-
-  let distanceScore = 0.5;
-  let distanceKm = null;
-  let isWithinRange = null;
-
-  if (isRemote) {
-    distanceScore = 1;
-    isWithinRange = true;
-  } else {
-    distanceKm = calculateDistanceKm(user, role);
-
-    if (distanceKm !== null) {
-      if (distanceKm <= maxDistanceKm) {
-        distanceScore = 1;
-        isWithinRange = true;
-      } else if (distanceKm <= maxDistanceKm + LOCATION_GRACE_KM) {
-        distanceScore = LOCATION_GRACE_SCORE;
-        isWithinRange = false;
-      } else {
-        distanceScore = 0;
-        isWithinRange = false;
-      }
-    }
-  }
-
-  const matchScore =
-    MATCH_WEIGHTS.tags * tagScore +
-    MATCH_WEIGHTS.badges * badgeScore +
-    MATCH_WEIGHTS.distance * distanceScore;
-
-  return {
-    matchScore: roundMatchValue(matchScore),
-    matchDetails: {
-      tagScore: roundMatchValue(tagScore),
-      badgeScore: roundMatchValue(badgeScore),
-      distanceScore: roundMatchValue(distanceScore),
-      matchingTags,
-      totalRequiredTags: requiredTagIds.length,
-      matchingBadges,
-      totalRequiredBadges: requiredBadgeKeys.length,
-      distanceKm: distanceKm !== null ? Math.round(distanceKm) : null,
-      maxDistanceKm,
-      isWithinRange,
-    },
-  };
-};
-
-const extractProfilePayload = (response) => {
-  const payload = response?.data ?? response;
-
-  if (!payload) return null;
-  if (payload?.success !== undefined) return payload?.data ?? null;
-
-  return payload?.data?.data ?? payload?.data ?? payload;
-};
-
-const extractListPayload = (response) => {
-  if (Array.isArray(response)) return response;
-  if (Array.isArray(response?.data)) return response.data;
-  if (Array.isArray(response?.data?.data)) return response.data.data;
-  return [];
-};
-
-const buildTagLookup = (tagData) => {
-  const nextMap = new Map();
-
-  for (const tag of tagData) {
-    nextMap.set(Number(tag.id), {
-      badgeCredits: Number(tag.badge_credits ?? tag.badgeCredits ?? 0),
-    });
-  }
-
-  return nextMap;
-};
-
-const buildBadgeLookup = (badgeData) => {
-  const nextMap = new Map();
-
-  for (const badge of badgeData) {
-    const name = (badge.badgeName ?? badge.badge_name ?? badge.name ?? "")
-      .trim()
-      .toLowerCase();
-    const credits = Number(
-      badge.totalCredits ?? badge.total_credits ?? badge.credits ?? 0,
-    );
-    const existing = nextMap.get(name);
-
-    nextMap.set(name, {
-      totalCredits: (existing?.totalCredits || 0) + credits,
-    });
-  }
-
-  return nextMap;
-};
 
 const getRoleRecordId = (record) =>
   record?.role?.id ?? record?.roleId ?? record?.role_id ?? null;

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -64,10 +64,10 @@ import {
   userProfileQueryKey,
   userTagsQueryKey,
 } from "../../hooks/useUserQueries";
-import { matchingService } from "../../services/matchingService";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { messageService } from "../../services/messageService";
+import useViewerPendingRequests from "../../hooks/useViewerPendingRequests";
 import { buildRoleInvitationAcceptedMessage } from "../../utils/roleEventMessages";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import {
@@ -250,13 +250,10 @@ const VacantRoleDetailsModal = ({
   const [applicationsLoading, setApplicationsLoading] = useState(false);
   const [applicationsModalOpen, setApplicationsModalOpen] = useState(false);
   const [highlightApplicantId, setHighlightApplicantId] = useState(null);
-  const [roleCandidateMatchMap, setRoleCandidateMatchMap] = useState({});
-  const [applicantProfileMap, setApplicantProfileMap] = useState({});
   const [roleInvitations, setRoleInvitations] = useState([]);
   const [invitationsLoading, setInvitationsLoading] = useState(false);
   const [invitationsModalOpen, setInvitationsModalOpen] = useState(false);
   const [highlightInviteeId, setHighlightInviteeId] = useState(null);
-  const [inviteeProfileMap, setInviteeProfileMap] = useState({});
   const [roleTeamMembers, setRoleTeamMembers] = useState([]);
   const [teamMembersLoading, setTeamMembersLoading] = useState(false);
   const [isApplicationsExpanded, setIsApplicationsExpanded] = useState(false);
@@ -361,13 +358,10 @@ const VacantRoleDetailsModal = ({
       setAllApplications([]);
       setApplicationsModalOpen(false);
       setHighlightApplicantId(null);
-      setRoleCandidateMatchMap({});
-      setApplicantProfileMap({});
       setRoleInvitations([]);
       setInvitationsLoading(false);
       setInvitationsModalOpen(false);
       setHighlightInviteeId(null);
-      setInviteeProfileMap({});
       setRoleTeamMembers([]);
       setTeamMembersLoading(false);
       setIsApplicationsExpanded(false);
@@ -422,6 +416,14 @@ const VacantRoleDetailsModal = ({
   const comparisonUserBadgesQuery = useUserBadges(comparisonUserId, {
     enabled: shouldFetchComparisonData,
   });
+  const {
+    data: viewerPendingData,
+    isLoading: viewerPendingLoading,
+    isFetching: viewerPendingFetching,
+    error: viewerPendingError,
+  } = useViewerPendingRequests(currentUser?.id, {
+    enabled: Boolean(isOpen && isAuthenticated && currentUser?.id),
+  });
   const roleMemberEntries = useMemo(
     () => [
       ...new Map(
@@ -454,6 +456,7 @@ const VacantRoleDetailsModal = ({
       displayRole &&
       canViewTeamMemberMatches &&
       isRoleOpen &&
+      isTeamMembersExpanded &&
       roleMemberEntries.length > 0,
   );
   const roleMemberMatchQueries = useQueries({
@@ -499,62 +502,6 @@ const VacantRoleDetailsModal = ({
         `${query.status}:${query.dataUpdatedAt ?? 0}:${query.errorUpdatedAt ?? 0}`,
     )
     .join("|");
-  const applicantProfileIds = useMemo(() => {
-    if (!isOpen || !canManage || !isRoleOpen) return [];
-
-    return [
-      ...new Set(
-        roleApplications
-          .map((application) => {
-            const applicant = application?.applicant || {};
-            return applicant.id ?? application.applicant_id ?? null;
-          })
-          .filter((id) => id != null)
-          .map(String),
-      ),
-    ];
-  }, [canManage, isOpen, isRoleOpen, roleApplications]);
-  const inviteeProfileIds = useMemo(() => {
-    if (!isOpen || !canManage || !isRoleOpen) return [];
-
-    return [
-      ...new Set(
-        roleInvitations
-          .map((invitation) => {
-            const invitee = invitation?.invitee || {};
-            return invitee.id ?? invitation.invitee_id ?? null;
-          })
-          .filter((id) => id != null)
-          .map(String),
-      ),
-    ];
-  }, [canManage, isOpen, isRoleOpen, roleInvitations]);
-  const applicantProfileQueries = useQueries({
-    queries: applicantProfileIds.map((applicantId) => ({
-      queryKey: userProfileQueryKey(applicantId),
-      queryFn: () => fetchUserProfile(applicantId),
-      staleTime: 30_000,
-    })),
-  });
-  const inviteeProfileQueries = useQueries({
-    queries: inviteeProfileIds.map((inviteeId) => ({
-      queryKey: userProfileQueryKey(inviteeId),
-      queryFn: () => fetchUserProfile(inviteeId),
-      staleTime: 30_000,
-    })),
-  });
-  const applicantProfileQuerySignature = applicantProfileQueries
-    .map(
-      (query) =>
-        `${query.status}:${query.dataUpdatedAt ?? 0}:${query.errorUpdatedAt ?? 0}`,
-    )
-    .join("|");
-  const inviteeProfileQuerySignature = inviteeProfileQueries
-    .map(
-      (query) =>
-        `${query.status}:${query.dataUpdatedAt ?? 0}:${query.errorUpdatedAt ?? 0}`,
-    )
-    .join("|");
   const roleNameForStatusMatch =
     displayRole?.roleName ??
     displayRole?.role_name ??
@@ -569,8 +516,6 @@ const VacantRoleDetailsModal = ({
       setViewerRoleStatusLoading(false);
       return;
     }
-
-    let cancelled = false;
 
     const fallbackTeam = {
       ...team,
@@ -667,87 +612,75 @@ const VacantRoleDetailsModal = ({
 
     setViewerRoleApplicationRecord(seededApplication);
     setViewerRoleInvitationRecord(seededInvitation);
-    setViewerRoleStatusLoading(true);
 
-    const fetchViewerRoleStatus = async () => {
-      const [applicationsResult, invitationsResult] = await Promise.allSettled([
-        teamService.getUserPendingApplications(),
-        teamService.getUserReceivedInvitations(),
-      ]);
+    if (viewerPendingLoading || viewerPendingFetching) {
+      setViewerRoleStatusLoading(true);
+      return;
+    }
 
-      if (cancelled) return;
-
-      let nextApplication = seededApplication;
-      let nextInvitation = seededInvitation;
-
-      if (applicationsResult.status === "fulfilled") {
-        const pendingApplications = Array.isArray(applicationsResult.value?.data)
-          ? applicationsResult.value.data
-          : [];
-        const foundApplication =
-          pendingApplications.find((application) =>
-            matchesRoleRecord(application, {
-              roleId,
-              teamId,
-              roleName: roleNameForStatusMatch,
-            }),
-          ) ?? null;
-
-        nextApplication = foundApplication
-          ? buildRoleStatusRecord(
-              foundApplication,
-              fallbackTeam,
-              fallbackRole,
-              { isInternalRoleApplication: viewerIsTeamMember },
-            )
-          : null;
-      }
-
-      if (invitationsResult.status === "fulfilled") {
-        const receivedInvitations = Array.isArray(invitationsResult.value?.data)
-          ? invitationsResult.value.data
-          : [];
-        const foundInvitation =
-          receivedInvitations.find((invitation) =>
-            matchesRoleRecord(invitation, {
-              roleId,
-              teamId,
-              roleName: roleNameForStatusMatch,
-            }),
-          ) ?? null;
-
-        nextInvitation = foundInvitation
-          ? buildRoleStatusRecord(
-              foundInvitation,
-              fallbackTeam,
-              fallbackRole,
-              { isInternal: viewerIsTeamMember },
-            )
-          : null;
-      }
-
-      setViewerRoleApplicationRecord(nextApplication);
-      setViewerRoleInvitationRecord(nextInvitation);
+    if (viewerPendingError) {
+      console.warn("Could not fetch viewer role status:", viewerPendingError);
       setViewerRoleStatusLoading(false);
-    };
+      return;
+    }
 
-    fetchViewerRoleStatus().catch((error) => {
-      console.warn("Could not fetch viewer role status:", error);
-      if (!cancelled) {
-        setViewerRoleApplicationRecord(seededApplication);
-        setViewerRoleInvitationRecord(seededInvitation);
-        setViewerRoleStatusLoading(false);
-      }
-    });
+    let nextApplication = seededApplication;
+    let nextInvitation = seededInvitation;
 
-    return () => {
-      cancelled = true;
-    };
+    const pendingApplications = Array.isArray(viewerPendingData?.applications)
+      ? viewerPendingData.applications
+      : [];
+    const foundApplication =
+      pendingApplications.find((application) =>
+        matchesRoleRecord(application, {
+          roleId,
+          teamId,
+          roleName: roleNameForStatusMatch,
+        }),
+      ) ?? null;
+
+    nextApplication = foundApplication
+      ? buildRoleStatusRecord(
+          foundApplication,
+          fallbackTeam,
+          fallbackRole,
+          { isInternalRoleApplication: viewerIsTeamMember },
+        )
+      : null;
+
+    const receivedInvitations = Array.isArray(viewerPendingData?.invitations)
+      ? viewerPendingData.invitations
+      : [];
+    const foundInvitation =
+      receivedInvitations.find((invitation) =>
+        matchesRoleRecord(invitation, {
+          roleId,
+          teamId,
+          roleName: roleNameForStatusMatch,
+        }),
+      ) ?? null;
+
+    nextInvitation = foundInvitation
+      ? buildRoleStatusRecord(
+          foundInvitation,
+          fallbackTeam,
+          fallbackRole,
+          { isInternal: viewerIsTeamMember },
+        )
+      : null;
+
+    setViewerRoleApplicationRecord(nextApplication);
+    setViewerRoleInvitationRecord(nextInvitation);
+    setViewerRoleStatusLoading(false);
   }, [
     displayRole,
     isAuthenticated,
     isOpen,
     viewerIsTeamMember,
+    viewerPendingData,
+    viewerPendingError,
+    viewerPendingFetching,
+    viewerPendingLoading,
     role,
     roleId,
     roleNameForStatusMatch,
@@ -948,138 +881,6 @@ const VacantRoleDetailsModal = ({
       cancelled = true;
     };
   }, [isOpen, canManage, teamId, roleId, status]);
-
-  useEffect(() => {
-    const roleCandidateIds = [
-      ...new Set(
-        [
-          ...roleApplications.map(
-            (application) => application?.applicant?.id ?? application?.applicant_id ?? null,
-          ),
-          ...roleInvitations.map(
-            (invitation) => invitation?.invitee?.id ?? invitation?.invitee_id ?? null,
-          ),
-        ]
-          .filter((id) => id != null)
-          .map(String),
-      ),
-    ];
-
-    if (!isOpen || !canManage || !roleId || !isRoleOpen || roleCandidateIds.length === 0) {
-      setRoleCandidateMatchMap({});
-      return;
-    }
-
-    let cancelled = false;
-
-    const fetchRoleCandidateMatches = async () => {
-      try {
-        const response = await matchingService.getMatchingCandidates(roleId, {
-          limit: Math.max(roleCandidateIds.length, 20),
-        });
-        if (cancelled) return;
-
-        const candidates = response?.data || [];
-        const nextMatchMap = {};
-
-        candidates.forEach((candidate) => {
-          const candidateId = candidate?.id ?? candidate?.userId ?? candidate?.user_id;
-          if (candidateId == null) return;
-
-          nextMatchMap[String(candidateId)] = {
-            ...candidate,
-            matchScore:
-              candidate?.matchScore ??
-              candidate?.match_score ??
-              candidate?.bestMatchScore ??
-              candidate?.best_match_score ??
-              null,
-            matchDetails:
-              candidate?.matchDetails ??
-              candidate?.match_details ??
-              null,
-          };
-        });
-
-        setRoleCandidateMatchMap(nextMatchMap);
-      } catch (err) {
-        console.warn("Could not fetch candidate match scores for role:", err);
-        if (!cancelled) {
-          setRoleCandidateMatchMap({});
-        }
-      }
-    };
-
-    fetchRoleCandidateMatches();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, canManage, isRoleOpen, roleApplications, roleInvitations, roleId]);
-
-  useEffect(() => {
-    if (applicantProfileIds.length === 0) {
-      setApplicantProfileMap({});
-      return;
-    }
-
-    if (
-      applicantProfileQueries.some(
-        (query) => query.isLoading || query.isFetching,
-      )
-    ) {
-      return;
-    }
-
-    const nextProfileMap = {};
-
-    applicantProfileIds.forEach((applicantId, index) => {
-      const query = applicantProfileQueries[index];
-
-      if (query?.isError) {
-        console.warn("Could not fetch applicant profile details:", query.error);
-        return;
-      }
-
-      if (!query?.data) return;
-
-      nextProfileMap[String(applicantId)] = query.data;
-    });
-
-    setApplicantProfileMap(nextProfileMap);
-  }, [applicantProfileIds, applicantProfileQuerySignature]);
-
-  useEffect(() => {
-    if (inviteeProfileIds.length === 0) {
-      setInviteeProfileMap({});
-      return;
-    }
-
-    if (
-      inviteeProfileQueries.some(
-        (query) => query.isLoading || query.isFetching,
-      )
-    ) {
-      return;
-    }
-
-    const nextProfileMap = {};
-
-    inviteeProfileIds.forEach((inviteeId, index) => {
-      const query = inviteeProfileQueries[index];
-
-      if (query?.isError) {
-        console.warn("Could not fetch invitee profile details:", query.error);
-        return;
-      }
-
-      if (!query?.data) return;
-
-      nextProfileMap[String(inviteeId)] = query.data;
-    });
-
-    setInviteeProfileMap(nextProfileMap);
-  }, [inviteeProfileIds, inviteeProfileQuerySignature]);
 
   useEffect(() => {
     if (!shouldFetchRoleMemberMatches) {
@@ -1683,7 +1484,7 @@ const VacantRoleDetailsModal = ({
     if (userId == null) return null;
 
     const key = String(userId);
-    return teamMemberScoreMap[key] ?? roleCandidateMatchMap[key] ?? null;
+    return teamMemberScoreMap[key] ?? null;
   };
   const isCurrentTeamMember = (userId) =>
     userId != null && currentTeamMemberIds.has(String(userId));
@@ -2734,14 +2535,9 @@ const VacantRoleDetailsModal = ({
                     application.applicant_id ??
                     null;
                   const applicantMatch = getRoleCandidateMatch(applicantId);
-                  const applicantProfileDetails =
-                    applicantId != null
-                      ? applicantProfileMap[String(applicantId)] ?? null
-                      : null;
                   const applicantProfile = {
                     ...(applicant || {}),
                     ...(applicantMatch || {}),
-                    ...(applicantProfileDetails || {}),
                   };
                   const firstName =
                     applicantProfile.firstName ??
@@ -2945,14 +2741,9 @@ const VacantRoleDetailsModal = ({
                     invitation.invitee_id ??
                     null;
                   const inviteeMatch = getRoleCandidateMatch(inviteeId);
-                  const inviteeProfileDetails =
-                    inviteeId != null
-                      ? inviteeProfileMap[String(inviteeId)] ?? null
-                      : null;
                   const inviteeProfile = {
                     ...(invitee || {}),
                     ...(inviteeMatch || {}),
-                    ...(inviteeProfileDetails || {}),
                   };
                   const firstName =
                     inviteeProfile.firstName ??
@@ -3130,7 +2921,33 @@ const VacantRoleDetailsModal = ({
           ) : null
         )}
 
-        {canViewTeamMemberMatches && isRoleOpen && (
+        {canViewTeamMemberMatches &&
+          isRoleOpen &&
+          roleMemberEntries.length > 0 &&
+          !isTeamMembersExpanded && (
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center">
+                  <Users size={18} className="mr-2 text-primary flex-shrink-0" />
+                  <h3 className="font-medium">Available team members</h3>
+                </div>
+                <span className="text-sm text-base-content/50">
+                  ({roleMemberEntries.length})
+                </span>
+              </div>
+
+              <button
+                type="button"
+                className="flex items-center gap-1 text-sm text-base-content/50 hover:text-base-content/80 transition-colors"
+                onClick={() => setIsTeamMembersExpanded(true)}
+              >
+                <ChevronRight size={14} />
+                Show matches
+              </button>
+            </div>
+          )}
+
+        {canViewTeamMemberMatches && isRoleOpen && isTeamMembersExpanded && (
           teamMembersLoading ? (
             <div className="flex justify-center py-3">
               <span className="loading loading-spinner loading-sm text-primary"></span>

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -1071,6 +1071,37 @@ const VacantRoleDetailsModal = ({
     setIsViewerInvitationDetailsOpen(false);
   };
 
+  const layoutRoleName =
+    displayRole?.roleName ?? displayRole?.role_name ?? "Vacant Role";
+  const layoutRolePostedDate =
+    displayRole?.createdAt ?? displayRole?.created_at ?? null;
+
+  useLayoutEffect(() => {
+    if (!displayRole) return;
+
+    const container = roleTitleContainerRef.current;
+    const probe = roleTitleProbeRef.current;
+    if (!container || !probe) return;
+
+    const update = () => {
+      const containerWidth = container.clientWidth;
+      if (containerWidth === 0) return;
+      const dateEl = roleDateRef.current;
+      const reservedWidth =
+        roleDateIsNarrowRef.current && dateEl ? dateEl.offsetWidth + 16 : 0;
+      probe.textContent = layoutRoleName;
+      setRoleDateIsNarrow(probe.scrollWidth > containerWidth - reservedWidth);
+    };
+
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(container);
+    if (roleDateRef.current) resizeObserver.observe(roleDateRef.current);
+    update();
+
+    return () => resizeObserver.disconnect();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayRole, layoutRoleName, !!layoutRolePostedDate]);
+
   if (!displayRole) return null;
 
   // Normalize camelCase/snake_case
@@ -1651,30 +1682,6 @@ const VacantRoleDetailsModal = ({
       return null;
     }
   })();
-
-  useLayoutEffect(() => {
-    const container = roleTitleContainerRef.current;
-    const probe = roleTitleProbeRef.current;
-    if (!container || !probe) return;
-
-    const update = () => {
-      const containerWidth = container.clientWidth;
-      if (containerWidth === 0) return;
-      const dateEl = roleDateRef.current;
-      const reservedWidth =
-        roleDateIsNarrowRef.current && dateEl ? dateEl.offsetWidth + 16 : 0;
-      probe.textContent = roleName;
-      setRoleDateIsNarrow(probe.scrollWidth > containerWidth - reservedWidth);
-    };
-
-    const resizeObserver = new ResizeObserver(update);
-    resizeObserver.observe(container);
-    if (roleDateRef.current) resizeObserver.observe(roleDateRef.current);
-    update();
-
-    return () => resizeObserver.disconnect();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [roleName, !!rolePostedDate]);
 
   const modalTitle = (
     <h2 className="text-xl font-medium text-primary leading-[110%] flex items-start gap-2 whitespace-nowrap">

--- a/src/components/users/InlineUserLink.jsx
+++ b/src/components/users/InlineUserLink.jsx
@@ -86,11 +86,19 @@ const InlineUserLink = ({
   // Normalize user ID from various possible field names
   const userId = user?.id || user?.user_id || user?.userId;
   const isFormerUser = isDeletedUser(user);
-  const hasInlineAvatar = Boolean(user?.avatar_url || user?.avatarUrl);
-  const hasInlineSyntheticFlag =
-    user?.is_synthetic != null || user?.isSynthetic != null;
+  // Only hydrate when the parent didn't pass enough to render a name —
+  // missing avatar / synthetic flag alone aren't worth a network round trip,
+  // since UserAvatar falls back to initials and the synthetic indicator is
+  // only meaningful for demo users.
+  const hasDisplayableName = Boolean(
+    user?.username ||
+      user?.first_name ||
+      user?.firstName ||
+      user?.last_name ||
+      user?.lastName,
+  );
   const needsInlineHydration =
-    !isFormerUser && Boolean(userId) && (!hasInlineAvatar || !hasInlineSyntheticFlag);
+    !isFormerUser && Boolean(userId) && !hasDisplayableName;
   const { data: resolvedInlineProfile = null } = useUserProfile(userId, {
     enabled: needsInlineHydration,
   });

--- a/src/components/users/InlineUserLink.jsx
+++ b/src/components/users/InlineUserLink.jsx
@@ -79,6 +79,7 @@ const InlineUserLink = ({
   avatarSize = "w-4 h-4",
   className = "",
   showAvatar = true,
+  displayName,
 }) => {
   // Try to get global modal context (returns null if not available)
   const userModalContext = useUserModalSafe();
@@ -108,7 +109,7 @@ const InlineUserLink = ({
   // Determine if we can handle clicks
   const canClick = !isFormerUser && userId && (userModalContext || onOpenUser);
   const inlineUser = mergeInlineUserData(user, resolvedInlineProfile);
-  const name = getDisplayName(inlineUser) || "Unknown";
+  const name = displayName ?? (getDisplayName(inlineUser) || "Unknown");
   const showDemoIndicator = !isFormerUser && Boolean(inlineUser?.is_synthetic || inlineUser?.isSynthetic);
 
   const handleClick = (e) => {

--- a/src/components/users/InlineUserLink.jsx
+++ b/src/components/users/InlineUserLink.jsx
@@ -8,18 +8,10 @@ import {
   getDisplayName,
   isDeletedUser,
 } from "../../utils/deletedUser";
+import { extractProfilePayload } from "../../utils/payloadExtractors";
 import UserAvatar from "./UserAvatar";
 
 const inlineUserProfileCache = new Map();
-
-const extractProfilePayload = (response) => {
-  const payload = response?.data ?? response;
-
-  if (!payload) return null;
-  if (payload?.success !== undefined) return payload?.data ?? null;
-
-  return payload?.data?.data ?? payload?.data ?? payload;
-};
 
 const getCachedInlineUserProfile = async (userId) => {
   const cacheKey = String(userId);

--- a/src/components/users/InlineUserLink.jsx
+++ b/src/components/users/InlineUserLink.jsx
@@ -1,41 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { FlaskConical } from "lucide-react";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
-import { userService } from "../../services/userService";
+import { useUserProfile } from "../../hooks/useUserQueries";
 import Tooltip from "../common/Tooltip";
 import { DEMO_PROFILE_TOOLTIP } from "../../utils/userHelpers";
 import {
   getDisplayName,
   isDeletedUser,
 } from "../../utils/deletedUser";
-import { extractProfilePayload } from "../../utils/payloadExtractors";
 import UserAvatar from "./UserAvatar";
-
-const inlineUserProfileCache = new Map();
-
-const getCachedInlineUserProfile = async (userId) => {
-  const cacheKey = String(userId);
-
-  if (inlineUserProfileCache.has(cacheKey)) {
-    return inlineUserProfileCache.get(cacheKey);
-  }
-
-  const request = (async () => {
-    const response = await userService.getUserById(userId);
-    return extractProfilePayload(response);
-  })();
-
-  inlineUserProfileCache.set(cacheKey, request);
-
-  try {
-    const result = await request;
-    inlineUserProfileCache.set(cacheKey, Promise.resolve(result));
-    return result;
-  } catch (error) {
-    inlineUserProfileCache.delete(cacheKey);
-    throw error;
-  }
-};
 
 const mergeInlineUserData = (user, profile) => {
   if (!profile) return user;
@@ -109,7 +82,6 @@ const InlineUserLink = ({
 }) => {
   // Try to get global modal context (returns null if not available)
   const userModalContext = useUserModalSafe();
-  const [resolvedInlineProfile, setResolvedInlineProfile] = useState(null);
 
   // Normalize user ID from various possible field names
   const userId = user?.id || user?.user_id || user?.userId;
@@ -119,31 +91,9 @@ const InlineUserLink = ({
     user?.is_synthetic != null || user?.isSynthetic != null;
   const needsInlineHydration =
     !isFormerUser && Boolean(userId) && (!hasInlineAvatar || !hasInlineSyntheticFlag);
-
-  useEffect(() => {
-    if (!needsInlineHydration) {
-      setResolvedInlineProfile(null);
-      return;
-    }
-
-    let cancelled = false;
-
-    getCachedInlineUserProfile(userId)
-      .then((profile) => {
-        if (!cancelled) {
-          setResolvedInlineProfile(profile);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setResolvedInlineProfile(null);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [needsInlineHydration, userId]);
+  const { data: resolvedInlineProfile = null } = useUserProfile(userId, {
+    enabled: needsInlineHydration,
+  });
 
   if (!user) return null;
 

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -10,6 +10,11 @@ import TagAwardsModal from "../badges/TagAwardsModal";
 import UserProfileHeaderSection from "./UserProfileHeaderSection";
 import { messageService } from "../../services/messageService";
 import { userService } from "../../services/userService";
+import {
+  useUserBadges,
+  useUserProfile,
+  useUserTags,
+} from "../../hooks/useUserQueries";
 import Button from "../common/Button";
 import Alert from "../common/Alert";
 import Tooltip from "../common/Tooltip";
@@ -155,135 +160,130 @@ const UserDetailsModal = ({
   const isNumericUserId = /^\d+$/.test(String(userId ?? "").trim());
   const visibleUserBadges = Array.isArray(user?.badges) ? user.badges : [];
   const hiddenAwardIds = user?.hidden_award_ids ?? user?.hiddenAwardIds ?? [];
+  const viewedUserProfileQuery = useUserProfile(userId, {
+    enabled: Boolean(isOpen && userId),
+  });
+  const viewedUserTagsQuery = useUserTags(userId, {
+    enabled: Boolean(isOpen && userId),
+  });
+  const shouldFetchCurrentUserMatchData =
+    Boolean(
+      isOpen &&
+        isAuthenticated &&
+        currentUser?.id &&
+        Number(currentUser.id) !== Number(userId) &&
+        (showMatchHighlights || hasRoleMatchTagIds || hasRoleMatchBadgeNames),
+    ) &&
+    !hasRoleMatchTagIds &&
+    !hasRoleMatchBadgeNames;
+  const currentUserTagsQuery = useUserTags(currentUser?.id, {
+    enabled: shouldFetchCurrentUserMatchData,
+  });
+  const currentUserBadgesQuery = useUserBadges(currentUser?.id, {
+    enabled: shouldFetchCurrentUserMatchData,
+  });
+  const currentUserProfileQuery = useUserProfile(currentUser?.id, {
+    enabled: Boolean(
+      isOpen && isAuthenticated && currentUser?.id && showMatchHighlights,
+    ),
+  });
 
-  const fetchUserDetails = useCallback(async () => {
-    try {
-      setLoading(true);
+  useEffect(() => {
+    setLoading(viewedUserProfileQuery.isLoading);
+  }, [viewedUserProfileQuery.isLoading]);
+
+  useEffect(() => {
+    if (!isOpen || !userId) return;
+    if (!viewedUserProfileQuery.data) return;
+
+    const userData = viewedUserProfileQuery.data;
+    const preservedDistanceKm =
+      distanceKm ??
+      user?.distanceKm ??
+      user?.distance_km ??
+      userData?.distanceKm ??
+      userData?.distance_km ??
+      null;
+
+    setError(null);
+    setShowDeletedUserPlaceholder(false);
+    setUser({
+      ...userData,
+      distance_km: preservedDistanceKm,
+      distanceKm: preservedDistanceKm,
+    });
+
+    setFormData({
+      firstName: userData?.first_name || userData?.firstName || "",
+      lastName: userData?.last_name || userData?.lastName || "",
+      bio: userData?.bio || "",
+      postalCode: userData?.postal_code || userData?.postalCode || "",
+      selectedTags: [],
+      tagExperienceLevels: {},
+      tagInterestLevels: {},
+    });
+  }, [
+    distanceKm,
+    isOpen,
+    user?.distanceKm,
+    user?.distance_km,
+    userId,
+    viewedUserProfileQuery.data,
+  ]);
+
+  useEffect(() => {
+    if (!isOpen || !userId) return;
+    setUserTags(viewedUserTagsQuery.data ?? []);
+  }, [isOpen, userId, viewedUserTagsQuery.data]);
+
+  useEffect(() => {
+    if (!viewedUserProfileQuery.error) return;
+
+    console.error("Error fetching user details:", viewedUserProfileQuery.error);
+    if (viewedUserProfileQuery.error.response?.status === 404 && isNumericUserId) {
+      setUser(null);
+      setUserTags([]);
       setError(null);
-      setShowDeletedUserPlaceholder(false);
-
-      const response = await userService.getUserById(userId);
-
-      // Robust unwrap: axios response + API wrapper { success, data }
-      const payload = response?.data ?? response;
-      const userData =
-        payload?.success !== undefined
-          ? payload?.data
-          : (payload?.data?.data ?? payload?.data ?? payload);
-
-      const preservedDistanceKm =
-        distanceKm ??
-        user?.distanceKm ??
-        user?.distance_km ??
-        userData?.distanceKm ??
-        userData?.distance_km ??
-        null;
-
-      setUser({
-        ...userData,
-        distance_km: preservedDistanceKm,
-        distanceKm: preservedDistanceKm,
-      });
-
-      // Fetch full tag objects (with badge_credits)
-      try {
-        const tagsResponse = await userService.getUserTags(userId);
-        setUserTags(tagsResponse?.data || []);
-      } catch (tagErr) {
-        console.error("Error fetching user tags:", tagErr);
-        setUserTags([]);
-      }
-
-      setFormData({
-        firstName: userData?.first_name || userData?.firstName || "",
-        lastName: userData?.last_name || userData?.lastName || "",
-        bio: userData?.bio || "",
-        postalCode: userData?.postal_code || userData?.postalCode || "",
-        selectedTags: [],
-        tagExperienceLevels: {},
-        tagInterestLevels: {},
-      });
-    } catch (err) {
-      console.error("Error fetching user details:", err);
-      if (err.response?.status === 404 && isNumericUserId) {
-        setUser(null);
-        setUserTags([]);
-        setError(null);
-        setShowDeletedUserPlaceholder(true);
-        return;
-      }
-      setShowDeletedUserPlaceholder(false);
-      setError("Failed to load user details. Please try again.");
-    } finally {
-      setLoading(false);
-    }
-  }, [distanceKm, isNumericUserId, user?.distanceKm, user?.distance_km, userId]);
-
-  useEffect(() => {
-    if (isOpen && userId) {
-      fetchUserDetails();
-    }
-  }, [isOpen, userId, fetchUserDetails]);
-
-  // Fetch CURRENT user's tags/badges for overlap highlighting (not the viewed user's)
-  useEffect(() => {
-    if (
-      !showMatchHighlights &&
-      !hasRoleMatchTagIds &&
-      !hasRoleMatchBadgeNames
-    ) {
+      setShowDeletedUserPlaceholder(true);
       return;
     }
-    if (!isOpen || !isAuthenticated || !currentUser?.id) return;
-    // Don't highlight own profile
-    if (Number(currentUser.id) === Number(userId)) return;
-    // Skip when role context provides the matching data
-    if (hasRoleMatchTagIds || hasRoleMatchBadgeNames) return;
 
-    const fetchCurrentUserData = async () => {
-      try {
-        const tagsRes = await userService.getUserTags(currentUser.id);
-        const tagData = Array.isArray(tagsRes?.data)
-          ? tagsRes.data
-          : tagsRes?.data?.data || [];
-        const tagIds = new Set(
-          tagData
-            .map((t) => Number(t.tagId ?? t.tag_id ?? t.id))
-            .filter(Number.isFinite),
-        );
-        setCurrentUserTagIds(tagIds);
+    setShowDeletedUserPlaceholder(false);
+    setError("Failed to load user details. Please try again.");
+  }, [isNumericUserId, viewedUserProfileQuery.error]);
 
-        const badgesRes = await userService.getUserBadges(currentUser.id);
-        const badgeData = Array.isArray(badgesRes?.data)
-          ? badgesRes.data
-          : badgesRes?.data?.data || [];
-        const badgeNames = new Set(
-          badgeData
-            .map((b) =>
-              (b.badgeName ?? b.badge_name ?? b.name ?? "")
-                .trim()
-                .toLowerCase(),
-            )
-            .filter(Boolean),
-        );
-        setCurrentUserBadgeNames(badgeNames);
-      } catch (err) {
-        console.warn(
-          "Could not fetch current user data for matching highlights:",
-          err,
-        );
-      }
-    };
+  useEffect(() => {
+    if (!viewedUserTagsQuery.error) return;
 
-    fetchCurrentUserData();
+    console.error("Error fetching user tags:", viewedUserTagsQuery.error);
+    setUserTags([]);
+  }, [viewedUserTagsQuery.error]);
+
+  // Resolve CURRENT user's tags/badges for overlap highlighting (not the viewed user's)
+  useEffect(() => {
+    if (!shouldFetchCurrentUserMatchData) return;
+
+    const tagIds = new Set(
+      (currentUserTagsQuery.data ?? [])
+        .map((t) => Number(t.tagId ?? t.tag_id ?? t.id))
+        .filter(Number.isFinite),
+    );
+    setCurrentUserTagIds(tagIds);
+
+    const badgeNames = new Set(
+      (currentUserBadgesQuery.data ?? [])
+        .map((b) =>
+          (b.badgeName ?? b.badge_name ?? b.name ?? "")
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean),
+    );
+    setCurrentUserBadgeNames(badgeNames);
   }, [
-    currentUser?.id,
-    hasRoleMatchBadgeNames,
-    hasRoleMatchTagIds,
-    isAuthenticated,
-    isOpen,
-    showMatchHighlights,
-    userId,
+    currentUserBadgesQuery.data,
+    currentUserTagsQuery.data,
+    shouldFetchCurrentUserMatchData,
   ]);
 
   useEffect(() => {
@@ -292,34 +292,34 @@ const UserDetailsModal = ({
       return;
     }
 
-    let cancelled = false;
+    setDistanceViewerUser(currentUserProfileQuery.data ?? currentUser);
+  }, [
+    currentUser,
+    currentUser?.id,
+    currentUserProfileQuery.data,
+    isAuthenticated,
+    isOpen,
+    showMatchHighlights,
+  ]);
 
-    const fetchDistanceViewerUser = async () => {
-      try {
-        const response = await userService.getUserById(currentUser.id);
-        const payload = response?.data ?? response;
-        const viewerData =
-          payload?.success !== undefined
-            ? payload?.data
-            : (payload?.data?.data ?? payload?.data ?? payload);
+  useEffect(() => {
+    if (!currentUserTagsQuery.error && !currentUserBadgesQuery.error) return;
 
-        if (!cancelled) {
-          setDistanceViewerUser(viewerData ?? currentUser);
-        }
-      } catch (err) {
-        console.warn("Could not fetch current user details for distance fallback:", err);
-        if (!cancelled) {
-          setDistanceViewerUser(currentUser);
-        }
-      }
-    };
+    console.warn("Could not fetch current user data for matching highlights:", {
+      tagsError: currentUserTagsQuery.error ?? null,
+      badgesError: currentUserBadgesQuery.error ?? null,
+    });
+  }, [currentUserBadgesQuery.error, currentUserTagsQuery.error]);
 
-    fetchDistanceViewerUser();
+  useEffect(() => {
+    if (!currentUserProfileQuery.error) return;
 
-    return () => {
-      cancelled = true;
-    };
-  }, [currentUser, currentUser?.id, isAuthenticated, isOpen, showMatchHighlights]);
+    console.warn(
+      "Could not fetch current user details for distance fallback:",
+      currentUserProfileQuery.error,
+    );
+    setDistanceViewerUser(currentUser);
+  }, [currentUser, currentUserProfileQuery.error]);
 
   useEffect(() => {
     setIsEditing(mode === "edit");

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { UI_TEXT } from "../../constants/uiText";
 import Modal from "../common/Modal";
 import UserBioSection from "./UserBioSection";
@@ -14,6 +15,8 @@ import {
   useUserBadges,
   useUserProfile,
   useUserTags,
+  userBadgesQueryKey,
+  userProfileQueryKey,
 } from "../../hooks/useUserQueries";
 import Button from "../common/Button";
 import Alert from "../common/Alert";
@@ -96,6 +99,7 @@ const UserDetailsModal = ({
   invitationPrefillRoleName = null,
 }) => {
   const { user: currentUser, isAuthenticated } = useAuth();
+  const queryClient = useQueryClient();
   const normalizedRoleMatchTagIds = useMemo(
     () => normalizeNumericSet(roleMatchTagIds),
     [roleMatchTagIds],
@@ -901,8 +905,13 @@ const UserDetailsModal = ({
           awardeeBio={user.bio}
           awardeeIsDemo={!!(user.is_synthetic ?? user.isSynthetic)}
           onAwardComplete={() => {
-            // Refresh user details to show updated badges
-            fetchUserDetails();
+            queryClient.invalidateQueries({
+              queryKey: userProfileQueryKey(user.id),
+            });
+            queryClient.invalidateQueries({
+              queryKey: userBadgesQueryKey(user.id),
+            });
+            viewedUserProfileQuery.refetch();
           }}
         />
       )}

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -911,7 +911,6 @@ const UserDetailsModal = ({
             queryClient.invalidateQueries({
               queryKey: userBadgesQueryKey(user.id),
             });
-            viewedUserProfileQuery.refetch();
           }}
         />
       )}

--- a/src/hooks/useBadgeQueries.js
+++ b/src/hooks/useBadgeQueries.js
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+import { badgeService } from "../services/badgeService";
+
+export const badgesQueryKey = ["badges"];
+
+export const sharedTeamsForAwardQueryKey = (userId) => [
+  "badges",
+  "sharedTeams",
+  userId ?? null,
+];
+
+const unwrapRows = (response) => {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.data)) return response.data;
+  if (Array.isArray(response?.data?.data)) return response.data.data;
+  return [];
+};
+
+export const fetchBadges = async () => unwrapRows(await badgeService.getAllBadges());
+
+export const fetchSharedTeamsForAward = async (userId) =>
+  unwrapRows(await badgeService.getSharedTeams(userId));
+
+export const useBadges = (options = {}) =>
+  useQuery({
+    queryKey: badgesQueryKey,
+    queryFn: fetchBadges,
+    staleTime: 5 * 60_000,
+    ...options,
+  });
+
+export const useSharedTeamsForAward = (userId, options = {}) =>
+  useQuery({
+    queryKey: sharedTeamsForAwardQueryKey(userId),
+    queryFn: () => fetchSharedTeamsForAward(userId),
+    enabled: Boolean(userId),
+    staleTime: 60_000,
+    ...options,
+  });

--- a/src/hooks/useLocationAutoFill.js
+++ b/src/hooks/useLocationAutoFill.js
@@ -39,7 +39,7 @@ export const useLocationAutoFill = ({
   // Use the existing location lookup hook
   // Pass country if available, otherwise let it auto-detect
   const { location, loading, error } = useLocation(
-    isRemote ? null : postalCode,
+    !isEditing || isRemote ? null : postalCode,
     country || null,
   );
 

--- a/src/hooks/useMyTeamsSort.js
+++ b/src/hooks/useMyTeamsSort.js
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
-import { teamService } from "../services/teamService";
+import { useCallback, useMemo, useState } from "react";
 
 const parseSortableTimestamp = (value) => {
   if (!value) return null;
@@ -94,7 +93,37 @@ const getRequestTimestamp = (item) => {
 const useMyTeamsSort = ({ teams = [], onSortChange } = {}) => {
   const [sortBy, setSortBy] = useState("newest");
   const [sortDir, setSortDir] = useState("desc");
-  const [teamNotificationMetrics, setTeamNotificationMetrics] = useState({});
+
+  // Derived from the team list. The backend's getUserTeams now returns the
+  // pending application/invitation counts and the latest request timestamp
+  // per team, so we no longer need per-team fetches here.
+  const teamNotificationMetrics = useMemo(() => {
+    const result = {};
+    for (const team of teams || []) {
+      if (!team?.id) continue;
+      const applicationsCount = Number(
+        team.pendingApplicationsCount ??
+          team.pending_applications_count ??
+          0,
+      );
+      const invitationsCount = Number(
+        team.pendingSentInvitationsCount ??
+          team.pending_sent_invitations_count ??
+          0,
+      );
+      const latestTimestamp = parseSortableTimestamp(
+        team.latestRequestTimestamp ?? team.latest_request_timestamp,
+      );
+
+      result[team.id] = {
+        latestTimestamp,
+        totalRequestCount:
+          (Number.isFinite(applicationsCount) ? applicationsCount : 0) +
+          (Number.isFinite(invitationsCount) ? invitationsCount : 0),
+      };
+    }
+    return result;
+  }, [teams]);
 
   const handleSortChange = useCallback(
     (nextSortBy) => {
@@ -121,71 +150,6 @@ const useMyTeamsSort = ({ teams = [], onSortChange } = {}) => {
     },
     [onSortChange, sortBy],
   );
-
-  useEffect(() => {
-    if (!["newest", "requests"].includes(sortBy) || teams.length === 0) {
-      return;
-    }
-
-    let isCancelled = false;
-
-    const fetchTeamNotificationTimestamps = async () => {
-      const entries = await Promise.all(
-        teams.filter(Boolean).map(async (team) => {
-          if (!team?.id) return null;
-
-          const [applicationsResponse, invitationsResponse] = await Promise.all(
-            [
-              teamService
-                .getTeamApplications(team.id, { skipAuthRedirect: true, skipErrorLog: true })
-                .catch(() => ({ data: [] })),
-              teamService
-                .getTeamSentInvitations(team.id, { skipAuthRedirect: true, skipErrorLog: true })
-                .catch(() => ({ data: [] })),
-            ],
-          );
-
-          const applications = applicationsResponse?.data || [];
-          const invitations = invitationsResponse?.data || [];
-
-          const latestApplicationTimestamp = applications.reduce(
-            (max, application) => Math.max(max, getRequestTimestamp(application)),
-            0,
-          );
-          const latestInvitationTimestamp = invitations.reduce(
-            (max, invitation) => Math.max(max, getRequestTimestamp(invitation)),
-            0,
-          );
-          const totalRequestCount = applications.length + invitations.length;
-
-          return [
-            team.id,
-            {
-              latestTimestamp:
-                Math.max(
-                  latestApplicationTimestamp,
-                  latestInvitationTimestamp,
-                ) || null,
-              totalRequestCount,
-            },
-          ];
-        }),
-      );
-
-      if (isCancelled) return;
-
-      setTeamNotificationMetrics((prev) => ({
-        ...prev,
-        ...Object.fromEntries(entries.filter(Boolean)),
-      }));
-    };
-
-    fetchTeamNotificationTimestamps();
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [sortBy, teams]);
 
   const sortPendingItems = useCallback(
     (items = []) => {

--- a/src/hooks/usePolledRequestRoles.js
+++ b/src/hooks/usePolledRequestRoles.js
@@ -1,0 +1,77 @@
+import { useEffect, useMemo, useState } from "react";
+import { vacantRoleService } from "../services/vacantRoleService";
+import { getRequestRoleId } from "../utils/teamRequestUtils";
+
+const unwrapRolePayload = (value) => {
+  const payload = value?.data ?? value;
+
+  return payload?.success !== undefined
+    ? payload?.data ?? null
+    : payload?.data?.data ?? payload?.data ?? payload;
+};
+
+const usePolledRequestRoles = (
+  requests,
+  {
+    isOpen,
+    teamId,
+    intervalMs = 20_000,
+  } = {},
+) => {
+  const [roleMap, setRoleMap] = useState({});
+
+  const roleIds = useMemo(
+    () => [
+      ...new Set(
+        (requests ?? [])
+          .map(getRequestRoleId)
+          .filter(Boolean)
+          .map(String),
+      ),
+    ],
+    [requests],
+  );
+
+  useEffect(() => {
+    if (!isOpen || !teamId || roleIds.length === 0) return;
+
+    let isCancelled = false;
+
+    const pollRoles = async () => {
+      try {
+        const results = await Promise.allSettled(
+          roleIds.map((id) => vacantRoleService.getVacantRoleById(teamId, id)),
+        );
+        if (isCancelled) return;
+
+        const nextMap = {};
+        results.forEach((result, i) => {
+          if (result.status === "fulfilled") {
+            const roleData = unwrapRolePayload(result.value);
+            if (roleData) nextMap[roleIds[i]] = roleData;
+          }
+        });
+        setRoleMap((prev) => ({ ...prev, ...nextMap }));
+      } catch {
+        // silent - keep showing last known role state
+      }
+    };
+
+    pollRoles();
+    const intervalId = setInterval(pollRoles, intervalMs);
+
+    return () => {
+      isCancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [intervalMs, isOpen, roleIds, teamId]);
+
+  useEffect(() => {
+    if (isOpen && teamId && roleIds.length > 0) return;
+    setRoleMap({});
+  }, [isOpen, roleIds.length, teamId]);
+
+  return roleMap;
+};
+
+export default usePolledRequestRoles;

--- a/src/hooks/usePolledRequestRoles.js
+++ b/src/hooks/usePolledRequestRoles.js
@@ -2,12 +2,10 @@ import { useEffect, useMemo, useState } from "react";
 import { vacantRoleService } from "../services/vacantRoleService";
 import { getRequestRoleId } from "../utils/teamRequestUtils";
 
-const unwrapRolePayload = (value) => {
+const unwrapListPayload = (value) => {
   const payload = value?.data ?? value;
-
-  return payload?.success !== undefined
-    ? payload?.data ?? null
-    : payload?.data?.data ?? payload?.data ?? payload;
+  const inner = payload?.data ?? payload;
+  return Array.isArray(inner) ? inner : [];
 };
 
 const usePolledRequestRoles = (
@@ -39,17 +37,16 @@ const usePolledRequestRoles = (
 
     const pollRoles = async () => {
       try {
-        const results = await Promise.allSettled(
-          roleIds.map((id) => vacantRoleService.getVacantRoleById(teamId, id)),
+        const response = await vacantRoleService.getVacantRolesByIds(
+          teamId,
+          roleIds,
         );
         if (isCancelled) return;
 
+        const roles = unwrapListPayload(response);
         const nextMap = {};
-        results.forEach((result, i) => {
-          if (result.status === "fulfilled") {
-            const roleData = unwrapRolePayload(result.value);
-            if (roleData) nextMap[roleIds[i]] = roleData;
-          }
+        roles.forEach((role) => {
+          if (role?.id != null) nextMap[String(role.id)] = role;
         });
         setRoleMap((prev) => ({ ...prev, ...nextMap }));
       } catch {

--- a/src/hooks/useSelfRoleMatchMap.js
+++ b/src/hooks/useSelfRoleMatchMap.js
@@ -1,14 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { matchingService } from "../services/matchingService";
-import { getRequestRoleId } from "../utils/teamRequestUtils";
+import {
+  getRequestRoleId,
+  isRequestForUser,
+} from "../utils/teamRequestUtils";
 
 const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
-
-const getRequestUserId = (request, userKey) =>
-  request?.[userKey]?.id ??
-  request?.[`${userKey}Id`] ??
-  request?.[`${userKey}_id`] ??
-  null;
 
 const useSelfRoleMatchMap = (
   requests,
@@ -26,14 +23,7 @@ const useSelfRoleMatchMap = (
     () => [
       ...new Set(
         (requests ?? [])
-          .filter((request) => {
-            const requestUserId = getRequestUserId(request, userKey);
-            return (
-              requestUserId != null &&
-              currentUserId != null &&
-              String(requestUserId) === String(currentUserId)
-            );
-          })
+          .filter((request) => isRequestForUser(request, userKey, currentUserId))
           .map(getRequestRoleId)
           .filter((roleId) => roleId != null)
           .map(String),

--- a/src/hooks/useSelfRoleMatchMap.js
+++ b/src/hooks/useSelfRoleMatchMap.js
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useState } from "react";
+import { matchingService } from "../services/matchingService";
+import { getRequestRoleId } from "../utils/teamRequestUtils";
+
+const SELF_ROLE_MATCH_FETCH_LIMIT = 1000;
+
+const getRequestUserId = (request, userKey) =>
+  request?.[userKey]?.id ??
+  request?.[`${userKey}Id`] ??
+  request?.[`${userKey}_id`] ??
+  null;
+
+const useSelfRoleMatchMap = (
+  requests,
+  {
+    isOpen,
+    teamId,
+    currentUserId,
+    userKey,
+    warningLabel = "request",
+  } = {},
+) => {
+  const [matchMap, setMatchMap] = useState({});
+
+  const selfRoleIds = useMemo(
+    () => [
+      ...new Set(
+        (requests ?? [])
+          .filter((request) => {
+            const requestUserId = getRequestUserId(request, userKey);
+            return (
+              requestUserId != null &&
+              currentUserId != null &&
+              String(requestUserId) === String(currentUserId)
+            );
+          })
+          .map(getRequestRoleId)
+          .filter((roleId) => roleId != null)
+          .map(String),
+      ),
+    ],
+    [currentUserId, requests, userKey],
+  );
+
+  useEffect(() => {
+    if (!isOpen || !teamId || !currentUserId || selfRoleIds.length === 0) {
+      setMatchMap({});
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchSelfRoleMatches = async () => {
+      try {
+        const response = await matchingService.getMatchingRolesForTeam(teamId, {
+          limit: SELF_ROLE_MATCH_FETCH_LIMIT,
+        });
+
+        if (cancelled) return;
+
+        const nextMatchMap = {};
+
+        (response?.data || []).forEach((role) => {
+          const roleId = role?.id;
+          if (roleId == null || !selfRoleIds.includes(String(roleId))) return;
+
+          nextMatchMap[String(roleId)] = {
+            matchScore:
+              role?.matchScore ??
+              role?.match_score ??
+              null,
+            matchDetails:
+              role?.matchDetails ??
+              role?.match_details ??
+              null,
+          };
+        });
+
+        setMatchMap(nextMatchMap);
+      } catch (error) {
+        if (!cancelled) {
+          console.warn(`Could not fetch self-${warningLabel} role match scores:`, error);
+          setMatchMap({});
+        }
+      }
+    };
+
+    fetchSelfRoleMatches();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentUserId, isOpen, selfRoleIds, teamId, warningLabel]);
+
+  return matchMap;
+};
+
+export default useSelfRoleMatchMap;

--- a/src/hooks/useTagQueries.js
+++ b/src/hooks/useTagQueries.js
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { tagService } from "../services/tagService";
+
+export const structuredTagsQueryKey = ["tags", "structured"];
+
+export const popularTagsQueryKey = (limit = 10, supercategory = null) => [
+  "tags",
+  "popular",
+  limit,
+  supercategory ?? null,
+];
+
+export const flattenStructuredTags = (structuredTags = []) =>
+  (structuredTags || [])
+    .flatMap((supercat) =>
+      (supercat.categories || []).map((category) => ({
+        category,
+        supercategory: supercat,
+      })),
+    )
+    .flatMap(({ category, supercategory }) =>
+      (category.tags || []).map((tag) => ({
+        ...tag,
+        supercategory: supercategory.name,
+        category: category.name,
+      })),
+    );
+
+export const useStructuredTags = (options = {}) =>
+  useQuery({
+    queryKey: structuredTagsQueryKey,
+    queryFn: tagService.getStructuredTags,
+    staleTime: 10 * 60_000,
+    ...options,
+  });
+
+export const usePopularTags = (
+  limit = 10,
+  supercategory = null,
+  options = {},
+) =>
+  useQuery({
+    queryKey: popularTagsQueryKey(limit, supercategory),
+    queryFn: () => tagService.getPopularTags(limit, supercategory),
+    staleTime: 10 * 60_000,
+    ...options,
+  });

--- a/src/hooks/useTeamRequestLists.js
+++ b/src/hooks/useTeamRequestLists.js
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+import { teamService } from "../services/teamService";
+
+export const teamApplicationsQueryKey = (teamId) => [
+  "team",
+  teamId ?? null,
+  "applications",
+];
+
+export const teamSentInvitationsQueryKey = (teamId) => [
+  "team",
+  teamId ?? null,
+  "sentInvitations",
+];
+
+const extractList = (response) => {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.data)) return response.data;
+  if (Array.isArray(response?.data?.data)) return response.data.data;
+  return [];
+};
+
+export const fetchTeamApplications = async (teamId) => {
+  const response = await teamService.getTeamApplications(teamId);
+  return extractList(response);
+};
+
+export const fetchTeamSentInvitations = async (teamId) => {
+  const response = await teamService.getTeamSentInvitations(teamId);
+  return extractList(response);
+};
+
+const useTeamRequestLists = (
+  teamId,
+  {
+    enabled = true,
+    applicationsEnabled = false,
+    invitationsEnabled = false,
+    staleTime = 15_000,
+  } = {},
+) => {
+  const canFetch = enabled && Boolean(teamId);
+
+  const applicationsQuery = useQuery({
+    queryKey: teamApplicationsQueryKey(teamId),
+    queryFn: () => fetchTeamApplications(teamId),
+    enabled: canFetch && applicationsEnabled,
+    staleTime,
+  });
+
+  const invitationsQuery = useQuery({
+    queryKey: teamSentInvitationsQueryKey(teamId),
+    queryFn: () => fetchTeamSentInvitations(teamId),
+    enabled: canFetch && invitationsEnabled,
+    staleTime,
+  });
+
+  return {
+    applications: applicationsQuery.data ?? [],
+    invitations: invitationsQuery.data ?? [],
+    applicationsQuery,
+    invitationsQuery,
+    applicationsLoaded: applicationsQuery.isFetched,
+    invitationsLoaded: invitationsQuery.isFetched,
+    refetchApplications: applicationsQuery.refetch,
+    refetchInvitations: invitationsQuery.refetch,
+  };
+};
+
+export default useTeamRequestLists;

--- a/src/hooks/useUserQueries.js
+++ b/src/hooks/useUserQueries.js
@@ -1,0 +1,95 @@
+import { useQuery } from "@tanstack/react-query";
+import { userService } from "../services/userService";
+
+export const userProfileQueryKey = (userId) => [
+  "users",
+  userId ?? null,
+  "profile",
+];
+
+export const userTagsQueryKey = (userId) => ["users", userId ?? null, "tags"];
+
+export const userBadgesQueryKey = (userId) => [
+  "users",
+  userId ?? null,
+  "badges",
+];
+
+export const unwrapUser = (response) => {
+  const candidates = [
+    response?.data?.data?.user,
+    response?.data?.user,
+    response?.user,
+    response?.data?.data,
+    response?.data,
+    response,
+  ];
+
+  for (const candidate of candidates) {
+    if (
+      candidate &&
+      typeof candidate === "object" &&
+      !Array.isArray(candidate) &&
+      candidate.success === undefined
+    ) {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
+export const unwrapRows = (response) => {
+  if (!response) return [];
+  if (Array.isArray(response)) return response;
+
+  if (response.success !== undefined) {
+    if (Array.isArray(response.data)) return response.data;
+    if (Array.isArray(response.data?.data)) return response.data.data;
+    return [];
+  }
+
+  const payload = response.data ?? response;
+
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload?.data?.data)) return payload.data.data;
+
+  return [];
+};
+
+export const fetchUserProfile = async (userId) =>
+  unwrapUser(await userService.getUserById(userId));
+
+export const fetchUserTags = async (userId) =>
+  unwrapRows(await userService.getUserTags(userId));
+
+export const fetchUserBadges = async (userId) =>
+  unwrapRows(await userService.getUserBadges(userId));
+
+export const useUserProfile = (userId, options = {}) =>
+  useQuery({
+    queryKey: userProfileQueryKey(userId),
+    queryFn: () => fetchUserProfile(userId),
+    enabled: Boolean(userId),
+    staleTime: 30_000,
+    ...options,
+  });
+
+export const useUserTags = (userId, options = {}) =>
+  useQuery({
+    queryKey: userTagsQueryKey(userId),
+    queryFn: () => fetchUserTags(userId),
+    enabled: Boolean(userId),
+    staleTime: 30_000,
+    ...options,
+  });
+
+export const useUserBadges = (userId, options = {}) =>
+  useQuery({
+    queryKey: userBadgesQueryKey(userId),
+    queryFn: () => fetchUserBadges(userId),
+    enabled: Boolean(userId),
+    staleTime: 30_000,
+    ...options,
+  });

--- a/src/hooks/useViewerMatchProfile.js
+++ b/src/hooks/useViewerMatchProfile.js
@@ -1,53 +1,23 @@
-import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "../contexts/AuthContext";
-import { userService } from "../services/userService";
+import {
+  fetchUserBadges,
+  fetchUserProfile,
+  fetchUserTags,
+  userBadgesQueryKey,
+  userProfileQueryKey,
+  userTagsQueryKey,
+} from "./useUserQueries";
 import { buildViewerTeamMatchProfile } from "../utils/teamMatchUtils";
+
+export const viewerMatchProfileQueryKey = (userId) => [
+  "viewer",
+  "matchProfile",
+  userId ?? null,
+];
 
 const idsMatch = (left, right) =>
   left != null && right != null && String(left) === String(right);
-
-const unwrapUser = (response) => {
-  const candidates = [
-    response?.data?.data?.user,
-    response?.data?.user,
-    response?.user,
-    response?.data?.data,
-    response?.data,
-    response,
-  ];
-
-  for (const candidate of candidates) {
-    if (
-      candidate &&
-      typeof candidate === "object" &&
-      !Array.isArray(candidate) &&
-      candidate.success === undefined
-    ) {
-      return candidate;
-    }
-  }
-
-  return null;
-};
-
-const unwrapRows = (response) => {
-  if (!response) return [];
-  if (Array.isArray(response)) return response;
-
-  if (response.success !== undefined) {
-    if (Array.isArray(response.data)) return response.data;
-    if (Array.isArray(response.data?.data)) return response.data.data;
-    return [];
-  }
-
-  const payload = response.data ?? response;
-
-  if (Array.isArray(payload)) return payload;
-  if (Array.isArray(payload?.data)) return payload.data;
-  if (Array.isArray(payload?.data?.data)) return payload.data.data;
-
-  return [];
-};
 
 const buildViewerMatchUser = ({ basicUser, freshUser, userId }) => {
   const resolvedId = freshUser?.id ?? basicUser?.id ?? userId ?? null;
@@ -62,121 +32,104 @@ const buildViewerMatchUser = ({ basicUser, freshUser, userId }) => {
   };
 };
 
-const useViewerMatchProfile = ({ userId } = {}) => {
-  const { user } = useAuth();
-  const [viewerMatchProfile, setViewerMatchProfile] = useState(null);
-  const [viewerDistanceSource, setViewerDistanceSource] = useState(null);
-  const [loading, setLoading] = useState(false);
+const fetchViewerMatchProfile = async ({ userId, basicUser, queryClient }) => {
+  try {
+    const [userResult, tagsResult, badgesResult] = await Promise.allSettled([
+      queryClient.fetchQuery({
+        queryKey: userProfileQueryKey(userId),
+        queryFn: () => fetchUserProfile(userId),
+        staleTime: 30_000,
+      }),
+      queryClient.fetchQuery({
+        queryKey: userTagsQueryKey(userId),
+        queryFn: () => fetchUserTags(userId),
+        staleTime: 30_000,
+      }),
+      queryClient.fetchQuery({
+        queryKey: userBadgesQueryKey(userId),
+        queryFn: () => fetchUserBadges(userId),
+        staleTime: 30_000,
+      }),
+    ]);
 
-  useEffect(() => {
-    if (!userId) {
-      setViewerMatchProfile(null);
-      setViewerDistanceSource(null);
-      setLoading(false);
-      return;
+    const freshUser =
+      userResult.status === "fulfilled" ? userResult.value : null;
+    const nextViewerDistanceSource = freshUser ?? basicUser ?? null;
+    const viewerMatchUser = buildViewerMatchUser({
+      basicUser,
+      freshUser: nextViewerDistanceSource,
+      userId,
+    });
+    const userTags =
+      tagsResult.status === "fulfilled" ? tagsResult.value : [];
+    const userBadges =
+      badgesResult.status === "fulfilled" ? badgesResult.value : [];
+
+    if (userResult.status === "rejected") {
+      console.warn(
+        "Could not fetch fresh viewer profile for match calculations:",
+        userResult.reason,
+      );
     }
 
-    let cancelled = false;
-    const basicUser = idsMatch(user?.id, userId) ? user : { id: userId };
+    if (
+      tagsResult.status === "rejected" ||
+      badgesResult.status === "rejected"
+    ) {
+      console.warn("Could not fully fetch viewer match metadata:", {
+        tagsError:
+          tagsResult.status === "rejected" ? tagsResult.reason : null,
+        badgesError:
+          badgesResult.status === "rejected" ? badgesResult.reason : null,
+      });
+    }
 
-    setLoading(true);
-
-    const fetchViewerMatchProfile = async () => {
-      try {
-        const [userResult, tagsResult, badgesResult] = await Promise.allSettled([
-          userService.getUserById(userId),
-          userService.getUserTags(userId),
-          userService.getUserBadges(userId),
-        ]);
-
-        if (cancelled) return;
-
-        const freshUser =
-          userResult.status === "fulfilled" ? unwrapUser(userResult.value) : null;
-        const nextViewerDistanceSource = freshUser ?? basicUser ?? null;
-        const viewerMatchUser = buildViewerMatchUser({
-          basicUser,
-          freshUser: nextViewerDistanceSource,
-          userId,
-        });
-        const userTags =
-          tagsResult.status === "fulfilled" ? unwrapRows(tagsResult.value) : [];
-        const userBadges =
-          badgesResult.status === "fulfilled"
-            ? unwrapRows(badgesResult.value)
-            : [];
-
-        if (userResult.status === "rejected") {
-          console.warn(
-            "Could not fetch fresh viewer profile for match calculations:",
-            userResult.reason,
-          );
-        }
-
-        if (
-          tagsResult.status === "rejected" ||
-          badgesResult.status === "rejected"
-        ) {
-          console.warn(
-            "Could not fully fetch viewer match metadata:",
-            {
-              tagsError:
-                tagsResult.status === "rejected" ? tagsResult.reason : null,
-              badgesError:
-                badgesResult.status === "rejected"
-                  ? badgesResult.reason
-                  : null,
-            },
-          );
-        }
-
-        setViewerDistanceSource(nextViewerDistanceSource);
-        setViewerMatchProfile(
-          viewerMatchUser
-            ? buildViewerTeamMatchProfile({
-                user: viewerMatchUser,
-                userTags,
-                userBadges,
-              })
-            : null,
-        );
-      } catch (error) {
-        console.warn("Could not build viewer match profile:", error);
-
-        if (cancelled) return;
-
-        const fallbackViewerMatchUser = buildViewerMatchUser({
-          basicUser,
-          freshUser: basicUser,
-          userId,
-        });
-
-        setViewerDistanceSource(basicUser);
-        setViewerMatchProfile(
-          fallbackViewerMatchUser
-            ? buildViewerTeamMatchProfile({
-                user: fallbackViewerMatchUser,
-              })
-            : null,
-        );
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
+    return {
+      viewerDistanceSource: nextViewerDistanceSource,
+      viewerMatchProfile: viewerMatchUser
+        ? buildViewerTeamMatchProfile({
+            user: viewerMatchUser,
+            userTags,
+            userBadges,
+          })
+        : null,
     };
+  } catch (error) {
+    console.warn("Could not build viewer match profile:", error);
 
-    fetchViewerMatchProfile();
+    const fallbackViewerMatchUser = buildViewerMatchUser({
+      basicUser,
+      freshUser: basicUser,
+      userId,
+    });
 
-    return () => {
-      cancelled = true;
+    return {
+      viewerDistanceSource: basicUser,
+      viewerMatchProfile: fallbackViewerMatchUser
+        ? buildViewerTeamMatchProfile({
+            user: fallbackViewerMatchUser,
+          })
+        : null,
     };
-  }, [userId, user]);
+  }
+};
+
+const useViewerMatchProfile = ({ userId } = {}) => {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const basicUser = idsMatch(user?.id, userId) ? user : { id: userId };
+  const query = useQuery({
+    queryKey: viewerMatchProfileQueryKey(userId),
+    queryFn: () =>
+      fetchViewerMatchProfile({ userId, basicUser, queryClient }),
+    enabled: Boolean(userId),
+    staleTime: 30_000,
+  });
 
   return {
-    viewerMatchProfile,
-    viewerDistanceSource,
-    loading,
+    viewerMatchProfile: query.data?.viewerMatchProfile ?? null,
+    viewerDistanceSource: query.data?.viewerDistanceSource ?? null,
+    loading: query.isLoading,
   };
 };
 

--- a/src/hooks/useViewerPendingRequests.js
+++ b/src/hooks/useViewerPendingRequests.js
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import { teamService } from "../services/teamService";
+
+export const viewerPendingRequestsQueryKey = (userId) => [
+  "viewer",
+  "pendingRequests",
+  userId ?? null,
+];
+
+export const fetchViewerPendingRequests = async () => {
+  const [appsRes, invitesRes] = await Promise.allSettled([
+    teamService.getUserPendingApplications(),
+    teamService.getUserReceivedInvitations(),
+  ]);
+
+  return {
+    applications:
+      appsRes.status === "fulfilled" && Array.isArray(appsRes.value?.data)
+        ? appsRes.value.data
+        : [],
+    invitations:
+      invitesRes.status === "fulfilled" && Array.isArray(invitesRes.value?.data)
+        ? invitesRes.value.data
+        : [],
+  };
+};
+
+const useViewerPendingRequests = (userId, { enabled = true } = {}) =>
+  useQuery({
+    queryKey: viewerPendingRequestsQueryKey(userId),
+    queryFn: fetchViewerPendingRequests,
+    enabled: enabled && Boolean(userId),
+    staleTime: 15_000,
+  });
+
+export default useViewerPendingRequests;

--- a/src/hooks/useViewerTeamMemberships.js
+++ b/src/hooks/useViewerTeamMemberships.js
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { teamService } from "../services/teamService";
+
+export const viewerTeamMembershipsQueryKey = (userId) => [
+  "viewer",
+  "teamMemberships",
+  userId ?? null,
+];
+
+const normalizeViewerTeamRole = (value) => {
+  const role = String(value ?? "").trim().toLowerCase();
+  return ["owner", "admin", "member"].includes(role) ? role : null;
+};
+
+const getTeamId = (team) => team?.id ?? team?.teamId ?? team?.team_id ?? null;
+
+export const fetchViewerTeamMemberships = async (userId) => {
+  if (!userId) return { teamIds: [], teamRoles: {} };
+
+  const teamIds = [];
+  const teamRoles = {};
+  const limit = 100;
+  let page = 1;
+  let totalPages = 1;
+
+  while (page <= totalPages) {
+    const response = await teamService.getUserTeams(userId, { page, limit });
+    const teams = Array.isArray(response?.data) ? response.data : [];
+
+    teams.forEach((team) => {
+      const teamId = getTeamId(team);
+      if (teamId == null) return;
+
+      const teamKey = String(teamId);
+      const role = normalizeViewerTeamRole(team.userRole ?? team.user_role);
+
+      teamIds.push(teamKey);
+      if (role) {
+        teamRoles[teamKey] = role;
+      }
+    });
+
+    const pagination = response?.pagination ?? {};
+    const nextTotalPages = Number(
+      pagination.totalPages ?? pagination.total_pages ?? 1,
+    );
+    totalPages =
+      Number.isFinite(nextTotalPages) && nextTotalPages > 0
+        ? nextTotalPages
+        : 1;
+
+    const hasNextPage = Boolean(
+      pagination.hasNextPage ??
+        pagination.has_next_page ??
+        page < totalPages,
+    );
+
+    if (!hasNextPage) break;
+    page += 1;
+  }
+
+  return { teamIds, teamRoles };
+};
+
+const useViewerTeamMemberships = (userId, { enabled = true } = {}) => {
+  const query = useQuery({
+    queryKey: viewerTeamMembershipsQueryKey(userId),
+    queryFn: () => fetchViewerTeamMemberships(userId),
+    enabled: enabled && Boolean(userId),
+    staleTime: 30_000,
+  });
+
+  const teamIdSet = useMemo(
+    () => new Set(query.data?.teamIds ?? []),
+    [query.data?.teamIds],
+  );
+
+  return {
+    ...query,
+    teamIdSet,
+    teamRoles: query.data?.teamRoles ?? {},
+  };
+};
+
+export default useViewerTeamMemberships;

--- a/src/lib/queryClient.js
+++ b/src/lib/queryClient.js
@@ -1,0 +1,12 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,9 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
 import App from "./App.jsx";
 import "./index.css";
+import { queryClient } from "./lib/queryClient";
 
 function RootWrapper() {
   React.useEffect(() => {
@@ -14,6 +16,8 @@ function RootWrapper() {
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <RootWrapper />
+    <QueryClientProvider client={queryClient}>
+      <RootWrapper />
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -217,6 +217,44 @@ const isCurrentUserRemovalPayload = (payload, userId) => {
   return /\byou\b/.test(text) && /removed from/.test(text);
 };
 
+const extractTeamDetailsPayload = (response) =>
+  response?.data && typeof response.data === "object" ? response.data : response;
+
+const mergeTeamDetailsIntoConversationData = (conversationData, teamPayload) => {
+  if (!conversationData || !teamPayload) return conversationData;
+
+  const currentTeam = conversationData.team || {};
+
+  return {
+    ...conversationData,
+    team: {
+      ...currentTeam,
+      avatarUrl:
+        currentTeam.avatarUrl ||
+        currentTeam.teamavatarUrl ||
+        currentTeam.teamavatar_url ||
+        teamPayload.avatarUrl ||
+        teamPayload.teamavatarUrl ||
+        teamPayload.teamavatar_url,
+      isSynthetic:
+        currentTeam.isSynthetic ??
+        currentTeam.is_synthetic ??
+        teamPayload.isSynthetic ??
+        teamPayload.is_synthetic ??
+        undefined,
+      is_synthetic:
+        currentTeam.is_synthetic ??
+        currentTeam.isSynthetic ??
+        teamPayload.is_synthetic ??
+        teamPayload.isSynthetic ??
+        undefined,
+      members: Array.isArray(teamPayload.members)
+        ? teamPayload.members
+        : currentTeam.members,
+    },
+  };
+};
+
 const getConversationUpdatedAt = (conversation) => {
   const timestamp =
     conversation?.updatedAt ??
@@ -698,6 +736,8 @@ const Chat = () => {
   const messagesRef = useRef([]);
   const chatSearchLoadingKeysRef = useRef(new Set());
   const pendingChatSearchTargetRef = useRef(null);
+  const teamDetailsCacheRef = useRef(new Map());
+  const teamDetailsRequestsRef = useRef(new Map());
   const [loadingMessages, setLoadingMessages] = useState(false);
 
   // ---- Message de-duplication (focus: ownership/system duplicates) ----
@@ -777,6 +817,36 @@ const Chat = () => {
   const canSendInActiveConversation =
     Boolean(activeConversation) && isCurrentUserActiveTeamMember;
 
+  const fetchTeamDetails = useCallback(async (teamId, { force = false } = {}) => {
+    if (!teamId) return null;
+
+    const cacheKey = String(teamId);
+
+    if (!force && teamDetailsCacheRef.current.has(cacheKey)) {
+      return teamDetailsCacheRef.current.get(cacheKey);
+    }
+
+    if (!force && teamDetailsRequestsRef.current.has(cacheKey)) {
+      return teamDetailsRequestsRef.current.get(cacheKey);
+    }
+
+    const request = teamService
+      .getTeamById(teamId)
+      .then((response) => {
+        const teamPayload = extractTeamDetailsPayload(response);
+        teamDetailsCacheRef.current.set(cacheKey, teamPayload);
+        teamDetailsRequestsRef.current.delete(cacheKey);
+        return teamPayload;
+      })
+      .catch((error) => {
+        teamDetailsRequestsRef.current.delete(cacheKey);
+        throw error;
+      });
+
+    teamDetailsRequestsRef.current.set(cacheKey, request);
+    return request;
+  }, []);
+
   const revokeTeamChatAccess = useCallback(
     (teamId, message = "You no longer have access to this team chat.") => {
       if (!teamId) return;
@@ -818,11 +888,7 @@ const Chat = () => {
     async (teamId) => {
       if (!teamId || !user?.id) return true;
 
-      const response = await teamService.getTeamById(teamId);
-      const teamPayload =
-        response?.data && typeof response.data === "object"
-          ? response.data
-          : response;
+      const teamPayload = await fetchTeamDetails(teamId, { force: true });
 
       if (!Array.isArray(teamPayload?.members)) {
         return true;
@@ -853,7 +919,39 @@ const Chat = () => {
 
       return true;
     },
-    [revokeTeamChatAccess, user?.id],
+    [fetchTeamDetails, revokeTeamChatAccess, user?.id],
+  );
+
+  const hydrateTeamConversationDetails = useCallback(
+    async (conversationDetails, teamId) => {
+      if (!conversationDetails?.data || !teamId) return false;
+
+      try {
+        const teamPayload = await fetchTeamDetails(teamId);
+
+        setIsTeamArchived(
+          Boolean(teamPayload?.archived_at || teamPayload?.status === "inactive"),
+        );
+
+        if (Array.isArray(teamPayload?.members)) {
+          if (!isUserTeamMember(teamPayload.members, user?.id)) {
+            revokeTeamChatAccess(teamId);
+            setLoadingMessages(false);
+            return true;
+          }
+
+          conversationDetails.data = mergeTeamDetailsIntoConversationData(
+            conversationDetails.data,
+            teamPayload,
+          );
+        }
+      } catch (teamError) {
+        console.error("Error fetching team member details:", teamError);
+      }
+
+      return false;
+    },
+    [fetchTeamDetails, revokeTeamChatAccess, user?.id],
   );
 
   const mentionParticipants = useMemo(() => {
@@ -1362,68 +1460,12 @@ const Chat = () => {
             type,
           );
 
-          // If it's a team conversation, fetch detailed team member information
           if (type === "team" && conversationDetails?.data) {
-            try {
-              const teamDetails = await teamService.getTeamById(conversationId);
-
-              // ✅ Check if team is archived
-              if (
-                teamDetails.data?.archived_at ||
-                teamDetails.data?.status === "inactive"
-              ) {
-                setIsTeamArchived(true);
-              } else {
-                setIsTeamArchived(false);
-              }
-
-              if (teamDetails?.data?.members) {
-                if (!isUserTeamMember(teamDetails.data.members, user?.id)) {
-                  setError("You no longer have access to this team chat.");
-                  setConversations((prev) =>
-                    prev.filter(
-                      (conversation) =>
-                        !(
-                          conversation.type === "team" &&
-                          String(conversation.id) === String(conversationId)
-                        ),
-                    ),
-                  );
-                  setActiveConversation(null);
-                  setMessages([]);
-                  setLoadingMessages(false);
-                  setShowChatView(false);
-                  navigate("/chat", { replace: true });
-                  return;
-                }
-
-                conversationDetails.data.team = {
-                  ...conversationDetails.data.team,
-                  avatarUrl:
-                    conversationDetails.data.team.avatarUrl ||
-                    conversationDetails.data.team.teamavatarUrl ||
-                    conversationDetails.data.team.teamavatar_url ||
-                    teamDetails.data.avatarUrl ||
-                    teamDetails.data.teamavatarUrl ||
-                    teamDetails.data.teamavatar_url,
-                  isSynthetic:
-                    conversationDetails.data.team.isSynthetic ??
-                    conversationDetails.data.team.is_synthetic ??
-                    teamDetails.data.isSynthetic ??
-                    teamDetails.data.is_synthetic ??
-                    undefined,
-                  is_synthetic:
-                    conversationDetails.data.team.is_synthetic ??
-                    conversationDetails.data.team.isSynthetic ??
-                    teamDetails.data.is_synthetic ??
-                    teamDetails.data.isSynthetic ??
-                    undefined,
-                  members: teamDetails.data.members,
-                };
-              }
-            } catch (teamError) {
-              console.error("Error fetching team member details:", teamError);
-            }
+            const accessRevoked = await hydrateTeamConversationDetails(
+              conversationDetails,
+              conversationId,
+            );
+            if (accessRevoked) return;
           }
 
           setActiveConversation(conversationDetails.data);
@@ -1477,64 +1519,11 @@ const Chat = () => {
           }
 
           if (type === "team" && conversationDetails?.data) {
-            try {
-              const teamDetails = await teamService.getTeamById(conversationId);
-
-              // ✅ Check if team is archived (also in fallback path)
-              if (
-                teamDetails.data?.archived_at ||
-                teamDetails.data?.status === "inactive"
-              ) {
-                setIsTeamArchived(true);
-              } else {
-                setIsTeamArchived(false);
-              }
-
-              if (teamDetails?.data?.members) {
-                if (!isUserTeamMember(teamDetails.data.members, user?.id)) {
-                  setError("You no longer have access to this team chat.");
-                  setConversations((prev) =>
-                    prev.filter(
-                      (conversation) =>
-                        !(
-                          conversation.type === "team" &&
-                          String(conversation.id) === String(conversationId)
-                        ),
-                    ),
-                  );
-                  setActiveConversation(null);
-                  setMessages([]);
-                  setLoadingMessages(false);
-                  setShowChatView(false);
-                  navigate("/chat", { replace: true });
-                  return;
-                }
-
-                conversationDetails.data.team = {
-                  ...conversationDetails.data.team,
-                  avatarUrl:
-                    conversationDetails.data.team.avatarUrl ||
-                    conversationDetails.data.team.teamavatarUrl ||
-                    conversationDetails.data.team.teamavatar_url ||
-                    teamDetails.data.avatarUrl ||
-                    teamDetails.data.teamavatarUrl ||
-                    teamDetails.data.teamavatar_url,
-                  isSynthetic:
-                    conversationDetails.data.team.isSynthetic ??
-                    conversationDetails.data.team.is_synthetic ??
-                    teamDetails.data.isSynthetic ??
-                    teamDetails.data.is_synthetic ??
-                    undefined,
-                  is_synthetic:
-                    conversationDetails.data.team.is_synthetic ??
-                    conversationDetails.data.team.isSynthetic ??
-                    teamDetails.data.is_synthetic ??
-                    teamDetails.data.isSynthetic ??
-                    undefined,
-                  members: teamDetails.data.members,
-                };
-              }
-            } catch (error) {}
+            const accessRevoked = await hydrateTeamConversationDetails(
+              conversationDetails,
+              conversationId,
+            );
+            if (accessRevoked) return;
           }
 
           if (type === "direct") {
@@ -1765,6 +1754,7 @@ const Chat = () => {
   }, [
     isAuthenticated,
     conversationId,
+    hydrateTeamConversationDetails,
     searchParams,
     setSearchParams,
     navigate,
@@ -2199,14 +2189,8 @@ const Chat = () => {
         return;
       }
 
-      teamService
-        .getTeamById(data.teamId)
-        .then((response) => {
-          const teamPayload =
-            response?.data && typeof response.data === "object"
-              ? response.data
-              : response;
-
+      fetchTeamDetails(data.teamId, { force: true })
+        .then((teamPayload) => {
           if (!Array.isArray(teamPayload?.members)) {
             return;
           }
@@ -2375,6 +2359,7 @@ const Chat = () => {
   }, [
     conversationId,
     handleKickedFromTeam,
+    fetchTeamDetails,
     isAuthenticated,
     navigate,
     refreshActiveTeamMembership,

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -187,7 +187,14 @@ const MyTeams = () => {
     if (!type || type.includes("invitation") || type.includes("invite")) {
       fetchPendingInvitations();
     }
-  }, [fetchPendingApplications, fetchPendingInvitations]);
+
+    // Also refresh the team list so each card's badge counts
+    // (pendingApplicationsCount / pendingSentInvitationsCount) stay live
+    // without per-card refetches.
+    if (user?.id) {
+      fetchUserTeams(currentPage, resultsPerPage);
+    }
+  }, [fetchPendingApplications, fetchPendingInvitations, fetchUserTeams, user?.id, currentPage, resultsPerPage]);
 
   useSocketEvents(
     user?.id

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -28,6 +28,7 @@ import { enrichTeamMatchData } from "../utils/teamMatchUtils";
 import useClientPagination from "../hooks/useClientPagination";
 import useMyTeamsSort from "../hooks/useMyTeamsSort";
 import useViewerMatchProfile from "../hooks/useViewerMatchProfile";
+import useViewerPendingRequests from "../hooks/useViewerPendingRequests";
 
 import {
   RESULTS_PER_PAGE_OPTIONS,
@@ -42,13 +43,24 @@ const MY_TEAMS_LIST_BADGES_WIDTH_CLASSNAME = "sm:w-32";
 
 const MyTeams = () => {
   const [teams, setTeams] = useState([]);
-  const [pendingApplications, setPendingApplications] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [loadingApplications, setLoadingApplications] = useState(true);
-  const [pendingInvitations, setPendingInvitations] = useState([]);
-  const [loadingInvitations, setLoadingInvitations] = useState(true);
   const [error, setError] = useState(null);
   const { user } = useAuth();
+  const {
+    data: viewerPending,
+    isLoading: viewerPendingLoading,
+    refetch: refetchViewerPending,
+  } = useViewerPendingRequests(user?.id, { enabled: Boolean(user?.id) });
+  const pendingApplications = useMemo(
+    () => viewerPending?.applications ?? [],
+    [viewerPending],
+  );
+  const pendingInvitations = useMemo(
+    () => viewerPending?.invitations ?? [],
+    [viewerPending],
+  );
+  const loadingApplications = viewerPendingLoading;
+  const loadingInvitations = viewerPendingLoading;
   const { viewerMatchProfile, viewerDistanceSource } = useViewerMatchProfile({
     userId: user?.id,
   });
@@ -179,66 +191,15 @@ const MyTeams = () => {
     [user?.id],
   );
 
-  // Fetch pending applications
-  const fetchPendingApplications = useCallback(async () => {
-    if (!user?.id) return;
-
-    try {
-      setLoadingApplications(true);
-      const response = await teamService.getUserPendingApplications();
-
-      if (response.success) {
-        setPendingApplications(response.data || []);
-      }
-    } catch (err) {
-      console.error("Error fetching pending applications:", err);
-    } finally {
-      setLoadingApplications(false);
-    }
-  }, [user?.id]);
-
-  // Fetch pending invitations
-  const fetchPendingInvitations = useCallback(async () => {
-    if (!user?.id) return;
-
-    try {
-      setLoadingInvitations(true);
-      const response = await teamService.getUserReceivedInvitations();
-
-      if (response.success) {
-        setPendingInvitations(response.data || []);
-      }
-    } catch (err) {
-      console.error("Error fetching pending invitations:", err);
-    } finally {
-      setLoadingInvitations(false);
-    }
-  }, [user?.id]);
-
-  // Initial data fetch
-  useEffect(() => {
-    fetchPendingApplications();
-    fetchPendingInvitations();
-  }, [fetchPendingApplications, fetchPendingInvitations]);
-
-  const handleRequestNotification = useCallback((payload = {}) => {
-    const type = String(payload.type ?? payload.notificationType ?? "").toLowerCase();
-
-    if (!type || type.includes("application")) {
-      fetchPendingApplications();
-    }
-
-    if (!type || type.includes("invitation") || type.includes("invite")) {
-      fetchPendingInvitations();
-    }
-
+  const handleRequestNotification = useCallback(() => {
+    refetchViewerPending();
     // Also refresh the team list so each card's badge counts
     // (pendingApplicationsCount / pendingSentInvitationsCount) stay live
     // without per-card refetches.
     if (user?.id) {
       fetchUserTeams(currentPage, resultsPerPage);
     }
-  }, [fetchPendingApplications, fetchPendingInvitations, fetchUserTeams, user?.id, currentPage, resultsPerPage]);
+  }, [refetchViewerPending, fetchUserTeams, user?.id, currentPage, resultsPerPage]);
 
   useSocketEvents(
     user?.id
@@ -404,7 +365,7 @@ const MyTeams = () => {
   const handleApplicationCancel = async (applicationId) => {
     try {
       await teamService.cancelApplication(applicationId);
-      fetchPendingApplications();
+      refetchViewerPending();
     } catch (error) {
       console.error("Error canceling application:", error);
     }
@@ -432,7 +393,7 @@ const MyTeams = () => {
       );
 
       // Refresh the data
-      fetchPendingInvitations();
+      refetchViewerPending();
       fetchUserTeams(currentPage, resultsPerPage);
     } catch (error) {
       console.error("Error accepting invitation:", error);
@@ -451,7 +412,7 @@ const MyTeams = () => {
       );
 
       // Refresh the data
-      fetchPendingInvitations();
+      refetchViewerPending();
     } catch (error) {
       console.error("Error declining invitation:", error);
     }

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -100,6 +100,50 @@ const MyTeams = () => {
   const [autoOpenApplicationsTeamId, setAutoOpenApplicationsTeamId] =
     useState(null);
 
+  // Bulk-fetched member badges keyed by team id. null = "still loading" so
+  // child cards wait instead of falling back to their own per-card fetch.
+  const [teamMemberBadgesById, setTeamMemberBadgesById] = useState(null);
+
+  const teamIdsKey = useMemo(
+    () =>
+      teams
+        .map((t) => t?.id)
+        .filter((id) => id != null)
+        .join(","),
+    [teams],
+  );
+
+  useEffect(() => {
+    if (!teamIdsKey) {
+      setTeamMemberBadgesById({});
+      return;
+    }
+
+    const ids = teamIdsKey.split(",").map((id) => parseInt(id, 10));
+    let cancelled = false;
+    setTeamMemberBadgesById(null);
+
+    teamService
+      .getMemberBadgesForTeams(ids)
+      .then((response) => {
+        if (!cancelled) {
+          setTeamMemberBadgesById(response?.data || {});
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("Failed to fetch bulk team member badges:", err);
+          // Surface as empty map so cards stop waiting and just show no badges
+          // rather than perpetually loading.
+          setTeamMemberBadgesById({});
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [teamIdsKey]);
+
   // Fetch user's teams with pagination
   const fetchUserTeams = useCallback(
     async (page = 1, limit = 10) => {
@@ -986,6 +1030,11 @@ const MyTeams = () => {
                         is_public:
                           team.is_public === true || team.isPublic === true,
                       }}
+                      teamMemberBadges={
+                        teamMemberBadgesById === null
+                          ? null
+                          : teamMemberBadgesById[team.id] || []
+                      }
                       onUpdate={handleTeamUpdate}
                       onDelete={handleTeamDelete}
                       onLeave={handleTeamLeave}
@@ -1045,6 +1094,11 @@ const MyTeams = () => {
                         is_public:
                           team.is_public === true || team.isPublic === true,
                       }}
+                      teamMemberBadges={
+                        teamMemberBadgesById === null
+                          ? null
+                          : teamMemberBadgesById[team.id] || []
+                      }
                       onUpdate={handleTeamUpdate}
                       onDelete={handleTeamDelete}
                       onLeave={handleTeamLeave}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -57,6 +57,8 @@ import ConfirmModal from "../components/common/ConfirmModal";
 import LocationInput from "../components/common/LocationInput";
 import { format } from "date-fns";
 
+const EMPTY_QUERY_ARRAY = [];
+
 const Profile = () => {
   const { user, updateUser, logout } = useAuth();
   const queryClient = useQueryClient();
@@ -82,12 +84,10 @@ const Profile = () => {
   } = useUserProfile(user?.id, {
     enabled: Boolean(user?.id),
   });
-  const { data: fetchedUserTags = [], error: userTagsError } = useUserTags(
-    user?.id,
-    {
+  const { data: fetchedUserTags = EMPTY_QUERY_ARRAY, error: userTagsError } =
+    useUserTags(user?.id, {
       enabled: Boolean(user?.id),
-    },
-  );
+    });
 
   // Compute effective userId for the hook (Profile uses localUser or auth user)
   const profileUserId = localUser?.id ?? user?.id;

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import FormSectionDivider from "../components/common/FormSectionDivider";
 import { useAuth } from "../contexts/AuthContext";
@@ -27,8 +28,14 @@ import {
 } from "lucide-react";
 import useAwardModals from "../hooks/useAwardModals";
 import { CATEGORY_COLORS } from "../constants/badgeConstants";
-import { tagService } from "../services/tagService";
 import { userService } from "../services/userService";
+import { useStructuredTags } from "../hooks/useTagQueries";
+import {
+  useUserProfile,
+  useUserTags,
+  userProfileQueryKey,
+  userTagsQueryKey,
+} from "../hooks/useUserQueries";
 import TagInput from "../components/tags/TagInput";
 import BadgesDisplaySection from "../components/badges/BadgesDisplaySection";
 import SupercategoryAwardsModal from "../components/badges/SupercategoryAwardsModal";
@@ -52,6 +59,7 @@ import { format } from "date-fns";
 
 const Profile = () => {
   const { user, updateUser, logout } = useAuth();
+  const queryClient = useQueryClient();
   const [localUser, setLocalUser] = useState(null);
   const [registrationMessage, setRegistrationMessage] = useState("");
   const [tags, setTags] = useState([]);
@@ -66,6 +74,20 @@ const Profile = () => {
   const [imageError, setImageError] = useState(false);
   const navigate = useNavigate();
   const { openUserModal } = useUserModal();
+  const { data: structuredTags = [], error: structuredTagsError } =
+    useStructuredTags();
+  const {
+    data: fetchedProfileUser,
+    error: profileUserError,
+  } = useUserProfile(user?.id, {
+    enabled: Boolean(user?.id),
+  });
+  const { data: fetchedUserTags = [], error: userTagsError } = useUserTags(
+    user?.id,
+    {
+      enabled: Boolean(user?.id),
+    },
+  );
 
   // Compute effective userId for the hook (Profile uses localUser or auth user)
   const profileUserId = localUser?.id ?? user?.id;
@@ -169,66 +191,15 @@ const Profile = () => {
     return false;
   };
 
-  // Fetch user details as a callback that doesn't re-create on each render
-  const fetchUserDetails = useCallback(async () => {
-    if (!user || !user.id || initialDataLoaded) return;
-
-    try {
-      setLoading(true);
-      const response = await userService.getUserById(user.id);
-
-      if (response && response.data) {
-        const apiUserData = response.data;
-
-        // Avoid updating the user context here - that's causing the loop
-        // Instead, just use the API data to update the form
-
-        // Update form data directly from API response
-        setFormData({
-          firstName: apiUserData.firstName || "",
-          lastName: apiUserData.lastName || "",
-          username: apiUserData.username || "",
-          email: apiUserData.email || apiUserData.email || "",
-          bio: apiUserData.bio || "",
-          postalCode: apiUserData.postalCode || "",
-          city: apiUserData.city || "",
-          country: apiUserData.country || "",
-          isPublic:
-            apiUserData.isPublic !== undefined ? apiUserData.isPublic : true,
-          profileImage: null,
-        });
-
-        // Set image preview if available
-        if (apiUserData.avatarUrl) {
-          setImagePreview(apiUserData.avatarUrl);
-        }
-
-        // Store API user locally (includes badges totals as `badges`)
-        setLocalUser(apiUserData);
-
-        // Mark initial data as loaded
-        setInitialDataLoaded(true);
-      }
-    } catch (error) {
-      console.error("Error fetching user details:", error);
-      setError("Failed to load user data. Please try again.");
-    } finally {
-      setLoading(false);
-    }
-  }, [user, initialDataLoaded]); // Only depend on user and initialDataLoaded
-
   useEffect(() => {
     const message = localStorage.getItem("registrationMessage");
     if (message) {
       setRegistrationMessage(message);
       localStorage.removeItem("registrationMessage");
     }
+  }, []);
 
-    // Fetch user details only if we haven't loaded initial data yet
-    if (user && !initialDataLoaded) {
-      fetchUserDetails();
-    }
-
+  useEffect(() => {
     // Initialize form data from context if available and we haven't loaded from API yet
     if (user && !initialDataLoaded) {
       setFormData({
@@ -250,34 +221,64 @@ const Profile = () => {
         setImagePreview(user.avatarUrl);
       }
     }
+  }, [user, initialDataLoaded]);
 
-    const fetchTags = async () => {
-      try {
-        const structuredTags = await tagService.getStructuredTags();
-        setTags(structuredTags);
-      } catch (error) {
-        console.error("Error fetching tags:", error);
+  useEffect(() => {
+    if (!fetchedProfileUser) return;
+
+    if (!initialDataLoaded || !isEditing) {
+      setFormData({
+        firstName: fetchedProfileUser.firstName || "",
+        lastName: fetchedProfileUser.lastName || "",
+        username: fetchedProfileUser.username || "",
+        email: fetchedProfileUser.email || "",
+        bio: fetchedProfileUser.bio || "",
+        postalCode: fetchedProfileUser.postalCode || "",
+        city: fetchedProfileUser.city || "",
+        country: fetchedProfileUser.country || "",
+        isPublic:
+          fetchedProfileUser.isPublic !== undefined
+            ? fetchedProfileUser.isPublic
+            : true,
+        profileImage: null,
+      });
+
+      if (fetchedProfileUser.avatarUrl) {
+        setImagePreview(fetchedProfileUser.avatarUrl);
       }
-    };
+    }
 
-    const fetchUserTags = async () => {
-      if (user) {
-        try {
-          const userTagsResponse = await userService.getUserTags(user.id);
-          const tagData = userTagsResponse.data || [];
-          setSelectedTags(tagData.map((tag) => tag.id));
-          setUserTagObjects(tagData);
-        } catch (error) {
-          console.error("Error fetching user tags:", error);
-        }
-      }
-    };
+    setLocalUser(fetchedProfileUser);
+    setInitialDataLoaded(true);
+  }, [fetchedProfileUser, initialDataLoaded, isEditing]);
 
-    // Badges are loaded via userService.getUserById(user.id) (totals -> user.badges)
+  useEffect(() => {
+    setTags(structuredTags);
+  }, [structuredTags]);
 
-    fetchTags();
-    fetchUserTags();
-  }, [user, initialDataLoaded, fetchUserDetails]); // Add initialDataLoaded and fetchUserDetails to dependencies
+  useEffect(() => {
+    setSelectedTags(fetchedUserTags.map((tag) => tag.id));
+    setUserTagObjects(fetchedUserTags);
+  }, [fetchedUserTags]);
+
+  useEffect(() => {
+    if (structuredTagsError) {
+      console.error("Error fetching tags:", structuredTagsError);
+    }
+  }, [structuredTagsError]);
+
+  useEffect(() => {
+    if (userTagsError) {
+      console.error("Error fetching user tags:", userTagsError);
+    }
+  }, [userTagsError]);
+
+  useEffect(() => {
+    if (profileUserError) {
+      console.error("Error fetching user details:", profileUserError);
+      setError("Failed to load user data. Please try again.");
+    }
+  }, [profileUserError]);
 
   // Reset image error state when user changes
   useEffect(() => {
@@ -757,6 +758,9 @@ const Profile = () => {
 
       // Update Profile's state with the new tags
       setSelectedTags(newTags);
+      queryClient.invalidateQueries({
+        queryKey: userTagsQueryKey(user.id),
+      });
 
       setSuccess("Tags updated successfully");
     } catch (error) {
@@ -857,6 +861,9 @@ const Profile = () => {
         // Update tags along with profile
         try {
           await userService.updateUserTags(user.id, selectedTags);
+          queryClient.invalidateQueries({
+            queryKey: userTagsQueryKey(user.id),
+          });
         } catch (tagError) {
           console.error("Error updating tags:", tagError);
           // Don't fail the whole operation if tags fail
@@ -893,6 +900,10 @@ const Profile = () => {
 
         // Force a local state update
         setLocalUser(updatedUser);
+        queryClient.setQueryData(userProfileQueryKey(user.id), updatedUser);
+        queryClient.invalidateQueries({
+          queryKey: userProfileQueryKey(user.id),
+        });
 
         // Reset form data with updated values
         setFormData((prev) => ({

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -74,7 +74,7 @@ const Profile = () => {
   const [imageError, setImageError] = useState(false);
   const navigate = useNavigate();
   const { openUserModal } = useUserModal();
-  const { data: structuredTags = [], error: structuredTagsError } =
+  const { data: structuredTags, error: structuredTagsError } =
     useStructuredTags();
   const {
     data: fetchedProfileUser,
@@ -253,7 +253,7 @@ const Profile = () => {
   }, [fetchedProfileUser, initialDataLoaded, isEditing]);
 
   useEffect(() => {
-    setTags(structuredTags);
+    if (structuredTags) setTags(structuredTags);
   }, [structuredTags]);
 
   useEffect(() => {

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1191,7 +1191,12 @@ const Profile = () => {
               <div className="form-control w-full">
                 <label className="label">
                   <span className="label-text">
-                    Select focus areas matching your interests and skills
+                    <span className="sm:hidden">
+                      Pick your interests and skills
+                    </span>
+                    <span className="hidden sm:inline">
+                      Select focus areas matching your interests and skills
+                    </span>
                   </span>
                 </label>
 

--- a/src/pages/PublicProfile.jsx
+++ b/src/pages/PublicProfile.jsx
@@ -7,17 +7,7 @@ import Alert from "../components/common/Alert";
 import BadgesDisplaySection from "../components/badges/BadgesDisplaySection";
 import UserAvatar from "../components/users/UserAvatar";
 import DeletedUserProfilePlaceholder from "../components/users/DeletedUserProfilePlaceholder";
-import { userService } from "../services/userService";
-
-const unwrapUserPayload = (response) => {
-  const payload = response?.data ?? response;
-
-  if (payload?.success !== undefined) {
-    return payload?.data ?? null;
-  }
-
-  return payload?.data?.data ?? payload?.data ?? payload ?? null;
-};
+import { useUserProfile } from "../hooks/useUserQueries";
 
 const getUserDisplayName = (user) => {
   const firstName = user?.firstName || user?.first_name || "";
@@ -30,65 +20,52 @@ const getUserDisplayName = (user) => {
 const PublicProfile = () => {
   const { id } = useParams();
   const navigate = useNavigate();
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [user, setUser] = useState(null);
   const [showDeletedUserPlaceholder, setShowDeletedUserPlaceholder] =
     useState(false);
 
   const isNumericUserId = /^\d+$/.test(String(id ?? "").trim());
+  const userProfileQuery = useUserProfile(id, {
+    enabled: Boolean(id),
+  });
+  const loading = Boolean(id) && userProfileQuery.isLoading;
 
   useEffect(() => {
-    let isCancelled = false;
-
-    const fetchUser = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        setShowDeletedUserPlaceholder(false);
-
-        const response = await userService.getUserById(id);
-        const userData = unwrapUserPayload(response);
-
-        if (isCancelled) return;
-
-        setUser(userData);
-      } catch (err) {
-        if (isCancelled) return;
-
-        console.error("Error fetching public profile:", err);
-
-        if (err.response?.status === 404 && isNumericUserId) {
-          setUser(null);
-          setError(null);
-          setShowDeletedUserPlaceholder(true);
-          return;
-        }
-
-        setUser(null);
-        setShowDeletedUserPlaceholder(false);
-        setError("Failed to load this profile. Please try again.");
-      } finally {
-        if (!isCancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
     if (!id) {
-      setLoading(false);
+      setUser(null);
+      setShowDeletedUserPlaceholder(false);
       setError("No profile ID was provided.");
-      return () => {
-        isCancelled = true;
-      };
+      return;
     }
 
-    fetchUser();
+    setError(null);
+  }, [id]);
 
-    return () => {
-      isCancelled = true;
-    };
-  }, [id, isNumericUserId]);
+  useEffect(() => {
+    if (!userProfileQuery.data) return;
+
+    setUser(userProfileQuery.data);
+    setError(null);
+    setShowDeletedUserPlaceholder(false);
+  }, [userProfileQuery.data]);
+
+  useEffect(() => {
+    if (!userProfileQuery.error) return;
+
+    console.error("Error fetching public profile:", userProfileQuery.error);
+
+    if (userProfileQuery.error.response?.status === 404 && isNumericUserId) {
+      setUser(null);
+      setError(null);
+      setShowDeletedUserPlaceholder(true);
+      return;
+    }
+
+    setUser(null);
+    setShowDeletedUserPlaceholder(false);
+    setError("Failed to load this profile. Please try again.");
+  }, [isNumericUserId, userProfileQuery.error]);
 
   const displayName = useMemo(() => getUserDisplayName(user), [user]);
   const username = user?.username ? `@${user.username}` : null;

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -82,6 +82,7 @@ const SORTING_OPTION_VALUES = new Set([
   "match",
   "locationPriority",
 ]);
+const EMPTY_QUERY_ARRAY = [];
 
 const getFilterableDistanceKm = (item) => {
   const matchDetails = item?.matchDetails ?? item?.match_details ?? null;
@@ -228,7 +229,7 @@ const sortByProximity = (items, sortDir) =>
 const SearchPage = () => {
   const location = useLocation();
   const { user, isAuthenticated, loading: authLoading } = useAuth();
-  const { data: structuredTags = [] } = useStructuredTags();
+  const { data: structuredTags = EMPTY_QUERY_ARRAY } = useStructuredTags();
 
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState({

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -227,7 +227,7 @@ const sortByProximity = (items, sortDir) =>
 
 const SearchPage = () => {
   const location = useLocation();
-  const { user, isAuthenticated } = useAuth();
+  const { user, isAuthenticated, loading: authLoading } = useAuth();
   const { data: structuredTags = [] } = useStructuredTags();
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -1041,6 +1041,10 @@ const SearchPage = () => {
   const showIncludeOwnTeamsFilter = isAuthenticated && searchType !== "users";
 
   useEffect(() => {
+    // Wait until auth resolves so we don't double-fetch with stale
+    // isAuthenticated baked into fetchData.
+    if (authLoading) return;
+
     const run = async () => {
       try {
         setLoading(true);
@@ -1111,6 +1115,7 @@ const SearchPage = () => {
 
     run();
   }, [
+    authLoading,
     fetchData,
     currentPage,
     resultsPerPage,

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -50,6 +50,7 @@ import {
 import useViewerMatchProfile from "../hooks/useViewerMatchProfile";
 import useViewerPendingRequests from "../hooks/useViewerPendingRequests";
 import useViewerTeamMemberships from "../hooks/useViewerTeamMemberships";
+import { useStructuredTags } from "../hooks/useTagQueries";
 import {
   buildSearchRequestCriteria,
   DISTANCE_SUBMENU_TYPE,
@@ -227,6 +228,7 @@ const sortByProximity = (items, sortDir) =>
 const SearchPage = () => {
   const location = useLocation();
   const { user, isAuthenticated } = useAuth();
+  const { data: structuredTags = [] } = useStructuredTags();
 
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState({
@@ -262,6 +264,20 @@ const SearchPage = () => {
   const viewerPendingInvitations = isAuthenticated
     ? viewerPendingRequestsQuery.data?.invitations ?? null
     : undefined;
+  const structuredTagLookup = useMemo(() => {
+    const lookup = {};
+    structuredTags.forEach((supercat) => {
+      supercat.categories?.forEach((cat) => {
+        cat.tags?.forEach((tag) => {
+          lookup[Number(tag.id)] = {
+            ...tag,
+            supercategory: supercat.name,
+          };
+        });
+      });
+    });
+    return lookup;
+  }, [structuredTags]);
 
   // ===== SORTING STATE =====
   const [sortBy, setSortBy] = useState(() => {
@@ -1134,37 +1150,26 @@ const SearchPage = () => {
       setSortDir("asc");
     }
 
-    const tagsParam = urlParams.get("tags");
-    if (tagsParam) {
-      const ids = tagsParam.split(",").map(Number).filter(Boolean);
-      if (ids.length > 0) {
-        // Resolve tag names from structured tag tree (IDs already set via lazy init)
-        tagService
-          .getStructuredTags()
-          .then((structure) => {
-            const lookup = {};
-            structure.forEach((supercat) => {
-              supercat.categories?.forEach((cat) => {
-                cat.tags?.forEach((tag) => {
-                  lookup[Number(tag.id)] = {
-                    ...tag,
-                    supercategory: supercat.name,
-                  };
-                });
-              });
-            });
-            const map = {};
-            ids.forEach((id) => {
-              if (lookup[id]) map[id] = lookup[id];
-            });
-            setFilterTagMap(map);
-          })
-          .catch(() => {});
-      }
-    }
     // Badge IDs already set via lazy init; names resolved by the allBadges effect
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(location.search);
+    const tagsParam = urlParams.get("tags");
+    if (!tagsParam) return;
+
+    const ids = tagsParam.split(",").map(Number).filter(Boolean);
+    if (ids.length === 0 || Object.keys(structuredTagLookup).length === 0) {
+      return;
+    }
+
+    const map = {};
+    ids.forEach((id) => {
+      if (structuredTagLookup[id]) map[id] = structuredTagLookup[id];
+    });
+    setFilterTagMap(map);
+  }, [location.search, structuredTagLookup]);
 
   useEffect(() => {
     if (!showSortDropdown) {

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -41,7 +41,6 @@ import Alert from "../components/common/Alert";
 import { searchService, getApiErrorMessage } from "../services/searchService";
 import { tagService } from "../services/tagService";
 import { badgeService } from "../services/badgeService";
-import { teamService } from "../services/teamService";
 import {
   enrichTeamMatchData,
   enrichUserMatchData,
@@ -49,6 +48,8 @@ import {
   getResultMatchScore,
 } from "../utils/teamMatchUtils";
 import useViewerMatchProfile from "../hooks/useViewerMatchProfile";
+import useViewerPendingRequests from "../hooks/useViewerPendingRequests";
+import useViewerTeamMemberships from "../hooks/useViewerTeamMemberships";
 import {
   buildSearchRequestCriteria,
   DISTANCE_SUBMENU_TYPE,
@@ -249,117 +250,18 @@ const SearchPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [hasSearched, setHasSearched] = useState(false);
-
-  // Fetched once and passed to every TeamCard so cards don't each re-fetch
-  // the viewer's global pending-application / pending-invitation lists.
-  const [viewerPendingApplications, setViewerPendingApplications] = useState(null);
-  const [viewerPendingInvitations, setViewerPendingInvitations] = useState(null);
-  const [viewerTeamRoles, setViewerTeamRoles] = useState({});
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      setViewerPendingApplications(null);
-      setViewerPendingInvitations(null);
-      return;
-    }
-
-    let cancelled = false;
-
-    (async () => {
-      try {
-        const [appsRes, invitesRes] = await Promise.allSettled([
-          teamService.getUserPendingApplications(),
-          teamService.getUserReceivedInvitations(),
-        ]);
-
-        if (cancelled) return;
-
-        if (appsRes.status === "fulfilled") {
-          setViewerPendingApplications(appsRes.value?.data || []);
-        }
-        if (invitesRes.status === "fulfilled") {
-          setViewerPendingInvitations(invitesRes.value?.data || []);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          console.error("Failed to load viewer pending requests:", err);
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuthenticated]);
-
-  useEffect(() => {
-    if (!isAuthenticated || !user?.id) {
-      setViewerTeamRoles({});
-      return;
-    }
-
-    let cancelled = false;
-
-    const fetchViewerTeamRoles = async () => {
-      const nextRoles = {};
-      const limit = 100;
-      let page = 1;
-      let totalPages = 1;
-
-      while (page <= totalPages) {
-        const response = await teamService.getUserTeams(user.id, {
-          page,
-          limit,
-        });
-        const teams = Array.isArray(response?.data) ? response.data : [];
-
-        teams.forEach((team) => {
-          const teamId = getSearchTeamId(team);
-          if (teamId == null) return;
-
-          const role = normalizeViewerTeamRole(
-            team.userRole ?? team.user_role,
-          );
-          if (role) {
-            nextRoles[String(teamId)] = role;
-          }
-        });
-
-        const pagination = response?.pagination ?? {};
-        const nextTotalPages = Number(
-          pagination.totalPages ?? pagination.total_pages ?? 1,
-        );
-        totalPages =
-          Number.isFinite(nextTotalPages) && nextTotalPages > 0
-            ? nextTotalPages
-            : 1;
-
-        const hasNextPage = Boolean(
-          pagination.hasNextPage ??
-            pagination.has_next_page ??
-            page < totalPages,
-        );
-
-        if (!hasNextPage) break;
-        page += 1;
-      }
-
-      if (!cancelled) {
-        setViewerTeamRoles(nextRoles);
-      }
-    };
-
-    fetchViewerTeamRoles().catch((err) => {
-      if (!cancelled) {
-        console.error("Failed to load viewer team roles:", err);
-        setViewerTeamRoles({});
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuthenticated, user?.id]);
+  const viewerPendingRequestsQuery = useViewerPendingRequests(user?.id, {
+    enabled: isAuthenticated,
+  });
+  const { teamRoles: viewerTeamRoles } = useViewerTeamMemberships(user?.id, {
+    enabled: isAuthenticated,
+  });
+  const viewerPendingApplications = isAuthenticated
+    ? viewerPendingRequestsQuery.data?.applications ?? null
+    : undefined;
+  const viewerPendingInvitations = isAuthenticated
+    ? viewerPendingRequestsQuery.data?.invitations ?? null
+    : undefined;
 
   // ===== SORTING STATE =====
   const [sortBy, setSortBy] = useState(() => {

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -41,6 +41,7 @@ import Alert from "../components/common/Alert";
 import { searchService, getApiErrorMessage } from "../services/searchService";
 import { tagService } from "../services/tagService";
 import { badgeService } from "../services/badgeService";
+import { teamService } from "../services/teamService";
 import {
   enrichTeamMatchData,
   enrichUserMatchData,
@@ -240,6 +241,47 @@ const SearchPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [hasSearched, setHasSearched] = useState(false);
+
+  // Fetched once and passed to every TeamCard so cards don't each re-fetch
+  // the viewer's global pending-application / pending-invitation lists.
+  const [viewerPendingApplications, setViewerPendingApplications] = useState(null);
+  const [viewerPendingInvitations, setViewerPendingInvitations] = useState(null);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setViewerPendingApplications(null);
+      setViewerPendingInvitations(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const [appsRes, invitesRes] = await Promise.allSettled([
+          teamService.getUserPendingApplications(),
+          teamService.getUserReceivedInvitations(),
+        ]);
+
+        if (cancelled) return;
+
+        if (appsRes.status === "fulfilled") {
+          setViewerPendingApplications(appsRes.value?.data || []);
+        }
+        if (invitesRes.status === "fulfilled") {
+          setViewerPendingInvitations(invitesRes.value?.data || []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Failed to load viewer pending requests:", err);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
 
   // ===== SORTING STATE =====
   const [sortBy, setSortBy] = useState(() => {
@@ -2299,6 +2341,8 @@ const SearchPage = () => {
                           onUpdate={handleTeamUpdate}
                           isSearchResult={true}
                           viewerDistanceSource={viewerDistanceSource}
+                          viewerPendingApplications={viewerPendingApplications}
+                          viewerPendingInvitations={viewerPendingInvitations}
                           roleMatchBadgeNames={roleMatchBadgeNames}
                           showMatchHighlights={sortBy === "match"}
                           showMatchScore={sortBy === "match"}
@@ -2371,6 +2415,8 @@ const SearchPage = () => {
                           onUpdate={handleTeamUpdate}
                           isSearchResult={true}
                           viewerDistanceSource={viewerDistanceSource}
+                          viewerPendingApplications={viewerPendingApplications}
+                          viewerPendingInvitations={viewerPendingInvitations}
                           roleMatchBadgeNames={roleMatchBadgeNames}
                           showMatchHighlights={sortBy === "match"}
                           showMatchScore={sortBy === "match"}

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -130,6 +130,14 @@ const getSearchItemDisplayName = (item) => {
   return getUserDisplayName(item);
 };
 
+const normalizeViewerTeamRole = (value) => {
+  const role = String(value ?? "").trim().toLowerCase();
+  return ["owner", "admin", "member"].includes(role) ? role : null;
+};
+
+const getSearchTeamId = (team) =>
+  team?.id ?? team?.teamId ?? team?.team_id ?? null;
+
 const getSearchItemActivityTime = (item) => {
   if (!item) return 0;
 
@@ -246,6 +254,7 @@ const SearchPage = () => {
   // the viewer's global pending-application / pending-invitation lists.
   const [viewerPendingApplications, setViewerPendingApplications] = useState(null);
   const [viewerPendingInvitations, setViewerPendingInvitations] = useState(null);
+  const [viewerTeamRoles, setViewerTeamRoles] = useState({});
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -282,6 +291,75 @@ const SearchPage = () => {
       cancelled = true;
     };
   }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !user?.id) {
+      setViewerTeamRoles({});
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchViewerTeamRoles = async () => {
+      const nextRoles = {};
+      const limit = 100;
+      let page = 1;
+      let totalPages = 1;
+
+      while (page <= totalPages) {
+        const response = await teamService.getUserTeams(user.id, {
+          page,
+          limit,
+        });
+        const teams = Array.isArray(response?.data) ? response.data : [];
+
+        teams.forEach((team) => {
+          const teamId = getSearchTeamId(team);
+          if (teamId == null) return;
+
+          const role = normalizeViewerTeamRole(
+            team.userRole ?? team.user_role,
+          );
+          if (role) {
+            nextRoles[String(teamId)] = role;
+          }
+        });
+
+        const pagination = response?.pagination ?? {};
+        const nextTotalPages = Number(
+          pagination.totalPages ?? pagination.total_pages ?? 1,
+        );
+        totalPages =
+          Number.isFinite(nextTotalPages) && nextTotalPages > 0
+            ? nextTotalPages
+            : 1;
+
+        const hasNextPage = Boolean(
+          pagination.hasNextPage ??
+            pagination.has_next_page ??
+            page < totalPages,
+        );
+
+        if (!hasNextPage) break;
+        page += 1;
+      }
+
+      if (!cancelled) {
+        setViewerTeamRoles(nextRoles);
+      }
+    };
+
+    fetchViewerTeamRoles().catch((err) => {
+      if (!cancelled) {
+        console.error("Failed to load viewer team roles:", err);
+        setViewerTeamRoles({});
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, user?.id]);
 
   // ===== SORTING STATE =====
   const [sortBy, setSortBy] = useState(() => {
@@ -871,6 +949,33 @@ const SearchPage = () => {
       ? sortByProximity(filteredResults.roles, sortDir)
       : filteredResults.roles;
 
+  const withViewerTeamRole = useCallback(
+    (team) => {
+      const teamId = getSearchTeamId(team);
+      const role =
+        teamId != null
+          ? viewerTeamRoles[String(teamId)] ??
+            normalizeViewerTeamRole(
+              team?.userRole ??
+                team?.user_role ??
+                team?.currentUserRole ??
+                team?.current_user_role,
+            )
+          : null;
+
+      if (!role) return team;
+
+      return {
+        ...team,
+        userRole: role,
+        user_role: role,
+        currentUserRole: role,
+        current_user_role: role,
+      };
+    },
+    [viewerTeamRoles],
+  );
+
   const displayedTeams = mergedDisplayItems
     ? []
     : searchType === "users"
@@ -893,6 +998,9 @@ const SearchPage = () => {
               _resultType: "user",
             })),
           ];
+  const visibleMapItemsWithViewerRoles = visibleMapItems.map((item) =>
+    item?._resultType === "team" ? withViewerTeamRole(item) : item,
+  );
 
   const hasActiveFilters =
     filterTagIds.length > 0 ||
@@ -2313,7 +2421,7 @@ const SearchPage = () => {
 
               {resultView === "map" && (
                 <SearchMapView
-                  items={visibleMapItems}
+                  items={visibleMapItemsWithViewerRoles}
                   searchType={searchType}
                   roleMatchTagIds={roleMatchTagIds}
                   roleMatchBadgeNames={roleMatchBadgeNames}
@@ -2337,7 +2445,7 @@ const SearchPage = () => {
                       item._resultType === "team" ? (
                         <TeamCard
                           key={`team-${item.id}`}
-                          team={item}
+                          team={withViewerTeamRole(item)}
                           onUpdate={handleTeamUpdate}
                           isSearchResult={true}
                           viewerDistanceSource={viewerDistanceSource}
@@ -2411,7 +2519,7 @@ const SearchPage = () => {
                       item._resultType === "team" ? (
                         <TeamCard
                           key={`team-${item.id}`}
-                          team={item}
+                          team={withViewerTeamRole(item)}
                           onUpdate={handleTeamUpdate}
                           isSearchResult={true}
                           viewerDistanceSource={viewerDistanceSource}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -63,4 +63,27 @@ api.interceptors.response.use(
   }
 );
 
+/**
+ * Thin wrapper that collapses the repetitive
+ *   try { (await api.X(...)).data } catch (e) { console.error(...); throw e }
+ * pattern used across service modules. Use this for the standard "fetch and
+ * unwrap response.data" case. For catch handlers that need additional logic
+ * (custom error wrapping, conditional logging, etc.), keep an explicit
+ * try/catch instead.
+ *
+ * @param {string} label - Short action description for the error log
+ *   (e.g. "fetching user details for ID 42"). Prefixed with "Error " on log.
+ * @param {() => Promise} requestFn - Function returning an axios Promise.
+ * @returns {Promise<*>} Resolves with response.data.
+ */
+export const call = async (label, requestFn) => {
+  try {
+    const response = await requestFn();
+    return response.data;
+  } catch (error) {
+    console.error(`Error ${label}:`, error);
+    throw error;
+  }
+};
+
 export default api;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -20,6 +20,7 @@ api.interceptors.request.use(
     }
 
     if (
+      config.skipRequestCaseTransform !== true &&
       config.data &&
       typeof config.data === "object" &&
       !(config.data instanceof FormData)
@@ -35,7 +36,7 @@ api.interceptors.request.use(
 // Add response interceptor to convert response data to camelCase
 api.interceptors.response.use(
   (response) => {
-    if (response.data) {
+    if (response.config?.skipResponseCaseTransform !== true && response.data) {
       response.data = snakeToCamel(response.data);
     }
     return response;

--- a/src/services/badgeService.js
+++ b/src/services/badgeService.js
@@ -1,4 +1,4 @@
-import api from "./api";
+import api, { call } from "./api";
 
 /**
  * Badge Service
@@ -10,15 +10,8 @@ export const badgeService = {
    * Fetches all available badges (grouped by category on the backend).
    * @returns {Promise<object>} { success: true, data: [...badges] }
    */
-  getAllBadges: async () => {
-    try {
-      const response = await api.get("/api/badges");
-      return response.data;
-    } catch (error) {
-      console.error("Error fetching all badges:", error);
-      throw error;
-    }
-  },
+  getAllBadges: () =>
+    call("fetching all badges", () => api.get("/api/badges")),
 
   /**
    * Award a badge to a user.
@@ -33,15 +26,8 @@ export const badgeService = {
    * @param {number} [awardData.tagId] - Optional tag ID (links award to a focus area)
    * @returns {Promise<object>} { success: true, data: {...award, hidden: true} }
    */
-  awardBadge: async (awardData) => {
-    try {
-      const response = await api.post("/api/badges/award", awardData);
-      return response.data;
-    } catch (error) {
-      console.error("Error awarding badge:", error);
-      throw error;
-    }
-  },
+  awardBadge: (awardData) =>
+    call("awarding badge", () => api.post("/api/badges/award", awardData)),
 
   /**
    * Get teams shared between the authenticated user and a target user.
@@ -49,15 +35,10 @@ export const badgeService = {
    * @param {number} userId - Target user ID
    * @returns {Promise<object>} { success: true, data: [...teams] }
    */
-  getSharedTeams: async (userId) => {
-    try {
-      const response = await api.get(`/api/badges/shared-teams/${userId}`);
-      return response.data;
-    } catch (error) {
-      console.error("Error fetching shared teams:", error);
-      throw error;
-    }
-  },
+  getSharedTeams: (userId) =>
+    call("fetching shared teams", () =>
+      api.get(`/api/badges/shared-teams/${userId}`),
+    ),
 };
 
 export default badgeService;

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -2,6 +2,34 @@ import api, { call } from "./api";
 
 let _pendingUnreadCount = null;
 
+const normalizeUnreadCountPayload = (payload) => {
+  const data = payload?.data ?? payload ?? {};
+  const rawFirstUnread = data.firstUnread ?? data.first_unread ?? null;
+  const firstUnread = rawFirstUnread
+    ? {
+        ...rawFirstUnread,
+        conversationId:
+          rawFirstUnread.conversationId ?? rawFirstUnread.conversation_id,
+        conversation_id:
+          rawFirstUnread.conversation_id ?? rawFirstUnread.conversationId,
+      }
+    : null;
+
+  return {
+    ...payload,
+    data: {
+      ...data,
+      count: data.count ?? 0,
+      firstUnread,
+      first_unread: firstUnread,
+      teamCount: data.teamCount ?? data.team_count ?? 0,
+      team_count: data.team_count ?? data.teamCount ?? 0,
+      senderCount: data.senderCount ?? data.sender_count ?? 0,
+      sender_count: data.sender_count ?? data.senderCount ?? 0,
+    },
+  };
+};
+
 export const messageService = {
   getConversations: () =>
     call("fetching conversations", () =>
@@ -14,8 +42,10 @@ export const messageService = {
     if (_pendingUnreadCount) return _pendingUnreadCount;
 
     _pendingUnreadCount = call("fetching unread count", () =>
-      api.get("/api/messages/unread-count"),
-    ).finally(() => {
+      api.get("/api/messages/unread-count", {
+        skipResponseCaseTransform: true,
+      }),
+    ).then(normalizeUnreadCountPayload).finally(() => {
       _pendingUnreadCount = null;
     });
 

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -186,6 +186,16 @@ const normalizeConversationListPayload = (payload) => {
   };
 };
 
+const normalizeConversationPayload = (payload) => {
+  const rawConversation = payload?.data ?? payload ?? null;
+  const conversation = normalizeConversation(rawConversation);
+
+  return {
+    ...payload,
+    data: conversation,
+  };
+};
+
 const normalizeUnreadCountPayload = (payload) => {
   const data = payload?.data ?? payload ?? {};
   const rawFirstUnread = data.firstUnread ?? data.first_unread ?? null;
@@ -240,8 +250,10 @@ export const messageService = {
 
   getConversationById: (conversationId, type = "direct") =>
     call(`fetching conversation ${conversationId}`, () =>
-      api.get(`/api/messages/conversations/${conversationId}?type=${type}`),
-    ),
+      api.get(`/api/messages/conversations/${conversationId}?type=${type}`, {
+        skipResponseCaseTransform: true,
+      }),
+    ).then(normalizeConversationPayload),
 
   getMessages: (conversationId, type = "direct", { before, limit } = {}) => {
     const params = new URLSearchParams({ type });

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -381,7 +381,9 @@ export const messageService = {
 
   deleteMessage: (messageId) =>
     call(`deleting message ${messageId}`, () =>
-      api.delete(`/api/messages/${messageId}`),
+      api.delete(`/api/messages/${messageId}`, {
+        skipResponseCaseTransform: true,
+      }),
     ),
 
   updateMessage: (messageId, content) =>

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -40,10 +40,19 @@ const FIELD_ALIASES = [
   ["lastMessageImageUrl", "last_message_image_url"],
   ["latestMessageImageUrl", "latest_message_image_url"],
   ["fileName", "file_name"],
+  ["fileSize", "file_size"],
   ["fileUrl", "file_url"],
+  ["fileExpiresAt", "file_expires_at"],
+  ["fileDeletedAt", "file_deleted_at"],
   ["imageUrl", "image_url"],
   ["replyTo", "reply_to"],
+  ["replyToId", "reply_to_id"],
   ["unreadCount", "unread_count"],
+  ["readByUsers", "read_by_users"],
+  ["readCount", "read_count"],
+  ["recipientCount", "recipient_count"],
+  ["editedAt", "edited_at"],
+  ["isEdited", "is_edited"],
   ["membershipStatus", "membership_status"],
   ["memberStatus", "member_status"],
   ["roleName", "role_name"],
@@ -97,11 +106,20 @@ const normalizeChatMessage = (message) => {
   if (!message || typeof message !== "object") return message;
   const normalized = addCaseAliases(message);
   const sender = normalizeChatUser(normalized.sender);
+  const readByUsers = Array.isArray(normalized.readByUsers)
+    ? normalized.readByUsers.map(normalizeChatUser)
+    : normalized.readByUsers;
   const replyTo = normalizeChatMessage(normalized.replyTo);
 
   return {
     ...normalized,
     ...(sender !== undefined ? { sender } : {}),
+    ...(readByUsers !== undefined
+      ? {
+          readByUsers,
+          read_by_users: readByUsers,
+        }
+      : {}),
     ...(replyTo !== undefined
       ? {
           replyTo,
@@ -196,6 +214,37 @@ const normalizeConversationPayload = (payload) => {
   };
 };
 
+const normalizeMessagesPayload = (payload) => {
+  const rawMessages = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : Array.isArray(payload?.data?.messages)
+        ? payload.data.messages
+        : Array.isArray(payload?.messages)
+          ? payload.messages
+          : [];
+  const messages = rawMessages.map(normalizeChatMessage);
+  const hasMore =
+    payload?.hasMore ??
+    payload?.has_more ??
+    payload?.data?.hasMore ??
+    payload?.data?.has_more ??
+    false;
+
+  if (Array.isArray(payload)) {
+    return { data: messages, hasMore };
+  }
+
+  return {
+    ...payload,
+    data: messages,
+    hasMore,
+    has_more: payload?.has_more ?? hasMore,
+    ...(Array.isArray(payload?.messages) ? { messages } : {}),
+  };
+};
+
 const normalizeUnreadCountPayload = (payload) => {
   const data = payload?.data ?? payload ?? {};
   const rawFirstUnread = data.firstUnread ?? data.first_unread ?? null;
@@ -264,8 +313,11 @@ export const messageService = {
       () =>
         api.get(
           `/api/messages/conversations/${conversationId}/messages?${params.toString()}`,
+          {
+            skipResponseCaseTransform: true,
+          },
         ),
-    );
+    ).then(normalizeMessagesPayload);
   },
 
   sendMessage: (conversationId, content, type = "direct") =>

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -386,8 +386,15 @@ export const messageService = {
 
   updateMessage: (messageId, content) =>
     call(`updating message ${messageId}`, () =>
-      api.patch(`/api/messages/${messageId}`, { content: content.trim() }),
-    ),
+      api.patch(
+        `/api/messages/${messageId}`,
+        { content: content.trim() },
+        {
+          skipRequestCaseTransform: true,
+          skipResponseCaseTransform: true,
+        },
+      ),
+    ).then(normalizeMessagePayload),
 };
 
 export default messageService;

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -360,11 +360,18 @@ export const messageService = {
   // without the server's reason.
   startConversation: async (recipientId, initialMessage = "") => {
     try {
-      const response = await api.post("/api/messages/conversations", {
-        recipientId: parseInt(recipientId),
-        initialMessage: initialMessage.trim(),
-      });
-      return response.data;
+      const response = await api.post(
+        "/api/messages/conversations",
+        {
+          recipient_id: parseInt(recipientId, 10),
+          initial_message: initialMessage.trim(),
+        },
+        {
+          skipRequestCaseTransform: true,
+          skipResponseCaseTransform: true,
+        },
+      );
+      return normalizeConversationPayload(response.data).data;
     } catch (error) {
       console.error("Error starting conversation:", error);
       console.error("Error response:", error.response?.data);

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -245,6 +245,18 @@ const normalizeMessagesPayload = (payload) => {
   };
 };
 
+const normalizeMessagePayload = (payload) => {
+  const rawMessage = payload?.data ?? payload ?? null;
+  const message = normalizeChatMessage(rawMessage);
+
+  return payload?.data !== undefined
+    ? {
+        ...payload,
+        data: message,
+      }
+    : message;
+};
+
 const normalizeUnreadCountPayload = (payload) => {
   const data = payload?.data ?? payload ?? {};
   const rawFirstUnread = data.firstUnread ?? data.first_unread ?? null;
@@ -320,13 +332,28 @@ export const messageService = {
     ).then(normalizeMessagesPayload);
   },
 
-  sendMessage: (conversationId, content, type = "direct") =>
-    call(`sending message in conversation ${conversationId}`, () =>
-      api.post(`/api/messages/conversations/${conversationId}/messages`, {
-        content,
-        type,
-      }),
-    ),
+  sendMessage: (conversationId, content, type = "direct", options = {}) => {
+    const payload = {
+      content,
+      type,
+    };
+
+    if (options.imageUrl !== undefined) payload.image_url = options.imageUrl;
+    if (options.fileUrl !== undefined) payload.file_url = options.fileUrl;
+    if (options.fileName !== undefined) payload.file_name = options.fileName;
+    if (options.replyToId !== undefined) payload.reply_to_id = options.replyToId;
+
+    return call(`sending message in conversation ${conversationId}`, () =>
+      api.post(
+        `/api/messages/conversations/${conversationId}/messages`,
+        payload,
+        {
+          skipRequestCaseTransform: true,
+          skipResponseCaseTransform: true,
+        },
+      ),
+    ).then(normalizeMessagePayload);
+  },
 
   // Keeps explicit try/catch — logs the response body in addition to the
   // standard error log because conversation start failures are hard to debug

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -1,129 +1,79 @@
-import api from "./api";
+import api, { call } from "./api";
 
 let _pendingUnreadCount = null;
 
 export const messageService = {
-  // Get all conversations for the current user
-  getConversations: async () => {
-    try {
-      const response = await api.get("/api/messages/conversations");
-      return response.data;
-    } catch (error) {
-      console.error("Error fetching conversations:", error);
-      throw error;
-    }
-  },
+  getConversations: () =>
+    call("fetching conversations", () =>
+      api.get("/api/messages/conversations"),
+    ),
 
-  // Get unread message count for current user
-  // Deduplicates concurrent calls: multiple callers within the same tick share one HTTP request.
+  // Deduplicates concurrent calls: multiple callers within the same tick
+  // share one HTTP request.
   getUnreadCount: () => {
     if (_pendingUnreadCount) return _pendingUnreadCount;
 
-    _pendingUnreadCount = api
-      .get("/api/messages/unread-count")
-      .then((response) => response.data)
-      .catch((error) => {
-        console.error("Error fetching unread count:", error);
-        throw error;
-      })
-      .finally(() => {
-        _pendingUnreadCount = null;
-      });
+    _pendingUnreadCount = call("fetching unread count", () =>
+      api.get("/api/messages/unread-count"),
+    ).finally(() => {
+      _pendingUnreadCount = null;
+    });
 
     return _pendingUnreadCount;
   },
 
-  // Get a specific conversation by ID
-  getConversationById: async (conversationId, type = "direct") => {
-    try {
-      const response = await api.get(
-        `/api/messages/conversations/${conversationId}?type=${type}`
-      );
-      return response.data;
-    } catch (error) {
-      console.error(`Error fetching conversation ${conversationId}:`, error);
-      throw error;
-    }
+  getConversationById: (conversationId, type = "direct") =>
+    call(`fetching conversation ${conversationId}`, () =>
+      api.get(`/api/messages/conversations/${conversationId}?type=${type}`),
+    ),
+
+  getMessages: (conversationId, type = "direct", { before, limit } = {}) => {
+    const params = new URLSearchParams({ type });
+    if (before) params.append("before", before);
+    if (limit) params.append("limit", limit);
+    return call(
+      `fetching messages for conversation ${conversationId}`,
+      () =>
+        api.get(
+          `/api/messages/conversations/${conversationId}/messages?${params.toString()}`,
+        ),
+    );
   },
 
-  // Get messages for a specific conversation
-  getMessages: async (conversationId, type = "direct", { before, limit } = {}) => {
-    try {
-      const params = new URLSearchParams({ type });
-      if (before) params.append("before", before);
-      if (limit) params.append("limit", limit);
-      const response = await api.get(
-        `/api/messages/conversations/${conversationId}/messages?${params.toString()}`
-      );
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error fetching messages for conversation ${conversationId}:`,
-        error
-      );
-      throw error;
-    }
-  },
+  sendMessage: (conversationId, content, type = "direct") =>
+    call(`sending message in conversation ${conversationId}`, () =>
+      api.post(`/api/messages/conversations/${conversationId}/messages`, {
+        content,
+        type,
+      }),
+    ),
 
-  // Send a message in a conversation
-  sendMessage: async (conversationId, content, type = "direct") => {
-    try {
-      const response = await api.post(
-        `/api/messages/conversations/${conversationId}/messages`,
-        {
-          content,
-          type,
-        }
-      );
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error sending message in conversation ${conversationId}:`,
-        error
-      );
-      throw error;
-    }
-  },
-
-  // Start a new conversation with a user
+  // Keeps explicit try/catch — logs the response body in addition to the
+  // standard error log because conversation start failures are hard to debug
+  // without the server's reason.
   startConversation: async (recipientId, initialMessage = "") => {
     try {
       const response = await api.post("/api/messages/conversations", {
-        recipientId: parseInt(recipientId), // Ensure it's a number
+        recipientId: parseInt(recipientId),
         initialMessage: initialMessage.trim(),
       });
-
       return response.data;
     } catch (error) {
       console.error("Error starting conversation:", error);
-      console.error("Error response:", error.response?.data); // More detailed error
+      console.error("Error response:", error.response?.data);
       throw error;
     }
   },
 
-  // Soft-delete a message
-  deleteMessage: async (messageId) => {
-    try {
-      const response = await api.delete(`/api/messages/${messageId}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error deleting message ${messageId}:`, error);
-      throw error;
-    }
-  },
+  deleteMessage: (messageId) =>
+    call(`deleting message ${messageId}`, () =>
+      api.delete(`/api/messages/${messageId}`),
+    ),
 
-  // Edit a message
-  updateMessage: async (messageId, content) => {
-    try {
-      const response = await api.patch(`/api/messages/${messageId}`, {
-        content: content.trim(),
-      });
-      return response.data;
-    } catch (error) {
-      console.error(`Error updating message ${messageId}:`, error);
-      throw error;
-    }
-  },
+  updateMessage: (messageId, content) =>
+    call(`updating message ${messageId}`, () =>
+      api.patch(`/api/messages/${messageId}`, { content: content.trim() }),
+    ),
 };
 
 export default messageService;

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -2,6 +2,190 @@ import api, { call } from "./api";
 
 let _pendingUnreadCount = null;
 
+const FIELD_ALIASES = [
+  ["createdAt", "created_at"],
+  ["updatedAt", "updated_at"],
+  ["deletedAt", "deleted_at"],
+  ["readAt", "read_at"],
+  ["sentAt", "sent_at"],
+  ["conversationId", "conversation_id"],
+  ["partnerId", "partner_id"],
+  ["partnerUser", "partner_user"],
+  ["teamId", "team_id"],
+  ["teamName", "team_name"],
+  ["userId", "user_id"],
+  ["senderId", "sender_id"],
+  ["senderFirstName", "sender_first_name"],
+  ["senderLastName", "sender_last_name"],
+  ["senderUsername", "sender_username"],
+  ["senderAvatarUrl", "sender_avatar_url"],
+  ["receiverId", "receiver_id"],
+  ["recipientId", "recipient_id"],
+  ["firstName", "first_name"],
+  ["lastName", "last_name"],
+  ["avatarUrl", "avatar_url"],
+  ["teamavatarUrl", "teamavatar_url"],
+  ["isSynthetic", "is_synthetic"],
+  ["isPublic", "is_public"],
+  ["lastMessage", "last_message"],
+  ["latestMessage", "latest_message"],
+  ["recentMessage", "recent_message"],
+  ["lastMessageContent", "last_message_content"],
+  ["latestMessageContent", "latest_message_content"],
+  ["lastMessageFileName", "last_message_file_name"],
+  ["lastMessageFilename", "last_message_filename"],
+  ["latestMessageFileName", "latest_message_file_name"],
+  ["lastMessageFileUrl", "last_message_file_url"],
+  ["latestMessageFileUrl", "latest_message_file_url"],
+  ["lastMessageImageUrl", "last_message_image_url"],
+  ["latestMessageImageUrl", "latest_message_image_url"],
+  ["fileName", "file_name"],
+  ["fileUrl", "file_url"],
+  ["imageUrl", "image_url"],
+  ["replyTo", "reply_to"],
+  ["unreadCount", "unread_count"],
+  ["membershipStatus", "membership_status"],
+  ["memberStatus", "member_status"],
+  ["roleName", "role_name"],
+  ["removedAt", "removed_at"],
+  ["leftAt", "left_at"],
+];
+
+const addCaseAliases = (value, aliases = FIELD_ALIASES) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+
+  const next = { ...value };
+  aliases.forEach(([camelKey, snakeKey]) => {
+    if (next[camelKey] === undefined && next[snakeKey] !== undefined) {
+      next[camelKey] = next[snakeKey];
+    }
+    if (next[snakeKey] === undefined && next[camelKey] !== undefined) {
+      next[snakeKey] = next[camelKey];
+    }
+  });
+  return next;
+};
+
+const normalizeChatUser = (user) => addCaseAliases(user);
+
+const normalizeChatMember = (member) => {
+  if (!member || typeof member !== "object") return member;
+  const normalized = addCaseAliases(member);
+  const user = normalizeChatUser(normalized.user);
+  return {
+    ...normalized,
+    ...(user !== undefined ? { user } : {}),
+  };
+};
+
+const normalizeChatTeam = (team) => {
+  if (!team || typeof team !== "object") return team;
+  const normalized = addCaseAliases(team);
+  const members = Array.isArray(normalized.members)
+    ? normalized.members.map(normalizeChatMember)
+    : normalized.members;
+
+  return {
+    ...normalized,
+    ...(members !== undefined ? { members } : {}),
+  };
+};
+
+const normalizeChatMessage = (message) => {
+  if (!message || typeof message !== "object") return message;
+  const normalized = addCaseAliases(message);
+  const sender = normalizeChatUser(normalized.sender);
+  const replyTo = normalizeChatMessage(normalized.replyTo);
+
+  return {
+    ...normalized,
+    ...(sender !== undefined ? { sender } : {}),
+    ...(replyTo !== undefined
+      ? {
+          replyTo,
+          reply_to: replyTo,
+        }
+      : {}),
+  };
+};
+
+const normalizeConversation = (conversation) => {
+  if (!conversation || typeof conversation !== "object") return conversation;
+
+  const normalized = addCaseAliases(conversation);
+  const partner = normalizeChatUser(normalized.partner);
+  const partnerUser = normalizeChatUser(normalized.partnerUser);
+  const team = normalizeChatTeam(normalized.team);
+  const members = Array.isArray(normalized.members)
+    ? normalized.members.map(normalizeChatMember)
+    : normalized.members;
+  const lastMessage = normalizeChatMessage(normalized.lastMessage);
+  const latestMessage = normalizeChatMessage(normalized.latestMessage);
+  const recentMessage = normalizeChatMessage(normalized.recentMessage);
+
+  return {
+    ...normalized,
+    ...(partner !== undefined
+      ? {
+          partner,
+        }
+      : {}),
+    ...(partnerUser !== undefined
+      ? {
+          partnerUser,
+          partner_user: partnerUser,
+        }
+      : {}),
+    ...(team !== undefined ? { team } : {}),
+    ...(members !== undefined ? { members } : {}),
+    ...(lastMessage !== undefined
+      ? {
+          lastMessage,
+          last_message: lastMessage,
+        }
+      : {}),
+    ...(latestMessage !== undefined
+      ? {
+          latestMessage,
+          latest_message: latestMessage,
+        }
+      : {}),
+    ...(recentMessage !== undefined
+      ? {
+          recentMessage,
+          recent_message: recentMessage,
+        }
+      : {}),
+  };
+};
+
+const normalizeConversationListPayload = (payload) => {
+  const rawConversations = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : Array.isArray(payload?.data?.conversations)
+        ? payload.data.conversations
+        : Array.isArray(payload?.conversations)
+          ? payload.conversations
+          : [];
+  const conversations = rawConversations.map(normalizeConversation);
+
+  if (Array.isArray(payload)) {
+    return { data: conversations };
+  }
+
+  return {
+    ...payload,
+    data: conversations,
+    ...(Array.isArray(payload?.conversations)
+      ? { conversations }
+      : {}),
+  };
+};
+
 const normalizeUnreadCountPayload = (payload) => {
   const data = payload?.data ?? payload ?? {};
   const rawFirstUnread = data.firstUnread ?? data.first_unread ?? null;
@@ -33,8 +217,10 @@ const normalizeUnreadCountPayload = (payload) => {
 export const messageService = {
   getConversations: () =>
     call("fetching conversations", () =>
-      api.get("/api/messages/conversations"),
-    ),
+      api.get("/api/messages/conversations", {
+        skipResponseCaseTransform: true,
+      }),
+    ).then(normalizeConversationListPayload),
 
   // Deduplicates concurrent calls: multiple callers within the same tick
   // share one HTTP request.

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -126,19 +126,27 @@ export const notificationService = {
 
   // Mark a single notification as read
   markAsRead: async (notificationId) => {
-    const response = await api.put(`/api/notifications/${notificationId}/read`);
+    const response = await api.put(
+      `/api/notifications/${notificationId}/read`,
+      undefined,
+      { skipResponseCaseTransform: true },
+    );
     return response.data;
   },
 
   // Mark all notifications as read
   markAllAsRead: async () => {
-    const response = await api.put("/api/notifications/read-all");
+    const response = await api.put("/api/notifications/read-all", undefined, {
+      skipResponseCaseTransform: true,
+    });
     return response.data;
   },
 
   // Delete a notification
   deleteNotification: async (notificationId) => {
-    const response = await api.delete(`/api/notifications/${notificationId}`);
+    const response = await api.delete(`/api/notifications/${notificationId}`, {
+      skipResponseCaseTransform: true,
+    });
     return response.data;
   },
 };

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -1,19 +1,92 @@
 import api from "./api";
 
+const FIELD_ALIASES = [
+  ["createdAt", "created_at"],
+  ["updatedAt", "updated_at"],
+  ["readAt", "read_at"],
+  ["navigateTo", "navigate_to"],
+  ["referenceId", "reference_id"],
+  ["referenceType", "reference_type"],
+  ["recipientId", "recipient_id"],
+  ["senderId", "sender_id"],
+  ["teamId", "team_id"],
+  ["teamName", "team_name"],
+  ["roleId", "role_id"],
+  ["roleName", "role_name"],
+  ["memberId", "member_id"],
+  ["userId", "user_id"],
+  ["notificationType", "notification_type"],
+  ["filledRoleName", "filled_role_name"],
+  ["roleApplicationId", "role_application_id"],
+  ["roleInvitationId", "role_invitation_id"],
+];
+
+const addCaseAliases = (value, aliases = FIELD_ALIASES) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+
+  const next = { ...value };
+  aliases.forEach(([camelKey, snakeKey]) => {
+    if (next[camelKey] === undefined && next[snakeKey] !== undefined) {
+      next[camelKey] = next[snakeKey];
+    }
+    if (next[snakeKey] === undefined && next[camelKey] !== undefined) {
+      next[snakeKey] = next[camelKey];
+    }
+  });
+  return next;
+};
+
+const normalizeNotification = (notification) => {
+  if (!notification || typeof notification !== "object") {
+    return notification;
+  }
+
+  const metadata = addCaseAliases(notification.metadata);
+  return addCaseAliases({
+    ...notification,
+    ...(metadata !== undefined ? { metadata } : {}),
+  });
+};
+
+const normalizeNotificationListPayload = (payload) => {
+  if (Array.isArray(payload)) {
+    return payload.map(normalizeNotification);
+  }
+
+  if (Array.isArray(payload?.data)) {
+    return {
+      ...payload,
+      data: payload.data.map(normalizeNotification),
+    };
+  }
+
+  const data = payload?.data ?? payload ?? {};
+  const rawNotifications =
+    data.notifications ?? data.data ?? payload?.notifications ?? [];
+  const notifications = Array.isArray(rawNotifications)
+    ? rawNotifications.map(normalizeNotification)
+    : rawNotifications;
+  const nextPayload = {
+    ...payload,
+    ...(Array.isArray(payload?.notifications) ? { notifications } : {}),
+  };
+
+  return {
+    ...nextPayload,
+    data: {
+      ...data,
+      notifications,
+      data: Array.isArray(data.data) ? notifications : data.data,
+    },
+  };
+};
+
 const normalizeUnreadCountPayload = (payload) => {
   const data = payload?.data ?? payload ?? {};
   const rawFirstUnread = data.firstUnread ?? data.first_unread ?? null;
-  const firstUnread = rawFirstUnread
-    ? {
-        ...rawFirstUnread,
-        navigateTo: rawFirstUnread.navigateTo ?? rawFirstUnread.navigate_to,
-        navigate_to: rawFirstUnread.navigate_to ?? rawFirstUnread.navigateTo,
-        referenceId:
-          rawFirstUnread.referenceId ?? rawFirstUnread.reference_id,
-        reference_id:
-          rawFirstUnread.reference_id ?? rawFirstUnread.referenceId,
-      }
-    : null;
+  const firstUnread = normalizeNotification(rawFirstUnread);
   const typeCounts = data.typeCounts ?? data.type_counts ?? {};
   const typeTeamCounts = data.typeTeamCounts ?? data.type_team_counts ?? {};
 
@@ -45,9 +118,10 @@ export const notificationService = {
   getNotifications: async (params = {}) => {
     const { limit = 50, offset = 0, unreadOnly = false } = params;
     const response = await api.get("/api/notifications", {
+      skipResponseCaseTransform: true,
       params: { limit, offset, unreadOnly },
     });
-    return response.data;
+    return normalizeNotificationListPayload(response.data);
   },
 
   // Mark a single notification as read

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -1,10 +1,44 @@
 import api from "./api";
 
+const normalizeUnreadCountPayload = (payload) => {
+  const data = payload?.data ?? payload ?? {};
+  const rawFirstUnread = data.firstUnread ?? data.first_unread ?? null;
+  const firstUnread = rawFirstUnread
+    ? {
+        ...rawFirstUnread,
+        navigateTo: rawFirstUnread.navigateTo ?? rawFirstUnread.navigate_to,
+        navigate_to: rawFirstUnread.navigate_to ?? rawFirstUnread.navigateTo,
+        referenceId:
+          rawFirstUnread.referenceId ?? rawFirstUnread.reference_id,
+        reference_id:
+          rawFirstUnread.reference_id ?? rawFirstUnread.referenceId,
+      }
+    : null;
+  const typeCounts = data.typeCounts ?? data.type_counts ?? {};
+  const typeTeamCounts = data.typeTeamCounts ?? data.type_team_counts ?? {};
+
+  return {
+    ...payload,
+    data: {
+      ...data,
+      count: data.count ?? 0,
+      firstUnread,
+      first_unread: firstUnread,
+      typeCounts,
+      type_counts: typeCounts,
+      typeTeamCounts,
+      type_team_counts: typeTeamCounts,
+    },
+  };
+};
+
 export const notificationService = {
   // Get unread notification count and first unread
   getUnreadCount: async () => {
-    const response = await api.get("/api/notifications/unread-count");
-    return response.data;
+    const response = await api.get("/api/notifications/unread-count", {
+      skipResponseCaseTransform: true,
+    });
+    return normalizeUnreadCountPayload(response.data);
   },
 
   // Get all notifications

--- a/src/services/tagService.js
+++ b/src/services/tagService.js
@@ -1,4 +1,4 @@
-import api from "./api";
+import api, { call } from "./api";
 
 const TAG_CACHE_TTL_MS = 10 * 60 * 1000;
 
@@ -81,28 +81,18 @@ export const tagService = {
 
   // Create a new tag
   createTag: async (tagData) => {
-    try {
-      const response = await api.post("/api/tags/create", tagData);
-      clearTagCaches();
-      return response.data;
-    } catch (error) {
-      console.error("Error creating tag:", error);
-      throw error;
-    }
+    const data = await call("creating tag", () =>
+      api.post("/api/tags/create", tagData),
+    );
+    clearTagCaches();
+    return data;
   },
 
   // Search tags
-  searchTags: async (query) => {
-    try {
-      const response = await api.get("/api/tags/search", {
-        params: { query },
-      });
-      return response.data;
-    } catch (error) {
-      console.error("Error searching tags:", error);
-      throw error;
-    }
-  },
+  searchTags: (query) =>
+    call("searching tags", () =>
+      api.get("/api/tags/search", { params: { query } }),
+    ),
   // NEW METHODS FOR AUTOCOMPLETE
 
   /**

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -1,46 +1,38 @@
-import api from "./api";
+import api, { call } from "./api";
 
 export const teamService = {
-  // Create a new team
+  // Create a new team — keeps explicit try/catch for the extra response-data
+  // log on failure (the axios interceptor logs error.response.data too, but
+  // this duplicate aids debugging team-creation specifically).
   createTeam: async (teamData) => {
     try {
-      // Ensure tags are properly formatted
       const formattedTags =
         teamData.tags?.map((tag) => {
           if (typeof tag === "object" && tag.tag_id) {
-            // If it's already an object with tag_id, ensure it's a number
             return { tag_id: parseInt(tag.tag_id, 10) };
           } else if (typeof tag === "number") {
-            // If it's already a number, use it directly
             return { tag_id: tag };
           } else {
-            // Otherwise, try to parse it as a number
             return { tag_id: parseInt(tag, 10) };
           }
         }) || [];
 
-      // Make sure is_public is properly set as a boolean
       const isPublic = teamData.is_public === true;
 
-      // 🔧 Correct handling of max_members:
-      // - null  -> stays null       (unlimited)
-      // - number/string -> parsed
-      // - undefined/empty -> default (20)
+      // max_members: null = unlimited; missing/empty = 20 (default)
       let maxMembers;
-
       if (teamData.max_members === null) {
-        maxMembers = null; // unlimited
+        maxMembers = null;
       } else if (
         teamData.max_members === undefined ||
         teamData.max_members === ""
       ) {
-        maxMembers = 20; // fallback default
+        maxMembers = 20;
       } else {
         const parsed = parseInt(teamData.max_members, 10);
         maxMembers = Number.isNaN(parsed) ? 20 : parsed;
       }
 
-      // Create validated team data with the avatar URL
       const validatedTeamData = {
         name: teamData.name,
         description: teamData.description || "",
@@ -49,7 +41,6 @@ export const teamService = {
         tags: formattedTags,
         teamavatar_url:
           teamData.teamavatar_url || teamData.teamavatarUrl || null,
-        // ADD THESE LOCATION FIELDS:
         is_remote: teamData.is_remote ?? false,
         postal_code: teamData.is_remote ? null : teamData.postal_code || null,
         city: teamData.is_remote ? null : teamData.city || null,
@@ -65,28 +56,18 @@ export const teamService = {
     }
   },
 
-  getUserPendingApplications: async () => {
-    try {
-      const response = await api.get(`/api/teams/applications/user`);
-      return response.data;
-    } catch (error) {
-      console.error("Error fetching user pending applications:", error);
-      throw error;
-    }
-  },
+  getUserPendingApplications: () =>
+    call("fetching user pending applications", () =>
+      api.get(`/api/teams/applications/user`),
+    ),
 
-  cancelApplication: async (applicationId) => {
-    try {
-      const response = await api.delete(
-        `/api/teams/applications/${applicationId}`,
-      );
-      return response.data;
-    } catch (error) {
-      console.error(`Error canceling application ${applicationId}:`, error);
-      throw error;
-    }
-  },
+  cancelApplication: (applicationId) =>
+    call(`canceling application ${applicationId}`, () =>
+      api.delete(`/api/teams/applications/${applicationId}`),
+    ),
 
+  // Keeps explicit try/catch — suppresses the error log for the expected
+  // 403 case when the caller opted in via skipAuthRedirect.
   getTeamApplications: async (teamId, requestConfig = {}) => {
     try {
       const response = await api.get(
@@ -102,15 +83,18 @@ export const teamService = {
     }
   },
 
-  handleTeamApplication: async (applicationId, action, response = "", fillRole = false) => {
+  // Keeps explicit try/catch — re-throws a wrapped Error with a friendlier
+  // message extracted from the server response.
+  handleTeamApplication: async (
+    applicationId,
+    action,
+    response = "",
+    fillRole = false,
+  ) => {
     try {
       const apiResponse = await api.put(
         `/api/teams/applications/${applicationId}`,
-        {
-          action,
-          response,
-          fillRole,
-        },
+        { action, response, fillRole },
       );
       return apiResponse.data;
     } catch (error) {
@@ -123,75 +107,40 @@ export const teamService = {
     }
   },
 
-  applyToJoinTeam: async (teamId, applicationData) => {
-    try {
-      const response = await api.post(
-        `/api/teams/${teamId}/apply`,
-        applicationData,
-      );
-      return response.data;
-    } catch (error) {
-      console.error(`Error applying to join team ${teamId}:`, error);
-      throw error;
-    }
-  },
+  applyToJoinTeam: (teamId, applicationData) =>
+    call(`applying to join team ${teamId}`, () =>
+      api.post(`/api/teams/${teamId}/apply`, applicationData),
+    ),
 
-  // Delete a team
-  deleteTeam: async (teamId) => {
-    try {
-      const response = await api.delete(`/api/teams/${teamId}`);
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error deleting team ${teamId}:`,
-        error.response ? error.response.data : error.message,
-      );
-      throw error;
-    }
-  },
+  deleteTeam: (teamId) =>
+    call(`deleting team ${teamId}`, () => api.delete(`/api/teams/${teamId}`)),
 
-  // Fetch all teams
-  getAllTeams: async (params = {}) => {
-    try {
-      const response = await api.get("/api/teams", { params });
-      return response.data;
-    } catch (error) {
-      console.error(
-        "Error fetching teams:",
-        error.response ? error.response.data : error.message,
-      );
-      throw error;
-    }
-  },
+  getAllTeams: (params = {}) =>
+    call("fetching teams", () => api.get("/api/teams", { params })),
 
-  // Fetch a single team by ID
-
+  // Keeps explicit try/catch — post-processes response to normalize boolean
+  // flags on the team and its members.
   getTeamById: async (teamId) => {
     const normalizeBoolean = (v) => {
       if (v === true) return true;
       if (v === false) return false;
-
       if (typeof v === "string") {
         const s = v.trim().toLowerCase();
         if (["true", "1", "t", "yes", "y"].includes(s)) return true;
         if (["false", "0", "f", "no", "n"].includes(s)) return false;
       }
-
       if (typeof v === "number") return v === 1;
-
       return undefined;
     };
 
     try {
       const response = await api.get(`/api/teams/${teamId}`);
 
-      // Backend returns: { success: true, data: team }
       const teamData = response.data?.data || response.data;
       if (!Array.isArray(teamData.members)) teamData.members = [];
 
       if (teamData && typeof teamData === "object") {
         teamData.is_public = normalizeBoolean(teamData.is_public);
-
         if (teamData.members && Array.isArray(teamData.members)) {
           teamData.members = teamData.members.map((member) => ({
             ...member,
@@ -207,89 +156,57 @@ export const teamService = {
     }
   },
 
-  // **
-  //  * Fetches all badge awards for team members linked to team focus areas.
-  //  * Returns rows in the same shape as user badge awards, with extra
-  //  * awarded_to_* fields for the recipient.
-  //  * @param {string|number} teamId - The team ID
-  //  * @returns {Promise<object>} { success: true, data: [...awards] }
-  //  */
-  getTeamBadgeAwards: async (teamId) => {
-    try {
-      const response = await api.get(`/api/teams/${teamId}/badge-awards`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error fetching badge awards for team ${teamId}:`, error);
-      throw error;
-    }
-  },
+  /**
+   * Fetches all badge awards for team members linked to team focus areas.
+   * Same shape as user badge awards, with extra awarded_to_* fields.
+   * @returns {Promise<object>} { success: true, data: [...awards] }
+   */
+  getTeamBadgeAwards: (teamId) =>
+    call(`fetching badge awards for team ${teamId}`, () =>
+      api.get(`/api/teams/${teamId}/badge-awards`),
+    ),
 
   /**
-   * Fetches aggregated badge summary for all members of a team.
-   * Returns one row per badge with total credits, award counts, etc.
-   * Shape is compatible with BadgesDisplaySection.
-   *
-   * @param {string|number} teamId - The team ID
-   * @returns {Promise<object>} { success: true, data: [...badges], meta: { totalCredits } }
+   * Aggregated badge summary for all members of a team. One row per badge
+   * with total credits and award counts. Compatible with BadgesDisplaySection.
+   * @returns {Promise<object>} { success, data: [...badges], meta: { totalCredits } }
    */
-  getTeamMemberBadges: async (teamId) => {
-    try {
-      const response = await api.get(`/api/teams/${teamId}/member-badges`);
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error fetching member badges for team ${teamId}:`,
-        error,
-      );
-      throw error;
-    }
-  },
+  getTeamMemberBadges: (teamId) =>
+    call(`fetching member badges for team ${teamId}`, () =>
+      api.get(`/api/teams/${teamId}/member-badges`),
+    ),
 
   /**
    * Bulk variant of getTeamMemberBadges for multiple teams in a single
    * request. Returns { data: { [teamId]: [...badges] }, meta: { ... } }.
    */
-  getMemberBadgesForTeams: async (teamIds) => {
-    try {
-      const ids = Array.isArray(teamIds) ? teamIds.filter(Boolean) : [];
-      if (ids.length === 0) {
-        return { success: true, data: {}, meta: { totalCreditsByTeam: {} } };
-      }
-      const response = await api.get(
-        `/api/teams/member-badges?teamIds=${ids.join(",")}`,
-      );
-      return response.data;
-    } catch (error) {
-      console.error("Error fetching bulk team member badges:", error);
-      throw error;
+  getMemberBadgesForTeams: (teamIds) => {
+    const ids = Array.isArray(teamIds) ? teamIds.filter(Boolean) : [];
+    if (ids.length === 0) {
+      return Promise.resolve({
+        success: true,
+        data: {},
+        meta: { totalCreditsByTeam: {} },
+      });
     }
+    return call("fetching bulk team member badges", () =>
+      api.get(`/api/teams/member-badges?teamIds=${ids.join(",")}`),
+    );
   },
 
   /**
-   * Fetches ALL badge awards for team members (not filtered by focus areas).
+   * ALL badge awards for team members (not filtered by focus areas).
    * Used by badge category and badge pill drill-down modals.
-   * Same row shape as getTeamBadgeAwards but without focus-area filtering.
-   *
-   * @param {string|number} teamId - The team ID
-   * @returns {Promise<object>} { success: true, data: [...awards] }
    */
-  getTeamMemberBadgeAwards: async (teamId) => {
-    try {
-      const response = await api.get(`/api/teams/${teamId}/member-badge-awards`);
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error fetching member badge awards for team ${teamId}:`,
-        error,
-      );
-      throw error;
-    }
-  },
+  getTeamMemberBadgeAwards: (teamId) =>
+    call(`fetching member badge awards for team ${teamId}`, () =>
+      api.get(`/api/teams/${teamId}/member-badge-awards`),
+    ),
 
-  // Update team details
+  // Keeps explicit try/catch — complex tag + location normalization needs to
+  // happen before the request.
   updateTeam: async (teamId, teamData) => {
     try {
-      // Ensure tags are properly formatted
       const formattedTags =
         teamData.tags?.map((tag) => {
           if (typeof tag === "object" && tag.tag_id) {
@@ -301,9 +218,8 @@ export const teamService = {
           }
         }) || [];
 
-      // --- Location normalization (accept snake_case or camelCase) ---
+      // Accept either snake_case or camelCase from the caller
       const isRemote = teamData.is_remote ?? teamData.isRemote ?? false;
-
       const toNullOrTrimmed = (v) => {
         if (v === null || v === undefined) return null;
         const s = String(v).trim();
@@ -317,12 +233,9 @@ export const teamService = {
       const state = isRemote ? null : toNullOrTrimmed(teamData.state);
       const country = isRemote ? null : toNullOrTrimmed(teamData.country);
 
-      // Create payload (prefer snake_case for backend)
       const dataToSend = {
         ...teamData,
         tags: formattedTags,
-
-        // ensure backend gets the right fields
         is_remote: Boolean(isRemote),
         postal_code,
         city,
@@ -339,7 +252,7 @@ export const teamService = {
           teamData.teamavatar_url || teamData.teamavatarUrl || null;
       }
 
-      // Optional: remove camelCase duplicates so you don't send both
+      // Remove camelCase duplicates so we don't send both forms
       delete dataToSend.isRemote;
       delete dataToSend.postalCode;
 
@@ -356,81 +269,39 @@ export const teamService = {
 
   /**
    * Deletes the team's avatar image and removes it from the team.
-   * @param {string|number} teamId - The ID of the team whose avatar to delete.
-   * @returns {Promise<object>} A promise resolving to the deletion result.
    */
-  deleteTeamAvatar: async (teamId) => {
-    try {
-      const response = await api.delete(`/api/teams/${teamId}/avatar`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error deleting avatar for team ${teamId}:`, error);
-      throw error;
-    }
-  },
+  deleteTeamAvatar: (teamId) =>
+    call(`deleting avatar for team ${teamId}`, () =>
+      api.delete(`/api/teams/${teamId}/avatar`),
+    ),
 
-  // Add a member to a team
-  addTeamMember: async (teamId, userId) => {
-    try {
-      const response = await api.post(`/api/teams/${teamId}/members`, {
-        memberId: userId,
-      });
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error adding member to team ${teamId}:`,
-        error.response ? error.response.data : error.message,
-      );
-      throw error;
-    }
-  },
+  addTeamMember: (teamId, userId) =>
+    call(`adding member to team ${teamId}`, () =>
+      api.post(`/api/teams/${teamId}/members`, { memberId: userId }),
+    ),
 
-  // Remove a member from a team
-  removeTeamMember: async (teamId, userId) => {
-    try {
-      const response = await api.delete(
-        `/api/teams/${teamId}/members/${userId}`,
-      );
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error removing member from team ${teamId}:`,
-        error.response ? error.response.data : error.message,
-      );
-      throw error;
-    }
-  },
+  removeTeamMember: (teamId, userId) =>
+    call(`removing member from team ${teamId}`, () =>
+      api.delete(`/api/teams/${teamId}/members/${userId}`),
+    ),
 
   /**
-   * Get all teams of the user with pagination
-   * @param {number} userId - User ID
-   * @param {number} page - Page number (default: 1)
-   * @param {number} limit - Results per page (default: 10)
+   * Get all teams of the user with pagination.
+   * @param {number} userId
+   * @param {{page?: number, limit?: number}} [opts]
    * @returns {Promise<Object>} User teams with pagination metadata
    */
-  getUserTeams: async (userId, { page = 1, limit = 10 } = {}) => {
-    try {
-      if (!userId) {
-        throw new Error("User ID is required");
-      }
-      const response = await api.get(`/api/teams/my-teams`, {
-        params: {
-          userId,
-          page,
-          limit,
-        },
-      });
-      return response.data;
-    } catch (error) {
-      console.error(
-        "Error fetching user teams:",
-        error.response ? error.response.data : error.message,
-      );
-      throw error;
+  getUserTeams: (userId, { page = 1, limit = 10 } = {}) => {
+    if (!userId) {
+      return Promise.reject(new Error("User ID is required"));
     }
+    return call("fetching user teams", () =>
+      api.get(`/api/teams/my-teams`, { params: { userId, page, limit } }),
+    );
   },
 
-  // Get user role in a team
+  // Keeps explicit try/catch — returns a synthetic default on error rather
+  // than rethrowing, so callers can render without role info.
   getUserRoleInTeam: async (teamId, userId) => {
     try {
       const response = await api.get(
@@ -442,34 +313,18 @@ export const teamService = {
         `Error fetching user role in team ${teamId}:`,
         error.response ? error.response.data : error.message,
       );
-      return { data: { role: null } }; // Return a default response on error
+      return { data: { role: null } };
     }
   },
 
-  // Update member role in a team
-  updateMemberRole: async (teamId, memberId, newRole) => {
-    try {
-      const response = await api.put(
-        `/api/teams/${teamId}/members/${memberId}/role`,
-        {
-          newRole: newRole,
-        },
-      );
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error updating member role in team ${teamId}:`,
-        error.response ? error.response.data : error.message,
-      );
-      throw error;
-    }
-  },
+  updateMemberRole: (teamId, memberId, newRole) =>
+    call(`updating member role in team ${teamId}`, () =>
+      api.put(`/api/teams/${teamId}/members/${memberId}/role`, { newRole }),
+    ),
 
   // ==================== INVITATION METHODS ====================
 
-  /**
-   * Get all pending invitations sent by a specific team
-   */
+  // Keeps explicit try/catch — suppresses log for the expected 403 case.
   getTeamSentInvitations: async (teamId, requestConfig = {}) => {
     try {
       const response = await api.get(
@@ -488,49 +343,30 @@ export const teamService = {
     }
   },
 
-  getTeamsWhereUserCanInvite: async (inviteeId = null) => {
-    try {
-      const params = inviteeId ? { inviteeId } : {};
-      const response = await api.get("/api/teams/can-invite", { params });
-      return response.data;
-    } catch (error) {
-      console.error("Error fetching teams for invite:", error);
-      throw error;
-    }
+  getTeamsWhereUserCanInvite: (inviteeId = null) => {
+    const params = inviteeId ? { inviteeId } : {};
+    return call("fetching teams for invite", () =>
+      api.get("/api/teams/can-invite", { params }),
+    );
   },
 
-  sendInvitation: async (teamId, inviteeId, message = "", roleId = null) => {
-    try {
-      const invitationData = {
-        inviteeId,
-        message,
-      };
-
-      if (roleId !== null && roleId !== undefined) {
-        invitationData.roleId = roleId;
-      }
-
-      const response = await api.post(
-        `/api/teams/${teamId}/invitations`,
-        invitationData,
-      );
-      return response.data;
-    } catch (error) {
-      console.error(`Error sending invitation to team ${teamId}:`, error);
-      throw error;
+  sendInvitation: (teamId, inviteeId, message = "", roleId = null) => {
+    const invitationData = { inviteeId, message };
+    if (roleId !== null && roleId !== undefined) {
+      invitationData.roleId = roleId;
     }
+    return call(`sending invitation to team ${teamId}`, () =>
+      api.post(`/api/teams/${teamId}/invitations`, invitationData),
+    );
   },
 
-  getUserReceivedInvitations: async () => {
-    try {
-      const response = await api.get("/api/teams/invitations/received");
-      return response.data;
-    } catch (error) {
-      console.error("Error fetching received invitations:", error);
-      throw error;
-    }
-  },
+  getUserReceivedInvitations: () =>
+    call("fetching received invitations", () =>
+      api.get("/api/teams/invitations/received"),
+    ),
 
+  // Keeps explicit try/catch — re-throws a wrapped Error with a friendlier
+  // message extracted from the server response.
   respondToInvitation: async (
     invitationId,
     action,
@@ -556,28 +392,15 @@ export const teamService = {
     }
   },
 
-  cancelInvitation: async (invitationId) => {
-    try {
-      const response = await api.delete(
-        `/api/teams/invitations/${invitationId}`,
-      );
-      return response.data;
-    } catch (error) {
-      console.error(`Error canceling invitation ${invitationId}:`, error);
-      throw error;
-    }
-  },
+  cancelInvitation: (invitationId) =>
+    call(`canceling invitation ${invitationId}`, () =>
+      api.delete(`/api/teams/invitations/${invitationId}`),
+    ),
 
-  cancelRoleInvitation: async (invitationId) => {
-    try {
-      const response = await api.delete(
-        `/api/teams/invitations/${invitationId}/role`,
-      );
-      return response.data;
-    } catch (error) {
-      console.error(`Error canceling role invitation ${invitationId}:`, error);
-      throw error;
-    }
-  },
+  cancelRoleInvitation: (invitationId) =>
+    call(`canceling role invitation ${invitationId}`, () =>
+      api.delete(`/api/teams/invitations/${invitationId}/role`),
+    ),
 };
+
 export default teamService;

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -246,6 +246,26 @@ export const teamService = {
   },
 
   /**
+   * Bulk variant of getTeamMemberBadges for multiple teams in a single
+   * request. Returns { data: { [teamId]: [...badges] }, meta: { ... } }.
+   */
+  getMemberBadgesForTeams: async (teamIds) => {
+    try {
+      const ids = Array.isArray(teamIds) ? teamIds.filter(Boolean) : [];
+      if (ids.length === 0) {
+        return { success: true, data: {}, meta: { totalCreditsByTeam: {} } };
+      }
+      const response = await api.get(
+        `/api/teams/member-badges?teamIds=${ids.join(",")}`,
+      );
+      return response.data;
+    } catch (error) {
+      console.error("Error fetching bulk team member badges:", error);
+      throw error;
+    }
+  },
+
+  /**
    * Fetches ALL badge awards for team members (not filtered by focus areas).
    * Used by badge category and badge pill drill-down modals.
    * Same row shape as getTeamBadgeAwards but without focus-area filtering.

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,4 +1,28 @@
 import api, { call } from "./api";
+import { snakeToCamel } from "../utils/formatters";
+
+// Preserves both snake_case and camelCase keys so callers that read either
+// casing keep working — many user-facing components defensively read both.
+const normalizeUserPayload = (payload) => {
+  const rawUser = payload?.data ?? payload ?? null;
+  if (!rawUser || typeof rawUser !== "object" || Array.isArray(rawUser)) {
+    return payload;
+  }
+
+  const normalized = { ...rawUser, ...snakeToCamel(rawUser) };
+
+  if (Array.isArray(rawUser.badges)) {
+    normalized.badges = rawUser.badges.map((badge) =>
+      badge && typeof badge === "object"
+        ? { ...badge, ...snakeToCamel(badge) }
+        : badge,
+    );
+  }
+
+  return payload?.data !== undefined
+    ? { ...payload, data: normalized }
+    : normalized;
+};
 
 export const userService = {
   /**
@@ -8,8 +32,10 @@ export const userService = {
    */
   getUserById: (userId) =>
     call(`fetching user details for ID ${userId}`, () =>
-      api.get(`/api/users/${userId}`),
-    ),
+      api.get(`/api/users/${userId}`, {
+        skipResponseCaseTransform: true,
+      }),
+    ).then(normalizeUserPayload),
 
   searchUsers: (query) =>
     api.get(`/api/users?search=${encodeURIComponent(query)}`),

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,39 +1,29 @@
-import api from "./api"; // Import the configured Axios instance
+import api, { call } from "./api";
 
-// Define the user service object
 export const userService = {
   /**
    * Fetches user details by their ID.
    * @param {string|number} userId - The ID of the user to fetch.
    * @returns {Promise<object>} A promise resolving to the user data.
    */
-  getUserById: async (userId) => {
-    try {
-      // Make GET request to the user endpoint
-      const response = await api.get(`/api/users/${userId}`);
-
-      // Return the data from the response (already converted to camelCase by interceptor)
-      return response.data;
-    } catch (error) {
-      // Log and re-throw errors for handling by the calling component
-      console.error(`Error fetching user details for ID ${userId}:`, error);
-      throw error;
-    }
-  },
+  getUserById: (userId) =>
+    call(`fetching user details for ID ${userId}`, () =>
+      api.get(`/api/users/${userId}`),
+    ),
 
   searchUsers: (query) =>
     api.get(`/api/users?search=${encodeURIComponent(query)}`),
 
   /**
-   * Updates user details. Includes a temporary mock fallback for development.
-   * @param {string|number} userId - The ID of the user to update.
-   * @param {object} userData - An object containing the user data fields to update (in camelCase).
-   * @returns {Promise<object>} A promise resolving to the backend response (or mock response).
+   * Updates user details. Keeps the verbose error block because we want the
+   * request payload in the log when the backend rejects an update.
+   * @param {string|number} userId
+   * @param {object} userData - Fields to update (camelCase).
+   * @returns {Promise<object>}
    */
   updateUser: async (userId, userData) => {
     try {
       const response = await api.put(`/api/users/${userId}`, userData);
-
       return response.data;
     } catch (error) {
       console.error("Error updating user:", error);
@@ -47,176 +37,108 @@ export const userService = {
     }
   },
 
-  // --- User Tags Functions ---
-  getUserTags: async (userId) => {
-    try {
-      const response = await api.get(`/api/users/${userId}/tags`);
-      return response.data; // Assumes backend returns { success: true, data: [...] }
-    } catch (error) {
-      console.error(`Error fetching user tags for ID ${userId}:`, error);
-      throw error;
-    }
-  },
+  // --- User Tags ---
+  getUserTags: (userId) =>
+    call(`fetching user tags for ID ${userId}`, () =>
+      api.get(`/api/users/${userId}/tags`),
+    ),
 
-  updateUserTags: async (userId, tagIds) => {
-    // tagIds is likely an array of numbers/strings
-    try {
-      // Backend expects payload like { tags: [{ tag_id: 1 }, { tag_id: 3 }] }
-      // The request interceptor handles converting the outer object keys to snake_case,
-      // but ensure the payload structure matches the backend controller's expectation.
-      // If backend expects snake_case { tag_id: ... }, send { tagId: ... } from here.
-      const payload = {
-        tags: tagIds.map((id) => ({ tagId: id })), // Send camelCase `tagId` here
-      };
-      const response = await api.put(`/api/users/${userId}/tags`, payload);
-      return response.data;
-    } catch (error) {
-      console.error(`Error updating user tags for ID ${userId}:`, error);
-      throw error;
-    }
-  },
+  updateUserTags: (userId, tagIds) =>
+    call(`updating user tags for ID ${userId}`, () =>
+      api.put(`/api/users/${userId}/tags`, {
+        // Backend expects { tags: [{ tag_id: ... }] }; send camelCase tagId
+        // here and rely on the request interceptor to convert to snake_case.
+        tags: tagIds.map((id) => ({ tagId: id })),
+      }),
+    ),
 
   /**
    * Fetches badges for a specific user.
-   * @param {string|number} userId - The ID of the user whose badges to fetch.
-   * @returns {Promise<object>} A promise resolving to the user's badges.
+   * @param {string|number} userId
+   * @returns {Promise<object>}
    */
-  getUserBadges: async (userId) => {
-    try {
-      const response = await api.get(`/api/users/${userId}/badges`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error fetching badges for user ${userId}:`, error);
-      throw error;
-    }
-  },
+  getUserBadges: (userId) =>
+    call(`fetching badges for user ${userId}`, () =>
+      api.get(`/api/users/${userId}/badges`),
+    ),
 
   /**
    * Hide or unhide one awarded badge event on the current user's profile.
-   * @param {string|number} userId - The profile owner.
-   * @param {string|number} awardId - The awarded badge event ID to update.
-   * @param {boolean} hidden - Whether the badge should be hidden.
-   * @returns {Promise<object>} A promise resolving to the updated visibility payload.
+   * @param {string|number} userId
+   * @param {string|number} awardId
+   * @param {boolean} hidden
+   * @returns {Promise<object>}
    */
-  updateUserBadgeVisibility: async (userId, awardId, hidden = true) => {
-    try {
-      const response = await api.patch(
-        `/api/users/${userId}/badges/awards/${awardId}/visibility`,
-        { hidden },
-      );
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error updating badge award ${awardId} visibility for user ${userId}:`,
-        error,
-      );
-      throw error;
-    }
-  },
+  updateUserBadgeVisibility: (userId, awardId, hidden = true) =>
+    call(
+      `updating badge award ${awardId} visibility for user ${userId}`,
+      () =>
+        api.patch(
+          `/api/users/${userId}/badges/awards/${awardId}/visibility`,
+          { hidden },
+        ),
+    ),
 
   /**
    * Delete one awarded badge event from the current user's profile.
-   * @param {string|number} userId - The profile owner.
-   * @param {string|number} awardId - The awarded badge event ID.
-   * @returns {Promise<object>} A promise resolving to the deletion result.
+   * @param {string|number} userId
+   * @param {string|number} awardId
+   * @returns {Promise<object>}
    */
-  deleteUserBadgeAward: async (userId, awardId) => {
-    try {
-      const response = await api.delete(`/api/badges/awards/${awardId}`);
-      return response.data;
-    } catch (error) {
-      console.error(
-        `Error deleting badge award ${awardId} for user ${userId}:`,
-        error,
-      );
-      throw error;
-    }
-  },
+  deleteUserBadgeAward: (userId, awardId) =>
+    call(`deleting badge award ${awardId} for user ${userId}`, () =>
+      api.delete(`/api/badges/awards/${awardId}`),
+    ),
 
   /**
    * Fetches a preview of everything affected by deleting the current user's account.
-   * @param {string|number} userId - The ID of the user to preview deletion for.
-   * @param {string} password - The user's current password.
-   * @returns {Promise<object>} A promise resolving to the deletion preview data.
+   * @param {string|number} userId
+   * @param {string} password
+   * @returns {Promise<object>}
    */
-  deletionPreview: async (userId, password) => {
-    try {
-      const response = await api.post(
+  deletionPreview: (userId, password) =>
+    call(`fetching deletion preview for user ${userId}`, () =>
+      api.post(
         `/api/users/${userId}/deletion-preview`,
         { password },
         { skipAuthRedirect: true },
-      );
-      return response.data;
-    } catch (error) {
-      console.error(`Error fetching deletion preview for user ${userId}:`, error);
-      throw error;
-    }
-  },
+      ),
+    ),
 
   /**
    * Deletes the current user's profile and all associated data.
-   * @param {string|number} userId - The ID of the user to delete.
-   * @param {string} password - The user's current password.
-   * @param {Array<object>} ownershipOverrides - Optional ownership transfer overrides.
-   * @returns {Promise<object>} A promise resolving to the deletion result.
+   * @param {string|number} userId
+   * @param {string} password
+   * @param {Array<object>} ownershipOverrides
+   * @returns {Promise<object>}
    */
-  deleteUser: async (userId, password, ownershipOverrides = []) => {
-    try {
-      const response = await api.delete(`/api/users/${userId}`, {
-        data: {
-          password,
-          ownershipOverrides,
-        },
+  deleteUser: (userId, password, ownershipOverrides = []) =>
+    call(`deleting user ${userId}`, () =>
+      api.delete(`/api/users/${userId}`, {
+        data: { password, ownershipOverrides },
         skipAuthRedirect: true,
-      });
-      return response.data;
-    } catch (error) {
-      console.error(`Error deleting user ${userId}:`, error);
-      throw error;
-    }
-  },
+      }),
+    ),
 
   /**
    * Deletes the user's avatar image and removes it from the profile.
-   * @param {string|number} userId - The ID of the user whose avatar to delete.
-   * @returns {Promise<object>} A promise resolving to the deletion result.
+   * @param {string|number} userId
+   * @returns {Promise<object>}
    */
-  deleteUserAvatar: async (userId) => {
-    try {
-      const response = await api.delete(`/api/users/${userId}/avatar`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error deleting avatar for user ${userId}:`, error);
-      throw error;
-    }
-  },
+  deleteUserAvatar: (userId) =>
+    call(`deleting avatar for user ${userId}`, () =>
+      api.delete(`/api/users/${userId}/avatar`),
+    ),
 
-  changePassword: async (currentPassword, newPassword) => {
-    try {
-      const response = await api.put("/api/auth/change-password", {
-        currentPassword,
-        newPassword,
-      });
-      return response.data;
-    } catch (error) {
-      console.error("Error changing password:", error);
-      throw error;
-    }
-  },
+  changePassword: (currentPassword, newPassword) =>
+    call("changing password", () =>
+      api.put("/api/auth/change-password", { currentPassword, newPassword }),
+    ),
 
-  changeEmail: async (newEmail, currentPassword) => {
-    try {
-      const response = await api.put("/api/auth/change-email", {
-        newEmail,
-        currentPassword,
-      });
-      return response.data;
-    } catch (error) {
-      console.error("Error changing email:", error);
-      throw error;
-    }
-  },
+  changeEmail: (newEmail, currentPassword) =>
+    call("changing email", () =>
+      api.put("/api/auth/change-email", { newEmail, currentPassword }),
+    ),
 };
 
-// Export the service object as the default export
 export default userService;

--- a/src/services/vacantRoleService.js
+++ b/src/services/vacantRoleService.js
@@ -32,6 +32,22 @@ export const vacantRoleService = {
   },
 
   /**
+   * Bulk-fetch vacant roles by IDs in one call. Bypasses the status filter
+   * so callers can detect transitions to filled/closed.
+   * @param {number} teamId
+   * @param {Array<number|string>} roleIds
+   */
+  async getVacantRolesByIds(teamId, roleIds) {
+    const ids = (roleIds ?? []).filter((id) => id != null && id !== "").join(",");
+    if (!ids) return { success: true, data: [] };
+
+    const response = await api.get(`/api/teams/${teamId}/vacant-roles`, {
+      params: { ids },
+    });
+    return response.data;
+  },
+
+  /**
    * Create a new vacant role
    * @param {number} teamId
    * @param {object} roleData - { role_name, bio, postal_code, city, country,

--- a/src/utils/matchHelpers.js
+++ b/src/utils/matchHelpers.js
@@ -1,0 +1,142 @@
+import { calculateDistanceKm } from "./locationUtils";
+
+export const MATCH_WEIGHTS = {
+  tags: 0.4,
+  badges: 0.3,
+  distance: 0.3,
+};
+
+export const LOCATION_GRACE_KM = 20;
+export const LOCATION_GRACE_SCORE = 0.25;
+
+export const roundMatchValue = (value) => Math.round(value * 100) / 100;
+
+export const extractCandidateMatchData = (candidateLike) => {
+  const rawScore =
+    candidateLike?.matchScore ??
+    candidateLike?.match_score ??
+    candidateLike?.bestMatchScore ??
+    candidateLike?.best_match_score ??
+    null;
+  const numericScore = Number(rawScore);
+
+  return {
+    matchScore: Number.isFinite(numericScore) ? numericScore : null,
+    matchDetails:
+      candidateLike?.matchDetails ??
+      candidateLike?.match_details ??
+      null,
+  };
+};
+
+export const buildTagLookup = (tagData) => {
+  const nextMap = new Map();
+
+  for (const tag of tagData) {
+    nextMap.set(Number(tag.id), {
+      badgeCredits: Number(tag.badge_credits ?? tag.badgeCredits ?? 0),
+    });
+  }
+
+  return nextMap;
+};
+
+export const buildBadgeLookup = (badgeData) => {
+  const nextMap = new Map();
+
+  for (const badge of badgeData) {
+    const name = (badge.badgeName ?? badge.badge_name ?? badge.name ?? "")
+      .trim()
+      .toLowerCase();
+    const credits = Number(
+      badge.totalCredits ?? badge.total_credits ?? badge.credits ?? 0,
+    );
+    const existing = nextMap.get(name);
+
+    nextMap.set(name, {
+      totalCredits: (existing?.totalCredits || 0) + credits,
+    });
+  }
+
+  return nextMap;
+};
+
+export const computeRoleUserMatch = ({
+  role,
+  tags,
+  badges,
+  user,
+  userTagMap,
+  userBadgeMap,
+}) => {
+  if (!role || !user) return null;
+
+  const requiredTagIds = tags
+    .map((tag) => Number(tag.tagId ?? tag.tag_id ?? tag.id))
+    .filter(Number.isFinite);
+  const requiredBadgeKeys = badges
+    .map((badge) =>
+      (badge.name ?? badge.badgeName ?? badge.badge_name ?? "")
+        .trim()
+        .toLowerCase(),
+    )
+    .filter(Boolean);
+
+  const matchingTags = requiredTagIds.filter((id) => userTagMap.has(id)).length;
+  const matchingBadges = requiredBadgeKeys.filter((key) => userBadgeMap.has(key)).length;
+
+  const tagScore =
+    requiredTagIds.length > 0 ? matchingTags / requiredTagIds.length : 0.5;
+  const badgeScore =
+    requiredBadgeKeys.length > 0
+      ? matchingBadges / requiredBadgeKeys.length
+      : 0.5;
+
+  const isRemote = role.isRemote ?? role.is_remote;
+  const maxDistanceKm = Number(role.maxDistanceKm ?? role.max_distance_km) || 50;
+
+  let distanceScore = 0.5;
+  let distanceKm = null;
+  let isWithinRange = null;
+
+  if (isRemote) {
+    distanceScore = 1;
+    isWithinRange = true;
+  } else {
+    distanceKm = calculateDistanceKm(user, role);
+
+    if (distanceKm !== null) {
+      if (distanceKm <= maxDistanceKm) {
+        distanceScore = 1;
+        isWithinRange = true;
+      } else if (distanceKm <= maxDistanceKm + LOCATION_GRACE_KM) {
+        distanceScore = LOCATION_GRACE_SCORE;
+        isWithinRange = false;
+      } else {
+        distanceScore = 0;
+        isWithinRange = false;
+      }
+    }
+  }
+
+  const matchScore =
+    MATCH_WEIGHTS.tags * tagScore +
+    MATCH_WEIGHTS.badges * badgeScore +
+    MATCH_WEIGHTS.distance * distanceScore;
+
+  return {
+    matchScore: roundMatchValue(matchScore),
+    matchDetails: {
+      tagScore: roundMatchValue(tagScore),
+      badgeScore: roundMatchValue(badgeScore),
+      distanceScore: roundMatchValue(distanceScore),
+      matchingTags,
+      totalRequiredTags: requiredTagIds.length,
+      matchingBadges,
+      totalRequiredBadges: requiredBadgeKeys.length,
+      distanceKm: distanceKm !== null ? Math.round(distanceKm) : null,
+      maxDistanceKm,
+      isWithinRange,
+    },
+  };
+};

--- a/src/utils/payloadExtractors.js
+++ b/src/utils/payloadExtractors.js
@@ -1,0 +1,15 @@
+export const extractProfilePayload = (response) => {
+  const payload = response?.data ?? response;
+
+  if (!payload) return null;
+  if (payload?.success !== undefined) return payload?.data ?? null;
+
+  return payload?.data?.data ?? payload?.data ?? payload;
+};
+
+export const extractListPayload = (response) => {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.data)) return response.data;
+  if (Array.isArray(response?.data?.data)) return response.data.data;
+  return [];
+};

--- a/src/utils/teamRequestUtils.js
+++ b/src/utils/teamRequestUtils.js
@@ -1,0 +1,76 @@
+export const normalizeNumericId = (value) => {
+  if (value === null || value === undefined || value === "") return null;
+
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+};
+
+export const numericIdsMatch = (left, right) => {
+  const normalizedLeft = normalizeNumericId(left);
+  const normalizedRight = normalizeNumericId(right);
+
+  if (normalizedLeft === null || normalizedRight === null) return false;
+  return normalizedLeft === normalizedRight;
+};
+
+export const idsMatch = (left, right) => {
+  if (left === null || left === undefined || right === null || right === undefined) {
+    return false;
+  }
+
+  return String(left) === String(right);
+};
+
+export const normalizeBoolean = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+
+  if (typeof value === "string") {
+    const normalizedValue = value.trim().toLowerCase();
+    if (["true", "1", "yes"].includes(normalizedValue)) return true;
+    if (["false", "0", "no"].includes(normalizedValue)) return false;
+  }
+
+  return null;
+};
+
+export const isExistingMemberStatus = (value) => {
+  if (typeof value !== "string") return false;
+
+  const normalizedValue = value.trim().toLowerCase();
+  return (
+    normalizedValue === "member" ||
+    normalizedValue === "existing-member" ||
+    normalizedValue === "existing_member"
+  );
+};
+
+export const getMemberUserId = (member) => {
+  const memberUser = member?.user || member;
+
+  return (
+    member?.userId ??
+    member?.user_id ??
+    member?.memberId ??
+    member?.member_id ??
+    memberUser?.userId ??
+    memberUser?.user_id ??
+    memberUser?.id ??
+    member?.id ??
+    null
+  );
+};
+
+export const extractRoleMatchData = (roleLike) => {
+  const rawScore = roleLike?.matchScore ?? roleLike?.match_score ?? null;
+  const numericScore = Number(rawScore);
+
+  return {
+    matchScore: Number.isFinite(numericScore) ? numericScore : null,
+    matchDetails:
+      roleLike?.matchDetails ??
+      roleLike?.match_details ??
+      roleLike?.scoreBreakdown ??
+      null,
+  };
+};

--- a/src/utils/teamRequestUtils.js
+++ b/src/utils/teamRequestUtils.js
@@ -89,6 +89,15 @@ export const getRequestUserId = (request, userKey) =>
   request?.[`${userKey}_id`] ??
   null;
 
+export const getRequestUser = (request, userKey) =>
+  request?.[userKey] ?? null;
+
+export const getRequestUserLabel = (request, userKey, fallback = "Their") => {
+  const user = getRequestUser(request, userKey);
+
+  return user?.first_name ?? user?.firstName ?? user?.username ?? fallback;
+};
+
 export const isRequestForUser = (request, userKey, userId) =>
   idsMatch(getRequestUserId(request, userKey), userId);
 
@@ -151,6 +160,130 @@ export const buildInvitationRoleForCard = (invitation, polledRole = null) => {
     is_synthetic: syntheticRoleFlag,
     isSynthetic: syntheticRoleFlag,
     ...(polledRole ?? {}),
+  };
+};
+
+const firstPresent = (...values) =>
+  values.find((value) => value !== undefined && value !== null);
+
+export const buildCurrentFilledRoleForCard = (
+  invitation,
+  filledUser = null,
+) => {
+  const currentRole =
+    invitation?.currentFilledRole ??
+    invitation?.current_filled_role ??
+    null;
+  const currentRoleLocation =
+    currentRole?.roleLocation ??
+    currentRole?.role_location ??
+    invitation?.currentFilledRoleLocation ??
+    invitation?.current_filled_role_location ??
+    null;
+  const filledUserId = getRequestUserId(invitation, "invitee");
+  const currentRoleSyntheticFlag = firstPresent(
+    currentRole?.isSynthetic,
+    currentRole?.is_synthetic,
+    invitation?.currentFilledRoleIsSynthetic,
+    invitation?.current_filled_role_is_synthetic,
+    invitation?.role_is_synthetic,
+  );
+  const currentRoleId = firstPresent(
+    currentRole?.id,
+    invitation?.current_filled_role_id,
+    invitation?.currentFilledRoleId,
+  );
+
+  if (currentRoleId == null) return null;
+
+  return {
+    ...(currentRole ?? {}),
+    id: currentRoleId,
+    role_name: firstPresent(
+      currentRole?.role_name,
+      currentRole?.roleName,
+      invitation?.current_filled_role_name,
+      invitation?.currentFilledRoleName,
+    ),
+    roleName: firstPresent(
+      currentRole?.roleName,
+      currentRole?.role_name,
+      invitation?.currentFilledRoleName,
+      invitation?.current_filled_role_name,
+    ),
+    status: currentRole?.status ?? "filled",
+    filled_by: firstPresent(currentRole?.filled_by, currentRole?.filledBy, filledUserId),
+    filledBy: firstPresent(currentRole?.filledBy, currentRole?.filled_by, filledUserId),
+    filled_by_user:
+      currentRole?.filled_by_user ??
+      currentRole?.filledByUser ??
+      filledUser ??
+      null,
+    filledByUser:
+      currentRole?.filledByUser ??
+      currentRole?.filled_by_user ??
+      filledUser ??
+      null,
+    is_synthetic: currentRoleSyntheticFlag,
+    isSynthetic: currentRoleSyntheticFlag,
+    is_remote: firstPresent(
+      currentRole?.is_remote,
+      currentRole?.isRemote,
+      invitation?.current_filled_role_is_remote,
+      invitation?.currentFilledRoleIsRemote,
+    ),
+    isRemote: firstPresent(
+      currentRole?.isRemote,
+      currentRole?.is_remote,
+      invitation?.currentFilledRoleIsRemote,
+      invitation?.current_filled_role_is_remote,
+    ),
+    city: firstPresent(
+      currentRole?.city,
+      currentRoleLocation?.city,
+      invitation?.current_filled_role_city,
+      invitation?.currentFilledRoleCity,
+    ),
+    state: firstPresent(
+      currentRole?.state,
+      currentRoleLocation?.state,
+      invitation?.current_filled_role_state,
+      invitation?.currentFilledRoleState,
+    ),
+    country: firstPresent(
+      currentRole?.country,
+      currentRoleLocation?.country,
+      invitation?.current_filled_role_country,
+      invitation?.currentFilledRoleCountry,
+    ),
+    postal_code: firstPresent(
+      currentRole?.postal_code,
+      currentRole?.postalCode,
+      currentRoleLocation?.postal_code,
+      currentRoleLocation?.postalCode,
+      invitation?.current_filled_role_postal_code,
+      invitation?.currentFilledRolePostalCode,
+    ),
+    postalCode: firstPresent(
+      currentRole?.postalCode,
+      currentRole?.postal_code,
+      currentRoleLocation?.postalCode,
+      currentRoleLocation?.postal_code,
+      invitation?.currentFilledRolePostalCode,
+      invitation?.current_filled_role_postal_code,
+    ),
+    max_distance_km: firstPresent(
+      currentRole?.max_distance_km,
+      currentRole?.maxDistanceKm,
+      invitation?.current_filled_role_max_distance_km,
+      invitation?.currentFilledRoleMaxDistanceKm,
+    ),
+    maxDistanceKm: firstPresent(
+      currentRole?.maxDistanceKm,
+      currentRole?.max_distance_km,
+      invitation?.currentFilledRoleMaxDistanceKm,
+      invitation?.current_filled_role_max_distance_km,
+    ),
   };
 };
 

--- a/src/utils/teamRequestUtils.js
+++ b/src/utils/teamRequestUtils.js
@@ -1,3 +1,5 @@
+import { format } from "date-fns";
+
 export const normalizeNumericId = (value) => {
   if (value === null || value === undefined || value === "") return null;
 
@@ -80,6 +82,41 @@ export const getRequestRoleId = (request) =>
 
 export const hasRequestRole = (request) =>
   Boolean(request?.role || request?.roleId || request?.role_id);
+
+export const getRequestUserId = (request, userKey) =>
+  request?.[userKey]?.id ??
+  request?.[`${userKey}Id`] ??
+  request?.[`${userKey}_id`] ??
+  null;
+
+export const isRequestForUser = (request, userKey, userId) =>
+  idsMatch(getRequestUserId(request, userKey), userId);
+
+export const getRequestDateValue = (request) =>
+  request?.created_at ??
+  request?.createdAt ??
+  request?.date ??
+  request?.applied_at ??
+  request?.appliedAt ??
+  request?.sent_at ??
+  request?.sentAt ??
+  request?.invited_at ??
+  request?.invitedAt ??
+  request?.submitted_at ??
+  request?.submittedAt ??
+  null;
+
+export const formatRequestDate = (request, fallback = "Unknown date") => {
+  const date = getRequestDateValue(request);
+  if (!date) return fallback;
+
+  try {
+    return format(new Date(date), "MMM d, yyyy");
+  } catch (error) {
+    console.error("Error formatting request date:", error);
+    return fallback;
+  }
+};
 
 export const getRequestRoleSyntheticFlag = (request) =>
   request?.role?.is_synthetic ??

--- a/src/utils/teamRequestUtils.js
+++ b/src/utils/teamRequestUtils.js
@@ -74,3 +74,103 @@ export const extractRoleMatchData = (roleLike) => {
       null,
   };
 };
+
+export const getRequestRoleId = (request) =>
+  request?.role?.id ?? request?.roleId ?? request?.role_id ?? null;
+
+export const hasRequestRole = (request) =>
+  Boolean(request?.role || request?.roleId || request?.role_id);
+
+export const getRequestRoleSyntheticFlag = (request) =>
+  request?.role?.is_synthetic ??
+  request?.role?.isSynthetic ??
+  request?.role_is_synthetic ??
+  request?.roleIsSynthetic ??
+  request?.is_synthetic ??
+  request?.isSynthetic;
+
+export const buildInvitationRoleForCard = (invitation, polledRole = null) => {
+  const syntheticRoleFlag = getRequestRoleSyntheticFlag(invitation);
+
+  if (invitation?.role) {
+    return {
+      ...invitation.role,
+      ...(polledRole ?? {}),
+      is_synthetic:
+        invitation.role.is_synthetic ??
+        invitation.role.isSynthetic ??
+        syntheticRoleFlag,
+      isSynthetic:
+        invitation.role.isSynthetic ??
+        invitation.role.is_synthetic ??
+        syntheticRoleFlag,
+    };
+  }
+
+  return {
+    id: invitation?.roleId ?? invitation?.role_id,
+    roleName: invitation?.roleName ?? invitation?.role_name,
+    role_name: invitation?.role_name ?? invitation?.roleName,
+    is_synthetic: syntheticRoleFlag,
+    isSynthetic: syntheticRoleFlag,
+    ...(polledRole ?? {}),
+  };
+};
+
+export const buildApplicationRoleForCard = (
+  application,
+  polledRole = null,
+  roleOverride = null,
+) => {
+  const syntheticRoleFlag = getRequestRoleSyntheticFlag(application);
+  const roleId = getRequestRoleId(application);
+
+  if (application?.role && roleId) {
+    return {
+      ...application.role,
+      ...(polledRole ?? {}),
+      is_synthetic:
+        application.role.is_synthetic ??
+        application.role.isSynthetic ??
+        syntheticRoleFlag,
+      isSynthetic:
+        application.role.isSynthetic ??
+        application.role.is_synthetic ??
+        syntheticRoleFlag,
+      status:
+        roleOverride?.status ??
+        polledRole?.status ??
+        application.role.status ??
+        "open",
+      filledBy:
+        roleOverride?.filledBy ??
+        polledRole?.filledBy ??
+        polledRole?.filled_by ??
+        application.role.filledBy ??
+        application.role.filled_by ??
+        null,
+      filledByUser:
+        roleOverride?.filledByUser ??
+        polledRole?.filledByUser ??
+        polledRole?.filled_by_user ??
+        application.role.filledByUser ??
+        application.role.filled_by_user ??
+        null,
+    };
+  }
+
+  return application?.role
+    ? {
+        ...application.role,
+        ...(polledRole ?? {}),
+        is_synthetic:
+          application.role.is_synthetic ??
+          application.role.isSynthetic ??
+          syntheticRoleFlag,
+        isSynthetic:
+          application.role.isSynthetic ??
+          application.role.is_synthetic ??
+          syntheticRoleFlag,
+      }
+    : null;
+};

--- a/src/utils/userHelpers.js
+++ b/src/utils/userHelpers.js
@@ -32,6 +32,9 @@ export const getUserInitials = (user) => {
   return "?";
 };
 
+export const getUserAvatarUrl = (user) =>
+  user?.avatar_url || user?.avatarUrl || null;
+
 /**
  * Get team initials for avatar fallback
  * Returns up to 3 letters from the first 3 words of the team name


### PR DESCRIPTION
## Summary

This branch consolidates a multi-session refactor effort across three themes. No new user-facing features; all changes are internal performance, structural, or maintainability improvements.

**1. N+1 API call eliminations**
- MyTeams page: ~70 → ~4-6 calls for a user with 14 teams (parent-provided data, embedded match scores, bulk member-badges endpoint).
- TeamInvitesModal: ~19 → 4 calls (-79%) via embedded match scores + InlineUserLink hydration gate.
- TeamApplicationsModal: ~5 → 3 calls (-40%) via embedded match scores.
- TeamDetailsModal: ~20 → 1-2 calls combined with TeamMembersSection synthetic-flag drop.
- VacantRoleDetailsModal: H audit removed applicant/invitee profile hydration and stale match calls.
- Profile / PublicProfile / Badge awarding: H audits clean per-modal-open patterns.
- SearchPage auth-race: gated search effect on `authLoading=false` so it no longer fires twice on page mount.

**2. Step D — Invitations + Applications modal unification**
- New shared components: `PersonRequestCard`, `RequestListModal`, `RequestRoleCard`.
- New shared hooks: `useTeamRequestLists`, `usePolledRequestRoles` (bulk vacant-roles poll), `useSelfRoleMatchMap`, `useViewerPendingRequests`, `useViewerTeamMemberships`.
- New shared utils: `teamRequestUtils.js` (`buildInvitationRoleForCard`, `buildApplicationRoleForCard`, `extractRoleMatchData`, etc.) and `matchHelpers.js`.
- TeamInvitesModal collapsed 609 → 449 lines (-26%); shared structure preserved as canonical pattern.

**3. Axios interceptor cleanup — explicit per-call data contracts**
- `src/services/api.js` now supports `skipRequestCaseTransform` and `skipResponseCaseTransform` config flags. The default global camelCase ↔ snake_case interceptor remains; call sites opt out individually.
- `messageService` (8/8) and `notificationService` (5/5) are fully off the global response interceptor. Each cleaned call normalizes its own payload via a service-local helper.
- `userService.getUserById` (1/12) is the first slice on the user side. New `normalizeUserPayload` helper preserves both casings on the user object and each nested badge entry.
- Motivation: the global interceptor caused the chat @mentions bell-tooltip footgun in a prior incident; the explicit per-call contracts close that class of bug.

**Other notable items in scope:**
- React Query (`@tanstack/react-query 5`) added and expanded across viewer data, profile modals, team modals, badge award, search map hydration, vacant role user metadata. Empty-array destructure defaults stabilized with module-level constants to prevent render-loop hazards.
- `call()` service-level helper collapses the repetitive `try { (await api.X()).data } catch (e) { ... }` pattern across services.
- Profile.jsx infinite render loop fix (React Query destructure default + effect dep).
- AwardCard narrow-viewport polish (responsive bottom row with `formatDisplayName` middle-initial fallback).
- Badge modal title pattern unified across SupercategoryAwardsModal and BadgeCategoryModal.
- `ImageUploader` stacks avatar above text + buttons (center-aligned) below `sm:` (640px).
- Profile focus-areas label swap on narrow viewports.
- `TagInput` downshift `getMenuProps` warning fixed by keeping the portal menu mounted while closed.

## Test plan

- [ ] **MyTeams page** — load with multiple teams; verify network panel shows ~4-6 calls, not ~70. Cards render badges, members, vacant roles, pending invitations/applications correctly.
- [ ] **TeamDetailsModal** (plain MyTeams open) — opens with ≤2 calls; member badges and vacant roles render; no per-member profile fetches.
- [ ] **TeamInvitesModal** — open from MyTeams; verify ~4 calls; member badges, match scores, invitee names render. Cancel an invitation; cancel only a role portion.
- [ ] **TeamApplicationsModal** — open from MyTeams; verify ~3 calls per role; approve, decline, reopen flows still work.
- [ ] **VacantRoleDetailsModal** — open from a team; viewer match data renders without fanout; "Show matches" expansion still triggers role-match fanout on demand.
- [ ] **BadgeAwardModal** — open from a teammate's profile; verify single `/api/badges` + single shared-teams lookup; submit a badge and confirm profile refreshes without double-refetch.
- [ ] **Profile (own)** — view mode + edit mode both render name/avatar/bio/location/tags/badges. Save changes; verify no infinite render loop (the "Maximum update depth exceeded" regression is closed).
- [ ] **PublicProfile** — visit another user's profile; same fields render.
- [ ] **UserDetailsModal** — opens from team member lists, awarder names; populates correctly.
- [ ] **Chat — direct conversation** — open via URL with a user not in your conversation list; virtual conversation appears with their name and avatar.
- [ ] **Chat — typing indicator** — when another user starts typing whose profile isn't cached; their display name resolves, not "Unknown".
- [ ] **Chat — send / receive / edit / reply / delete** — text + image + file all work end-to-end; reply previews render for role event messages.
- [ ] **Chat — @mentions** — type `@` to see dropdown, select a person or "all members"; mention renders in message bubble and notification toast; navbar bell-tooltip badge updates.
- [ ] **Notifications — bell click** — first bell click marks the top unread as read and navigates; second click advances to the next unread. (The `null` → `undefined` axios body trap was caught and fixed in this branch.)
- [ ] **SearchPage** — load `/search`; verify only one search request fires on mount (not two). List view and map view both render; team/user/role markers click through to popups.
- [ ] **Responsiveness** — narrow the viewport below 640px on Profile edit:
  - Avatar uploader stacks vertically with text/buttons centered.
  - Focus areas label reads "Pick your interests and skills".
  - TagInput dropdown opens cleanly on click; no console warning about `getMenuProps`.
- [ ] **`npm run build`** completes; pre-existing Vite warnings (VacantRoleDetailsModal mixed import, chunk size) are unchanged.

## Notes for reviewer

- This branch depends on the backend branch `refactor/ModalRespo` for the bulk endpoints (`/api/teams/:teamId/vacant-roles?ids=`, member-badges bulk, embedded `is_synthetic` flags, embedded match scores). Merge backend first.
- The interceptor cleanup is intentionally incomplete (userService 1/12, teamService 0/30, etc.). Remaining services still rely on the default global interceptor; explicit opt-outs were applied only where the data contracts have been verified end-to-end. Plan to continue in follow-up branches per the project memory handover.
- Pre-existing structural debt deferred: TeamCard.jsx (3143 lines, 46 hooks) and Chat.jsx (3377 lines) decompositions are explicitly out of scope.
