### PR TITLE
Polish search bar UX and result view controls

### DIFF
--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -26,6 +26,7 @@ import {
   UserPlus,
 } from "lucide-react";
 import SearchHelp from "./SearchHelp";
+import Tooltip from "./common/Tooltip";
 import {
   getBadgeIcon,
   getCategoryIcon,
@@ -35,6 +36,7 @@ import {
   CATEGORY_COLORS,
   DEFAULT_COLOR,
   FOCUS_GREEN,
+  FOCUS_GREEN_DARK,
 } from "../constants/badgeConstants";
 
 const hexToRgba = (hex, alpha) => {
@@ -45,6 +47,29 @@ const hexToRgba = (hex, alpha) => {
 };
 
 const MIN_QUERY_HINT = "Enter at least 2 characters";
+const BOOLEAN_OPERATOR_SPLIT_PATTERN = /\b(?:AND|OR|NOT)\b/i;
+
+const cleanSuggestionSegment = (value) =>
+  value
+    .replace(/[()]/g, " ")
+    .replace(/^[\s"'-]+|[\s"')]+$/g, "")
+    .trim();
+
+const getSuggestionQuery = (value, cursorIndex = value.length) => {
+  const beforeCursor = value.slice(0, cursorIndex);
+  const segmentAtCursor = cleanSuggestionSegment(
+    beforeCursor.split(BOOLEAN_OPERATOR_SPLIT_PATTERN).pop() || "",
+  );
+
+  if (segmentAtCursor) return segmentAtCursor;
+
+  const fallbackSegments = value
+    .split(BOOLEAN_OPERATOR_SPLIT_PATTERN)
+    .map(cleanSuggestionSegment)
+    .filter(Boolean);
+
+  return fallbackSegments[fallbackSegments.length - 1] || "";
+};
 
 const getCriteriaPillIcon = (pill) => {
   if (pill.key === "maxDistance") return Ruler;
@@ -97,6 +122,7 @@ const BooleanSearchInput = ({
   onSearch,
   initialQuery = "",
   placeholder = "Search teams and users...",
+  compactPlaceholder = null,
   className = "",
   activePills = [],
   onRemoveActivePill,
@@ -108,6 +134,7 @@ const BooleanSearchInput = ({
   onSelectTagSuggestion,
   onSelectBadgeSuggestion,
   leftAdornment = null,
+  resetSignal = 0,
 }) => {
   const [query, setQuery] = useState(initialQuery);
   const [hasBooleanOperators, setHasBooleanOperators] = useState(false);
@@ -237,12 +264,12 @@ const BooleanSearchInput = ({
 
   const showMinQueryHint = query.trim().length > 0 && query.trim().length < 2;
   const hasLeftAdornment = Boolean(leftAdornment);
-  const leftAdornmentWidthPx = hasLeftAdornment ? 24 : 0;
+  const leftAdornmentWidthPx = hasLeftAdornment ? 28 : 0;
   const minimumInputWidthPx = query.trim().length > 0 ? 132 : 180;
   const inputTextWidthPx = Math.max(
     minimumInputWidthPx,
     query.trim().length > 0
-      ? measuredTextWidths.query + 8
+      ? measuredTextWidths.query + 32
       : measuredTextWidths.placeholder + 12,
   ) + leftAdornmentWidthPx;
 
@@ -260,7 +287,7 @@ const BooleanSearchInput = ({
 
   const baseHelperWidthPx =
     24 +
-    (hasBooleanOperators ? 72 : 0) +
+    (hasBooleanOperators ? (isCompactLayout ? 20 : 72) : 0) +
     (showMinQueryHint ? measuredTextWidths.hint + 8 : 0);
   const fieldInsetsPx = baseHelperWidthPx + 28;
   const fieldInsetsWithInlinePillsPx =
@@ -309,9 +336,14 @@ const BooleanSearchInput = ({
   }, []);
 
   useEffect(() => {
+    if (suggestionsTimerRef.current) {
+      clearTimeout(suggestionsTimerRef.current);
+    }
     setQuery(initialQuery);
     setHasBooleanOperators(checkBooleanOperators(initialQuery));
-  }, [initialQuery, checkBooleanOperators]);
+    setSuggestions({ tags: [], badges: [] });
+    setShowDropdown(false);
+  }, [initialQuery, resetSignal, checkBooleanOperators]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(max-width: 639px)");
@@ -365,14 +397,17 @@ const BooleanSearchInput = ({
 
   const handleChange = (e) => {
     const value = e.target.value;
+    const cursorIndex = e.target.selectionStart ?? value.length;
     setQuery(value);
     setHasBooleanOperators(checkBooleanOperators(value));
 
     if (suggestionsTimerRef.current) clearTimeout(suggestionsTimerRef.current);
 
-    if (value.trim().length >= 2 && onSearchSuggestions) {
+    const suggestionQuery = getSuggestionQuery(value, cursorIndex);
+
+    if (suggestionQuery.length >= 2 && onSearchSuggestions) {
       suggestionsTimerRef.current = setTimeout(async () => {
-        const result = await onSearchSuggestions(value.trim());
+        const result = await onSearchSuggestions(suggestionQuery);
         const newSuggestions = result || { tags: [], badges: [] };
         setSuggestions(newSuggestions);
         const hasAny =
@@ -381,6 +416,30 @@ const BooleanSearchInput = ({
           0;
         setShowDropdown(hasAny);
       }, 300);
+    } else {
+      setSuggestions({ tags: [], badges: [] });
+      setShowDropdown(false);
+    }
+  };
+
+  const handleSuggestionRefresh = () => {
+    const value = inputRef.current?.value ?? query;
+    const cursorIndex = inputRef.current?.selectionStart ?? value.length;
+    const suggestionQuery = getSuggestionQuery(value, cursorIndex);
+
+    if (suggestionsTimerRef.current) clearTimeout(suggestionsTimerRef.current);
+
+    if (suggestionQuery.length >= 2 && onSearchSuggestions) {
+      suggestionsTimerRef.current = setTimeout(async () => {
+        const result = await onSearchSuggestions(suggestionQuery);
+        const newSuggestions = result || { tags: [], badges: [] };
+        setSuggestions(newSuggestions);
+        const hasAny =
+          (newSuggestions.tags?.length || 0) +
+            (newSuggestions.badges?.length || 0) >
+          0;
+        setShowDropdown(hasAny);
+      }, 150);
     } else {
       setSuggestions({ tags: [], badges: [] });
       setShowDropdown(false);
@@ -396,25 +455,68 @@ const BooleanSearchInput = ({
   };
 
   const handleKeyDown = (e) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
       handleSubmit(e);
     } else if (e.key === "Escape") {
       setShowDropdown(false);
     }
   };
 
+  const resizeTextarea = useCallback(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
+  useEffect(() => { resizeTextarea(); }, [query, resizeTextarea]);
+
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    let prevWidth = el.offsetWidth;
+    const observer = new ResizeObserver((entries) => {
+      const newWidth = entries[0].contentRect.width;
+      if (newWidth !== prevWidth) {
+        prevWidth = newWidth;
+        resizeTextarea();
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [resizeTextarea]);
+
   const handleSelectTag = (tag) => {
     onSelectTagSuggestion?.(tag);
-    setQuery("");
-    setSuggestions({ tags: [], badges: [] });
-    setShowDropdown(false);
+    const nextSuggestions = {
+      tags: suggestions.tags.filter((item) => Number(item.id) !== Number(tag.id)),
+      badges: suggestions.badges,
+    };
+    setSuggestions(nextSuggestions);
+    setShowDropdown(
+      (nextSuggestions.tags?.length || 0) +
+        (nextSuggestions.badges?.length || 0) >
+        0,
+    );
+    requestAnimationFrame(() => inputRef.current?.focus());
   };
 
   const handleSelectBadge = (badge) => {
     onSelectBadgeSuggestion?.(badge);
-    setQuery("");
-    setSuggestions({ tags: [], badges: [] });
-    setShowDropdown(false);
+    const nextSuggestions = {
+      tags: suggestions.tags,
+      badges: suggestions.badges.filter(
+        (item) => Number(item.id) !== Number(badge.id),
+      ),
+    };
+    setSuggestions(nextSuggestions);
+    setShowDropdown(
+      (nextSuggestions.tags?.length || 0) +
+        (nextSuggestions.badges?.length || 0) >
+        0,
+    );
+    requestAnimationFrame(() => inputRef.current?.focus());
   };
 
   const rootClassName = isCompactLayout
@@ -451,10 +553,10 @@ const BooleanSearchInput = ({
   const alignHelperToTopPillRow = showStackedPills;
   const helperControlsClassName = alignHelperToTopPillRow
     ? "absolute right-8 top-2 flex items-center gap-1 pointer-events-auto"
-    : "absolute right-8 top-1/2 -translate-y-1/2 flex items-center gap-1 pointer-events-auto";
+    : "absolute right-8 top-2 flex items-center gap-1 pointer-events-auto";
   const infoIconClassName = alignHelperToTopPillRow
     ? "absolute right-2 top-2 flex items-center pointer-events-auto"
-    : "absolute inset-y-0 right-2 flex items-center pointer-events-auto";
+    : "absolute right-2 top-2 flex items-center pointer-events-auto";
   const pillBaseClassName =
     "inline-grid grid-cols-[0.625rem_minmax(0,auto)_0.625rem] items-start gap-1 rounded-lg px-2.5 py-[0.1875rem] text-xs font-medium leading-[1.1] transition-opacity hover:opacity-80";
   const pillIconClassName = "flex h-[1.1em] w-2.5 items-center justify-center";
@@ -462,7 +564,7 @@ const BooleanSearchInput = ({
   const pillLabelClassName = "min-w-0 text-left leading-[1.1]";
   const pillCloseClassName = "flex h-[1.1em] w-2.5 items-center justify-center";
   const pillTooltipClassName =
-    "tooltip tooltip-top tooltip-lomir inline-flex z-10 hover:z-[80] focus-within:z-[80]";
+    "tooltip tooltip-top tooltip-lomir inline-flex z-10 hover:z-[500] focus-within:z-[500]";
 
   const renderBadgePill = (pill) => {
     const color = CATEGORY_COLORS[pill.category] || DEFAULT_COLOR;
@@ -643,20 +745,21 @@ const BooleanSearchInput = ({
                   <div className="shrink-0">{leftAdornment}</div>
                 )}
 
-                <input
+                <textarea
                   ref={inputRef}
-                  type="text"
                   value={query}
                   onChange={handleChange}
+                  onFocus={handleSuggestionRefresh}
+                  onClick={handleSuggestionRefresh}
                   onKeyDown={handleKeyDown}
-                  placeholder={placeholder}
-                  className="min-w-0 flex-1 bg-transparent text-sm focus:outline-none"
+                  placeholder={isCompactLayout && compactPlaceholder ? compactPlaceholder : placeholder}
+                  className="min-w-0 flex-1 bg-transparent text-sm focus:outline-none leading-snug px-0 py-0"
                   style={{
                     overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
+                    resize: "none",
                   }}
                   minLength={2}
+                  rows={1}
                 />
               </div>
             </div>
@@ -687,14 +790,16 @@ const BooleanSearchInput = ({
                 </>
               )}
               {hasBooleanOperators && (
-                <span className="inline-flex items-center rounded-full bg-primary px-2 py-0.5 text-xs font-bold text-white">
-                  Advanced
-                </span>
+                <Tooltip content="Advanced Search active" position="top">
+                  <span className={`inline-flex items-center justify-center rounded-full text-xs font-bold text-white ${isCompactLayout ? "w-5 h-5" : "px-2 py-0.5"}`} style={{ backgroundColor: FOCUS_GREEN_DARK }}>
+                    <span className="-translate-y-px">{isCompactLayout ? "A" : "Advanced"}</span>
+                  </span>
+                </Tooltip>
               )}
             </div>
 
             <div className={infoIconClassName}>
-              <SearchHelp anchorRef={inputRef} />
+              <SearchHelp anchorRef={fieldRef} />
             </div>
 
             {typeof document !== "undefined" && createPortal(
@@ -852,7 +957,7 @@ const BooleanSearchInput = ({
 
           <button
             type="submit"
-            className="btn btn-primary h-[38px] min-h-0 px-3 sm:px-4 shrink-0"
+            className="btn btn-primary h-[32px] sm:h-[38px] min-h-0 px-2 sm:px-4 shrink-0"
             disabled={query.trim().length < 2}
             aria-label="Search"
           >

--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -731,8 +731,9 @@ const BooleanSearchInput = ({
 
           <button
             type="submit"
-            className="btn btn-primary"
+            className="btn btn-primary h-[38px] min-h-0 px-3 sm:px-4 shrink-0"
             disabled={query.trim().length < 2}
+            aria-label="Search"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -740,6 +741,7 @@ const BooleanSearchInput = ({
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -748,7 +750,7 @@ const BooleanSearchInput = ({
                 d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
               />
             </svg>
-            Search
+            <span className="sr-only sm:not-sr-only">Search</span>
           </button>
         </div>
 

--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -148,6 +148,7 @@ const BooleanSearchInput = ({
 
   const inputRef = useRef(null);
   const fieldRef = useRef(null);
+  const searchHelpRef = useRef(null);
   const queryMeasureRef = useRef(null);
   const placeholderMeasureRef = useRef(null);
   const hintMeasureRef = useRef(null);
@@ -286,12 +287,13 @@ const BooleanSearchInput = ({
     totalPillCount > 0 ? pillsWidthPx + pillsGapPx + 8 : 0;
 
   const baseHelperWidthPx =
-    24 +
-    (hasBooleanOperators ? (isCompactLayout ? 20 : 72) : 0) +
     (showMinQueryHint ? measuredTextWidths.hint + 8 : 0);
-  const fieldInsetsPx = baseHelperWidthPx + 28;
+  const indicatorInRowPx = hasBooleanOperators
+    ? (isCompactLayout ? 20 : 72)
+    : 20;
+  const fieldInsetsPx = baseHelperWidthPx + 32 + indicatorInRowPx;
   const fieldInsetsWithInlinePillsPx =
-    baseHelperWidthPx + inlinePillsWidthPx + 28;
+    baseHelperWidthPx + inlinePillsWidthPx + 28 + indicatorInRowPx;
   const estimatedFieldMaxWidthPx = Math.max(
     320,
     Math.min(viewportWidth - 16, 896) - 128,
@@ -307,8 +309,8 @@ const BooleanSearchInput = ({
   const helperWidthPx =
     baseHelperWidthPx + (showInlinePills ? inlinePillsWidthPx : 0);
   const fieldRightPaddingPx = showStackedPills
-    ? 48
-    : Math.max(48, helperWidthPx + 16);
+    ? 12
+    : Math.max(12, helperWidthPx + 8);
   const fieldWidthPx = Math.min(
     estimatedFieldMaxWidthPx,
     Math.max(
@@ -466,7 +468,11 @@ const BooleanSearchInput = ({
   const resizeTextarea = useCallback(() => {
     const el = inputRef.current;
     if (!el) return;
-    el.style.height = "auto";
+    if (!el.value) {
+      el.style.height = "";
+      return;
+    }
+    el.style.height = "0";
     el.style.height = `${el.scrollHeight}px`;
   }, []);
 
@@ -550,13 +556,7 @@ const BooleanSearchInput = ({
         maxWidth: "100%",
         paddingRight: `${fieldRightPaddingPx}px`,
       };
-  const alignHelperToTopPillRow = showStackedPills;
-  const helperControlsClassName = alignHelperToTopPillRow
-    ? "absolute right-8 top-2 flex items-center gap-1 pointer-events-auto"
-    : "absolute right-8 top-2 flex items-center gap-1 pointer-events-auto";
-  const infoIconClassName = alignHelperToTopPillRow
-    ? "absolute right-2 top-2 flex items-center pointer-events-auto"
-    : "absolute right-2 top-2 flex items-center pointer-events-auto";
+  const helperControlsClassName = "absolute right-2 top-2 flex items-center gap-1 pointer-events-auto";
   const pillBaseClassName =
     "inline-grid grid-cols-[0.625rem_minmax(0,auto)_0.625rem] items-start gap-1 rounded-lg px-2.5 py-[0.1875rem] text-xs font-medium leading-[1.1] transition-opacity hover:opacity-80";
   const pillIconClassName = "flex h-[1.1em] w-2.5 items-center justify-center";
@@ -721,7 +721,7 @@ const BooleanSearchInput = ({
           <div className={fieldSlotClassName}>
             <div ref={fieldRef} className={fieldClassName} style={fieldStyle}>
               {showStackedPills && (
-                <div className="mb-1 flex flex-wrap gap-2">
+                <div className="mb-2.5 flex flex-wrap gap-2">
                   {badgePills.length > 0 && (
                     <div className="flex flex-wrap gap-1">
                       {badgePills.map(renderBadgePill)}
@@ -761,6 +761,23 @@ const BooleanSearchInput = ({
                   minLength={2}
                   rows={1}
                 />
+
+                <div className="shrink-0 flex items-center">
+                  {hasBooleanOperators && (
+                    <Tooltip content="Search tips" position="top">
+                      <button
+                        type="button"
+                        onClick={(e) => searchHelpRef.current?.open(e.currentTarget)}
+                        className={`inline-flex items-center justify-center rounded-full text-xs font-bold text-white transition-opacity hover:opacity-80 ${isCompactLayout ? "w-5 h-5" : "px-2 py-0.5"}`}
+                        style={{ backgroundColor: FOCUS_GREEN_DARK }}
+                        aria-label="Search tips (Advanced Search active)"
+                      >
+                        <span className="-translate-y-px">{isCompactLayout ? "A" : "Advanced"}</span>
+                      </button>
+                    </Tooltip>
+                  )}
+                  <SearchHelp ref={searchHelpRef} anchorRef={fieldRef} hideButton={hasBooleanOperators} />
+                </div>
               </div>
             </div>
 
@@ -789,17 +806,6 @@ const BooleanSearchInput = ({
                   )}
                 </>
               )}
-              {hasBooleanOperators && (
-                <Tooltip content="Advanced Search active" position="top">
-                  <span className={`inline-flex items-center justify-center rounded-full text-xs font-bold text-white ${isCompactLayout ? "w-5 h-5" : "px-2 py-0.5"}`} style={{ backgroundColor: FOCUS_GREEN_DARK }}>
-                    <span className="-translate-y-px">{isCompactLayout ? "A" : "Advanced"}</span>
-                  </span>
-                </Tooltip>
-              )}
-            </div>
-
-            <div className={infoIconClassName}>
-              <SearchHelp anchorRef={fieldRef} />
             </div>
 
             {typeof document !== "undefined" && createPortal(

--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -306,6 +306,8 @@ const BooleanSearchInput = ({
   const fieldInsetsPx = sideControlsWidthPx + 32;
   const fieldInsetsWithInlinePillsPx =
     Math.max(baseHelperWidthPx + inlinePillsWidthPx, indicatorInRowPx) + 28;
+  const desktopQueryWithPillsMinWidthPx =
+    !isCompactLayout && query.length > 0 && totalPillCount > 0 ? 400 : 0;
   const estimatedFieldMaxWidthPx = Math.max(
     320,
     Math.min(viewportWidth - 16, 896) - 128,
@@ -314,6 +316,8 @@ const BooleanSearchInput = ({
     inputTextWidthPx + fieldInsetsWithInlinePillsPx;
   const canInlinePills =
     totalPillCount > 0 &&
+    query.trim().length === 0 &&
+    !hasVisibleLeftAdornment &&
     !hasBooleanOperators &&
     !isCompactLayout &&
     desiredSingleRowWidthPx <= estimatedFieldMaxWidthPx;
@@ -335,6 +339,7 @@ const BooleanSearchInput = ({
       inputTextWidthPx +
         (showInlinePills ? fieldInsetsWithInlinePillsPx : fieldInsetsPx),
       showStackedPills ? stackedPillsWidthPx + fieldInsetsPx : 0,
+      desktopQueryWithPillsMinWidthPx,
     ),
   );
 
@@ -579,7 +584,10 @@ const BooleanSearchInput = ({
   const trailingControlsStyle = {
     bottom: isCompactLayout && hasBooleanOperators ? "0.625rem" : "0.5625rem",
     ...(isCompactLayout && hasVisibleLeftAdornment
-      ? { right: hasBooleanOperators ? "0.625rem" : "1.875rem" }
+      ? {
+          right:
+            hasBooleanOperators || showStackedPills ? "0.625rem" : "1.875rem",
+        }
       : trailingControlsOffsetPx > 0
         ? { right: "1.875rem" }
         : {}),

--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -265,18 +265,26 @@ const BooleanSearchInput = ({
 
   const showMinQueryHint = query.trim().length > 0 && query.trim().length < 2;
   const hasLeftAdornment = Boolean(leftAdornment);
-  const leftAdornmentWidthPx = hasLeftAdornment ? 28 : 0;
   const minimumInputWidthPx = query.trim().length > 0 ? 132 : 180;
   const inputTextWidthPx = Math.max(
     minimumInputWidthPx,
     query.trim().length > 0
       ? measuredTextWidths.query + 32
       : measuredTextWidths.placeholder + 12,
-  ) + leftAdornmentWidthPx;
+  );
 
   // Combined pill width calculations across all three groups
   const allPills = [...badgePills, ...focusAreaPills, ...activePills];
   const totalPillCount = allPills.length;
+  const hasVisibleLeftAdornment =
+    hasLeftAdornment &&
+    (query.trim().length > 0 ||
+      initialQuery.trim().length > 0 ||
+      totalPillCount > 0);
+  const showResetInTrailingControls =
+    hasVisibleLeftAdornment && hasBooleanOperators;
+  const topAdornmentWidthPx =
+    hasVisibleLeftAdornment && !showResetInTrailingControls ? 22 : 0;
   const pillsWidthPx = allPills.reduce(
     (sum, pill) => sum + pill.label.length * 8 + 28,
     0,
@@ -287,13 +295,17 @@ const BooleanSearchInput = ({
     totalPillCount > 0 ? pillsWidthPx + pillsGapPx + 8 : 0;
 
   const baseHelperWidthPx =
-    (showMinQueryHint ? measuredTextWidths.hint + 8 : 0);
-  const indicatorInRowPx = hasBooleanOperators
-    ? (isCompactLayout ? 20 : 72)
+    (showMinQueryHint ? measuredTextWidths.hint + 8 : 0) +
+    topAdornmentWidthPx;
+  const trailingIndicatorWidthPx = hasBooleanOperators
+    ? (isCompactLayout ? 20 : 42)
     : 20;
-  const fieldInsetsPx = baseHelperWidthPx + 32 + indicatorInRowPx;
+  const indicatorInRowPx =
+    trailingIndicatorWidthPx + (showResetInTrailingControls ? 26 : 0);
+  const sideControlsWidthPx = Math.max(baseHelperWidthPx, indicatorInRowPx);
+  const fieldInsetsPx = sideControlsWidthPx + 32;
   const fieldInsetsWithInlinePillsPx =
-    baseHelperWidthPx + inlinePillsWidthPx + 28 + indicatorInRowPx;
+    Math.max(baseHelperWidthPx + inlinePillsWidthPx, indicatorInRowPx) + 28;
   const estimatedFieldMaxWidthPx = Math.max(
     320,
     Math.min(viewportWidth - 16, 896) - 128,
@@ -302,15 +314,21 @@ const BooleanSearchInput = ({
     inputTextWidthPx + fieldInsetsWithInlinePillsPx;
   const canInlinePills =
     totalPillCount > 0 &&
+    !hasBooleanOperators &&
     !isCompactLayout &&
     desiredSingleRowWidthPx <= estimatedFieldMaxWidthPx;
   const showInlinePills = canInlinePills;
   const showStackedPills = totalPillCount > 0 && !showInlinePills;
   const helperWidthPx =
     baseHelperWidthPx + (showInlinePills ? inlinePillsWidthPx : 0);
-  const fieldRightPaddingPx = showStackedPills
-    ? 12
-    : Math.max(12, helperWidthPx + 8);
+  const trailingControlsOffsetPx =
+    hasVisibleLeftAdornment && !showStackedPills && !isCompactLayout && !hasBooleanOperators
+      ? 30
+      : 0;
+  const fieldRightPaddingPx = Math.max(helperWidthPx, 12) + 8;
+  const textRowRightPaddingPx = isCompactLayout
+    ? 0
+    : indicatorInRowPx + trailingControlsOffsetPx + 8;
   const fieldWidthPx = Math.min(
     estimatedFieldMaxWidthPx,
     Math.max(
@@ -557,8 +575,20 @@ const BooleanSearchInput = ({
         paddingRight: `${fieldRightPaddingPx}px`,
       };
   const helperControlsClassName = "absolute right-2 top-2 flex items-center gap-1 pointer-events-auto";
+  const trailingControlsClassName = "absolute right-2 flex items-center gap-1 pointer-events-auto";
+  const trailingControlsStyle = {
+    bottom: isCompactLayout && hasBooleanOperators ? "0.625rem" : "0.5625rem",
+    ...(isCompactLayout && hasVisibleLeftAdornment
+      ? { right: hasBooleanOperators ? "0.625rem" : "1.875rem" }
+      : trailingControlsOffsetPx > 0
+        ? { right: "1.875rem" }
+        : {}),
+  };
   const pillBaseClassName =
     "inline-grid grid-cols-[0.625rem_minmax(0,auto)_0.625rem] items-start gap-1 rounded-lg px-2.5 py-[0.1875rem] text-xs font-medium leading-[1.1] transition-opacity hover:opacity-80";
+  const advancedIndicatorClassName = isCompactLayout
+    ? "inline-flex h-3.5 w-3.5 items-center justify-center rounded-full p-0 text-[0.625rem] font-medium leading-none text-white transition-opacity hover:opacity-80"
+    : "inline-flex h-[1.125rem] items-center justify-center rounded-lg px-2 py-0 text-xs font-medium leading-[1.1] text-white transition-opacity hover:opacity-80";
   const pillIconClassName = "flex h-[1.1em] w-2.5 items-center justify-center";
   const pillSvgClassName = "h-2.5 w-2.5";
   const pillLabelClassName = "min-w-0 text-left leading-[1.1]";
@@ -740,11 +770,7 @@ const BooleanSearchInput = ({
                 </div>
               )}
 
-              <div className="flex min-w-0 items-center gap-2">
-                {hasLeftAdornment && (
-                  <div className="shrink-0">{leftAdornment}</div>
-                )}
-
+              <div className="flex min-w-0 items-end gap-2">
                 <textarea
                   ref={inputRef}
                   value={query}
@@ -753,31 +779,36 @@ const BooleanSearchInput = ({
                   onClick={handleSuggestionRefresh}
                   onKeyDown={handleKeyDown}
                   placeholder={isCompactLayout && compactPlaceholder ? compactPlaceholder : placeholder}
-                  className="min-w-0 flex-1 bg-transparent text-sm focus:outline-none leading-snug px-0 py-0"
+                  className="min-w-0 flex-1 bg-transparent text-sm leading-[1.25] focus:outline-none px-0 py-0"
                   style={{
                     overflow: "hidden",
+                    paddingRight: `${textRowRightPaddingPx}px`,
                     resize: "none",
                   }}
                   minLength={2}
                   rows={1}
                 />
 
-                <div className="shrink-0 flex items-center">
-                  {hasBooleanOperators && (
-                    <Tooltip content="Search tips" position="top">
-                      <button
-                        type="button"
-                        onClick={(e) => searchHelpRef.current?.open(e.currentTarget)}
-                        className={`inline-flex items-center justify-center rounded-full text-xs font-bold text-white transition-opacity hover:opacity-80 ${isCompactLayout ? "w-5 h-5" : "px-2 py-0.5"}`}
-                        style={{ backgroundColor: FOCUS_GREEN_DARK }}
-                        aria-label="Search tips (Advanced Search active)"
-                      >
-                        <span className="-translate-y-px">{isCompactLayout ? "A" : "Advanced"}</span>
-                      </button>
-                    </Tooltip>
-                  )}
-                  <SearchHelp ref={searchHelpRef} anchorRef={fieldRef} hideButton={hasBooleanOperators} />
-                </div>
+              </div>
+              <div
+                className={trailingControlsClassName}
+                style={trailingControlsStyle}
+              >
+                {showResetInTrailingControls && leftAdornment}
+                {hasBooleanOperators && (
+                  <Tooltip content="Search tips" position="top">
+                    <button
+                      type="button"
+                      onClick={(e) => searchHelpRef.current?.open(e.currentTarget)}
+                      className={advancedIndicatorClassName}
+                      style={{ backgroundColor: FOCUS_GREEN_DARK }}
+                      aria-label="Search tips (Advanced Search active)"
+                    >
+                      <span className={isCompactLayout ? "leading-none" : pillLabelClassName}>{isCompactLayout ? "A" : "Advanced"}</span>
+                    </button>
+                  </Tooltip>
+                )}
+                <SearchHelp ref={searchHelpRef} anchorRef={fieldRef} hideButton={hasBooleanOperators} />
               </div>
             </div>
 
@@ -806,6 +837,7 @@ const BooleanSearchInput = ({
                   )}
                 </>
               )}
+              {hasVisibleLeftAdornment && !showResetInTrailingControls && leftAdornment}
             </div>
 
             {typeof document !== "undefined" && createPortal(

--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -604,8 +604,7 @@ const BooleanSearchInput = ({
   const pillTooltipClassName =
     "tooltip tooltip-top tooltip-lomir inline-flex z-10 hover:z-[500] focus-within:z-[500]";
 
-  const renderBadgePill = (pill) => {
-    const color = CATEGORY_COLORS[pill.category] || DEFAULT_COLOR;
+  const renderColoredFilterPill = ({ pill, color, icon, onRemove }) => {
     const tooltipText = `Remove ${pill.label}`;
     return (
       <span
@@ -615,12 +614,12 @@ const BooleanSearchInput = ({
       >
         <button
           type="button"
-          onClick={() => onRemoveBadgePill?.(pill.id)}
+          onClick={() => onRemove?.(pill.id)}
           className={pillBaseClassName}
           style={{ backgroundColor: color, color: "white" }}
           aria-label={tooltipText}
         >
-          <span className={pillIconClassName}>{getBadgeIcon(pill.label, "white", 10, 3)}</span>
+          <span className={pillIconClassName}>{icon}</span>
           <span className={pillLabelClassName}>{pill.label}</span>
           <span className={pillCloseClassName}>
             <X size={10} strokeWidth={3} className={pillSvgClassName} />
@@ -630,31 +629,21 @@ const BooleanSearchInput = ({
     );
   };
 
+  const renderBadgePill = (pill) =>
+    renderColoredFilterPill({
+      pill,
+      color: CATEGORY_COLORS[pill.category] || DEFAULT_COLOR,
+      icon: getBadgeIcon(pill.label, "white", 10, 3),
+      onRemove: onRemoveBadgePill,
+    });
+
   const renderFocusAreaPill = (pill) => {
-    const tooltipText = `Remove ${pill.label}`;
-    return (
-      <span
-        key={pill.key}
-        className={pillTooltipClassName}
-        data-tip={tooltipText}
-      >
-        <button
-          type="button"
-          onClick={() => onRemoveFocusAreaPill?.(pill.id)}
-          className={pillBaseClassName}
-          style={{ backgroundColor: FOCUS_GREEN, color: "white" }}
-          aria-label={tooltipText}
-        >
-          <span className={pillIconClassName}>
-            <Tag size={10} strokeWidth={3} className={pillSvgClassName} />
-          </span>
-          <span className={pillLabelClassName}>{pill.label}</span>
-          <span className={pillCloseClassName}>
-            <X size={10} strokeWidth={3} className={pillSvgClassName} />
-          </span>
-        </button>
-      </span>
-    );
+    return renderColoredFilterPill({
+      pill,
+      color: FOCUS_GREEN,
+      icon: <Tag size={10} strokeWidth={3} className={pillSvgClassName} />,
+      onRemove: onRemoveFocusAreaPill,
+    });
   };
 
   const renderCriteriaPill = (pill) => {

--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -6,7 +6,25 @@ import {
   useLayoutEffect,
 } from "react";
 import { createPortal } from "react-dom";
-import { Tag, Award, UserSearch, Users, X, Layers } from "lucide-react";
+import {
+  Tag,
+  Award,
+  UserSearch,
+  Users,
+  X,
+  Layers,
+  ArrowDownAZ,
+  ArrowUpZA,
+  Clock,
+  FlaskConical,
+  Globe,
+  MapPin,
+  Ruler,
+  Sparkles,
+  Target,
+  UserMinus,
+  UserPlus,
+} from "lucide-react";
 import SearchHelp from "./SearchHelp";
 import {
   getBadgeIcon,
@@ -27,6 +45,43 @@ const hexToRgba = (hex, alpha) => {
 };
 
 const MIN_QUERY_HINT = "Enter at least 2 characters";
+
+const getCriteriaPillIcon = (pill) => {
+  if (pill.key === "maxDistance") return Ruler;
+  if (pill.key === "openRolesOnly") return UserSearch;
+  if (pill.key === "includeOwnTeams") return Users;
+  if (pill.key === "includeDemoData") return FlaskConical;
+
+  if (pill.key !== "sort") return null;
+
+  switch (pill.label) {
+    case "Best Match":
+      return Target;
+    case "Name Z-A":
+      return ArrowUpZA;
+    case "Name A-Z":
+      return ArrowDownAZ;
+    case "Active":
+    case "Inactive":
+      return Clock;
+    case "Newest":
+    case "Oldest":
+      return Sparkles;
+    case "Most Spots":
+      return UserPlus;
+    case "Almost Full":
+      return UserMinus;
+    case "Most Open Roles":
+    case "Least Open Roles":
+      return UserSearch;
+    case "Remote First":
+      return Globe;
+    case "Nearest First":
+      return MapPin;
+    default:
+      return null;
+  }
+};
 
 /**
  * Enhanced Search Input with Boolean Search Support
@@ -400,91 +455,157 @@ const BooleanSearchInput = ({
   const infoIconClassName = alignHelperToTopPillRow
     ? "absolute right-2 top-2 flex items-center pointer-events-auto"
     : "absolute inset-y-0 right-2 flex items-center pointer-events-auto";
+  const pillBaseClassName =
+    "inline-grid grid-cols-[0.625rem_minmax(0,auto)_0.625rem] items-start gap-1 rounded-lg px-2.5 py-[0.1875rem] text-xs font-medium leading-[1.1] transition-opacity hover:opacity-80";
+  const pillIconClassName = "flex h-[1.1em] w-2.5 items-center justify-center";
+  const pillSvgClassName = "h-2.5 w-2.5";
+  const pillLabelClassName = "min-w-0 text-left leading-[1.1]";
+  const pillCloseClassName = "flex h-[1.1em] w-2.5 items-center justify-center";
+  const pillTooltipClassName =
+    "tooltip tooltip-top tooltip-lomir inline-flex z-10 hover:z-[80] focus-within:z-[80]";
 
   const renderBadgePill = (pill) => {
     const color = CATEGORY_COLORS[pill.category] || DEFAULT_COLOR;
+    const tooltipText = `Remove ${pill.label}`;
     return (
-      <button
+      <span
         key={pill.key}
-        type="button"
-        onClick={() => onRemoveBadgePill?.(pill.id)}
-        className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium transition-opacity hover:opacity-80"
-        style={{ backgroundColor: color, color: "white" }}
-        title={`Remove ${pill.label}`}
+        className={pillTooltipClassName}
+        data-tip={tooltipText}
       >
-        <span className="shrink-0">{getBadgeIcon(pill.label, "white", 10)}</span>
-        <span>{pill.label}</span>
-        <X size={10} />
-      </button>
+        <button
+          type="button"
+          onClick={() => onRemoveBadgePill?.(pill.id)}
+          className={pillBaseClassName}
+          style={{ backgroundColor: color, color: "white" }}
+          aria-label={tooltipText}
+        >
+          <span className={pillIconClassName}>{getBadgeIcon(pill.label, "white", 10, 3)}</span>
+          <span className={pillLabelClassName}>{pill.label}</span>
+          <span className={pillCloseClassName}>
+            <X size={10} strokeWidth={3} className={pillSvgClassName} />
+          </span>
+        </button>
+      </span>
     );
   };
 
-  const renderFocusAreaPill = (pill) => (
-    <button
-      key={pill.key}
-      type="button"
-      onClick={() => onRemoveFocusAreaPill?.(pill.id)}
-      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium transition-opacity hover:opacity-80"
-      style={{ backgroundColor: FOCUS_GREEN, color: "white" }}
-      title={`Remove ${pill.label}`}
-    >
-      <Tag size={10} className="shrink-0" />
-      <span>{pill.label}</span>
-      <X size={10} />
-    </button>
-  );
+  const renderFocusAreaPill = (pill) => {
+    const tooltipText = `Remove ${pill.label}`;
+    return (
+      <span
+        key={pill.key}
+        className={pillTooltipClassName}
+        data-tip={tooltipText}
+      >
+        <button
+          type="button"
+          onClick={() => onRemoveFocusAreaPill?.(pill.id)}
+          className={pillBaseClassName}
+          style={{ backgroundColor: FOCUS_GREEN, color: "white" }}
+          aria-label={tooltipText}
+        >
+          <span className={pillIconClassName}>
+            <Tag size={10} strokeWidth={3} className={pillSvgClassName} />
+          </span>
+          <span className={pillLabelClassName}>{pill.label}</span>
+          <span className={pillCloseClassName}>
+            <X size={10} strokeWidth={3} className={pillSvgClassName} />
+          </span>
+        </button>
+      </span>
+    );
+  };
 
   const renderCriteriaPill = (pill) => {
     const pillLabelNode = pill.shortLabel ? (
       <>
-        <span className="hidden sm:inline">{pill.label}</span>
-        <span className="sm:hidden">{pill.shortLabel}</span>
+        <span className={`hidden sm:inline ${pillLabelClassName}`}>{pill.label}</span>
+        <span className={`sm:hidden ${pillLabelClassName}`}>{pill.shortLabel}</span>
       </>
     ) : (
-      <span>{pill.label}</span>
+      <span className={pillLabelClassName}>{pill.label}</span>
     );
 
     if (pill.type === "role") {
+      const tooltipText = `Remove ${pill.removeLabel ?? pill.label}`;
       return (
-        <button
+        <span
           key={pill.key}
-          type="button"
-          onClick={() => onRemoveActivePill?.(pill.key)}
-          className="inline-flex items-center gap-1 rounded-full border border-amber-400 bg-amber-50 px-2 py-0.5 text-xs font-bold text-amber-700 transition-colors hover:border-amber-500 hover:bg-amber-100"
-          title={`Remove ${pill.label}`}
+          className={pillTooltipClassName}
+          data-tip={tooltipText}
         >
-          <UserSearch size={12} className="flex-shrink-0" />
-          {pillLabelNode}
-          <span aria-hidden="true">×</span>
-        </button>
+          <button
+            type="button"
+            onClick={() => onRemoveActivePill?.(pill.key)}
+            className={`${pillBaseClassName} border border-amber-400 bg-amber-50 text-amber-700 transition-colors hover:border-amber-500 hover:bg-amber-100 hover:opacity-100`}
+            aria-label={tooltipText}
+          >
+            <span className={pillIconClassName}>
+              <UserSearch size={12} className={pillSvgClassName} />
+            </span>
+            {pillLabelNode}
+            <span className={pillCloseClassName} aria-hidden="true">
+              <X size={10} strokeWidth={2.5} className={pillSvgClassName} />
+            </span>
+          </button>
+        </span>
       );
     }
     if (pill.type === "excludeTeam") {
+      const tooltipText = `Remove ${pill.removeLabel ?? pill.label}`;
       return (
-        <button
+        <span
           key={pill.key}
-          type="button"
-          onClick={() => onRemoveActivePill?.(pill.key)}
-          className="inline-flex items-center gap-1 rounded-full border border-slate-400 bg-slate-50 px-2 py-0.5 text-xs font-bold text-slate-600 transition-colors hover:border-slate-500 hover:bg-slate-100"
-          title={`Remove ${pill.label}`}
+          className={pillTooltipClassName}
+          data-tip={tooltipText}
         >
-          <Users size={12} className="flex-shrink-0" />
-          {pillLabelNode}
-          <span aria-hidden="true">×</span>
-        </button>
+          <button
+            type="button"
+            onClick={() => onRemoveActivePill?.(pill.key)}
+            className={`${pillBaseClassName} border border-slate-400 bg-slate-50 text-slate-600 transition-colors hover:border-slate-500 hover:bg-slate-100 hover:opacity-100`}
+            aria-label={tooltipText}
+          >
+            <span className={pillIconClassName}>
+              <Users size={12} className={pillSvgClassName} />
+            </span>
+            {pillLabelNode}
+            <span className={pillCloseClassName} aria-hidden="true">
+              <X size={10} strokeWidth={2.5} className={pillSvgClassName} />
+            </span>
+          </button>
+        </span>
       );
     }
+    const CriteriaIcon = getCriteriaPillIcon(pill);
+    const tooltipText = `Remove ${pill.removeLabel ?? pill.label}`;
     return (
-      <button
+      <span
         key={pill.key}
-        type="button"
-        onClick={() => onRemoveActivePill?.(pill.key)}
-        className="inline-flex items-center gap-1 rounded-full border border-[var(--color-primary)] bg-[#f0fdf4] px-2 py-0.5 text-xs font-bold text-[var(--color-primary)] transition-colors hover:border-[var(--color-primary-focus)] hover:bg-[#dcfce7] hover:text-[var(--color-primary-focus)]"
-        title={`Remove ${pill.label}`}
+        className={pillTooltipClassName}
+        data-tip={tooltipText}
       >
-        {pillLabelNode}
-        <span aria-hidden="true">x</span>
-      </button>
+        <button
+          type="button"
+          onClick={() => onRemoveActivePill?.(pill.key)}
+          className={`${pillBaseClassName} border border-[var(--color-primary)] bg-[#f0fdf4] text-[var(--color-primary)] transition-colors hover:border-[var(--color-primary-focus)] hover:bg-[#dcfce7] hover:text-[var(--color-primary-focus)] hover:opacity-100`}
+          aria-label={tooltipText}
+        >
+          <span className={pillIconClassName} aria-hidden="true">
+            {CriteriaIcon ? (
+              <CriteriaIcon
+                size={12}
+                strokeWidth={2.5}
+                className={pillSvgClassName}
+              />
+            ) : null}
+          </span>
+          {pillLabelNode}
+          <span className={pillCloseClassName} aria-hidden="true">
+            <X size={10} strokeWidth={2.5} className={pillSvgClassName} />
+          </span>
+        </button>
+      </span>
     );
   };
 

--- a/src/components/SearchHelp.jsx
+++ b/src/components/SearchHelp.jsx
@@ -19,20 +19,31 @@ const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }
   const POPUP_WIDTH = 320;
   const GAP = 8;
   const ARROW_H = 12;
+  const ARROW_W = 48;
+  const VIEWPORT_MARGIN = 8;
+  const TRIGGER_SIDE_OFFSET = 40;
 
   const openFromEl = (triggerEl) => {
     const anchorEl = anchorRef?.current;
     if (!anchorEl || !triggerEl) return;
     const barRect = anchorEl.getBoundingClientRect();
     const triggerRect = triggerEl.getBoundingClientRect();
-    const popupLeft = Math.max(
-      8,
-      Math.min(barRect.right - POPUP_WIDTH, window.innerWidth - POPUP_WIDTH - 8),
+    const popupWidth = Math.min(
+      POPUP_WIDTH,
+      window.innerWidth - VIEWPORT_MARGIN * 2,
     );
-    setPopupStyle({ top: barRect.bottom + GAP, left: popupLeft });
+    const triggerCenter = triggerRect.left + triggerRect.width / 2;
+    const viewportMaxLeft = window.innerWidth - popupWidth - VIEWPORT_MARGIN;
+    const preferredLeft = triggerCenter - popupWidth + TRIGGER_SIDE_OFFSET;
+    const popupLeft = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(preferredLeft, viewportMaxLeft),
+    );
+
+    setPopupStyle({ top: barRect.bottom + GAP, left: popupLeft, width: popupWidth });
     setArrowStyle({
       top: barRect.bottom + GAP - ARROW_H,
-      left: triggerRect.left + triggerRect.width / 2,
+      left: triggerCenter,
     });
     setIsOpen(true);
   };
@@ -52,16 +63,16 @@ const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }
     <>
       {/* Inline trigger inside the input */}
       {!hideButton && (
-        <div className={`relative ${className}`}>
+        <div className={`relative flex h-[1.125rem] items-center ${className}`}>
           <Tooltip content="Search tips" position="top">
             <button
               ref={triggerRef}
               type="button"
               onClick={(e) => openFromEl(e.currentTarget)}
-              className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-transparent p-0 text-[var(--color-primary-focus)] transition-colors hover:text-[var(--color-primary)] focus:outline-none"
+              className="inline-flex h-[1.125rem] w-[1.125rem] items-center justify-center rounded-full bg-transparent p-0 text-[var(--color-primary-focus)] transition-colors hover:text-[var(--color-primary)] focus:outline-none"
               aria-label="Search tips"
             >
-              <Info className="h-4 w-4" />
+              <Info className="h-3.5 w-3.5" />
             </button>
           </Tooltip>
         </div>
@@ -74,22 +85,22 @@ const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }
             {/* Backdrop: click to close */}
             <button
               type="button"
-              className="absolute inset-0 cursor-default"
+              className="absolute inset-0 z-0 cursor-default"
               onClick={() => setIsOpen(false)}
               aria-label="Close search tips"
             />
 
-            {/* Arrow pointing up toward the "i" icon */}
+            {/* Arrow pointing up toward the visible search tips trigger */}
             <div
               style={{
                 position: "fixed",
                 top: `${arrowStyle.top}px`,
                 left: `${arrowStyle.left}px`,
                 transform: "translateX(-50%) rotate(180deg)",
-                width: "48px",
+                width: `${ARROW_W}px`,
                 height: `${ARROW_H}px`,
                 backgroundColor: "#ffffff",
-                zIndex: 10000,
+                zIndex: 2,
                 pointerEvents: "none",
                 WebkitMaskImage: `url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.500009 1C3.5 1 3.00001 7 6.00001 7C9 7 8.5 1 11.5 1C12 1 12 0.5 12 0H0C0 0.5 0 1 0.500009 1Z' fill='white'/%3E%3C/svg%3E")`,
                 maskImage: `url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.500009 1C3.5 1 3.00001 7 6.00001 7C9 7 8.5 1 11.5 1C12 1 12 0.5 12 0H0C0 0.5 0 1 0.500009 1Z' fill='white'/%3E%3C/svg%3E")`,
@@ -103,7 +114,7 @@ const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }
 
             {/* Popup box */}
             <div
-              className="fixed w-80 p-4 bg-base-100 rounded-lg shadow-lg border border-base-300"
+              className="fixed z-[1] w-80 p-4 bg-base-100 rounded-lg shadow-lg"
               style={popupStyle}
             >
               <div className="flex justify-between items-center mb-3">

--- a/src/components/SearchHelp.jsx
+++ b/src/components/SearchHelp.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from "react";
 import { Info } from "lucide-react";
 import { createPortal } from "react-dom";
+import Tooltip from "./common/Tooltip";
 
 /**
  * SearchHelp (Inline)
@@ -13,6 +14,11 @@ const SearchHelp = ({ className = "", anchorRef }) => {
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef(null);
   const [popupStyle, setPopupStyle] = useState({});
+  const [arrowStyle, setArrowStyle] = useState({});
+
+  const POPUP_WIDTH = 320;
+  const GAP = 8;
+  const ARROW_H = 12;
 
   const examples = [
     { query: "react AND node", description: 'Must contain both "react" AND "node"' },
@@ -27,20 +33,28 @@ const SearchHelp = ({ className = "", anchorRef }) => {
     <>
       {/* Inline trigger inside the input */}
       <div className={`relative ${className}`}>
-        {/* DaisyUI tooltip with Lomir theme */}
-        <div className="tooltip tooltip-left tooltip-lomir" data-tip="Search tips">
+        <Tooltip content="Search tips" position="top">
           <button
             ref={triggerRef}
             type="button"
             onClick={() => {
               const anchorEl = anchorRef?.current;
-              if (!anchorEl) return;
+              const triggerEl = triggerRef.current;
+              if (!anchorEl || !triggerEl) return;
 
-              const rect = anchorEl.getBoundingClientRect();
+              const barRect = anchorEl.getBoundingClientRect();
+              const triggerRect = triggerEl.getBoundingClientRect();
 
-              setPopupStyle({
-                top: rect.bottom + 16, // 1rem gap
-                left: rect.right, // align to the input's right edge
+              const popupLeft = Math.max(
+                8,
+                Math.min(barRect.right - POPUP_WIDTH, window.innerWidth - POPUP_WIDTH - 8),
+              );
+              const popupTop = barRect.bottom + GAP;
+
+              setPopupStyle({ top: popupTop, left: popupLeft });
+              setArrowStyle({
+                top: barRect.bottom + GAP - ARROW_H,
+                left: triggerRect.left + triggerRect.width / 2,
               });
 
               setIsOpen(true);
@@ -50,7 +64,7 @@ const SearchHelp = ({ className = "", anchorRef }) => {
           >
             <Info className="h-4 w-4" />
           </button>
-        </div>
+        </Tooltip>
       </div>
 
       {/* Portal popup on top of everything */}
@@ -65,9 +79,31 @@ const SearchHelp = ({ className = "", anchorRef }) => {
               aria-label="Close search tips"
             />
 
+            {/* Arrow pointing up toward the "i" icon */}
+            <div
+              style={{
+                position: "fixed",
+                top: `${arrowStyle.top}px`,
+                left: `${arrowStyle.left}px`,
+                transform: "translateX(-50%) rotate(180deg)",
+                width: "48px",
+                height: `${ARROW_H}px`,
+                backgroundColor: "#ffffff",
+                zIndex: 10000,
+                pointerEvents: "none",
+                WebkitMaskImage: `url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.500009 1C3.5 1 3.00001 7 6.00001 7C9 7 8.5 1 11.5 1C12 1 12 0.5 12 0H0C0 0.5 0 1 0.500009 1Z' fill='white'/%3E%3C/svg%3E")`,
+                maskImage: `url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.500009 1C3.5 1 3.00001 7 6.00001 7C9 7 8.5 1 11.5 1C12 1 12 0.5 12 0H0C0 0.5 0 1 0.500009 1Z' fill='white'/%3E%3C/svg%3E")`,
+                WebkitMaskRepeat: "no-repeat",
+                maskRepeat: "no-repeat",
+                WebkitMaskSize: "contain",
+                maskSize: "contain",
+                filter: "drop-shadow(0 2px 6px rgba(4, 80, 20, 0.12))",
+              }}
+            />
+
             {/* Popup box */}
             <div
-              className="fixed w-80 p-4 bg-base-100 rounded-lg shadow-lg border border-base-300 -translate-x-full"
+              className="fixed w-80 p-4 bg-base-100 rounded-lg shadow-lg border border-base-300"
               style={popupStyle}
             >
               <div className="flex justify-between items-center mb-3">

--- a/src/components/SearchHelp.jsx
+++ b/src/components/SearchHelp.jsx
@@ -1,4 +1,10 @@
-import React, { useState, useRef, forwardRef, useImperativeHandle } from "react";
+import React, {
+  useState,
+  useRef,
+  useLayoutEffect,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import { Info } from "lucide-react";
 import { createPortal } from "react-dom";
 import Tooltip from "./common/Tooltip";
@@ -13,23 +19,26 @@ import Tooltip from "./common/Tooltip";
 const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }, ref) => {
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef(null);
+  const activeTriggerRef = useRef(null);
+  const popupRef = useRef(null);
   const [popupStyle, setPopupStyle] = useState({});
   const [arrowStyle, setArrowStyle] = useState({});
 
-  const POPUP_WIDTH = 320;
+  const POPUP_MAX_WIDTH = 320;
   const GAP = 8;
   const ARROW_H = 12;
   const ARROW_W = 48;
   const VIEWPORT_MARGIN = 8;
   const TRIGGER_SIDE_OFFSET = 40;
+  const ARROW_X_OFFSET = -14;
 
-  const openFromEl = (triggerEl) => {
+  const positionPopup = (triggerEl, measuredWidth = POPUP_MAX_WIDTH) => {
     const anchorEl = anchorRef?.current;
     if (!anchorEl || !triggerEl) return;
     const barRect = anchorEl.getBoundingClientRect();
     const triggerRect = triggerEl.getBoundingClientRect();
     const popupWidth = Math.min(
-      POPUP_WIDTH,
+      measuredWidth,
       window.innerWidth - VIEWPORT_MARGIN * 2,
     );
     const triggerCenter = triggerRect.left + triggerRect.width / 2;
@@ -40,15 +49,33 @@ const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }
       Math.min(preferredLeft, viewportMaxLeft),
     );
 
-    setPopupStyle({ top: barRect.bottom + GAP, left: popupLeft, width: popupWidth });
+    setPopupStyle({
+      top: barRect.bottom + GAP,
+      left: popupLeft,
+      maxWidth: popupWidth,
+      width: "max-content",
+    });
     setArrowStyle({
       top: barRect.bottom + GAP - ARROW_H,
-      left: triggerCenter,
+      left: triggerCenter + ARROW_X_OFFSET,
     });
+  };
+
+  const openFromEl = (triggerEl) => {
+    activeTriggerRef.current = triggerEl;
+    positionPopup(triggerEl);
     setIsOpen(true);
   };
 
   useImperativeHandle(ref, () => ({ open: openFromEl }));
+
+  useLayoutEffect(() => {
+    if (!isOpen || !popupRef.current || !activeTriggerRef.current) return;
+    positionPopup(
+      activeTriggerRef.current,
+      popupRef.current.getBoundingClientRect().width,
+    );
+  }, [isOpen]);
 
   const examples = [
     { query: "react AND node", description: 'Must contain both "react" AND "node"' },
@@ -114,7 +141,8 @@ const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }
 
             {/* Popup box */}
             <div
-              className="fixed z-[1] w-80 p-4 bg-base-100 rounded-lg shadow-lg"
+              ref={popupRef}
+              className="fixed z-[1] p-4 bg-base-100 rounded-lg shadow-lg"
               style={popupStyle}
             >
               <div className="flex justify-between items-center mb-3">
@@ -138,7 +166,10 @@ const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }
               <div className="space-y-2">
                 {examples.map((example, index) => (
                   <div key={index} className="text-sm">
-                    <code className="bg-base-200 px-1.5 py-0.5 rounded font-mono text-xs">
+                    <code
+                      className="px-1.5 py-0.5 rounded font-mono text-xs"
+                      style={{ backgroundColor: "rgba(0, 146, 19, 0.05)" }}
+                    >
                       {example.query}
                     </code>
                     <p className="text-base-content/60 text-xs mt-0.5">
@@ -150,7 +181,9 @@ const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }
 
               <div className="mt-3 pt-3 border-t border-base-300">
                 <p className="text-xs text-base-content/50">
-                  Operators are case-insensitive (AND, and, And all work)
+                  Operators are case-insensitive
+                  <br />
+                  (AND, and, And all work)
                 </p>
               </div>
             </div>

--- a/src/components/SearchHelp.jsx
+++ b/src/components/SearchHelp.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, forwardRef, useImperativeHandle } from "react";
 import { Info } from "lucide-react";
 import { createPortal } from "react-dom";
 import Tooltip from "./common/Tooltip";
@@ -10,7 +10,7 @@ import Tooltip from "./common/Tooltip";
  * - Click icon to toggle popup
  * - Popup uses a portal so it always appears on top of everything
  */
-const SearchHelp = ({ className = "", anchorRef }) => {
+const SearchHelp = forwardRef(({ className = "", anchorRef, hideButton = false }, ref) => {
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef(null);
   const [popupStyle, setPopupStyle] = useState({});
@@ -19,6 +19,25 @@ const SearchHelp = ({ className = "", anchorRef }) => {
   const POPUP_WIDTH = 320;
   const GAP = 8;
   const ARROW_H = 12;
+
+  const openFromEl = (triggerEl) => {
+    const anchorEl = anchorRef?.current;
+    if (!anchorEl || !triggerEl) return;
+    const barRect = anchorEl.getBoundingClientRect();
+    const triggerRect = triggerEl.getBoundingClientRect();
+    const popupLeft = Math.max(
+      8,
+      Math.min(barRect.right - POPUP_WIDTH, window.innerWidth - POPUP_WIDTH - 8),
+    );
+    setPopupStyle({ top: barRect.bottom + GAP, left: popupLeft });
+    setArrowStyle({
+      top: barRect.bottom + GAP - ARROW_H,
+      left: triggerRect.left + triggerRect.width / 2,
+    });
+    setIsOpen(true);
+  };
+
+  useImperativeHandle(ref, () => ({ open: openFromEl }));
 
   const examples = [
     { query: "react AND node", description: 'Must contain both "react" AND "node"' },
@@ -32,40 +51,21 @@ const SearchHelp = ({ className = "", anchorRef }) => {
   return (
     <>
       {/* Inline trigger inside the input */}
-      <div className={`relative ${className}`}>
-        <Tooltip content="Search tips" position="top">
-          <button
-            ref={triggerRef}
-            type="button"
-            onClick={() => {
-              const anchorEl = anchorRef?.current;
-              const triggerEl = triggerRef.current;
-              if (!anchorEl || !triggerEl) return;
-
-              const barRect = anchorEl.getBoundingClientRect();
-              const triggerRect = triggerEl.getBoundingClientRect();
-
-              const popupLeft = Math.max(
-                8,
-                Math.min(barRect.right - POPUP_WIDTH, window.innerWidth - POPUP_WIDTH - 8),
-              );
-              const popupTop = barRect.bottom + GAP;
-
-              setPopupStyle({ top: popupTop, left: popupLeft });
-              setArrowStyle({
-                top: barRect.bottom + GAP - ARROW_H,
-                left: triggerRect.left + triggerRect.width / 2,
-              });
-
-              setIsOpen(true);
-            }}
-            className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-transparent p-0 text-[var(--color-primary-focus)] transition-colors hover:text-[var(--color-primary)] focus:outline-none"
-            aria-label="Search tips"
-          >
-            <Info className="h-4 w-4" />
-          </button>
-        </Tooltip>
-      </div>
+      {!hideButton && (
+        <div className={`relative ${className}`}>
+          <Tooltip content="Search tips" position="top">
+            <button
+              ref={triggerRef}
+              type="button"
+              onClick={(e) => openFromEl(e.currentTarget)}
+              className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-transparent p-0 text-[var(--color-primary-focus)] transition-colors hover:text-[var(--color-primary)] focus:outline-none"
+              aria-label="Search tips"
+            >
+              <Info className="h-4 w-4" />
+            </button>
+          </Tooltip>
+        </div>
+      )}
 
       {/* Portal popup on top of everything */}
       {isOpen &&
@@ -148,6 +148,6 @@ const SearchHelp = ({ className = "", anchorRef }) => {
         )}
     </>
   );
-};
+});
 
 export default SearchHelp;

--- a/src/components/common/ResultViewToggle.jsx
+++ b/src/components/common/ResultViewToggle.jsx
@@ -1,0 +1,88 @@
+import React from "react";
+import {
+  Grid3x3,
+  List as ListIcon,
+  Map as MapIcon,
+  createLucideIcon,
+} from "lucide-react";
+
+const Grid3x2Icon = createLucideIcon("Grid3x2", [
+  ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "grid-3x2-frame" }],
+  ["path", { d: "M3 12h18", key: "grid-3x2-row" }],
+  ["path", { d: "M9 3v18", key: "grid-3x2-col-1" }],
+  ["path", { d: "M15 3v18", key: "grid-3x2-col-2" }],
+]);
+
+const VIEW_MODE_OPTIONS = {
+  card: {
+    label: "Card",
+    ariaLabel: "Card view",
+    tooltip: "Card View",
+    Icon: Grid3x2Icon,
+  },
+  mini: {
+    label: "Mini Card",
+    ariaLabel: "Mini card view",
+    tooltip: "Mini Card View",
+    Icon: Grid3x3,
+  },
+  list: {
+    label: "List",
+    ariaLabel: "List view",
+    tooltip: "List View",
+    Icon: ListIcon,
+  },
+  map: {
+    label: "Map",
+    ariaLabel: "Map view",
+    tooltip: "Map View",
+    Icon: MapIcon,
+  },
+};
+
+const ResultViewToggle = ({
+  value,
+  onChange,
+  modes = ["card", "mini", "list"],
+  className = "",
+}) => (
+  <div
+    className={`flex flex-wrap items-center justify-end text-sm leading-[1.15] font-normal text-base-content/60 gap-x-1.5 gap-y-1 sm:gap-x-3 ${className}`}
+    role="group"
+    aria-label="Result view"
+  >
+    {modes.map((mode) => {
+      const option = VIEW_MODE_OPTIONS[mode];
+      if (!option) return null;
+
+      const isActive = value === mode;
+      const Icon = option.Icon;
+
+      return (
+        <button
+          key={mode}
+          type="button"
+          aria-pressed={isActive}
+          aria-label={option.ariaLabel}
+          data-tip={isActive ? option.tooltip : `Switch to ${option.tooltip}`}
+          onClick={() => onChange(mode)}
+          className={`tooltip tooltip-top tooltip-lomir inline-flex items-center gap-1 rounded p-1 sm:p-0 hover:text-base-content transition-colors ${
+            isActive ? "font-bold text-base-content" : ""
+          }`}
+        >
+          <Icon
+            className="inline-block w-[0.735rem] h-[0.735rem] shrink-0"
+            strokeWidth={isActive ? 3 : 2}
+            aria-hidden="true"
+            focusable="false"
+          />
+          <span className="hidden sm:inline" aria-hidden="true">
+            {option.label}
+          </span>
+        </button>
+      );
+    })}
+  </div>
+);
+
+export default ResultViewToggle;

--- a/src/index.css
+++ b/src/index.css
@@ -986,6 +986,13 @@ body {
   opacity: 1 !important;
 }
 
+@media (min-width: 640px) {
+  .tooltip.tooltip-lomir.search-type-tooltip[data-tip]::before,
+  .tooltip.tooltip-lomir.search-type-tooltip::after {
+    display: none !important;
+  }
+}
+
 /* ===== Profile dropdown menu ===== */
 .profile-dropdown {
   background-color: #ffffff !important;

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -6,6 +6,7 @@ import Button from "../components/common/Button";
 import TeamCard from "../components/teams/TeamCard";
 import Section from "../components/layout/Section";
 import Pagination from "../components/common/Pagination";
+import ResultViewToggle from "../components/common/ResultViewToggle";
 import { teamService } from "../services/teamService";
 import useSocketEvents from "../hooks/useSocketEvents";
 import { useAuth } from "../contexts/AuthContext";
@@ -644,37 +645,7 @@ const MyTeams = () => {
           </button>
         </div>
 
-        <div className="flex items-center text-sm font-normal text-base-content/60 gap-1 -ml-2">
-          <button
-            type="button"
-            onClick={() => setResultView("card")}
-            className={`px-2 py-1 rounded hover:text-base-content transition-colors ${
-              resultView === "card" ? "font-bold text-base-content" : ""
-            }`}
-          >
-            Card
-          </button>
-          <span className="text-base-content/30">|</span>
-          <button
-            type="button"
-            onClick={() => setResultView("mini")}
-            className={`px-2 py-1 rounded hover:text-base-content transition-colors ${
-              resultView === "mini" ? "font-bold text-base-content" : ""
-            }`}
-          >
-            Mini Card
-          </button>
-          <span className="text-base-content/30">|</span>
-          <button
-            type="button"
-            onClick={() => setResultView("list")}
-            className={`px-2 py-1 rounded hover:text-base-content transition-colors ${
-              resultView === "list" ? "font-bold text-base-content" : ""
-            }`}
-          >
-            List
-          </button>
-        </div>
+        <ResultViewToggle value={resultView} onChange={setResultView} />
       </div>
 
       {/* Pending Invitations Section */}

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -18,6 +18,7 @@ import SearchMapView from "../components/search/SearchMapView";
 import Pagination from "../components/common/Pagination";
 import BooleanSearchInput from "../components/BooleanSearchInput";
 import Tooltip from "../components/common/Tooltip";
+import ResultViewToggle from "../components/common/ResultViewToggle";
 import {
   User,
   UserSearch,
@@ -2274,8 +2275,8 @@ const SearchPage = () => {
         <div>
           {hasVisibleResults && (
             <section className="mb-8">
-              <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-1 mb-4">
-                <h2 className="flex flex-wrap items-baseline gap-x-2 text-sm leading-[1.15] font-semibold">
+              <div className="flex flex-wrap items-start sm:items-center justify-between gap-x-4 gap-y-1 mb-4">
+                <h2 className="flex flex-wrap items-center gap-x-2 text-sm leading-[1.15] font-semibold">
                   <span className="whitespace-nowrap">
                     {searchType === "all" && "All"}
                     {searchType === "teams" && "Teams"}
@@ -2295,51 +2296,11 @@ const SearchPage = () => {
                   </span>
                 </h2>
 
-                <div className="flex flex-wrap items-center justify-end text-sm leading-[1.15] font-normal text-base-content/60 gap-1">
-                  <button
-                    type="button"
-                    aria-pressed={resultView === "card"}
-                    onClick={() => setResultView("card")}
-                    className={`pl-0 pr-2 rounded hover:text-base-content transition-colors ${
-                      resultView === "card" ? "font-bold text-base-content" : ""
-                    }`}
-                  >
-                    Card
-                  </button>
-                  <span className="text-base-content/30">|</span>
-                  <button
-                    type="button"
-                    aria-pressed={resultView === "mini"}
-                    onClick={() => setResultView("mini")}
-                    className={`px-2 rounded hover:text-base-content transition-colors ${
-                      resultView === "mini" ? "font-bold text-base-content" : ""
-                    }`}
-                  >
-                    Mini Card
-                  </button>
-                  <span className="text-base-content/30">|</span>
-                  <button
-                    type="button"
-                    aria-pressed={resultView === "list"}
-                    onClick={() => setResultView("list")}
-                    className={`px-2 rounded hover:text-base-content transition-colors ${
-                      resultView === "list" ? "font-bold text-base-content" : ""
-                    }`}
-                  >
-                    List
-                  </button>
-                  <span className="text-base-content/30">|</span>
-                  <button
-                    type="button"
-                    aria-pressed={resultView === "map"}
-                    onClick={() => setResultView("map")}
-                    className={`px-2 rounded hover:text-base-content transition-colors ${
-                      resultView === "map" ? "font-bold text-base-content" : ""
-                    }`}
-                  >
-                    Map
-                  </button>
-                </div>
+                <ResultViewToggle
+                  value={resultView}
+                  onChange={setResultView}
+                  modes={["card", "mini", "list", "map"]}
+                />
               </div>
 
               {resultView === "map" && (

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -65,6 +65,7 @@ import {
   RESULTS_PER_PAGE_OPTIONS,
   DEFAULT_RESULTS_PER_PAGE,
 } from "../constants/pagination";
+import { CATEGORY_ORDER } from "../constants/badgeConstants";
 import {
   calculateDistanceKm,
   locationsHaveDifferentKnownParts,
@@ -84,6 +85,11 @@ const SORTING_OPTION_VALUES = new Set([
   "locationPriority",
 ]);
 const EMPTY_QUERY_ARRAY = [];
+
+const getBadgeCategoryOrder = (category) => {
+  const index = CATEGORY_ORDER.indexOf(category || "Other");
+  return index === -1 ? CATEGORY_ORDER.length : index;
+};
 
 const getFilterableDistanceKm = (item) => {
   const matchDetails = item?.matchDetails ?? item?.match_details ?? null;
@@ -1022,12 +1028,19 @@ const SearchPage = () => {
     label: filterTagMap[id]?.name || `Tag ${id}`,
   }));
 
-  const badgePills = filterBadgeIds.map((id) => ({
-    key: `badge-${id}`,
-    id,
-    label: filterBadgeMap[id]?.name || `Badge ${id}`,
-    category: filterBadgeMap[id]?.category || "",
-  }));
+  const badgePills = filterBadgeIds
+    .map((id) => ({
+      key: `badge-${id}`,
+      id,
+      label: filterBadgeMap[id]?.name || `Badge ${id}`,
+      category: filterBadgeMap[id]?.category || "",
+    }))
+    .sort((a, b) => {
+      const categoryDiff =
+        getBadgeCategoryOrder(a.category) - getBadgeCategoryOrder(b.category);
+      if (categoryDiff !== 0) return categoryDiff;
+      return a.label.localeCompare(b.label);
+    });
   const activeCriteriaPills = getActiveCriteriaPills({
     sortBy,
     sortDir,
@@ -2027,7 +2040,12 @@ const SearchPage = () => {
   };
   return (
     <PageContainer
-      title="Search teams, people or open roles"
+      title={
+        <>
+          <span className="inline-block">Find teams, people</span>{" "}
+          <span className="inline-block">or open roles</span>
+        </>
+      }
       titleAlignment="center"
       variant="muted"
     >

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1988,7 +1988,7 @@ const SearchPage = () => {
       variant="muted"
     >
       <div className="w-full max-w-4xl mx-auto mb-8">
-        <div className="flex justify-center space-x-2 pt-2 mb-2">
+        <div className="relative z-20 flex justify-center space-x-2 pt-2 mb-2">
           <div className="btn-group">
             <button
               type="button"
@@ -1997,6 +1997,7 @@ const SearchPage = () => {
                   ? "btn-primary"
                   : "btn-ghost hover:bg-base-200"
               }`}
+              aria-pressed={searchType === "all"}
               onClick={() => handleToggleChange("all")}
             >
               All
@@ -2004,41 +2005,50 @@ const SearchPage = () => {
 
             <button
               type="button"
-              className={`btn btn-sm ${
+              className={`btn btn-sm tooltip tooltip-top tooltip-lomir search-type-tooltip ${
                 searchType === "teams"
                   ? "btn-primary"
                   : "btn-ghost hover:bg-base-200"
               }`}
+              data-tip="Teams"
+              aria-label="Teams"
+              aria-pressed={searchType === "teams"}
               onClick={() => handleToggleChange("teams")}
             >
-              <Users2 className="w-4 h-4 mr-1" />
-              Teams
+              <Users2 className="w-4 h-4 sm:mr-1" aria-hidden="true" />
+              <span className="sr-only sm:not-sr-only">Teams</span>
             </button>
 
             <button
               type="button"
-              className={`btn btn-sm ${
+              className={`btn btn-sm tooltip tooltip-top tooltip-lomir search-type-tooltip ${
                 searchType === "users"
                   ? "btn-primary"
                   : "btn-ghost hover:bg-base-200"
               }`}
+              data-tip="People"
+              aria-label="People"
+              aria-pressed={searchType === "users"}
               onClick={() => handleToggleChange("users")}
             >
-              <User className="w-4 h-4 mr-1" />
-              People
+              <User className="w-4 h-4 sm:mr-1" aria-hidden="true" />
+              <span className="sr-only sm:not-sr-only">People</span>
             </button>
 
             <button
               type="button"
-              className={`btn btn-sm ${
+              className={`btn btn-sm tooltip tooltip-top tooltip-lomir search-type-tooltip ${
                 searchType === "roles"
                   ? "btn-primary"
                   : "btn-ghost hover:bg-base-200"
               }`}
+              data-tip="Open Roles"
+              aria-label="Open Roles"
+              aria-pressed={searchType === "roles"}
               onClick={() => handleToggleChange("roles")}
             >
-              <UserSearch className="w-4 h-4 mr-1" />
-              Open Roles
+              <UserSearch className="w-4 h-4 sm:mr-1" aria-hidden="true" />
+              <span className="sr-only sm:not-sr-only">Open Roles</span>
             </button>
           </div>
         </div>

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1774,7 +1774,7 @@ const SearchPage = () => {
   const renderFilterOptionsToggle = () => (
     <Tooltip
       content={
-        showFilterOptions ? "Hide filter controls" : "Show filter controls"
+        showFilterOptions ? "Click to hide filters" : "Show filter controls"
       }
       wrapperClassName="inline-flex items-center shrink-0"
     >
@@ -1792,8 +1792,8 @@ const SearchPage = () => {
         }
       >
         <Filter className="w-3.5 h-3.5 shrink-0" />
-        <span className="hidden sm:inline">{showFilterOptions ? "Hide Filters" : "Show Filters ..."}</span>
-        <span className="sm:hidden">{showFilterOptions ? "Hide Filters" : "Filters ..."}</span>
+        <span className="hidden sm:inline">{showFilterOptions ? "Hide Filters:" : "Show Filters ..."}</span>
+        <span className="sm:hidden">{showFilterOptions ? "Hide Filters:" : "Filters ..."}</span>
       </button>
     </Tooltip>
   );

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -254,6 +254,7 @@ const SearchPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [hasSearched, setHasSearched] = useState(false);
+  const [searchInputResetSignal, setSearchInputResetSignal] = useState(0);
   const viewerPendingRequestsQuery = useViewerPendingRequests(user?.id, {
     enabled: isAuthenticated,
   });
@@ -1377,7 +1378,12 @@ const SearchPage = () => {
     setOpenSubmenuKey(null);
   };
 
-  const handleResetSortFilters = () => {
+  const handleResetSearchInput = () => {
+    setSearchInputResetSignal((value) => value + 1);
+    setSearchQuery("");
+    setHasSearched(false);
+    setError(null);
+    setSearchType("all");
     setSortBy("name");
     setSortDir("asc");
     setMaxDistance(null);
@@ -1386,9 +1392,40 @@ const SearchPage = () => {
     setOpenRolesOnly(false);
     setIncludeOwnTeams(true);
     setIncludeDemoData(true);
+    setFilterTagIds([]);
+    setFilterTagMap({});
+    setFilterBadgeIds([]);
+    setFilterBadgeMap({});
+    setMatchRoleId(null);
+    setMatchRoleName(null);
+    setMatchRoleMaxDistanceKm(null);
+    setExcludeTeamId(null);
+    setExcludeTeamName(null);
     setOpenSubmenuKey(null);
     setShowFilterOptions(false);
     setCurrentPage(1);
+
+    const newParams = new URLSearchParams(window.location.search);
+    [
+      "type",
+      "sort",
+      "proximity",
+      "tags",
+      "badges",
+      "roleId",
+      "roleName",
+      "roleMaxDistanceKm",
+      "excludeTeamId",
+      "excludeTeamName",
+    ].forEach((param) => newParams.delete(param));
+    const nextSearch = newParams.toString();
+    window.history.replaceState(
+      {},
+      "",
+      nextSearch
+        ? `${window.location.pathname}?${nextSearch}`
+        : window.location.pathname,
+    );
   };
 
   const handleSortChange = (newSortBy) => {
@@ -1713,6 +1750,12 @@ const SearchPage = () => {
     !includeDemoData ||
     (sortBy === "capacity" && capacityMode !== "spots") ||
     (customDistanceInput && customDistanceInput.trim() !== "");
+  const hasSearchInputContent =
+    searchQuery.trim() ||
+    activeCriteriaPills.length > 0 ||
+    focusAreaPills.length > 0 ||
+    badgePills.length > 0 ||
+    searchType !== "all";
 
   const isFilterOptionsActive =
     showFilterOptions ||
@@ -2056,7 +2099,7 @@ const SearchPage = () => {
 
         <div
           ref={sortFilterRef}
-          className="mx-auto w-full max-w-full px-2 sm:px-0"
+          className="mx-auto w-full max-w-full"
         >
           <div className="mx-auto w-full max-w-full sm:w-fit">
             <div className="flex w-full max-w-full items-center gap-2">
@@ -2070,7 +2113,7 @@ const SearchPage = () => {
                 <button
                   type="button"
                   onClick={handleSortDropdownToggle}
-                  className="shrink-0 rounded-lg p-2 transition-colors"
+                  className="shrink-0 rounded-lg p-0.5 sm:p-1 transition-colors"
                   aria-label={
                     showSortDropdown
                       ? "Hide Filtering & Sorting Options"
@@ -2078,7 +2121,7 @@ const SearchPage = () => {
                   }
                 >
                   <SlidersHorizontal
-                    className="w-5 h-5"
+                    className="w-4 h-4 sm:w-5 sm:h-5"
                     color={sortIconColor}
                   />
                 </button>
@@ -2095,6 +2138,13 @@ const SearchPage = () => {
                         ? "Matching results to your profile — type to narrow"
                         : "Try: hiking AND photography, or hiking NOT photography"
                   }
+                  compactPlaceholder={
+                    matchRoleId
+                      ? "Type to narrow results..."
+                      : sortBy === "match"
+                        ? "Type to narrow results..."
+                        : "Try: hiking AND photo"
+                  }
                   activePills={activeCriteriaPills}
                   onRemoveActivePill={handleActivePillRemove}
                   focusAreaPills={focusAreaPills}
@@ -2104,23 +2154,22 @@ const SearchPage = () => {
                   onSelectTagSuggestion={handleAddTagFilter}
                   onSelectBadgeSuggestion={handleAddBadgeFilter}
                   onSearchSuggestions={handleSearchSuggestions}
+                  resetSignal={searchInputResetSignal}
                   leftAdornment={
-                    isSortModified ? (
-                      <div className="transition-all duration-200 opacity-100 scale-100">
-                        <Tooltip content="Reset sorting and filters">
-                          <button
-                            type="button"
-                            onClick={handleResetSortFilters}
-                            className="shrink-0 rounded-lg p-0.5 transition-colors"
-                            aria-label="Reset sorting and filters"
-                          >
-                            <RotateCcw
-                              className="w-3.5 h-3.5"
-                              color="var(--color-primary-focus)"
-                            />
-                          </button>
-                        </Tooltip>
-                      </div>
+                    hasSearchInputContent ? (
+                      <Tooltip content="Clear search input">
+                        <button
+                          type="button"
+                          onClick={handleResetSearchInput}
+                          className="shrink-0 rounded-lg p-0.5 transition-colors hover:bg-base-200"
+                          aria-label="Clear search input"
+                        >
+                          <RotateCcw
+                            className="w-3.5 h-3.5"
+                            color="var(--color-primary-focus)"
+                          />
+                        </button>
+                      </Tooltip>
                     ) : null
                   }
                   className="min-w-0 w-full sm:w-auto sm:max-w-full"
@@ -2129,7 +2178,7 @@ const SearchPage = () => {
             </div>
 
             {showSortDropdown && (
-              <div className="mt-2 py-1 pl-11">
+              <div className="mt-2 py-1 pl-7 sm:pl-9">
                 <div className="space-y-[6px]">
                   <div className="flex flex-row flex-wrap items-start gap-x-3 gap-y-[6px]">
                     <div

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -2156,21 +2156,19 @@ const SearchPage = () => {
                   onSearchSuggestions={handleSearchSuggestions}
                   resetSignal={searchInputResetSignal}
                   leftAdornment={
-                    hasSearchInputContent ? (
-                      <Tooltip content="Clear search input">
-                        <button
-                          type="button"
-                          onClick={handleResetSearchInput}
-                          className="shrink-0 rounded-lg p-0.5 transition-colors hover:bg-base-200"
-                          aria-label="Clear search input"
-                        >
-                          <RotateCcw
-                            className="w-3.5 h-3.5"
-                            color="var(--color-primary-focus)"
-                          />
-                        </button>
-                      </Tooltip>
-                    ) : null
+                    <Tooltip content="Clear search input">
+                      <button
+                        type="button"
+                        onClick={handleResetSearchInput}
+                        className="shrink-0 rounded-lg p-0.5 transition-colors hover:bg-base-200"
+                        aria-label="Clear search input"
+                      >
+                        <RotateCcw
+                          className="w-3.5 h-3.5"
+                          color="var(--color-primary-focus)"
+                        />
+                      </button>
+                    </Tooltip>
                   }
                   className="min-w-0 w-full sm:w-auto sm:max-w-full"
                 />

--- a/src/pages/searchPageHelpers.js
+++ b/src/pages/searchPageHelpers.js
@@ -143,7 +143,8 @@ export const getActiveCriteriaPills = ({
   if (maxDistance !== null) {
     pills.push({
       key: "maxDistance",
-      label: `Within ${maxDistance} km`,
+      label: `< ${maxDistance} km`,
+      removeLabel: `Within ${maxDistance} km`,
     });
   }
 

--- a/src/utils/badgeIconUtils.jsx
+++ b/src/utils/badgeIconUtils.jsx
@@ -91,10 +91,11 @@ export const getCategoryIcon = (category, color, size = 16) => {
  * @param {string} badgeName - Badge name (e.g. "Team Player")
  * @param {string} color - Hex color for the icon
  * @param {number} [size=16] - Icon size in px
+ * @param {number} [strokeWidth=2] - Icon stroke width
  * @returns {React.ReactElement}
  */
-export const getBadgeIcon = (badgeName, color, size = 16) => {
-  const iconProps = { size, style: { color } };
+export const getBadgeIcon = (badgeName, color, size = 16, strokeWidth = 2) => {
+  const iconProps = { size, strokeWidth, style: { color } };
 
   switch (badgeName) {
     // Collaboration Skills


### PR DESCRIPTION
## Summary
- Refined the search page header, search-type controls, filter toggle copy, and responsive spacing around the main search bar.
- Reworked `BooleanSearchInput` with an auto-growing textarea, better single-line/stacked pill behavior, accessible remove tooltips, and compact mobile placeholders.
- Improved Boolean search suggestions so tag/badge suggestions are based on the current query segment instead of the entire Boolean expression.
- Added clearer advanced-search affordances: inline `Advanced`/`A` indicator plus a repositioned search tips popup.
- Expanded reset behavior to clear the query, filters, role matching params, sorting/distance options, selected pills, and related URL params.
- Added a shared `ResultViewToggle` component and reused it on Search and My Teams for card, mini card, list, and map view switching.
- Sorted badge filter pills by category order, then label, and tightened badge/criteria pill icon styling.

## Testing
- `git diff --check origin/dev...HEAD`
- `npm run build`

## Notes
- `npm run lint` currently fails because the repo has existing lint issues. Scoped changed-file lint also reports:
  - `src/pages/SearchPage.jsx`: unused `hasSearchInputContent`
  - `src/components/SearchHelp.jsx`: missing `positionPopup` dependency warning
  - existing-looking unused values in `src/pages/MyTeams.jsx`