### PR TITLE
improve UX for registration form and settings

### DIFF
--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -81,12 +81,17 @@ const RegisterForm = () => {
   const validateForm = () => {
     const newErrors = {};
 
-    if (!formData.username) newErrors.username = "Username is required";
+    if (!formData.username) {
+      newErrors.username = ["Please enter a username."];
+    } else {
+      const usernameErrors = getUsernameValidationErrors(formData.username);
+      if (usernameErrors.length > 0) newErrors.username = usernameErrors;
+    }
 
     if (!formData.email) {
       newErrors.email = "Email is required";
     } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
-      newErrors.email = "Email is invalid";
+      newErrors.email = "Please enter a valid email address (e.g. your@email.com).";
     }
 
     if (!formData.password) {
@@ -122,6 +127,61 @@ const RegisterForm = () => {
       const remainingErrors = { ...prev };
       delete remainingErrors[fieldName];
       return remainingErrors;
+    });
+  };
+
+  const getUsernameValidationErrors = (username) => {
+    const usernameErrors = [];
+
+    if (username.length < 3) {
+      usernameErrors.push("Username must be at least 3 characters.");
+    }
+
+    if (username.length > 30) {
+      usernameErrors.push("Username must be no longer than 30 characters.");
+    }
+
+    if (!/^[a-zA-Z0-9]*$/.test(username)) {
+      usernameErrors.push(
+        "Username can only contain letters and numbers — no spaces or special characters.",
+      );
+    }
+
+    return usernameErrors;
+  };
+
+  const handleEmailBlur = () => {
+    if (!formData.email) return;
+
+    setErrors((prev) => {
+      const nextErrors = { ...prev };
+
+      if (!/\S+@\S+\.\S+/.test(formData.email)) {
+        nextErrors.email =
+          "Please enter a valid email address (e.g. your@email.com).";
+      } else {
+        delete nextErrors.email;
+      }
+
+      return nextErrors;
+    });
+  };
+
+  const handleUsernameBlur = () => {
+    if (!formData.username) return;
+
+    const usernameErrors = getUsernameValidationErrors(formData.username);
+
+    setErrors((prev) => {
+      const nextErrors = { ...prev };
+
+      if (usernameErrors.length > 0) {
+        nextErrors.username = usernameErrors;
+      } else {
+        delete nextErrors.username;
+      }
+
+      return nextErrors;
     });
   };
 
@@ -311,6 +371,12 @@ const RegisterForm = () => {
     }
   };
 
+  const usernameErrorMessages = Array.isArray(errors.username)
+    ? errors.username
+    : errors.username
+      ? [errors.username]
+      : [];
+
   const passwordErrorMessages = Array.isArray(errors.password)
     ? errors.password
     : errors.password
