### PR TITLE
ui: polish auth forms, settings, and page layout consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,12 @@ The chat page supports both direct (1-to-1) and team group conversations.
 
 ---
 
+## Deferred Features
+
+- **Forgot password flow** — The full reset flow is implemented (`ForgotPassword.jsx`, `ResetPassword.jsx`, `/api/auth/forgot-password`, `/api/auth/reset-password`) but the "Forgot password?" link on the login form is currently hidden. Re-enable it in `src/components/auth/LoginForm.jsx` once email delivery is confirmed stable.
+
+---
+
 ## Related
 
 - **Backend repo:** [Lomir-backend](https://github.com/KasparSinitsin/Lomir-backend)

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../../contexts/AuthContext";
 import Card from "../common/Card";
 import Button from "../common/Button";
 import FormGroup from "../common/FormGroup";
+import { Eye, EyeOff } from "lucide-react";
 
 const LoginForm = () => {
   const [formData, setFormData] = useState({
@@ -12,6 +13,7 @@ const LoginForm = () => {
   });
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const { login } = useAuth();
   const navigate = useNavigate();
 
@@ -26,6 +28,8 @@ const LoginForm = () => {
 
     if (!formData.password) {
       newErrors.password = "Password is required";
+    } else if (formData.password.length < 6) {
+      newErrors.password = "Password incomplete or wrong";
     }
 
     setErrors(newErrors);
@@ -38,6 +42,9 @@ const LoginForm = () => {
       ...formData,
       [name]: value,
     });
+    if (errors[name] || errors.form) {
+      setErrors((prev) => ({ ...prev, [name]: undefined, form: undefined }));
+    }
   };
 
   const handleSubmit = async (e) => {
@@ -54,8 +61,10 @@ const LoginForm = () => {
 
       if (result.success) {
         navigate("/profile");
+      } else if (result.message === "Invalid email") {
+        setErrors({ email: result.message });
       } else {
-        setErrors({ form: result.message });
+        setErrors({ password: result.message });
       }
     } catch (error) {
       setErrors({ form: "An unexpected error occurred. Please try again." });
@@ -80,7 +89,7 @@ const LoginForm = () => {
           </div>
         )}
 
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} noValidate>
           <FormGroup
             label="Email"
             htmlFor="email"
@@ -104,15 +113,31 @@ const LoginForm = () => {
             error={errors.password}
             required
           >
-            <input
-              id="password"
-              type="password"
-              name="password"
-              placeholder="••••••••"
-              className={`input input-bordered w-full ${errors.password ? "input-error" : ""}`}
-              value={formData.password}
-              onChange={handleChange}
-            />
+            <div className="relative">
+              <input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                name="password"
+                placeholder="••••••••"
+                className={`input input-bordered w-full pr-12 ${errors.password ? "input-error" : ""}`}
+                value={formData.password}
+                onChange={handleChange}
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-0 flex items-center px-3 text-base-content/60 transition-colors hover:text-base-content"
+                onClick={() => setShowPassword((prev) => !prev)}
+                onMouseDown={(e) => e.preventDefault()}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                aria-pressed={showPassword}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </button>
+            </div>
           </FormGroup>
 
           <div className="text-right mt-1">

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -140,11 +140,13 @@ const LoginForm = () => {
             </div>
           </FormGroup>
 
+          {/* Forgot password link — hidden for now, re-enable when email delivery is stable
           <div className="text-right mt-1">
             <Link to="/forgot-password" className="link link-primary text-sm">
               Forgot password?
             </Link>
           </div>
+          */}
 
           <div className="mt-6">
             <Button

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -67,9 +67,12 @@ const LoginForm = () => {
   return (
     <div className="max-w-md mx-auto w-full">
       <Card>
-        <h2 className="text-2xl font-bold text-center text-primary mb-6">
+        <h2 className="card-title text-2xl font-bold text-center justify-center mt-6 mb-4 text-success">
           Login
         </h2>
+        <p className="text-center text-base-content/70 mb-6">
+          Welcome back to Lomir
+        </p>
 
         {errors.form && (
           <div className="alert alert-error mb-6">

--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -444,7 +444,7 @@ const RegisterForm = () => {
     <div className="w-full">
       <Card className="w-full">
         <div className="card-body">
-          <h2 className="card-title text-2xl font-bold text-center justify-center mb-2">
+          <h2 className="card-title text-2xl font-bold text-center justify-center mb-4 text-success">
             Create Account
           </h2>
           <p className="text-center text-base-content/70 mb-6">

--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -81,12 +81,17 @@ const RegisterForm = () => {
   const validateForm = () => {
     const newErrors = {};
 
-    if (!formData.username) newErrors.username = "Username is required";
+    if (!formData.username) {
+      newErrors.username = ["Please enter a username."];
+    } else {
+      const usernameErrors = getUsernameValidationErrors(formData.username);
+      if (usernameErrors.length > 0) newErrors.username = usernameErrors;
+    }
 
     if (!formData.email) {
       newErrors.email = "Email is required";
     } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
-      newErrors.email = "Email is invalid";
+      newErrors.email = "Please enter a valid email address (e.g. your@email.com).";
     }
 
     if (!formData.password) {
@@ -122,6 +127,61 @@ const RegisterForm = () => {
       const remainingErrors = { ...prev };
       delete remainingErrors[fieldName];
       return remainingErrors;
+    });
+  };
+
+  const getUsernameValidationErrors = (username) => {
+    const usernameErrors = [];
+
+    if (username.length < 3) {
+      usernameErrors.push("Username must be at least 3 characters.");
+    }
+
+    if (username.length > 30) {
+      usernameErrors.push("Username must be no longer than 30 characters.");
+    }
+
+    if (!/^[a-zA-Z0-9]*$/.test(username)) {
+      usernameErrors.push(
+        "Username can only contain letters and numbers — no spaces or special characters.",
+      );
+    }
+
+    return usernameErrors;
+  };
+
+  const handleEmailBlur = () => {
+    if (!formData.email) return;
+
+    setErrors((prev) => {
+      const nextErrors = { ...prev };
+
+      if (!/\S+@\S+\.\S+/.test(formData.email)) {
+        nextErrors.email =
+          "Please enter a valid email address (e.g. your@email.com).";
+      } else {
+        delete nextErrors.email;
+      }
+
+      return nextErrors;
+    });
+  };
+
+  const handleUsernameBlur = () => {
+    if (!formData.username) return;
+
+    const usernameErrors = getUsernameValidationErrors(formData.username);
+
+    setErrors((prev) => {
+      const nextErrors = { ...prev };
+
+      if (usernameErrors.length > 0) {
+        nextErrors.username = usernameErrors;
+      } else {
+        delete nextErrors.username;
+      }
+
+      return nextErrors;
     });
   };
 
@@ -311,6 +371,12 @@ const RegisterForm = () => {
     }
   };
 
+  const usernameErrorMessages = Array.isArray(errors.username)
+    ? errors.username
+    : errors.username
+      ? [errors.username]
+      : [];
+
   const passwordErrorMessages = Array.isArray(errors.password)
     ? errors.password
     : errors.password
@@ -407,18 +473,27 @@ const RegisterForm = () => {
                     type="text"
                     placeholder="Choose a username"
                     className={`input input-bordered w-full ${
-                      errors.username ? "input-error" : ""
+                      usernameErrorMessages.length > 0 ? "input-error" : ""
                     }`}
                     value={formData.username}
                     onChange={handleChange}
+                    onFocus={() => clearFieldError("username")}
+                    onBlur={handleUsernameBlur}
                     name="username"
                   />
-                  {errors.username && (
-                    <label className="label">
-                      <span className="label-text-alt text-error">
-                        {errors.username}
-                      </span>
-                    </label>
+                  {usernameErrorMessages.length === 0 && (
+                    <p className="form-helper-text mt-2 px-1">
+                      3–30 characters, letters and numbers only (no spaces).
+                    </p>
+                  )}
+                  {usernameErrorMessages.length > 0 && (
+                    <div className="mt-2 px-1 flex flex-col gap-0.5">
+                      {usernameErrorMessages.map((err) => (
+                        <p key={err} className="text-xs text-error">
+                          {err}
+                        </p>
+                      ))}
+                    </div>
                   )}
                 </div>
 
@@ -436,14 +511,14 @@ const RegisterForm = () => {
                     }`}
                     value={formData.email}
                     onChange={handleChange}
+                    onFocus={() => clearFieldError("email")}
+                    onBlur={handleEmailBlur}
                     name="email"
                   />
                   {errors.email && (
-                    <label className="label">
-                      <span className="label-text-alt text-error">
-                        {errors.email}
-                      </span>
-                    </label>
+                    <p className="text-xs text-error mt-2 px-1">
+                      {errors.email}
+                    </p>
                   )}
                 </div>
               </div>
@@ -490,16 +565,13 @@ const RegisterForm = () => {
                     </p>
                   )}
                   {passwordErrorMessages.length > 0 && (
-                    <label className="label mt-2 flex flex-col items-start gap-0.5">
+                    <div className="mt-2 px-1 flex flex-col gap-0.5">
                       {passwordErrorMessages.map((passwordError) => (
-                        <span
-                          key={passwordError}
-                          className="label-text-alt text-error"
-                        >
+                        <p key={passwordError} className="text-xs text-error">
                           {passwordError}
-                        </span>
+                        </p>
                       ))}
-                    </label>
+                    </div>
                   )}
                 </div>
 
@@ -540,11 +612,9 @@ const RegisterForm = () => {
                     </button>
                   </div>
                   {errors.confirmPassword && (
-                    <label className="label">
-                      <span className="label-text-alt text-error">
-                        {errors.confirmPassword}
-                      </span>
-                    </label>
+                    <p className="text-xs text-error mt-2 px-1">
+                      {errors.confirmPassword}
+                    </p>
                   )}
                 </div>
               </div>

--- a/src/components/common/Alert.jsx
+++ b/src/components/common/Alert.jsx
@@ -33,7 +33,7 @@ const Alert = ({
     <div
       className={`alert ${alertClasses[type]} !text-white w-fit transition-opacity duration-1000 ${fading ? "opacity-0" : "opacity-100"} ${className}`}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex items-start gap-2">
         {type === "info" && (
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/layout/Grid.jsx
+++ b/src/components/layout/Grid.jsx
@@ -1,21 +1,32 @@
 import React from 'react';
 
-const Grid = ({ 
-  children, 
+const GAP = { 0: 'gap-0', 1: 'gap-1', 2: 'gap-2', 3: 'gap-3', 4: 'gap-4', 5: 'gap-5', 6: 'gap-6', 8: 'gap-8', 10: 'gap-10', 12: 'gap-12' };
+const COLS = { 1: 'grid-cols-1', 2: 'grid-cols-2', 3: 'grid-cols-3', 4: 'grid-cols-4', 5: 'grid-cols-5', 6: 'grid-cols-6' };
+const SM   = { 1: 'sm:grid-cols-1', 2: 'sm:grid-cols-2', 3: 'sm:grid-cols-3', 4: 'sm:grid-cols-4' };
+const MD   = { 1: 'md:grid-cols-1', 2: 'md:grid-cols-2', 3: 'md:grid-cols-3', 4: 'md:grid-cols-4' };
+const LG   = { 1: 'lg:grid-cols-1', 2: 'lg:grid-cols-2', 3: 'lg:grid-cols-3', 4: 'lg:grid-cols-4' };
+const XL   = { 1: 'xl:grid-cols-1', 2: 'xl:grid-cols-2', 3: 'xl:grid-cols-3', 4: 'xl:grid-cols-4' };
+
+const Grid = ({
+  children,
   cols = 1,
   sm = null,
   md = null,
   lg = null,
   xl = null,
   gap = 6,
-  className = ''
+  className = '',
 }) => {
-  const getColClasses = () => {
-    return `grid-cols-${cols} ${sm ? `sm:grid-cols-${sm}` : ''} ${md ? `md:grid-cols-${md}` : ''} ${lg ? `lg:grid-cols-${lg}` : ''} ${xl ? `xl:grid-cols-${xl}` : ''}`;
-  };
-  
+  const colClasses = [
+    COLS[cols] ?? `grid-cols-${cols}`,
+    sm ? (SM[sm] ?? `sm:grid-cols-${sm}`) : '',
+    md ? (MD[md] ?? `md:grid-cols-${md}`) : '',
+    lg ? (LG[lg] ?? `lg:grid-cols-${lg}`) : '',
+    xl ? (XL[xl] ?? `xl:grid-cols-${xl}`) : '',
+  ].filter(Boolean).join(' ');
+
   return (
-    <div className={`grid ${getColClasses()} gap-${gap} ${className}`}>
+    <div className={`grid ${colClasses} ${GAP[gap] ?? `gap-${gap}`} ${className}`}>
       {children}
     </div>
   );

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -2895,7 +2895,7 @@ const TeamCard = ({
         titleClassName={
           viewMode === "mini" ? "text-base mb-0.5 leading-[110%]" : ""
         }
-        marginClassName={viewMode === "mini" ? "mb-2" : ""}
+        marginClassName="mb-0"
         imageOverlay={avatarOverlay}
         imageInnerOverlay={demoAvatarOverlay}
       >

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -1192,7 +1192,7 @@ const VacantRoleCard = ({
           titleClassName={
             viewMode === "mini" ? "text-base mb-0.5 leading-[110%]" : ""
           }
-          marginClassName={viewMode === "mini" ? "mb-2" : ""}
+          marginClassName="mb-0"
           imageOverlay={
             searchResultTypeOverlay ??
             (matchTier ? renderMatchOverlay({ size: 20, iconSize: 10 }) : null)

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -432,7 +432,7 @@ const UserCard = ({
       titleClassName={
         viewMode === "mini" ? "text-base mb-0.5 leading-[110%]" : ""
       }
-      marginClassName={viewMode === "mini" ? "mb-2" : ""}
+      marginClassName="mb-0"
       imageOverlay={avatarOverlay}
       imageInnerOverlay={demoAvatarOverlay}
     >

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -142,7 +142,9 @@ export const AuthProvider = ({ children }) => {
   const login = async (credentials) => {
     try {
       setLoading(true);
-      const response = await api.post("/api/auth/login", credentials);
+      const response = await api.post("/api/auth/login", credentials, {
+        skipAuthRedirect: true,
+      });
       const { token, user } = response.data.data;
 
       const enhancedUser = normalizeAuthUser(user);

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -56,8 +56,9 @@ const ForgotPassword = () => {
   // Success state
   if (status === "success") {
     return (
-      <div className="max-w-md mx-auto mt-12">
-        <Card className="w-full">
+      <div className="content-container">
+        <div className="max-w-md mx-auto w-full">
+        <Card>
           <div className="card-body text-center py-10 px-8">
             <CheckCircle size={56} className="mx-auto mb-4 text-success" />
 
@@ -93,12 +94,14 @@ const ForgotPassword = () => {
             </div>
           </div>
         </Card>
+        </div>
       </div>
     );
   }
 
   // Form state
   return (
+    <div className="content-container">
     <div className="max-w-md mx-auto w-full">
       <Card>
         <div className="card-body">
@@ -162,6 +165,7 @@ const ForgotPassword = () => {
           </div>
         </div>
       </Card>
+    </div>
     </div>
   );
 };

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,7 +1,9 @@
 import LoginForm from "../components/auth/LoginForm";
 
-const Login = () => {
-  return <LoginForm />;
-};
+const Login = () => (
+  <div className="content-container">
+    <LoginForm />
+  </div>
+);
 
 export default Login;

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -112,23 +112,25 @@ const ResetPassword = () => {
   // No token state
   if (!token && status !== "error") {
     return (
-      <div className="max-w-md mx-auto mt-12">
-        <Card className="w-full">
-          <div className="card-body text-center py-10 px-8">
-            <XCircle size={56} className="mx-auto mb-4 text-error" />
-            <h2 className="card-title text-2xl font-bold justify-center mb-3">
-              Invalid Link
-            </h2>
-            <p className="text-base-content/70 mb-8">
-              No reset token found. Please request a new password reset link.
-            </p>
-            <Link to="/forgot-password" className="w-full">
-              <Button variant="primary" fullWidth>
-                Request New Link
-              </Button>
-            </Link>
-          </div>
-        </Card>
+      <div className="content-container">
+        <div className="max-w-md mx-auto w-full">
+          <Card>
+            <div className="card-body text-center py-10 px-8">
+              <XCircle size={56} className="mx-auto mb-4 text-error" />
+              <h2 className="card-title text-2xl font-bold justify-center mb-3">
+                Invalid Link
+              </h2>
+              <p className="text-base-content/70 mb-8">
+                No reset token found. Please request a new password reset link.
+              </p>
+              <Link to="/forgot-password" className="w-full">
+                <Button variant="primary" fullWidth>
+                  Request New Link
+                </Button>
+              </Link>
+            </div>
+          </Card>
+        </div>
       </div>
     );
   }
@@ -136,24 +138,26 @@ const ResetPassword = () => {
   // Success state
   if (status === "success") {
     return (
-      <div className="max-w-md mx-auto mt-12">
-        <Card className="w-full">
-          <div className="card-body text-center py-10 px-8">
-            <CheckCircle size={56} className="mx-auto mb-4 text-success" />
+      <div className="content-container">
+        <div className="max-w-md mx-auto w-full">
+          <Card>
+            <div className="card-body text-center py-10 px-8">
+              <CheckCircle size={56} className="mx-auto mb-4 text-success" />
 
-            <h2 className="card-title text-2xl font-bold justify-center mb-3">
-              Password Reset!
-            </h2>
+              <h2 className="card-title text-2xl font-bold justify-center mb-3">
+                Password Reset!
+              </h2>
 
-            <p className="text-base-content/70 mb-8">{message}</p>
+              <p className="text-base-content/70 mb-8">{message}</p>
 
-            <Link to="/login" className="w-full">
-              <Button variant="primary" fullWidth>
-                Log in with new password
-              </Button>
-            </Link>
-          </div>
-        </Card>
+              <Link to="/login" className="w-full">
+                <Button variant="primary" fullWidth>
+                  Log in with new password
+                </Button>
+              </Link>
+            </div>
+          </Card>
+        </div>
       </div>
     );
   }
@@ -161,139 +165,143 @@ const ResetPassword = () => {
   // Error state (invalid/expired token)
   if (status === "error") {
     return (
-      <div className="max-w-md mx-auto mt-12">
-        <Card className="w-full">
-          <div className="card-body text-center py-10 px-8">
-            <XCircle size={56} className="mx-auto mb-4 text-error" />
+      <div className="content-container">
+        <div className="max-w-md mx-auto w-full">
+          <Card>
+            <div className="card-body text-center py-10 px-8">
+              <XCircle size={56} className="mx-auto mb-4 text-error" />
 
-            <h2 className="card-title text-2xl font-bold justify-center mb-3">
-              Reset Failed
-            </h2>
+              <h2 className="card-title text-2xl font-bold justify-center mb-3">
+                Reset Failed
+              </h2>
 
-            <p className="text-base-content/70 mb-8">{message}</p>
+              <p className="text-base-content/70 mb-8">{message}</p>
 
-            <div className="space-y-3">
-              <Link to="/forgot-password" className="w-full block">
-                <Button variant="primary" fullWidth>
-                  Request New Reset Link
-                </Button>
-              </Link>
-              <Link to="/login" className="w-full block">
-                <Button variant="ghost" fullWidth>
-                  Back to Login
-                </Button>
-              </Link>
+              <div className="space-y-3">
+                <Link to="/forgot-password" className="w-full block">
+                  <Button variant="primary" fullWidth>
+                    Request New Reset Link
+                  </Button>
+                </Link>
+                <Link to="/login" className="w-full block">
+                  <Button variant="ghost" fullWidth>
+                    Back to Login
+                  </Button>
+                </Link>
+              </div>
             </div>
-          </div>
-        </Card>
+          </Card>
+        </div>
       </div>
     );
   }
 
   // Form state
   return (
-    <div className="max-w-md mx-auto w-full">
-      <Card>
-        <div className="card-body">
-          <div className="text-center mb-6">
-            <KeyRound size={48} className="mx-auto mb-4 text-primary" />
-            <h2 className="text-2xl font-bold text-primary">
-              Create New Password
-            </h2>
-            <p className="text-base-content/70 mt-2">
-              Enter your new password below.
-            </p>
-          </div>
-
-          <form onSubmit={handleSubmit}>
-            <FormGroup
-              label="New Password"
-              htmlFor="password"
-              error={errors.password}
-              required
-            >
-              <div className="relative">
-                <input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  name="password"
-                  placeholder="••••••••"
-                  className={`input input-bordered w-full pr-10 ${
-                    errors.password ? "input-error" : ""
-                  }`}
-                  value={formData.password}
-                  onChange={handleChange}
-                  disabled={status === "submitting"}
-                />
-                <button
-                  type="button"
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
-                  onClick={() => setShowPassword(!showPassword)}
-                >
-                  {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
-                </button>
-              </div>
-            </FormGroup>
-
-            <FormGroup
-              label="Confirm New Password"
-              htmlFor="confirmPassword"
-              error={errors.confirmPassword}
-              required
-            >
-              <div className="relative">
-                <input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? "text" : "password"}
-                  name="confirmPassword"
-                  placeholder="••••••••"
-                  className={`input input-bordered w-full pr-10 ${
-                    errors.confirmPassword ? "input-error" : ""
-                  }`}
-                  value={formData.confirmPassword}
-                  onChange={handleChange}
-                  disabled={status === "submitting"}
-                />
-                <button
-                  type="button"
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                >
-                  {showConfirmPassword ? (
-                    <EyeOff size={20} />
-                  ) : (
-                    <Eye size={20} />
-                  )}
-                </button>
-              </div>
-            </FormGroup>
-
-            <div className="mt-6">
-              <Button
-                type="submit"
-                variant="primary"
-                fullWidth
-                disabled={status === "submitting"}
-              >
-                {status === "submitting" ? (
-                  <>
-                    <Loader2 size={20} className="animate-spin mr-2" />
-                    Resetting...
-                  </>
-                ) : (
-                  "Reset Password"
-                )}
-              </Button>
+    <div className="content-container">
+      <div className="max-w-md mx-auto w-full">
+        <Card>
+          <div className="card-body">
+            <div className="text-center mb-6">
+              <KeyRound size={48} className="mx-auto mb-4 text-primary" />
+              <h2 className="text-2xl font-bold text-primary">
+                Create New Password
+              </h2>
+              <p className="text-base-content/70 mt-2">
+                Enter your new password below.
+              </p>
             </div>
-          </form>
 
-          <div className="text-center mt-6">
-            <Link to="/login" className="link link-primary text-sm">
-              Back to Login
-            </Link>
+            <form onSubmit={handleSubmit}>
+              <FormGroup
+                label="New Password"
+                htmlFor="password"
+                error={errors.password}
+                required
+              >
+                <div className="relative">
+                  <input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    name="password"
+                    placeholder="••••••••"
+                    className={`input input-bordered w-full pr-10 ${
+                      errors.password ? "input-error" : ""
+                    }`}
+                    value={formData.password}
+                    onChange={handleChange}
+                    disabled={status === "submitting"}
+                  />
+                  <button
+                    type="button"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
+                    onClick={() => setShowPassword(!showPassword)}
+                  >
+                    {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+                  </button>
+                </div>
+              </FormGroup>
+
+              <FormGroup
+                label="Confirm New Password"
+                htmlFor="confirmPassword"
+                error={errors.confirmPassword}
+                required
+              >
+                <div className="relative">
+                  <input
+                    id="confirmPassword"
+                    type={showConfirmPassword ? "text" : "password"}
+                    name="confirmPassword"
+                    placeholder="••••••••"
+                    className={`input input-bordered w-full pr-10 ${
+                      errors.confirmPassword ? "input-error" : ""
+                    }`}
+                    value={formData.confirmPassword}
+                    onChange={handleChange}
+                    disabled={status === "submitting"}
+                  />
+                  <button
+                    type="button"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff size={20} />
+                    ) : (
+                      <Eye size={20} />
+                    )}
+                  </button>
+                </div>
+              </FormGroup>
+
+              <div className="mt-6">
+                <Button
+                  type="submit"
+                  variant="primary"
+                  fullWidth
+                  disabled={status === "submitting"}
+                >
+                  {status === "submitting" ? (
+                    <>
+                      <Loader2 size={20} className="animate-spin mr-2" />
+                      Resetting...
+                    </>
+                  ) : (
+                    "Reset Password"
+                  )}
+                </Button>
+              </div>
+            </form>
+
+            <div className="text-center mt-6">
+              <Link to="/login" className="link link-primary text-sm">
+                Back to Login
+              </Link>
+            </div>
           </div>
-        </div>
-      </Card>
+        </Card>
+      </div>
     </div>
   );
 };

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -970,7 +970,7 @@ const Settings = () => {
             </form>
           ) : (
             <div className="space-y-4">
-              <Alert type="warning" className="w-full">
+              <Alert type="warning" className="w-full mb-2">
                 Please review this carefully. Deleting your account is
                 irreversible.
               </Alert>
@@ -1159,11 +1159,7 @@ const Settings = () => {
                 </Card>
               )}
 
-              <Card
-                hoverable={false}
-                marginClassName="mb-0"
-                contentClassName="space-y-4"
-              >
+              <div className="space-y-4">
                 <div className="flex items-center gap-2 text-primary">
                   <Trash2 size={18} />
                   <h3 className="text-base font-semibold">Summary</h3>
@@ -1184,7 +1180,7 @@ const Settings = () => {
                     {directMessagesCount === 1 ? "" : "s"} will be deleted
                   </p>
                 </div>
-              </Card>
+              </div>
 
               <div className="flex justify-end gap-3 pt-2">
                 <Button

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -922,25 +922,20 @@ const Settings = () => {
           <section className="space-y-4">
             <FormSectionDivider text="Danger Zone" icon={Trash2} />
 
-            <div className="form-control w-full">
-              <label className="label">
-                <span className="label-text">Delete Account</span>
-              </label>
-              <div className="flex items-center justify-between">
-                <p className="form-helper-text">
-                  Permanently delete your profile, messages, teams, and all
-                  associated data. This cannot be undone.
-                </p>
-                <Button
-                  variant="errorOutline"
-                  size="sm"
-                  onClick={openDeleteModal}
-                  icon={<Trash2 size={16} />}
-                  className="flex-shrink-0 ml-4"
-                >
-                  Delete Account
-                </Button>
-              </div>
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <p className="form-helper-text">
+                Permanently delete your profile, messages, teams, and all
+                associated data. This cannot be undone.
+              </p>
+              <Button
+                variant="errorOutline"
+                size="sm"
+                onClick={openDeleteModal}
+                icon={<Trash2 size={16} />}
+                className="flex-shrink-0 mx-auto sm:mx-0 sm:ml-4"
+              >
+                Delete Account
+              </Button>
             </div>
           </section>
         </div>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -10,7 +10,7 @@ import VisibilityToggle from "../components/common/VisibilityToggle";
 import Modal from "../components/common/Modal";
 import { userService } from "../services/userService";
 import { teamService } from "../services/teamService";
-import { AlertTriangle, Eye, KeyRound, Shield, Trash2, Users } from "lucide-react";
+import { AlertTriangle, Eye, EyeOff, KeyRound, Shield, Trash2, Users } from "lucide-react";
 
 const DELETE_STEP_PASSWORD = "password";
 const DELETE_STEP_SUMMARY = "summary";
@@ -284,6 +284,10 @@ const Settings = () => {
   const [passwordErrors, setPasswordErrors] = useState({});
   const [passwordLoading, setPasswordLoading] = useState(false);
   const [showPasswordForm, setShowPasswordForm] = useState(false);
+  const [showCurrentPasswordForEmail, setShowCurrentPasswordForEmail] = useState(false);
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const validatePassword = () => {
     const errs = {};
@@ -692,6 +696,7 @@ const Settings = () => {
                   onClick={() => {
                     setShowEmailForm(!showEmailForm);
                     setEmailErrors({});
+                    setShowCurrentPasswordForEmail(false);
                   }}
                 >
                   {showEmailForm ? "Cancel" : "Change"}
@@ -727,18 +732,30 @@ const Settings = () => {
                       Confirm with Current Password
                     </span>
                   </label>
-                  <input
-                    type="password"
-                    className={inputClass(emailErrors.currentPasswordForEmail)}
-                    value={emailData.currentPasswordForEmail}
-                    onChange={(e) =>
-                      setEmailData({
-                        ...emailData,
-                        currentPasswordForEmail: e.target.value,
-                      })
-                    }
-                    placeholder="••••••••"
-                  />
+                  <div className="relative">
+                    <input
+                      type={showCurrentPasswordForEmail ? "text" : "password"}
+                      className={`${inputClass(emailErrors.currentPasswordForEmail)} pr-12`}
+                      value={emailData.currentPasswordForEmail}
+                      onChange={(e) =>
+                        setEmailData({
+                          ...emailData,
+                          currentPasswordForEmail: e.target.value,
+                        })
+                      }
+                      placeholder="••••••••"
+                    />
+                    <button
+                      type="button"
+                      className="absolute inset-y-0 right-0 flex items-center px-3 text-base-content/60 transition-colors hover:text-base-content"
+                      onClick={() => setShowCurrentPasswordForEmail((prev) => !prev)}
+                      onMouseDown={(e) => e.preventDefault()}
+                      aria-label={showCurrentPasswordForEmail ? "Hide password" : "Show password"}
+                      aria-pressed={showCurrentPasswordForEmail}
+                    >
+                      {showCurrentPasswordForEmail ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
                   <FieldError msg={emailErrors.currentPasswordForEmail} />
                 </div>
 
@@ -774,6 +791,9 @@ const Settings = () => {
                   onClick={() => {
                     setShowPasswordForm(!showPasswordForm);
                     setPasswordErrors({});
+                    setShowCurrentPassword(false);
+                    setShowNewPassword(false);
+                    setShowConfirmPassword(false);
                   }}
                 >
                   {showPasswordForm ? "Cancel" : "Change"}
@@ -791,18 +811,30 @@ const Settings = () => {
                   <label className="label">
                     <span className="label-text">Current Password</span>
                   </label>
-                  <input
-                    type="password"
-                    className={inputClass(passwordErrors.currentPassword)}
-                    value={passwordData.currentPassword}
-                    onChange={(e) =>
-                      setPasswordData({
-                        ...passwordData,
-                        currentPassword: e.target.value,
-                      })
-                    }
-                    placeholder="••••••••"
-                  />
+                  <div className="relative">
+                    <input
+                      type={showCurrentPassword ? "text" : "password"}
+                      className={`${inputClass(passwordErrors.currentPassword)} pr-12`}
+                      value={passwordData.currentPassword}
+                      onChange={(e) =>
+                        setPasswordData({
+                          ...passwordData,
+                          currentPassword: e.target.value,
+                        })
+                      }
+                      placeholder="••••••••"
+                    />
+                    <button
+                      type="button"
+                      className="absolute inset-y-0 right-0 flex items-center px-3 text-base-content/60 transition-colors hover:text-base-content"
+                      onClick={() => setShowCurrentPassword((prev) => !prev)}
+                      onMouseDown={(e) => e.preventDefault()}
+                      aria-label={showCurrentPassword ? "Hide password" : "Show password"}
+                      aria-pressed={showCurrentPassword}
+                    >
+                      {showCurrentPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
                   <FieldError msg={passwordErrors.currentPassword} />
                 </div>
 
@@ -810,18 +842,30 @@ const Settings = () => {
                   <label className="label">
                     <span className="label-text">New Password</span>
                   </label>
-                  <input
-                    type="password"
-                    className={inputClass(passwordErrors.newPassword)}
-                    value={passwordData.newPassword}
-                    onChange={(e) =>
-                      setPasswordData({
-                        ...passwordData,
-                        newPassword: e.target.value,
-                      })
-                    }
-                    placeholder="••••••••"
-                  />
+                  <div className="relative">
+                    <input
+                      type={showNewPassword ? "text" : "password"}
+                      className={`${inputClass(passwordErrors.newPassword)} pr-12`}
+                      value={passwordData.newPassword}
+                      onChange={(e) =>
+                        setPasswordData({
+                          ...passwordData,
+                          newPassword: e.target.value,
+                        })
+                      }
+                      placeholder="••••••••"
+                    />
+                    <button
+                      type="button"
+                      className="absolute inset-y-0 right-0 flex items-center px-3 text-base-content/60 transition-colors hover:text-base-content"
+                      onClick={() => setShowNewPassword((prev) => !prev)}
+                      onMouseDown={(e) => e.preventDefault()}
+                      aria-label={showNewPassword ? "Hide password" : "Show password"}
+                      aria-pressed={showNewPassword}
+                    >
+                      {showNewPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
                   <FieldError msg={passwordErrors.newPassword} />
                 </div>
 
@@ -829,18 +873,30 @@ const Settings = () => {
                   <label className="label">
                     <span className="label-text">Confirm New Password</span>
                   </label>
-                  <input
-                    type="password"
-                    className={inputClass(passwordErrors.confirmPassword)}
-                    value={passwordData.confirmPassword}
-                    onChange={(e) =>
-                      setPasswordData({
-                        ...passwordData,
-                        confirmPassword: e.target.value,
-                      })
-                    }
-                    placeholder="••••••••"
-                  />
+                  <div className="relative">
+                    <input
+                      type={showConfirmPassword ? "text" : "password"}
+                      className={`${inputClass(passwordErrors.confirmPassword)} pr-12`}
+                      value={passwordData.confirmPassword}
+                      onChange={(e) =>
+                        setPasswordData({
+                          ...passwordData,
+                          confirmPassword: e.target.value,
+                        })
+                      }
+                      placeholder="••••••••"
+                    />
+                    <button
+                      type="button"
+                      className="absolute inset-y-0 right-0 flex items-center px-3 text-base-content/60 transition-colors hover:text-base-content"
+                      onClick={() => setShowConfirmPassword((prev) => !prev)}
+                      onMouseDown={(e) => e.preventDefault()}
+                      aria-label={showConfirmPassword ? "Hide password" : "Show password"}
+                      aria-pressed={showConfirmPassword}
+                    >
+                      {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
                   <FieldError msg={passwordErrors.confirmPassword} />
                 </div>
 


### PR DESCRIPTION
**Summary**

- Registration form — Improved field layout, validation feedback, and overall UX; tightened settings-form UX in the same pass
- Login form — Clearer password validation message, improved page layout, and fixed grid card spacing on search/browse pages; "Forgot password?" link temporarily hidden until email delivery is confirmed stable (full reset flow remains in place)
- Settings — Added password visibility toggles to the change-password and change-email sections; centered the delete-account button on narrow viewports and removed a redundant label
- Auth page layout consistency — Wrapped all states of ForgotPassword and ResetPassword (form, success, error, no-token) in the shared content-container div so narrow viewports get the same horizontal margins as the login and register pages
- README — Added a "Deferred Features" section documenting the hidden forgot-password entry point and where to re-enable it
