### PR TITLE
Improve pill readability on narrow viewports

### DIFF
--- a/src/components/badges/BadgeAwardModal.jsx
+++ b/src/components/badges/BadgeAwardModal.jsx
@@ -923,7 +923,7 @@ const BadgeAwardModal = ({
                         className="flex-shrink-0"
                       />
                       <span
-                        className="badge badge-outline p-3 bg-white/60 inline-flex items-center gap-1.5 text-sm font-medium"
+                        className="badge badge-outline py-1 px-3 bg-white/60 inline-flex items-center gap-1.5 text-sm font-medium leading-tight h-auto"
                         style={{ borderColor: badgeColor, color: badgeColor }}
                       >
                         {selectedTag.name}

--- a/src/components/badges/BadgeCategoryCard.jsx
+++ b/src/components/badges/BadgeCategoryCard.jsx
@@ -80,7 +80,7 @@ const BadgeCategoryCard = ({
             return (
               <span
                 key={badge.id ?? badge.badge_id ?? badge.name}
-                className={`badge badge-outline p-3 bg-white/60 ${
+                className={`badge badge-outline py-1 px-3 bg-white/60 leading-tight h-auto ${
                   onBadgeClick
                     ? "cursor-pointer hover:opacity-90 transition-opacity"
                     : ""

--- a/src/components/badges/BadgesDisplaySection.jsx
+++ b/src/components/badges/BadgesDisplaySection.jsx
@@ -357,7 +357,7 @@ const BadgesDisplaySection = ({
                             ? highlightRef
                             : undefined
                         }
-                        className={`badge badge-outline p-3 bg-white/60 ${isClickable ? "cursor-pointer hover:shadow-md transition-shadow" : ""} ${
+                        className={`badge badge-outline py-1 px-3 bg-white/60 leading-tight h-auto inline-flex items-start gap-1 ${isClickable ? "cursor-pointer hover:shadow-md transition-shadow" : ""} ${
                           highlightBadgeName &&
                           badge.name?.toLowerCase() ===
                             highlightBadgeName.toLowerCase()
@@ -391,14 +391,14 @@ const BadgesDisplaySection = ({
                         {isBadgeMatch && (
                           <Check
                             size={12}
-                            className="flex-shrink-0"
+                            className="flex-shrink-0 mt-[3px]"
                             style={{ color: categoryColor }}
                           />
                         )}
                         {badge.name}
                         {credits && showCredits && (
-                          <span className="ml-1 opacity-70">
-                            | {credits}ct.
+                          <span className="opacity-70 self-stretch border-l border-current pl-1 flex items-start">
+                            {credits}ct.
                           </span>
                         )}
                       </span>

--- a/src/components/tags/TagInput.jsx
+++ b/src/components/tags/TagInput.jsx
@@ -477,9 +477,9 @@ const TagInput = ({
               return (
                 <span
                   key={tagId}
-                  className="badge badge-primary badge-lg gap-2"
+                  className="badge badge-primary badge-lg gap-2 leading-none items-start h-auto py-1.5"
                 >
-                  <TagIcon size={14} />
+                  <TagIcon size={14} className="shrink-0 mt-px" />
                   {tag?.name ?? `Focus Area ${tagId}`}
                   <button
                     type="button"

--- a/src/components/tags/TagsDisplaySection.jsx
+++ b/src/components/tags/TagsDisplaySection.jsx
@@ -322,7 +322,7 @@ const TagsDisplaySection = ({
       <Tooltip key={tag.key} content={tooltipText}>
         <span
           ref={isHighlighted ? highlightTagRef : undefined}
-          className={`badge badge-outline p-3 bg-white/60 inline-flex items-center gap-1 ${isClickable ? "cursor-pointer hover:shadow-md transition-shadow" : ""} ${
+          className={`badge badge-outline py-1 px-3 bg-white/60 leading-tight h-auto inline-flex items-start gap-1 ${isClickable ? "cursor-pointer hover:shadow-md transition-shadow" : ""} ${
             isHighlighted ? "animate-badge-highlight" : ""
           }`}
           style={{
@@ -347,13 +347,15 @@ const TagsDisplaySection = ({
           {isUserMatch && (
             <Check
               size={12}
-              className="flex-shrink-0"
+              className="flex-shrink-0 mt-[3px]"
               style={{ color: FOCUS_GREEN }}
             />
           )}
           {tag.name}
           {hasBadgeCredits && (
-            <span className="ml-1 opacity-70">| {tag.badgeCredits}ct.</span>
+            <span className="opacity-70 self-stretch border-l border-current pl-1 flex items-start">
+              {tag.badgeCredits}ct.
+            </span>
           )}
         </span>
       </Tooltip>


### PR DESCRIPTION
Focus area and badge pills were difficult to read on narrow/mobile viewports due to fixed DaisyUI badge heights clipping wrapped text, loose line-height, and misaligned icons and credit separators.

Changes across TagInput, TagsDisplaySection, BadgesDisplaySection, BadgeCategoryCard, BadgeAwardModal:

h-auto — overrides DaisyUI's fixed badge height so pills grow cleanly when text wraps to multiple lines
py-1 px-3 (display pills) / py-1.5 (edit pills) — replaces the old p-3 which, combined with h-auto, created excessive vertical padding; the new values approximate the original compact pill height for single-line labels
leading-tight / leading-none — tightens line spacing for multi-line pill text
items-start — aligns flex content to the first text line instead of vertically centering across all lines
Icon offsets (mt-px, mt-[3px]) — nudge the tag and checkmark icons to the optical center of the first text line
Credit separator — replaces the inline | Xct. text pattern with a self-stretch border-l span, so the divider line runs the full pill height and the credit count pins to the top row