@@ -407,18 +473,27 @@ const RegisterForm = () => {
                     type="text"
                     placeholder="Choose a username"
                     className={`input input-bordered w-full ${
-                      errors.username ? "input-error" : ""
+                      usernameErrorMessages.length > 0 ? "input-error" : ""
                     }`}
                     value={formData.username}
                     onChange={handleChange}
+                    onFocus={() => clearFieldError("username")}
+                    onBlur={handleUsernameBlur}
                     name="username"
                   />
-                  {errors.username && (
-                    <label className="label">
-                      <span className="label-text-alt text-error">
-                        {errors.username}
-                      </span>
-                    </label>
+                  {usernameErrorMessages.length === 0 && (
+                    <p className="form-helper-text mt-2 px-1">
+                      3–30 characters, letters and numbers only (no spaces).
+                    </p>
+                  )}
+                  {usernameErrorMessages.length > 0 && (
+                    <div className="mt-2 px-1 flex flex-col gap-0.5">
+                      {usernameErrorMessages.map((err) => (
+                        <p key={err} className="text-xs text-error">
+                          {err}
+                        </p>
+                      ))}
+                    </div>
                   )}
                 </div>
 
@@ -436,14 +511,14 @@ const RegisterForm = () => {
                     }`}
                     value={formData.email}
                     onChange={handleChange}
+                    onFocus={() => clearFieldError("email")}
+                    onBlur={handleEmailBlur}
                     name="email"
                   />
                   {errors.email && (
-                    <label className="label">
-                      <span className="label-text-alt text-error">
-                        {errors.email}
-                      </span>
-                    </label>
+                    <p className="text-xs text-error mt-2 px-1">
+                      {errors.email}
+                    </p>
                   )}
                 </div>
               </div>
@@ -490,16 +565,13 @@ const RegisterForm = () => {
                     </p>
                   )}
                   {passwordErrorMessages.length > 0 && (
-                    <label className="label mt-2 flex flex-col items-start gap-0.5">
+                    <div className="mt-2 px-1 flex flex-col gap-0.5">
                       {passwordErrorMessages.map((passwordError) => (
-                        <span
-                          key={passwordError}
-                          className="label-text-alt text-error"
-                        >
+                        <p key={passwordError} className="text-xs text-error">
                           {passwordError}
-                        </span>
+                        </p>
                       ))}
-                    </label>
+                    </div>
                   )}
                 </div>
 
@@ -540,11 +612,9 @@ const RegisterForm = () => {
                     </button>
                   </div>
                   {errors.confirmPassword && (
-                    <label className="label">
-                      <span className="label-text-alt text-error">
-                        {errors.confirmPassword}
-                      </span>
-                    </label>
+                    <p className="text-xs text-error mt-2 px-1">
+                      {errors.confirmPassword}
+                    </p>
                   )}
                 </div>
               </div>

--- a/src/components/common/Alert.jsx
+++ b/src/components/common/Alert.jsx
@@ -33,7 +33,7 @@ const Alert = ({
     <div
       className={`alert ${alertClasses[type]} !text-white w-fit transition-opacity duration-1000 ${fading ? "opacity-0" : "opacity-100"} ${className}`}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex items-start gap-2">
         {type === "info" && (
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -970,7 +970,7 @@ const Settings = () => {
             </form>
           ) : (
             <div className="space-y-4">
-              <Alert type="warning" className="w-full">
+              <Alert type="warning" className="w-full mb-2">
                 Please review this carefully. Deleting your account is
                 irreversible.
               </Alert>
@@ -1159,11 +1159,7 @@ const Settings = () => {
                 </Card>
               )}
 
-              <Card
-                hoverable={false}
-                marginClassName="mb-0"
-                contentClassName="space-y-4"
-              >
+              <div className="space-y-4">
                 <div className="flex items-center gap-2 text-primary">
                   <Trash2 size={18} />
                   <h3 className="text-base font-semibold">Summary</h3>
@@ -1184,7 +1180,7 @@ const Settings = () => {
                     {directMessagesCount === 1 ? "" : "s"} will be deleted
                   </p>
                 </div>
-              </Card>
+              </div>
 
               <div className="flex justify-end gap-3 pt-2">
                 <Button


### PR DESCRIPTION
Summary
Add username requirements hint below the username field (3–30 chars, letters and numbers only, no spaces), with specific blur-time validation errors
Add blur-time validation for the email field with a descriptive error message when the address is invalid or incomplete
Fix error and hint text clipping on narrow/mobile viewports in the registration form (replaced DaisyUI label/label-text-alt pattern with <p> tags that wrap correctly)
Fix alert icon alignment — icon now aligns to the first line of text instead of being vertically centred across multi-line messages
Replace the Card component with a plain <div> for the account-deletion Summary section, removing the unneeded shadow and border
Test plan
 Register with an invalid username (too short, too long, spaces, special characters) — specific error should appear on blur and clear on focus
 Register with an incomplete email address — error should appear on blur and clear on focus
 Verify hint texts (username, password) are readable on a narrow mobile viewport with no clipping
 Trigger a multi-line alert and confirm the icon aligns with the first line of text
 Open the account deletion flow and confirm the Summary section has no card shadow or border