### PR TITLE
hide forgot password link on login form; note deferred feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,12 @@ The chat page supports both direct (1-to-1) and team group conversations.
 
 ---
 
+## Deferred Features
+
+- **Forgot password flow** — The full reset flow is implemented (`ForgotPassword.jsx`, `ResetPassword.jsx`, `/api/auth/forgot-password`, `/api/auth/reset-password`) but the "Forgot password?" link on the login form is currently hidden. Re-enable it in `src/components/auth/LoginForm.jsx` once email delivery is confirmed stable.
+
+---
+
 ## Related
 
 - **Backend repo:** [Lomir-backend](https://github.com/KasparSinitsin/Lomir-backend)

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -140,11 +140,13 @@ const LoginForm = () => {
             </div>
           </FormGroup>
 
+          {/* Forgot password link — hidden for now, re-enable when email delivery is stable
           <div className="text-right mt-1">
             <Link to="/forgot-password" className="link link-primary text-sm">
               Forgot password?
             </Link>
           </div>
+          */}
 
           <div className="mt-6">
             <Button


### PR DESCRIPTION
hide forgot password link on login form; note deferred feature in README

The reset flow (ForgotPassword, ResetPassword, backend routes) is fully
implemented but the entry point is disabled until email delivery is fully implemented with a final lomir domain.