### PR TITLE
align ForgotPassword and ResetPassword page layout with login/register

### DIFF
--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -56,8 +56,9 @@ const ForgotPassword = () => {
   // Success state
   if (status === "success") {
     return (
-      <div className="max-w-md mx-auto mt-12">
-        <Card className="w-full">
+      <div className="content-container">
+        <div className="max-w-md mx-auto w-full">
+        <Card>
           <div className="card-body text-center py-10 px-8">
             <CheckCircle size={56} className="mx-auto mb-4 text-success" />
 
@@ -93,12 +94,14 @@ const ForgotPassword = () => {
             </div>
           </div>
         </Card>
+        </div>
       </div>
     );
   }
 
   // Form state
   return (
+    <div className="content-container">
     <div className="max-w-md mx-auto w-full">
       <Card>
         <div className="card-body">
@@ -162,6 +165,7 @@ const ForgotPassword = () => {
           </div>
         </div>
       </Card>
+    </div>
     </div>
   );
 };

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -112,23 +112,25 @@ const ResetPassword = () => {
   // No token state
   if (!token && status !== "error") {
     return (
-      <div className="max-w-md mx-auto mt-12">
-        <Card className="w-full">
-          <div className="card-body text-center py-10 px-8">
-            <XCircle size={56} className="mx-auto mb-4 text-error" />
-            <h2 className="card-title text-2xl font-bold justify-center mb-3">
-              Invalid Link
-            </h2>
-            <p className="text-base-content/70 mb-8">
-              No reset token found. Please request a new password reset link.
-            </p>
-            <Link to="/forgot-password" className="w-full">
-              <Button variant="primary" fullWidth>
-                Request New Link
-              </Button>
-            </Link>
-          </div>
-        </Card>
+      <div className="content-container">
+        <div className="max-w-md mx-auto w-full">
+          <Card>
+            <div className="card-body text-center py-10 px-8">
+              <XCircle size={56} className="mx-auto mb-4 text-error" />
+              <h2 className="card-title text-2xl font-bold justify-center mb-3">
+                Invalid Link
+              </h2>
+              <p className="text-base-content/70 mb-8">
+                No reset token found. Please request a new password reset link.
+              </p>
+              <Link to="/forgot-password" className="w-full">
+                <Button variant="primary" fullWidth>
+                  Request New Link
+                </Button>
+              </Link>
+            </div>
+          </Card>
+        </div>
       </div>
     );
   }
@@ -136,24 +138,26 @@ const ResetPassword = () => {
   // Success state
   if (status === "success") {
     return (
-      <div className="max-w-md mx-auto mt-12">
-        <Card className="w-full">
-          <div className="card-body text-center py-10 px-8">
-            <CheckCircle size={56} className="mx-auto mb-4 text-success" />
+      <div className="content-container">
+        <div className="max-w-md mx-auto w-full">
+          <Card>
+            <div className="card-body text-center py-10 px-8">
+              <CheckCircle size={56} className="mx-auto mb-4 text-success" />
 
-            <h2 className="card-title text-2xl font-bold justify-center mb-3">
-              Password Reset!
-            </h2>
+              <h2 className="card-title text-2xl font-bold justify-center mb-3">
+                Password Reset!
+              </h2>
 
-            <p className="text-base-content/70 mb-8">{message}</p>
+              <p className="text-base-content/70 mb-8">{message}</p>
 
-            <Link to="/login" className="w-full">
-              <Button variant="primary" fullWidth>
-                Log in with new password
-              </Button>
-            </Link>
-          </div>
-        </Card>
+              <Link to="/login" className="w-full">
+                <Button variant="primary" fullWidth>
+                  Log in with new password
+                </Button>
+              </Link>
+            </div>
+          </Card>
+        </div>
       </div>
     );
   }
@@ -161,139 +165,143 @@ const ResetPassword = () => {
   // Error state (invalid/expired token)
   if (status === "error") {
     return (
-      <div className="max-w-md mx-auto mt-12">
-        <Card className="w-full">
-          <div className="card-body text-center py-10 px-8">
-            <XCircle size={56} className="mx-auto mb-4 text-error" />
+      <div className="content-container">
+        <div className="max-w-md mx-auto w-full">
+          <Card>
+            <div className="card-body text-center py-10 px-8">
+              <XCircle size={56} className="mx-auto mb-4 text-error" />
 
-            <h2 className="card-title text-2xl font-bold justify-center mb-3">
-              Reset Failed
-            </h2>
+              <h2 className="card-title text-2xl font-bold justify-center mb-3">
+                Reset Failed
+              </h2>
 
-            <p className="text-base-content/70 mb-8">{message}</p>
+              <p className="text-base-content/70 mb-8">{message}</p>
 
-            <div className="space-y-3">
-              <Link to="/forgot-password" className="w-full block">
-                <Button variant="primary" fullWidth>
-                  Request New Reset Link
-                </Button>
-              </Link>
-              <Link to="/login" className="w-full block">
-                <Button variant="ghost" fullWidth>
-                  Back to Login
-                </Button>
-              </Link>
+              <div className="space-y-3">
+                <Link to="/forgot-password" className="w-full block">
+                  <Button variant="primary" fullWidth>
+                    Request New Reset Link
+                  </Button>
+                </Link>
+                <Link to="/login" className="w-full block">
+                  <Button variant="ghost" fullWidth>
+                    Back to Login
+                  </Button>
+                </Link>
+              </div>
             </div>
-          </div>
-        </Card>
+          </Card>
+        </div>
       </div>
     );
   }
 
   // Form state
   return (
-    <div className="max-w-md mx-auto w-full">
-      <Card>
-        <div className="card-body">
-          <div className="text-center mb-6">
-            <KeyRound size={48} className="mx-auto mb-4 text-primary" />
-            <h2 className="text-2xl font-bold text-primary">
-              Create New Password
-            </h2>
-            <p className="text-base-content/70 mt-2">
-              Enter your new password below.
-            </p>
-          </div>
-
-          <form onSubmit={handleSubmit}>
-            <FormGroup
-              label="New Password"
-              htmlFor="password"
-              error={errors.password}
-              required
-            >
-              <div className="relative">
-                <input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  name="password"
-                  placeholder="••••••••"
-                  className={`input input-bordered w-full pr-10 ${
-                    errors.password ? "input-error" : ""
-                  }`}
-                  value={formData.password}
-                  onChange={handleChange}
-                  disabled={status === "submitting"}
-                />
-                <button
-                  type="button"
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
-                  onClick={() => setShowPassword(!showPassword)}
-                >
-                  {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
-                </button>
-              </div>
-            </FormGroup>
-
-            <FormGroup
-              label="Confirm New Password"
-              htmlFor="confirmPassword"
-              error={errors.confirmPassword}
-              required
-            >
-              <div className="relative">
-                <input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? "text" : "password"}
-                  name="confirmPassword"
-                  placeholder="••••••••"
-                  className={`input input-bordered w-full pr-10 ${
-                    errors.confirmPassword ? "input-error" : ""
-                  }`}
-                  value={formData.confirmPassword}
-                  onChange={handleChange}
-                  disabled={status === "submitting"}
-                />
-                <button
-                  type="button"
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                >
-                  {showConfirmPassword ? (
-                    <EyeOff size={20} />
-                  ) : (
-                    <Eye size={20} />
-                  )}
-                </button>
-              </div>
-            </FormGroup>
-
-            <div className="mt-6">
-              <Button
-                type="submit"
-                variant="primary"
-                fullWidth
-                disabled={status === "submitting"}
-              >
-                {status === "submitting" ? (
-                  <>
-                    <Loader2 size={20} className="animate-spin mr-2" />
-                    Resetting...
-                  </>
-                ) : (
-                  "Reset Password"
-                )}
-              </Button>
+    <div className="content-container">
+      <div className="max-w-md mx-auto w-full">
+        <Card>
+          <div className="card-body">
+            <div className="text-center mb-6">
+              <KeyRound size={48} className="mx-auto mb-4 text-primary" />
+              <h2 className="text-2xl font-bold text-primary">
+                Create New Password
+              </h2>
+              <p className="text-base-content/70 mt-2">
+                Enter your new password below.
+              </p>
             </div>
-          </form>
 
-          <div className="text-center mt-6">
-            <Link to="/login" className="link link-primary text-sm">
-              Back to Login
-            </Link>
+            <form onSubmit={handleSubmit}>
+              <FormGroup
+                label="New Password"
+                htmlFor="password"
+                error={errors.password}
+                required
+              >
+                <div className="relative">
+                  <input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    name="password"
+                    placeholder="••••••••"
+                    className={`input input-bordered w-full pr-10 ${
+                      errors.password ? "input-error" : ""
+                    }`}
+                    value={formData.password}
+                    onChange={handleChange}
+                    disabled={status === "submitting"}
+                  />
+                  <button
+                    type="button"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
+                    onClick={() => setShowPassword(!showPassword)}
+                  >
+                    {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+                  </button>
+                </div>
+              </FormGroup>
+
+              <FormGroup
+                label="Confirm New Password"
+                htmlFor="confirmPassword"
+                error={errors.confirmPassword}
+                required
+              >
+                <div className="relative">
+                  <input
+                    id="confirmPassword"
+                    type={showConfirmPassword ? "text" : "password"}
+                    name="confirmPassword"
+                    placeholder="••••••••"
+                    className={`input input-bordered w-full pr-10 ${
+                      errors.confirmPassword ? "input-error" : ""
+                    }`}
+                    value={formData.confirmPassword}
+                    onChange={handleChange}
+                    disabled={status === "submitting"}
+                  />
+                  <button
+                    type="button"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff size={20} />
+                    ) : (
+                      <Eye size={20} />
+                    )}
+                  </button>
+                </div>
+              </FormGroup>
+
+              <div className="mt-6">
+                <Button
+                  type="submit"
+                  variant="primary"
+                  fullWidth
+                  disabled={status === "submitting"}
+                >
+                  {status === "submitting" ? (
+                    <>
+                      <Loader2 size={20} className="animate-spin mr-2" />
+                      Resetting...
+                    </>
+                  ) : (
+                    "Reset Password"
+                  )}
+                </Button>
+              </div>
+            </form>
+
+            <div className="text-center mt-6">
+              <Link to="/login" className="link link-primary text-sm">
+                Back to Login
+              </Link>
+            </div>
           </div>
-        </div>
-      </Card>
+        </Card>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Summary
Registration form UX: Improved field layout, validation messages, and overall structure of the registration form; tightened settings form UX in the same pass
Login form: Clearer password validation message, fixed page layout, and corrected grid card spacing on the search/browse pages
Settings: Added password visibility toggles to the change-password and change-email sections; centered the delete-account button on narrow viewports and removed a redundant label
Auth page layout consistency: Wrapped ForgotPassword and ResetPassword (all states: form, success, error, no-token) in the shared content-container div so narrow viewports get the same horizontal margins as the login and register pages
Test plan
 Register a new account — check field layout, validation messages, and error states on mobile and desktop
 Log in with a wrong password — verify the validation message is clear
 Open Settings → Change Password and Change Email — confirm visibility toggles work on both fields
 Open Settings on a narrow viewport — confirm the delete-account button is centered
 Visit /forgot-password on a narrow viewport — confirm left/right margins match the login page
 Submit the forgot-password form and check the "Check your email" success state — same margins
 Open a reset-password link (/reset-password?token=...) on a narrow viewport — confirm all four states (form, success, error, no-token) have consistent margins