### PR TITLE
Search bar responsiveness, UX polish & alert system overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Contact the project owner for a demo login, or register a new account with a val
 
 ## Features
 
-- **Search & Discovery** — Find teams, users, and vacant roles by keyword, tags, badges, or location; toggle between list view and interactive map view
+- **Search & Discovery** — Find teams, users, and vacant roles by keyword, tags, badges, or location; use Boolean search helpers, responsive filter/sort controls, and shared card/mini/list/map view toggles
 - **Best Match Sorting** — Weighted matching algorithm scores teams and roles against your profile (tags 40%, badges 30%, distance 30%)
 - **Map View** — Leaflet-powered map with custom markers for teams, users, and roles; popups with detail cards; distance-based filtering and proximity sorting
-- **Team Management** — Create teams, manage members and roles, post vacant roles, handle applications and invitations with role-specific targeting; action buttons for already-filled or closed roles are disabled with status-aware tooltips; role cards update in real time while modals are open
+- **Team Management** — Create teams, manage members and roles, post vacant roles, handle applications and invitations with role-specific targeting; My Teams uses the same responsive sort and result-view controls as search
 - **User Profiles** — Customizable profiles with interest tags, badges, avatar uploads (ImageKit), and geocoded location
 - **Real-Time Chat** — Direct and team group messaging with typing indicators, read receipts, file/image sharing, @mentions, reply threading, and rich system event messages (Socket.IO)
 - **Badge System** — Browse 30 badges across 5 color-coded categories; award badges to teammates with reasons and team context
@@ -160,6 +160,7 @@ Lomir-frontend/
 │   │   ├── search/                 # SearchMapView (Leaflet map with markers/popups)
 │   │   ├── common/                 # Shared UI: Button, Card, Modal, Alert, Pagination,
 │   │   │                           #   ImageUploader, LocationInput, TurnstileWidget,
+│   │   │                           #   FilterSortOptionButton, ResultViewToggle,
 │   │   │                           #   PersonRequestCard, RequestListModal, Tooltip...
 │   │   └── layout/                 # Navbar, Footer, PageContainer, Grid, Section
 │   ├── contexts/
@@ -232,8 +233,8 @@ Lomir-frontend/
 | Route | Page | Description |
 |---|---|---|
 | `/` | Landing Page | Public homepage with feature overview |
-| `/search` | Search | Find teams, users, and roles; list/map toggle; advanced filtering by tags, badges, distance |
-| `/teams/my-teams` | My Teams | Teams you belong to, pending invitations and applications |
+| `/search` | Search | Find teams, users, and roles; Boolean search input; shared result-view toggle; advanced filtering by tags, badges, distance |
+| `/teams/my-teams` | My Teams | Teams you belong to, pending invitations and applications; shared sort and result-view controls |
 | `/profile` | Profile | Edit your profile, tags, avatar, and location |
 | `/profile/:id` | Public Profile | View any user's profile; shows placeholder for deleted/missing users |
 | `/chat` | Chat | Direct messages and team group chat with file/image sharing, @mentions, and reply threading |
@@ -249,6 +250,8 @@ The search page supports multiple sort and filter modes:
 **Sort options:** Name (A–Z / Z–A), Newest, Recently updated, Best Match, Proximity (nearest / remote first), Capacity (member slots or open roles)
 
 **Filter options:** Filter by tags, filter by badges, distance radius, open roles only, exclude teams you're already in, include/exclude demo data
+
+**Responsive controls:** Search and My Teams share `FilterSortOptionButton` for compact sort/filter toolbar actions and `ResultViewToggle` for card, mini-card, list, and map/list view modes. These controls keep icon size, active state styling, spacing, and narrow-viewport alignment consistent across both pages.
 
 **Best Match scoring** uses the backend matching engine (tag overlap 40%, badge overlap 30%, distance 30%) and falls back to client-side profile overlap calculations when backend scores aren't available.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import {
 import { AuthProvider } from "./contexts/AuthContext";
 import { UserModalProvider } from "./contexts/UserModalContext";
 import { TeamModalProvider } from "./contexts/TeamModalContext";
+import { ToastProvider } from "./contexts/ToastContext";
 import Navbar from "./components/layout/Navbar";
 import Footer from "./components/layout/Footer";
 import ProtectedRoute from "./components/layout/ProtectedRoute";
@@ -42,6 +43,7 @@ function AppLayout() {
   ].includes(location.pathname);
 
   return (
+    <ToastProvider>
     <TeamModalProvider>
       <UserModalProvider>
         <div
@@ -105,6 +107,7 @@ function AppLayout() {
         </div>
       </UserModalProvider>
     </TeamModalProvider>
+    </ToastProvider>
   );
 }
 

--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -307,8 +307,7 @@ const BooleanSearchInput = ({
     (query.trim().length > 0 ||
       initialQuery.trim().length > 0 ||
       totalPillCount > 0);
-  const showResetInTrailingControls =
-    hasVisibleLeftAdornment && hasBooleanOperators;
+  const showResetInTrailingControls = hasVisibleLeftAdornment;
   const topAdornmentWidthPx =
     hasVisibleLeftAdornment && !showResetInTrailingControls ? 22 : 0;
   const pillsWidthPx = allPills.reduce(
@@ -351,10 +350,7 @@ const BooleanSearchInput = ({
   const showStackedPills = totalPillCount > 0 && !showInlinePills;
   const helperWidthPx =
     baseHelperWidthPx + (showInlinePills ? inlinePillsWidthPx : 0);
-  const trailingControlsOffsetPx =
-    hasVisibleLeftAdornment && !showStackedPills && !isCompactLayout && !hasBooleanOperators
-      ? 30
-      : 0;
+  const trailingControlsOffsetPx = 0;
   const fieldRightPaddingPx = Math.max(helperWidthPx, 12) + 8;
   const textRowRightPaddingPx = isCompactLayout
     ? 0
@@ -611,8 +607,7 @@ const BooleanSearchInput = ({
     bottom: isCompactLayout && hasBooleanOperators ? "0.625rem" : "0.5625rem",
     ...(isCompactLayout && hasVisibleLeftAdornment
       ? {
-          right:
-            hasBooleanOperators || showStackedPills ? "0.625rem" : "1.875rem",
+          right: "0.625rem",
         }
       : trailingControlsOffsetPx > 0
         ? { right: "1.875rem" }

--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -16,10 +16,12 @@ import {
   ArrowDownAZ,
   ArrowUpZA,
   Clock,
+  Filter,
   FlaskConical,
   Globe,
   MapPin,
-  Ruler,
+  Radius,
+  SlidersHorizontal,
   Sparkles,
   Target,
   UserMinus,
@@ -71,8 +73,18 @@ const getSuggestionQuery = (value, cursorIndex = value.length) => {
   return fallbackSegments[fallbackSegments.length - 1] || "";
 };
 
+const splitLeadingSign = (value) => {
+  const match = String(value ?? "").match(/^([+-])\s+(.+)$/);
+  return match
+    ? { sign: match[1], label: match[2] }
+    : { sign: null, label: value };
+};
+
+const getFilterPillAriaLabel = (removeAction, filterName) =>
+  `${removeAction}: ${filterName}`;
+
 const getCriteriaPillIcon = (pill) => {
-  if (pill.key === "maxDistance") return Ruler;
+  if (pill.key === "maxDistance") return Radius;
   if (pill.key === "openRolesOnly") return UserSearch;
   if (pill.key === "includeOwnTeams") return Users;
   if (pill.key === "includeDemoData") return FlaskConical;
@@ -106,6 +118,20 @@ const getCriteriaPillIcon = (pill) => {
     default:
       return null;
   }
+};
+
+const getCriteriaFilterType = (pill) => {
+  if (pill.type === "role") return "searchTerm";
+  if (pill.key === "sort") return "sort";
+  return "filter";
+};
+
+const getRemoveActionParts = (removeAction) => {
+  const [firstWord, ...restWords] = removeAction.split(" ");
+  return {
+    firstWord,
+    restText: restWords.join(" "),
+  };
 };
 
 /**
@@ -602,22 +628,52 @@ const BooleanSearchInput = ({
   const pillLabelClassName = "min-w-0 text-left leading-[1.1]";
   const pillCloseClassName = "flex h-[1.1em] w-2.5 items-center justify-center";
   const pillTooltipClassName =
-    "tooltip tooltip-top tooltip-lomir inline-flex z-10 hover:z-[500] focus-within:z-[500]";
+    "inline-flex z-10 hover:z-[500] focus-within:z-[500]";
+  const renderPillTooltipContent = (Icon, filterName, removeAction) => (
+    <span className="inline-flex flex-wrap items-center gap-y-0.5">
+      <span>{getRemoveActionParts(removeAction).firstWord}</span>
+      <span className="inline-flex items-center whitespace-nowrap">
+        {Icon ? (
+          <Icon
+            size={13}
+            strokeWidth={2.5}
+            className="mx-1"
+            aria-hidden="true"
+          />
+        ) : null}
+        <span>{getRemoveActionParts(removeAction).restText}:&nbsp;</span>
+      </span>
+      <span>{filterName}</span>
+    </span>
+  );
 
-  const renderColoredFilterPill = ({ pill, color, icon, onRemove }) => {
-    const tooltipText = `Remove ${pill.label}`;
+  const renderColoredFilterPill = ({
+    pill,
+    color,
+    icon,
+    onRemove,
+    TooltipIcon,
+    removeAction,
+  }) => {
+    const tooltipContent = renderPillTooltipContent(
+      TooltipIcon,
+      pill.label,
+      removeAction,
+    );
+    const ariaLabel = getFilterPillAriaLabel(removeAction, pill.label);
     return (
-      <span
+      <Tooltip
         key={pill.key}
-        className={pillTooltipClassName}
-        data-tip={tooltipText}
+        content={tooltipContent}
+        position="top"
+        wrapperClassName={pillTooltipClassName}
       >
         <button
           type="button"
           onClick={() => onRemove?.(pill.id)}
-          className={pillBaseClassName}
-          style={{ backgroundColor: color, color: "white" }}
-          aria-label={tooltipText}
+          className={`${pillBaseClassName} border`}
+          style={{ backgroundColor: color, borderColor: color, color: "white" }}
+          aria-label={ariaLabel}
         >
           <span className={pillIconClassName}>{icon}</span>
           <span className={pillLabelClassName}>{pill.label}</span>
@@ -625,7 +681,7 @@ const BooleanSearchInput = ({
             <X size={10} strokeWidth={3} className={pillSvgClassName} />
           </span>
         </button>
-      </span>
+      </Tooltip>
     );
   };
 
@@ -635,6 +691,8 @@ const BooleanSearchInput = ({
       color: CATEGORY_COLORS[pill.category] || DEFAULT_COLOR,
       icon: getBadgeIcon(pill.label, "white", 10, 3),
       onRemove: onRemoveBadgePill,
+      TooltipIcon: Award,
+      removeAction: "Remove Badge",
     });
 
   const renderFocusAreaPill = (pill) => {
@@ -643,98 +701,137 @@ const BooleanSearchInput = ({
       color: FOCUS_GREEN,
       icon: <Tag size={10} strokeWidth={3} className={pillSvgClassName} />,
       onRemove: onRemoveFocusAreaPill,
+      TooltipIcon: Tag,
+      removeAction: "Remove Focus Area",
     });
   };
 
   const renderCriteriaPill = (pill) => {
+    const labelParts = splitLeadingSign(pill.label);
+    const shortLabelParts = pill.shortLabel
+      ? splitLeadingSign(pill.shortLabel)
+      : null;
+    const pillSign = labelParts.sign || shortLabelParts?.sign;
+    const criteriaPillClassName = `${pillBaseClassName}${
+      pillSign ? " grid-cols-[auto_minmax(0,auto)_0.625rem]" : ""
+    }`;
+    const renderLeadingIcon = (iconNode, ariaHidden = false) => (
+      <span
+        className={`${pillIconClassName}${pillSign ? " w-auto gap-px" : ""}`}
+        aria-hidden={ariaHidden ? "true" : undefined}
+      >
+        {pillSign && <span className="leading-none">{pillSign}</span>}
+        {iconNode}
+      </span>
+    );
     const pillLabelNode = pill.shortLabel ? (
       <>
-        <span className={`hidden sm:inline ${pillLabelClassName}`}>{pill.label}</span>
-        <span className={`sm:hidden ${pillLabelClassName}`}>{pill.shortLabel}</span>
+        <span className={`hidden sm:inline ${pillLabelClassName}`}>{labelParts.label}</span>
+        <span className={`sm:hidden ${pillLabelClassName}`}>{shortLabelParts.label}</span>
       </>
     ) : (
-      <span className={pillLabelClassName}>{pill.label}</span>
+      <span className={pillLabelClassName}>{labelParts.label}</span>
+    );
+    const criteriaType = getCriteriaFilterType(pill);
+    const criteriaTooltipIcon =
+      criteriaType === "searchTerm"
+        ? UserSearch
+        : criteriaType === "sort"
+          ? SlidersHorizontal
+          : Filter;
+    const criteriaRemoveAction =
+      criteriaType === "searchTerm"
+        ? "Remove Role Name"
+        : criteriaType === "sort"
+          ? "Remove Sorting"
+          : "Remove Filter";
+    const criteriaFilterName = pill.removeLabel ?? pill.label;
+    const tooltipContent = renderPillTooltipContent(
+      criteriaTooltipIcon,
+      criteriaFilterName,
+      criteriaRemoveAction,
+    );
+    const ariaLabel = getFilterPillAriaLabel(
+      criteriaRemoveAction,
+      criteriaFilterName,
     );
 
     if (pill.type === "role") {
-      const tooltipText = `Remove ${pill.removeLabel ?? pill.label}`;
       return (
-        <span
+        <Tooltip
           key={pill.key}
-          className={pillTooltipClassName}
-          data-tip={tooltipText}
+          content={tooltipContent}
+          position="top"
+          wrapperClassName={pillTooltipClassName}
         >
           <button
             type="button"
             onClick={() => onRemoveActivePill?.(pill.key)}
-            className={`${pillBaseClassName} border border-amber-400 bg-amber-50 text-amber-700 transition-colors hover:border-amber-500 hover:bg-amber-100 hover:opacity-100`}
-            aria-label={tooltipText}
+            className={`${criteriaPillClassName} border border-amber-400 bg-amber-50 text-amber-700 transition-colors hover:border-amber-500 hover:bg-amber-100 hover:opacity-100`}
+            aria-label={ariaLabel}
           >
-            <span className={pillIconClassName}>
-              <UserSearch size={12} className={pillSvgClassName} />
-            </span>
+            {renderLeadingIcon(<UserSearch size={12} className={pillSvgClassName} />)}
             {pillLabelNode}
             <span className={pillCloseClassName} aria-hidden="true">
               <X size={10} strokeWidth={2.5} className={pillSvgClassName} />
             </span>
           </button>
-        </span>
+        </Tooltip>
       );
     }
     if (pill.type === "excludeTeam") {
-      const tooltipText = `Remove ${pill.removeLabel ?? pill.label}`;
       return (
-        <span
+        <Tooltip
           key={pill.key}
-          className={pillTooltipClassName}
-          data-tip={tooltipText}
+          content={tooltipContent}
+          position="top"
+          wrapperClassName={pillTooltipClassName}
         >
           <button
             type="button"
             onClick={() => onRemoveActivePill?.(pill.key)}
-            className={`${pillBaseClassName} border border-slate-400 bg-slate-50 text-slate-600 transition-colors hover:border-slate-500 hover:bg-slate-100 hover:opacity-100`}
-            aria-label={tooltipText}
+            className={`${criteriaPillClassName} border border-slate-400 bg-slate-50 text-slate-600 transition-colors hover:border-slate-500 hover:bg-slate-100 hover:opacity-100`}
+            aria-label={ariaLabel}
           >
-            <span className={pillIconClassName}>
-              <Users size={12} className={pillSvgClassName} />
-            </span>
+            {renderLeadingIcon(<Users size={12} className={pillSvgClassName} />)}
             {pillLabelNode}
             <span className={pillCloseClassName} aria-hidden="true">
               <X size={10} strokeWidth={2.5} className={pillSvgClassName} />
             </span>
           </button>
-        </span>
+        </Tooltip>
       );
     }
     const CriteriaIcon = getCriteriaPillIcon(pill);
-    const tooltipText = `Remove ${pill.removeLabel ?? pill.label}`;
     return (
-      <span
+      <Tooltip
         key={pill.key}
-        className={pillTooltipClassName}
-        data-tip={tooltipText}
+        content={tooltipContent}
+        position="top"
+        wrapperClassName={pillTooltipClassName}
       >
         <button
           type="button"
           onClick={() => onRemoveActivePill?.(pill.key)}
-          className={`${pillBaseClassName} border border-[var(--color-primary)] bg-[#f0fdf4] text-[var(--color-primary)] transition-colors hover:border-[var(--color-primary-focus)] hover:bg-[#dcfce7] hover:text-[var(--color-primary-focus)] hover:opacity-100`}
-          aria-label={tooltipText}
+          className={`${criteriaPillClassName} border border-[var(--color-primary)] bg-[#f0fdf4] text-[var(--color-primary)] transition-colors hover:border-[var(--color-primary-focus)] hover:bg-[#dcfce7] hover:text-[var(--color-primary-focus)] hover:opacity-100`}
+          aria-label={ariaLabel}
         >
-          <span className={pillIconClassName} aria-hidden="true">
-            {CriteriaIcon ? (
+          {renderLeadingIcon(
+            CriteriaIcon ? (
               <CriteriaIcon
                 size={12}
                 strokeWidth={2.5}
                 className={pillSvgClassName}
               />
-            ) : null}
-          </span>
+            ) : null,
+            true,
+          )}
           {pillLabelNode}
           <span className={pillCloseClassName} aria-hidden="true">
             <X size={10} strokeWidth={2.5} className={pillSvgClassName} />
           </span>
         </button>
-      </span>
+      </Tooltip>
     );
   };
 

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../../contexts/AuthContext";
 import Card from "../common/Card";
 import Button from "../common/Button";
 import FormGroup from "../common/FormGroup";
+import Alert from "../common/Alert";
 import { Eye, EyeOff } from "lucide-react";
 
 const LoginForm = () => {
@@ -84,9 +85,7 @@ const LoginForm = () => {
         </p>
 
         {errors.form && (
-          <div className="alert alert-error mb-6">
-            <span>{errors.form}</span>
-          </div>
+          <Alert type="error" message={errors.form} className="mb-6 w-full shadow-sm" />
         )}
 
         <form onSubmit={handleSubmit} noValidate>

--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -5,6 +5,7 @@ import { UI_TEXT } from "../../constants/uiText";
 import TagInput from "../tags/TagInput";
 import Card from "../common/Card";
 import Button from "../common/Button";
+import Alert from "../common/Alert";
 import FormSectionDivider from "../common/FormSectionDivider";
 import {
   Tag,
@@ -402,13 +403,12 @@ const RegisterForm = () => {
             </p>
 
             {resendMessage && (
-              <div
-                className={`alert ${
-                  resendStatus === "sent" ? "alert-success" : "alert-error"
-                } mb-4`}
-              >
-                <span>{resendMessage}</span>
-              </div>
+              <Alert
+                type={resendStatus === "sent" ? "success" : "error"}
+                message={resendMessage}
+                onClose={() => setResendMessage("")}
+                className="mb-4 w-full shadow-sm"
+              />
             )}
 
             <div className="flex flex-col gap-2 w-full">
@@ -452,9 +452,7 @@ const RegisterForm = () => {
           </p>
 
           {errors.form && (
-            <div className="alert alert-error mb-4">
-              <span>{errors.form}</span>
-            </div>
+            <Alert type="error" message={errors.form} className="mb-4 w-full shadow-sm" />
           )}
 
           <form onSubmit={handleSubmit} className="space-y-12">

--- a/src/components/common/Alert.jsx
+++ b/src/components/common/Alert.jsx
@@ -6,19 +6,23 @@ const Alert = ({
   children,
   onClose,
   className = "",
+  autoCloseMs = 15000,
 }) => {
   const [fading, setFading] = useState(false);
 
   useEffect(() => {
     if (!onClose) return;
     setFading(false);
-    const fadeTimer = setTimeout(() => setFading(true), 2000);
-    const closeTimer = setTimeout(onClose, 3000);
+    const fadeTimer = setTimeout(
+      () => setFading(true),
+      Math.max(0, autoCloseMs - 1000),
+    );
+    const closeTimer = setTimeout(onClose, autoCloseMs);
     return () => {
       clearTimeout(fadeTimer);
       clearTimeout(closeTimer);
     };
-  }, [type, message, onClose]);
+  }, [type, message, onClose, autoCloseMs]);
 
   const alertClasses = {
     info: "alert-info",
@@ -31,9 +35,9 @@ const Alert = ({
 
   return (
     <div
-      className={`alert ${alertClasses[type]} !text-white w-fit transition-opacity duration-1000 ${fading ? "opacity-0" : "opacity-100"} ${className}`}
+      className={`alert ${alertClasses[type]} !text-white w-fit transition-opacity duration-1000 border-0 outline-none ${fading ? "opacity-0" : "opacity-100"} ${className}`}
     >
-      <div className="flex items-start gap-2">
+      <div className="flex items-center gap-2">
         {type === "info" && (
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -113,7 +117,7 @@ const Alert = ({
       </div>
       {onClose && (
         <button
-          className="btn btn-sm btn-ghost text-white hover:bg-white/20 text-xl font-light"
+          className="text-white hover:text-white/70 text-xl font-light leading-none p-0 bg-transparent border-none cursor-pointer self-start"
           onClick={onClose}
         >
           ×

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -267,12 +267,13 @@ const Card = ({
       {rowTooltipVisible && rowTooltipPosition && clickTooltip && createPortal(
         <div
           role="tooltip"
-          className="fixed z-[9999] bg-white text-[var(--color-primary-focus)] rounded-lg whitespace-pre-line text-left max-w-[280px] pointer-events-none"
+          className="lomir-tooltip-bubble fixed z-[9999] bg-white text-[var(--color-primary-focus)] rounded-lg whitespace-pre-line text-left max-w-[280px] pointer-events-none"
           style={{
             top: `${rowTooltipPosition.top}px`,
             left: `${rowTooltipPosition.left}px`,
             padding: "0.5rem 0.75rem",
             fontSize: "0.775rem",
+            lineHeight: 1.15,
             fontWeight: 450,
             boxShadow: "0 2px 8px rgba(4, 80, 20, 0.15)",
           }}
@@ -371,12 +372,13 @@ const Card = ({
       {rowTooltipVisible && rowTooltipPosition && clickTooltip && createPortal(
         <div
           role="tooltip"
-          className="fixed z-[9999] bg-white text-[var(--color-primary-focus)] rounded-lg whitespace-pre-line text-left max-w-[280px] pointer-events-none"
+          className="lomir-tooltip-bubble fixed z-[9999] bg-white text-[var(--color-primary-focus)] rounded-lg whitespace-pre-line text-left max-w-[280px] pointer-events-none"
           style={{
             top: `${rowTooltipPosition.top}px`,
             left: `${rowTooltipPosition.left}px`,
             padding: "0.5rem 0.75rem",
             fontSize: "0.775rem",
+            lineHeight: 1.15,
             fontWeight: 450,
             boxShadow: "0 2px 8px rgba(4, 80, 20, 0.15)",
           }}

--- a/src/components/common/FilterSortOptionButton.jsx
+++ b/src/components/common/FilterSortOptionButton.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+const BASE_CLASS_NAME =
+  "flex items-center gap-0.5 px-1 text-xs leading-[1.05] sm:gap-1 sm:leading-normal rounded transition-colors shrink-0";
+const ACTIVE_CLASS_NAME = "text-[var(--color-primary)] font-bold";
+const INACTIVE_CLASS_NAME =
+  "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium";
+const ICON_CLASS_NAME =
+  "w-[0.735rem] h-[0.735rem] sm:w-3.5 sm:h-3.5 shrink-0";
+
+const FilterSortOptionButton = React.forwardRef(
+  (
+    {
+      icon: Icon,
+      label,
+      mobileLabel,
+      active = false,
+      className = "",
+      iconClassName = "",
+      children,
+      type = "button",
+      ...buttonProps
+    },
+    ref,
+  ) => {
+    const hasResponsiveLabel = mobileLabel && mobileLabel !== label;
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={`${BASE_CLASS_NAME} ${
+          active ? ACTIVE_CLASS_NAME : INACTIVE_CLASS_NAME
+        } ${className}`}
+        {...buttonProps}
+      >
+        {Icon && (
+          <Icon className={`${ICON_CLASS_NAME} ${iconClassName}`.trim()} />
+        )}
+        {children ??
+          (hasResponsiveLabel ? (
+            <>
+              <span className="hidden sm:inline">{label}</span>
+              <span className="sm:hidden">{mobileLabel}</span>
+            </>
+          ) : (
+            <span>{label}</span>
+          ))}
+      </button>
+    );
+  },
+);
+
+FilterSortOptionButton.displayName = "FilterSortOptionButton";
+
+export default FilterSortOptionButton;

--- a/src/components/common/FilterSortOptionButton.jsx
+++ b/src/components/common/FilterSortOptionButton.jsx
@@ -14,6 +14,7 @@ const FilterSortOptionButton = React.forwardRef(
       icon: Icon,
       label,
       mobileLabel,
+      prefix = null,
       active = false,
       className = "",
       iconClassName = "",
@@ -24,6 +25,9 @@ const FilterSortOptionButton = React.forwardRef(
     ref,
   ) => {
     const hasResponsiveLabel = mobileLabel && mobileLabel !== label;
+    const iconNode = Icon ? (
+      <Icon className={`${ICON_CLASS_NAME} ${iconClassName}`.trim()} />
+    ) : null;
 
     return (
       <button
@@ -34,8 +38,13 @@ const FilterSortOptionButton = React.forwardRef(
         } ${className}`}
         {...buttonProps}
       >
-        {Icon && (
-          <Icon className={`${ICON_CLASS_NAME} ${iconClassName}`.trim()} />
+        {prefix ? (
+          <span className="inline-flex items-center gap-px">
+            <span className="leading-none">{prefix}</span>
+            {iconNode}
+          </span>
+        ) : (
+          iconNode
         )}
         {children ??
           (hasResponsiveLabel ? (

--- a/src/components/common/RequestListModal.jsx
+++ b/src/components/common/RequestListModal.jsx
@@ -1,35 +1,9 @@
 import React from "react";
 import { User, X, Mail } from "lucide-react";
 import Modal from "./Modal";
-import ScreenAlert from "./ScreenAlert";
+import Alert from "./Alert";
 import Button from "./Button";
 
-/**
- * RequestListModal Component
- *
- * A reusable modal wrapper for displaying lists of requests
- * (applications, invitations, etc.)
- *
- * Used by: TeamApplicationsModal, TeamInvitesModal
- *
- * @param {Object} props
- * @param {boolean} props.isOpen - Whether the modal is open
- * @param {Function} props.onClose - Callback to close the modal
- * @param {string} props.title - Main title text
- * @param {string} props.subtitle - Subtitle with context (e.g., team name)
- * @param {number} props.itemCount - Number of items in the list
- * @param {string} props.itemName - Singular name for items (e.g., "application", "invitation")
- * @param {string} props.footerText - Optional footer help text
- * @param {string} props.error - Error message to display
- * @param {Function} props.onErrorClose - Callback to clear error
- * @param {string} props.success - Success message to display
- * @param {Function} props.onSuccessClose - Callback to clear success
- * @param {React.ReactNode} props.emptyIcon - Icon for empty state (default: User)
- * @param {string} props.emptyTitle - Title for empty state
- * @param {string} props.emptyMessage - Message for empty state
- * @param {React.ReactNode} props.children - List content to render
- * @param {React.ReactNode} props.extraModals - Additional modals to render (e.g., UserDetailsModal)
- */
 const RequestListModal = ({
   // Modal control
   isOpen,
@@ -47,8 +21,6 @@ const RequestListModal = ({
   // Alerts
   error,
   onErrorClose,
-  success,
-  onSuccessClose,
 
   // Empty state
   emptyIcon,
@@ -66,10 +38,8 @@ const RequestListModal = ({
 }) => {
   // ============ Computed Values ============
 
-  // Pluralize item name
   const pluralItemName = itemCount === 1 ? itemName : `${itemName}s`;
 
-  // Custom header with count
   const customHeader = (
     <div>
       <h2 className="text-xl font-medium text-primary leading-[110%] mb-[0.2em]">
@@ -82,7 +52,6 @@ const RequestListModal = ({
     </div>
   );
 
-  // Footer with summary
   const footer =
     itemCount > 0 ? (
       <div className="flex flex-wrap justify-between items-center gap-y-1 text-sm text-base-content/70">
@@ -93,7 +62,6 @@ const RequestListModal = ({
       </div>
     ) : null;
 
-  // Default empty state icon
   const EmptyIcon = emptyIcon || User;
 
   // ============ Render ============
@@ -113,6 +81,11 @@ const RequestListModal = ({
         closeOnEscape={true}
         showCloseButton={true}
       >
+        {/* Error shown inline — visible at the point of action */}
+        {error && (
+          <Alert type="error" message={error} onClose={onErrorClose} className="mb-4 w-full shadow-sm" />
+        )}
+
         {/* Content: Empty State or List */}
         {itemCount === 0 ? (
           <div className="text-center py-12">
@@ -131,21 +104,6 @@ const RequestListModal = ({
           <div className="space-y-4">{children}</div>
         )}
       </Modal>
-
-      <ScreenAlert
-        alerts={[
-          error && {
-            type: "error",
-            message: error,
-            onClose: onErrorClose,
-          },
-          success && {
-            type: "success",
-            message: success,
-            onClose: onSuccessClose,
-          },
-        ]}
-      />
 
       {/* Extra modals (e.g., UserDetailsModal) rendered outside */}
       {extraModals}

--- a/src/components/common/ResultViewToggle.jsx
+++ b/src/components/common/ResultViewToggle.jsx
@@ -44,45 +44,51 @@ const ResultViewToggle = ({
   value,
   onChange,
   modes = ["card", "mini", "list"],
+  align = "end",
   className = "",
-}) => (
-  <div
-    className={`flex flex-wrap items-center justify-end text-sm leading-[1.15] font-normal text-base-content/60 gap-x-1.5 gap-y-1 sm:gap-x-3 ${className}`}
-    role="group"
-    aria-label="Result view"
-  >
-    {modes.map((mode) => {
-      const option = VIEW_MODE_OPTIONS[mode];
-      if (!option) return null;
+}) => {
+  const alignmentClassName =
+    align === "responsive-start" ? "justify-start sm:justify-end" : "justify-end";
 
-      const isActive = value === mode;
-      const Icon = option.Icon;
+  return (
+    <div
+      className={`flex flex-wrap items-center ${alignmentClassName} text-sm leading-[1.15] font-normal text-base-content/60 gap-x-1.5 gap-y-1 sm:gap-x-3 ${className}`}
+      role="group"
+      aria-label="Result view"
+    >
+      {modes.map((mode) => {
+        const option = VIEW_MODE_OPTIONS[mode];
+        if (!option) return null;
 
-      return (
-        <button
-          key={mode}
-          type="button"
-          aria-pressed={isActive}
-          aria-label={option.ariaLabel}
-          data-tip={isActive ? option.tooltip : `Switch to ${option.tooltip}`}
-          onClick={() => onChange(mode)}
-          className={`tooltip tooltip-top tooltip-lomir inline-flex items-center gap-1 rounded p-1 sm:p-0 hover:text-base-content transition-colors ${
-            isActive ? "font-bold text-base-content" : ""
-          }`}
-        >
-          <Icon
-            className="inline-block w-[0.735rem] h-[0.735rem] shrink-0"
-            strokeWidth={isActive ? 3 : 2}
-            aria-hidden="true"
-            focusable="false"
-          />
-          <span className="hidden sm:inline" aria-hidden="true">
-            {option.label}
-          </span>
-        </button>
-      );
-    })}
-  </div>
-);
+        const isActive = value === mode;
+        const Icon = option.Icon;
+
+        return (
+          <button
+            key={mode}
+            type="button"
+            aria-pressed={isActive}
+            aria-label={option.ariaLabel}
+            data-tip={isActive ? option.tooltip : `Switch to ${option.tooltip}`}
+            onClick={() => onChange(mode)}
+            className={`tooltip tooltip-top tooltip-lomir inline-flex items-center gap-1 rounded p-1 sm:p-0 hover:text-base-content transition-colors ${
+              isActive ? "font-bold text-base-content" : ""
+            }`}
+          >
+            <Icon
+              className="inline-block w-[0.735rem] h-[0.735rem] shrink-0"
+              strokeWidth={isActive ? 3 : 2}
+              aria-hidden="true"
+              focusable="false"
+            />
+            <span className="hidden sm:inline" aria-hidden="true">
+              {option.label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
 
 export default ResultViewToggle;

--- a/src/components/common/ScreenAlert.jsx
+++ b/src/components/common/ScreenAlert.jsx
@@ -2,23 +2,24 @@ import React from "react";
 import { createPortal } from "react-dom";
 import Alert from "./Alert";
 
-const ScreenAlert = ({ alerts, type, message, onClose }) => {
+const ScreenAlert = ({ alerts, type, message, onClose, autoCloseMs }) => {
   const alertItems = (
-    alerts ?? (message ? [{ type, message, onClose }] : [])
+    alerts ?? (message ? [{ type, message, onClose, autoCloseMs }] : [])
   ).filter((alert) => alert?.type && alert?.message);
 
   if (alertItems.length === 0 || typeof document === "undefined") return null;
 
   return createPortal(
-    <div className="pointer-events-none fixed inset-0 z-[9999] flex items-center justify-center px-4">
-      <div className="flex max-w-[min(calc(100vw-2rem),32rem)] flex-col items-center gap-3">
+    <div className="pointer-events-none fixed left-0 top-0 z-[9999] flex h-[100dvh] w-screen items-center justify-center px-4">
+      <div className="flex w-[70vw] max-w-[70vw] flex-col items-center gap-3 sm:w-auto sm:max-w-[min(calc(100vw-2rem),32rem)]">
         {alertItems.map((alert, index) => (
           <Alert
-            key={`${alert.type}-${index}`}
+            key={`${alert.type}-${index}-${alert.successId ?? ''}`}
             type={alert.type}
             message={alert.message}
             onClose={alert.onClose}
-            className="pointer-events-auto max-w-full shadow-[0_4px_10px_rgba(0,0,0,0.12),0_12px_30px_rgba(0,0,0,0.18),0_28px_56px_rgba(0,0,0,0.14)] ring-1 ring-white/20"
+            autoCloseMs={alert.autoCloseMs}
+            className="pointer-events-auto !w-full max-w-full shadow-[0_4px_10px_rgba(0,0,0,0.12),0_12px_30px_rgba(0,0,0,0.18),0_28px_56px_rgba(0,0,0,0.14)] sm:!w-fit"
           />
         ))}
       </div>

--- a/src/components/common/Tooltip.jsx
+++ b/src/components/common/Tooltip.jsx
@@ -189,6 +189,7 @@ const Tooltip = ({
               ref={tooltipRef}
               role="tooltip"
               className={`
+                lomir-tooltip-bubble
                 fixed z-[9999]
                 bg-white
                 text-[var(--color-primary-focus)]
@@ -203,6 +204,7 @@ const Tooltip = ({
                 left: `${coords.left}px`,
                 padding: "0.5rem 0.75rem",
                 fontSize: "0.775rem",
+                lineHeight: 1.15,
                 fontWeight: 450,
                 boxShadow: "0 2px 8px rgba(4, 80, 20, 0.15)",
               }}

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useQueries } from "@tanstack/react-query";
+import { useToast } from "../../contexts/ToastContext";
 import { createPortal } from "react-dom";
 import {
   AttributionControl,
@@ -1938,6 +1939,7 @@ const SearchMapView = ({
   viewerLocation = null,
   proximityRadiusKm = null,
 }) => {
+  const showToast = useToast();
   const teamModal = useTeamModalSafe();
   const userModal = useUserModalSafe();
   const authContext = useAuth();
@@ -2024,8 +2026,8 @@ const SearchMapView = ({
   }, [refreshUserStatusData]);
 
   const handleApplicationReminder = useCallback(async () => {
-    window.alert("Reminder feature coming soon!");
-  }, []);
+    showToast("Reminder feature coming soon!", "violet");
+  }, [showToast]);
 
   const itemsWithUserLocationDetails = useMemo(
     () =>

--- a/src/components/tags/TagsDisplaySection.jsx
+++ b/src/components/tags/TagsDisplaySection.jsx
@@ -11,6 +11,7 @@ import {
 import { SUPERCATEGORY_ICONS } from "../../utils/badgeIconUtils";
 import Tooltip from "../common/Tooltip";
 import Button from "../common/Button";
+import Alert from "../common/Alert";
 import TagInput from "./TagInput";
 import { UI_TEXT } from "../../constants/uiText";
 
@@ -448,14 +449,15 @@ const TagsDisplaySection = ({
 
         {/* Error/Success Messages */}
         {error && (
-          <div className="alert alert-error mb-4">
-            <span>{error}</span>
-          </div>
+          <Alert type="error" message={error} className="mb-4 w-full shadow-sm" />
         )}
         {success && (
-          <div className="alert alert-success mb-4">
-            <span>{success}</span>
-          </div>
+          <Alert
+            type="success"
+            message={success}
+            onClose={() => setSuccess(null)}
+            className="mb-4 w-full shadow-sm"
+          />
         )}
 
         {/* Tag Input */}
@@ -509,9 +511,12 @@ const TagsDisplaySection = ({
 
       {/* Success Message (after save) */}
       {success && (
-        <div className="alert alert-success mb-4">
-          <span>{success}</span>
-        </div>
+        <Alert
+          type="success"
+          message={success}
+          onClose={() => setSuccess(null)}
+          className="mb-4 w-full shadow-sm"
+        />
       )}
 
       {/* Tags display */}

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -1,4 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
+import { useToast } from "../../contexts/ToastContext";
 import {
   Calendar,
   Users,
@@ -47,6 +48,7 @@ const TeamApplicationDetailsModal = ({
   notificationHighlight = false,
 }) => {
   // ============ State ============
+  const showToast = useToast();
   const loading = false;
   const [actionLoading, setActionLoading] = useState(null);
   const [error, setError] = useState(null);
@@ -235,6 +237,7 @@ const TeamApplicationDetailsModal = ({
       setActionLoading("cancel");
       setError(null);
       await onCancel(application.id);
+      showToast("Application cancelled successfully.", "success");
       setIsCancelDialogOpen(false);
       onClose();
     } catch (err) {
@@ -414,13 +417,12 @@ const TeamApplicationDetailsModal = ({
         closeOnEscape={true}
         showCloseButton={true}
       >
-        {/* Error Alert */}
         {error && (
           <Alert
             type="error"
             message={error}
             onClose={() => setError(null)}
-            className="mb-4"
+            className="mb-4 w-full shadow-sm"
           />
         )}
 

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Check, CheckCheck, UserCheck, X as Decline, User, Users, Mail, MessageSquare, AlertTriangle, ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import RequestListModal from "../common/RequestListModal";
+import { useToast } from "../../contexts/ToastContext";
 import PersonRequestCard from "../common/PersonRequestCard";
 import Button from "../common/Button";
 import Modal from "../common/Modal";
@@ -54,9 +55,10 @@ const TeamApplicationsModal = ({
   const { openTeamModal } = useTeamModal();
 
   // ============ State ============
+  const showToast = useToast();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(null);
+  const showSuccess = (message) => showToast(message, "success");
   const [responses, setResponses] = useState({});
   const [responseExpanded, setResponseExpanded] = useState({});
   const [selectedUserId, setSelectedUserId] = useState(null);
@@ -161,7 +163,7 @@ const TeamApplicationsModal = ({
           "the role";
         const currentRoleName =
           actionData.deferredByCurrentRoleName ?? "their current role";
-        setSuccess(
+        showSuccess(
           `Application approved! ${roleName} is now a role offer the member can accept once they leave ${currentRoleName}.`,
         );
       } else if (action === "approve" && fillRole && roleFilled) {
@@ -169,9 +171,9 @@ const TeamApplicationsModal = ({
           application?.role?.roleName ??
           application?.role?.role_name ??
           "the role";
-        setSuccess(`Application approved! ${roleName} has been marked as filled.`);
+        showSuccess(`Application approved! ${roleName} has been marked as filled.`);
       } else {
-        setSuccess(
+        showSuccess(
           `Application ${action === "approve" ? "approved" : "declined"} successfully!`
         );
       }
@@ -242,7 +244,7 @@ const TeamApplicationsModal = ({
           return next;
         });
 
-        setSuccess("Role reopened successfully!");
+        showSuccess("Role reopened successfully!");
 
         try {
           await onRoleStatusChanged?.(roleId, "open");
@@ -331,8 +333,6 @@ const TeamApplicationsModal = ({
       footerText="Review each application carefully before making decisions."
       error={error}
       onErrorClose={() => setError(null)}
-      success={success}
-      onSuccessClose={() => setSuccess(null)}
       emptyIcon={User}
       emptyTitle="No pending applications"
       emptyMessage="When users apply to join your team, they'll appear here."

--- a/src/components/teams/TeamEditForm.jsx
+++ b/src/components/teams/TeamEditForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect, useMemo } from "react";
+import { useToast } from "../../contexts/ToastContext";
 import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
 import ConfirmModal from "../common/ConfirmModal";
@@ -52,6 +53,8 @@ const TeamEditForm = ({
   const [avatarDeleteLoading, setAvatarDeleteLoading] = useState(false);
   const [isAvatarDeleteDialogOpen, setIsAvatarDeleteDialogOpen] =
     useState(false);
+
+  const showToast = useToast();
 
   // Location auto-fill hook
   const { getSuggestedUpdates } = useLocationAutoFill({
@@ -205,10 +208,11 @@ const TeamEditForm = ({
       }
     } catch (error) {
       console.error("Error deleting team avatar:", error);
-      alert(
+      showToast(
         error.response?.data?.message ||
           error.message ||
           "Failed to remove team picture. Please try again.",
+        "error",
       );
     } finally {
       setAvatarDeleteLoading(false);

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -1,4 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
+import { useToast } from "../../contexts/ToastContext";
 import {
   Calendar,
   MessageSquare,
@@ -158,6 +159,7 @@ const TeamInvitationDetailsModal = ({
   const { user: currentUser } = useAuth();
 
   // ============ State ============
+  const showToast = useToast();
   const [loading] = useState(false);
   const [actionLoading, setActionLoading] = useState(null); // "acceptRole" | "switchRole" | "acceptTeam" | "decline" | null
   const [error, setError] = useState(null);
@@ -339,6 +341,7 @@ const TeamInvitationDetailsModal = ({
       setActionLoading("acceptRole");
       setError(null);
       await onAccept(invitation.id, responseMessage, true);
+      showToast("Invitation accepted! You've joined the team and taken on the role.", "success");
       setResponseMessage("");
       onClose();
     } catch (err) {
@@ -353,6 +356,7 @@ const TeamInvitationDetailsModal = ({
       setActionLoading("switchRole");
       setError(null);
       await onAccept(invitation.id, responseMessage, true, { switchRoles: true });
+      showToast("Role switched successfully! You've joined the team with the new role.", "success");
       setResponseMessage("");
       onClose();
     } catch (err) {
@@ -367,6 +371,7 @@ const TeamInvitationDetailsModal = ({
       setActionLoading("acceptTeam");
       setError(null);
       await onAccept(invitation.id, responseMessage, false);
+      showToast("Invitation accepted! You've joined the team.", "success");
       setResponseMessage("");
       onClose();
     } catch (err) {
@@ -381,6 +386,7 @@ const TeamInvitationDetailsModal = ({
       setActionLoading("decline");
       setError(null);
       await onDecline(invitation.id, responseMessage);
+      showToast("Invitation declined.", "success");
       setResponseMessage("");
       onClose();
     } catch (err) {

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { useToast } from "../../contexts/ToastContext";
 import {
   User,
   Users,
@@ -58,9 +59,10 @@ const TeamInvitesModal = ({
   highlightUserId = null,
 }) => {
   // ============ State ============
+  const showToast = useToast();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(null);
+  const showSuccess = (message) => showToast(message, "success");
   const [pendingCancelInvitationId, setPendingCancelInvitationId] =
     useState(null);
   const [pendingCancelType, setPendingCancelType] = useState("team");
@@ -136,16 +138,13 @@ const TeamInvitesModal = ({
         await onCancelInvitation(pendingCancelInvitationId);
       }
 
-      setSuccess(
+      showSuccess(
         pendingCancelType === "role"
           ? "Role invitation canceled successfully!"
           : "Team invitation canceled successfully!",
       );
       setPendingCancelInvitationId(null);
       setPendingCancelType("team");
-
-      // Clear success after 3 seconds
-      setTimeout(() => setSuccess(null), 3000);
     } catch (err) {
       setError(err.message || "Failed to cancel invitation");
     } finally {
@@ -208,8 +207,6 @@ const TeamInvitesModal = ({
       footerText="You can cancel invitations that haven't been responded to."
       error={error}
       onErrorClose={() => setError(null)}
-      success={success}
-      onSuccessClose={() => setSuccess(null)}
       emptyIcon={User}
       emptyTitle="No pending invitations"
       emptyMessage="Invitations you send to users will appear here."

--- a/src/contexts/ToastContext.jsx
+++ b/src/contexts/ToastContext.jsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useRef, useState } from "react";
+import ScreenAlert from "../components/common/ScreenAlert";
+
+const ToastContext = createContext(null);
+
+export const ToastProvider = ({ children }) => {
+  const [toast, setToast] = useState(null); // { message, id, type }
+  const idRef = useRef(0);
+
+  const showToast = (message, type = "success") => {
+    setToast({ message, id: ++idRef.current, type });
+  };
+
+  return (
+    <ToastContext.Provider value={showToast}>
+      {children}
+      <ScreenAlert
+        alerts={[
+          toast && {
+            type: toast.type,
+            message: toast.message,
+            onClose: () => setToast(null),
+            successId: toast.id,
+          },
+        ]}
+      />
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);

--- a/src/index.css
+++ b/src/index.css
@@ -934,6 +934,7 @@ body {
   border-radius: 0.5rem !important;
   padding: 0.5rem 0.75rem !important;
   font-size: 0.775rem !important;
+  line-height: 1.15 !important;
   box-shadow: 0 2px 8px rgba(4, 80, 20, 0.15) !important;
   pointer-events: none;
 
@@ -976,9 +977,20 @@ body {
   border-radius: 0.5rem !important;
   padding: 0.5rem 0.75rem !important;
   font-size: 0.775rem !important;
+  line-height: 1.15 !important;
   box-shadow: 0 2px 8px rgba(4, 80, 20, 0.15) !important;
   pointer-events: none;
   z-index: 40 !important;
+}
+
+.tooltip.tooltip-lomir > .tooltip-content p,
+.lomir-tooltip-bubble p {
+  margin: 0;
+}
+
+.tooltip.tooltip-lomir > .tooltip-content p + p,
+.lomir-tooltip-bubble p + p {
+  margin-top: 0.3rem;
 }
 
 .tooltip.tooltip-lomir:hover > .tooltip-content,

--- a/src/pages/BadgeOverview.jsx
+++ b/src/pages/BadgeOverview.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useEffect, useState } from 'react';
 import PageContainer from '../components/layout/PageContainer';
 import BadgeCategorySection from '../components/badges/BadgeCategorySection';
+import Alert from '../components/common/Alert';
 import api from '../services/api';
 
 const BadgeOverview = () => {
@@ -54,9 +55,7 @@ const BadgeOverview = () => {
   if (error) {
     return (
       <PageContainer>
-        <div className="alert alert-error">
-          <span>{error}</span>
-        </div>
+        <Alert type="error" message={error} className="w-full shadow-sm" />
       </PageContainer>
     );
   }

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -4,7 +4,8 @@ import api from "../services/api";
 import Card from "../components/common/Card";
 import Button from "../components/common/Button";
 import FormGroup from "../components/common/FormGroup";
-import { Mail, ArrowLeft, CheckCircle, AlertCircle } from "lucide-react";
+import Alert from "../components/common/Alert";
+import { Mail, ArrowLeft, CheckCircle } from "lucide-react";
 
 const ForgotPassword = () => {
   const [email, setEmail] = useState("");
@@ -116,10 +117,7 @@ const ForgotPassword = () => {
           </div>
 
           {status === "error" && (
-            <div className="alert alert-error mb-6">
-              <AlertCircle size={20} />
-              <span>{message}</span>
-            </div>
+            <Alert type="error" message={message} className="mb-6 w-full shadow-sm" />
           )}
 
           <form onSubmit={handleSubmit}>

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -6,6 +6,7 @@ import Button from "../components/common/Button";
 import TeamCard from "../components/teams/TeamCard";
 import Section from "../components/layout/Section";
 import Pagination from "../components/common/Pagination";
+import FilterSortOptionButton from "../components/common/FilterSortOptionButton";
 import ResultViewToggle from "../components/common/ResultViewToggle";
 import { teamService } from "../services/teamService";
 import useSocketEvents from "../hooks/useSocketEvents";
@@ -603,49 +604,42 @@ const MyTeams = () => {
     <PageContainer title="My Teams" action={CreateTeamAction} variant="muted">
       <div className="flex flex-wrap items-center justify-between gap-y-0.5 mb-6">
         <div className="flex flex-wrap items-center gap-1 -ml-2">
-          <button
-            type="button"
+          <FilterSortOptionButton
             onClick={() => handleSortChange("name")}
-            className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
-              sortBy === "name"
-                ? "text-[var(--color-primary)] font-bold"
-                : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
-            }`}
-          >
-            {sortDir === "desc" && sortBy === "name" ? (
-              <ArrowUpZA className="w-3.5 h-3.5 shrink-0" />
-            ) : (
-              <ArrowDownAZ className="w-3.5 h-3.5 shrink-0" />
-            )}
-            {sortBy === "name" && sortDir === "desc" ? "Z-A" : "A-Z"}
-          </button>
-          <button
-            type="button"
+            icon={
+              sortDir === "desc" && sortBy === "name"
+                ? ArrowUpZA
+                : ArrowDownAZ
+            }
+            label={sortBy === "name" && sortDir === "desc" ? "Z-A" : "A-Z"}
+            active={sortBy === "name"}
+          />
+          <FilterSortOptionButton
             onClick={() => handleSortChange("recent")}
-            className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
-              sortBy === "recent"
-                ? "text-[var(--color-primary)] font-bold"
-                : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
-            }`}
-          >
-            <Clock className="w-3.5 h-3.5 shrink-0" />
-            {sortBy === "recent" && sortDir === "asc" ? "Inactive" : "Active"}
-          </button>
-          <button
-            type="button"
+            icon={Clock}
+            label={
+              sortBy === "recent" && sortDir === "asc"
+                ? "Inactive"
+                : "Active"
+            }
+            active={sortBy === "recent"}
+          />
+          <FilterSortOptionButton
             onClick={() => handleSortChange("newest")}
-            className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
-              sortBy === "newest"
-                ? "text-[var(--color-primary)] font-bold"
-                : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
-            }`}
-          >
-            <Sparkles className="w-3.5 h-3.5 shrink-0" />
-            {sortBy === "newest" && sortDir === "asc" ? "Oldest" : "Newest"}
-          </button>
+            icon={Sparkles}
+            label={
+              sortBy === "newest" && sortDir === "asc" ? "Oldest" : "Newest"
+            }
+            active={sortBy === "newest"}
+          />
         </div>
 
-        <ResultViewToggle value={resultView} onChange={setResultView} />
+        <ResultViewToggle
+          value={resultView}
+          onChange={setResultView}
+          align="responsive-start"
+          className="-ml-2 sm:ml-0"
+        />
       </div>
 
       {/* Pending Invitations Section */}

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Link, useSearchParams } from "react-router-dom";
+import { useToast } from "../contexts/ToastContext";
 import PageContainer from "../components/layout/PageContainer";
 import Grid from "../components/layout/Grid";
 import Button from "../components/common/Button";
+import Alert from "../components/common/Alert";
 import TeamCard from "../components/teams/TeamCard";
 import Section from "../components/layout/Section";
 import Pagination from "../components/common/Pagination";
@@ -44,6 +46,7 @@ const MY_TEAMS_LIST_TAGS_WIDTH_CLASSNAME = "sm:w-36";
 const MY_TEAMS_LIST_BADGES_WIDTH_CLASSNAME = "sm:w-32";
 
 const MyTeams = () => {
+  const showToast = useToast();
   const [teams, setTeams] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -374,8 +377,7 @@ const MyTeams = () => {
   };
 
   const handleSendReminder = async (applicationId) => {
-    // TODO: Implement send reminder functionality
-    alert("Reminder feature coming soon!");
+    showToast("Reminder feature coming soon!", "violet");
   };
 
   // Invitation handlers
@@ -574,9 +576,7 @@ const MyTeams = () => {
   if (error) {
     return (
       <PageContainer variant="muted">
-        <div className="alert alert-error">
-          <span>{error}</span>
-        </div>
+        <Alert type="error" message={error} className="w-full shadow-sm" />
       </PageContainer>
     );
   }

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -34,7 +34,7 @@ import {
   SlidersHorizontal,
   UserPlus,
   UserMinus,
-  Ruler,
+  Radius,
   MapPin,
   Globe,
   Target,
@@ -528,7 +528,7 @@ const SearchPage = () => {
       value: "locationPriority",
       sortValue: "proximity",
       defaultDir: "asc",
-      labelAsc: "Nearest First",
+      labelAsc: "Nearest",
       labelRemote: "Remote First",
       shortLabelAsc: "Near 1st",
       shortLabelRemote: "Remote 1st",
@@ -545,7 +545,7 @@ const SearchPage = () => {
       labelAsc: "Distance",
       shortLabelAsc: "Distance",
       tooltipAsc: "Filter results by distance from your location",
-      iconAsc: Ruler,
+      iconAsc: Radius,
     },
     {
       value: "capacity",
@@ -2218,11 +2218,8 @@ const SearchPage = () => {
                             <FilterSortOptionButton
                               onClick={handleIncludeOwnTeamsToggle}
                               icon={IncludeOwnTeamsIcon}
-                              label={
-                                effectiveIncludeOwnTeams
-                                  ? "+ My Teams"
-                                  : "- My Teams"
-                              }
+                              prefix={effectiveIncludeOwnTeams ? "+" : "-"}
+                              label="My Teams"
                               active={!effectiveIncludeOwnTeams}
                               disabled={loading}
                               aria-label={
@@ -2254,10 +2251,9 @@ const SearchPage = () => {
                               setCurrentPage(1);
                             }}
                             icon={FlaskConical}
-                            label={
-                              includeDemoData ? "+ Demo Data" : "- Demo Data"
-                            }
-                            mobileLabel={includeDemoData ? "+ Demo" : "- Demo"}
+                            prefix={includeDemoData ? "+" : "-"}
+                            label="Demo Data"
+                            mobileLabel="Demo"
                             active={!includeDemoData}
                             disabled={loading}
                             aria-label={

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -18,6 +18,7 @@ import SearchMapView from "../components/search/SearchMapView";
 import Pagination from "../components/common/Pagination";
 import BooleanSearchInput from "../components/BooleanSearchInput";
 import Tooltip from "../components/common/Tooltip";
+import FilterSortOptionButton from "../components/common/FilterSortOptionButton";
 import ResultViewToggle from "../components/common/ResultViewToggle";
 import {
   User,
@@ -1763,13 +1764,6 @@ const SearchPage = () => {
     !includeDemoData ||
     (sortBy === "capacity" && capacityMode !== "spots") ||
     (customDistanceInput && customDistanceInput.trim() !== "");
-  const hasSearchInputContent =
-    searchQuery.trim() ||
-    activeCriteriaPills.length > 0 ||
-    focusAreaPills.length > 0 ||
-    badgePills.length > 0 ||
-    searchType !== "all";
-
   const isFilterOptionsActive =
     showFilterOptions ||
     maxDistance !== null ||
@@ -1794,24 +1788,18 @@ const SearchPage = () => {
         maxDistance,
       });
     const optionButton = (
-      <button
+      <FilterSortOptionButton
         ref={(node) => {
           sortButtonRefs.current[option.value] = node;
         }}
-        type="button"
         onClick={() => handleTopLevelSortOptionClick(option.value)}
-        className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
-          isActive
-            ? "text-[var(--color-primary)] font-bold"
-            : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
-        }`}
+        icon={IconComponent}
+        label={label}
+        mobileLabel={shortLabel}
+        active={isActive}
         disabled={loading}
         aria-label={tooltip ? `${label} - ${tooltip}` : label}
-      >
-        <IconComponent className="w-3.5 h-3.5 shrink-0" />
-        <span className="hidden sm:inline">{label}</span>
-        <span className="sm:hidden">{shortLabel}</span>
-      </button>
+      />
     );
 
     return tooltip ? (
@@ -1834,23 +1822,17 @@ const SearchPage = () => {
       }
       wrapperClassName="inline-flex items-center shrink-0"
     >
-      <button
-        type="button"
+      <FilterSortOptionButton
         onClick={handleFilterOptionsToggle}
-        className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
-          isFilterOptionsActive
-            ? "text-[var(--color-primary)] font-bold"
-            : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
-        }`}
+        icon={Filter}
+        label={showFilterOptions ? "Hide Filters:" : "Show Filters ..."}
+        mobileLabel={showFilterOptions ? "Hide Filters:" : "Filters ..."}
+        active={isFilterOptionsActive}
         disabled={loading}
         aria-label={
           showFilterOptions ? "Hide filter controls" : "Show filter controls"
         }
-      >
-        <Filter className="w-3.5 h-3.5 shrink-0" />
-        <span className="hidden sm:inline">{showFilterOptions ? "Hide Filters:" : "Show Filters ..."}</span>
-        <span className="sm:hidden">{showFilterOptions ? "Hide Filters:" : "Filters ..."}</span>
-      </button>
+      />
     </Tooltip>
   );
 
@@ -2051,7 +2033,7 @@ const SearchPage = () => {
     >
       <div className="w-full max-w-4xl mx-auto mb-8">
         <div className="relative z-20 flex justify-center space-x-2 pt-2 mb-2">
-          <div className="btn-group">
+          <div className="flex items-center gap-1">
             <button
               type="button"
               className={`btn btn-sm ${
@@ -2067,7 +2049,7 @@ const SearchPage = () => {
 
             <button
               type="button"
-              className={`btn btn-sm tooltip tooltip-top tooltip-lomir search-type-tooltip ${
+              className={`btn btn-sm !gap-0.5 tooltip tooltip-top tooltip-lomir search-type-tooltip ${
                 searchType === "teams"
                   ? "btn-primary"
                   : "btn-ghost hover:bg-base-200"
@@ -2077,13 +2059,13 @@ const SearchPage = () => {
               aria-pressed={searchType === "teams"}
               onClick={() => handleToggleChange("teams")}
             >
-              <Users2 className="w-4 h-4 sm:mr-1" aria-hidden="true" />
+              <Users2 className="w-4 h-4" aria-hidden="true" />
               <span className="sr-only sm:not-sr-only">Teams</span>
             </button>
 
             <button
               type="button"
-              className={`btn btn-sm tooltip tooltip-top tooltip-lomir search-type-tooltip ${
+              className={`btn btn-sm !gap-0.5 tooltip tooltip-top tooltip-lomir search-type-tooltip ${
                 searchType === "users"
                   ? "btn-primary"
                   : "btn-ghost hover:bg-base-200"
@@ -2093,13 +2075,13 @@ const SearchPage = () => {
               aria-pressed={searchType === "users"}
               onClick={() => handleToggleChange("users")}
             >
-              <User className="w-4 h-4 sm:mr-1" aria-hidden="true" />
+              <User className="w-4 h-4" aria-hidden="true" />
               <span className="sr-only sm:not-sr-only">People</span>
             </button>
 
             <button
               type="button"
-              className={`btn btn-sm tooltip tooltip-top tooltip-lomir search-type-tooltip ${
+              className={`btn btn-sm !gap-0.5 tooltip tooltip-top tooltip-lomir search-type-tooltip ${
                 searchType === "roles"
                   ? "btn-primary"
                   : "btn-ghost hover:bg-base-200"
@@ -2109,7 +2091,7 @@ const SearchPage = () => {
               aria-pressed={searchType === "roles"}
               onClick={() => handleToggleChange("roles")}
             >
-              <UserSearch className="w-4 h-4 sm:mr-1" aria-hidden="true" />
+              <UserSearch className="w-4 h-4" aria-hidden="true" />
               <span className="sr-only sm:not-sr-only">Open Roles</span>
             </button>
           </div>
@@ -2194,9 +2176,9 @@ const SearchPage = () => {
             </div>
 
             {showSortDropdown && (
-              <div className="mt-2 py-1 pl-7 sm:pl-9">
-                <div className="space-y-[6px]">
-                  <div className="flex flex-row flex-wrap items-start gap-x-3 gap-y-[6px]">
+              <div className="mt-1.5 py-0.5 pl-7 sm:mt-2 sm:py-1 sm:pl-9">
+                <div className="space-y-[3px] sm:space-y-[6px]">
+                  <div className="flex flex-row flex-wrap items-start gap-x-1 gap-y-[3px] sm:gap-x-3 sm:gap-y-[6px]">
                     <div
                       role="group"
                       aria-label="Sort options"
@@ -2209,7 +2191,7 @@ const SearchPage = () => {
                   </div>
 
                   {showFilterOptions && (
-                    <div className="flex flex-row flex-wrap items-start gap-x-3 gap-y-[6px]">
+                    <div className="flex flex-row flex-wrap items-start gap-x-1 gap-y-[3px] sm:gap-x-3 sm:gap-y-[6px]">
                       {renderFilterOptionsToggle()}
                       <div
                         role="group"
@@ -2233,28 +2215,22 @@ const SearchPage = () => {
                             }
                             wrapperClassName="inline-flex items-center shrink-0"
                           >
-                            <button
-                              type="button"
+                            <FilterSortOptionButton
                               onClick={handleIncludeOwnTeamsToggle}
-                              className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
-                                !effectiveIncludeOwnTeams
-                                  ? "text-[var(--color-primary)] font-bold"
-                                  : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
-                              }`}
+                              icon={IncludeOwnTeamsIcon}
+                              label={
+                                effectiveIncludeOwnTeams
+                                  ? "+ My Teams"
+                                  : "- My Teams"
+                              }
+                              active={!effectiveIncludeOwnTeams}
                               disabled={loading}
                               aria-label={
                                 effectiveIncludeOwnTeams
                                   ? "Include My Teams"
                                   : "Exclude My Teams"
                               }
-                            >
-                              <IncludeOwnTeamsIcon className="w-3.5 h-3.5 shrink-0" />
-                              <span>
-                                {effectiveIncludeOwnTeams
-                                  ? "+ My Teams"
-                                  : "- My Teams"}
-                              </span>
-                            </button>
+                            />
                           </Tooltip>
                         </div>
                       )}
@@ -2272,32 +2248,24 @@ const SearchPage = () => {
                           }
                           wrapperClassName="inline-flex items-center shrink-0"
                         >
-                          <button
-                            type="button"
+                          <FilterSortOptionButton
                             onClick={() => {
                               setIncludeDemoData((prev) => !prev);
                               setCurrentPage(1);
                             }}
-                            className={`flex items-center gap-1 px-1 text-xs rounded transition-colors shrink-0 ${
-                              !includeDemoData
-                                ? "text-[var(--color-primary)] font-bold"
-                                : "text-[var(--color-primary-focus)]/70 hover:text-[var(--color-primary-focus)] hover:font-medium"
-                            }`}
+                            icon={FlaskConical}
+                            label={
+                              includeDemoData ? "+ Demo Data" : "- Demo Data"
+                            }
+                            mobileLabel={includeDemoData ? "+ Demo" : "- Demo"}
+                            active={!includeDemoData}
                             disabled={loading}
                             aria-label={
                               includeDemoData
                                 ? "Include test/demo profiles, roles and teams"
                                 : "Show only real users, roles and teams"
                             }
-                          >
-                            <FlaskConical className="w-3.5 h-3.5 shrink-0" />
-                            <span className="hidden sm:inline">
-                              {includeDemoData ? "+ Demo Data" : "- Demo Data"}
-                            </span>
-                            <span className="sm:hidden">
-                              {includeDemoData ? "+ Demo" : "- Demo"}
-                            </span>
-                          </button>
+                          />
                         </Tooltip>
                       </div>
                     </div>
@@ -2365,6 +2333,8 @@ const SearchPage = () => {
                   value={resultView}
                   onChange={setResultView}
                   modes={["card", "mini", "list", "map"]}
+                  align="responsive-start"
+                  className="-ml-1 sm:ml-0"
                 />
               </div>
 

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -20,6 +20,7 @@ import BooleanSearchInput from "../components/BooleanSearchInput";
 import Tooltip from "../components/common/Tooltip";
 import FilterSortOptionButton from "../components/common/FilterSortOptionButton";
 import ResultViewToggle from "../components/common/ResultViewToggle";
+import ScreenAlert from "../components/common/ScreenAlert";
 import {
   User,
   UserSearch,
@@ -262,6 +263,8 @@ const SearchPage = () => {
   const [error, setError] = useState(null);
   const [hasSearched, setHasSearched] = useState(false);
   const [searchInputResetSignal, setSearchInputResetSignal] = useState(0);
+  const [dismissedNoResultsAlertKey, setDismissedNoResultsAlertKey] =
+    useState(null);
   const viewerPendingRequestsQuery = useViewerPendingRequests(user?.id, {
     enabled: isAuthenticated,
   });
@@ -944,6 +947,23 @@ const SearchPage = () => {
         filteredResults.users.length === 0 &&
         filteredResults.roles.length === 0) &&
     !loading;
+  const noResultsAlertKey = [
+    searchQuery.trim(),
+    searchType,
+    sortBy,
+    sortDir,
+    capacityMode,
+    maxDistance ?? "any-distance",
+    openRolesOnly,
+    includeOwnTeams,
+    includeDemoData,
+    matchRoleId ?? "any-role",
+    excludeTeamId ?? "any-team",
+    filterTagIds.join(","),
+    filterBadgeIds.join(","),
+  ].join("|");
+  const showNoResultsAlert =
+    noResultsFound && dismissedNoResultsAlertKey !== noResultsAlertKey;
 
   const hasVisibleResults =
     filteredResults.teams.length > 0 ||
@@ -2160,7 +2180,7 @@ const SearchPage = () => {
                       <button
                         type="button"
                         onClick={handleResetSearchInput}
-                        className="shrink-0 rounded-lg p-0.5 transition-colors hover:bg-base-200"
+                        className="inline-flex h-[1.125rem] w-[1.125rem] shrink-0 items-center justify-center rounded-full bg-transparent p-0 transition-colors hover:bg-base-200"
                         aria-label="Clear search input"
                       >
                         <RotateCcw
@@ -2274,6 +2294,15 @@ const SearchPage = () => {
       </div>
 
       {renderSortSubmenuPortal()}
+      <ScreenAlert
+        type="violet"
+        message={
+          showNoResultsAlert
+            ? "No teams, users or Roles found matching this search query. Try a different search term."
+            : null
+        }
+        onClose={() => setDismissedNoResultsAlertKey(noResultsAlertKey)}
+      />
 
       {error && (
         <Alert
@@ -2281,18 +2310,6 @@ const SearchPage = () => {
           message={error}
           className="max-w-xl mx-auto mb-4"
           onClose={() => setError(null)}
-        />
-      )}
-
-      {noResultsFound && (
-        <Alert
-          type="info"
-          message={
-            searchQuery.trim()
-              ? `No ${searchType === "all" ? "teams or users" : searchType} found matching "${searchQuery}". Try a different search term.`
-              : `No matching ${searchType === "all" ? "teams or users" : searchType} found for the current filters. Try adjusting or removing some filters.`
-          }
-          className="max-w-xl mx-auto"
         />
       )}
 

--- a/src/pages/searchPageHelpers.js
+++ b/src/pages/searchPageHelpers.js
@@ -155,14 +155,16 @@ export const getActiveCriteriaPills = ({
   if (!effectiveIncludeOwnTeams) {
     pills.push({
       key: "includeOwnTeams",
-      label: "Exclude My Teams",
+      label: "- My Teams",
+      removeLabel: "Exclude My Teams",
     });
   }
 
   if (!includeDemoData) {
     pills.push({
       key: "includeDemoData",
-      label: "Exclude Demo Data",
+      label: "- Demo",
+      removeLabel: "Exclude Demo Data",
     });
   }
 
@@ -175,9 +177,11 @@ export const getActiveCriteriaPills = ({
   }
 
   if (excludeTeamId) {
+    const excludedTeamName = excludeTeamName || "team";
     pills.push({
       key: "excludeTeam",
-      label: `Excl. ${excludeTeamName || "team"} members`,
+      label: `- ${excludedTeamName} members`,
+      removeLabel: `Exclude ${excludedTeamName} members`,
       type: "excludeTeam",
     });
   }


### PR DESCRIPTION
This branch covers three areas: search bar UX improvements carried over from the ui/SearchBarUX merge, a systematic polish pass on Lomir's alert/notification UI, and a fix for a reliability bug where success toasts were silently lost.

Search bar & results controls
Unified responsive result-view controls (list/map toggle, sort/filter pills) across mobile and desktop breakpoints
Moved the Advanced search indicator and boolean mode toggle inline with the search input — no layout shift on toggle
Search input uses a textarea for multi-line queries, with correct single-line sizing when collapsed
Filter pills show grouped labels with tooltips; excluded teams are surfaced with a dedicated pill
Dropdown headers, suggestion items, and tag/badge inputs share a consistent appearance and handle narrow viewports without overflow
Boolean search input cleaned up and aligned
Alert & notification UI
Removed the DaisyUI default border and outline from all alert types (border-0 outline-none)
Fixed vertical alignment: the left icon and text use items-center; the × close button uses self-start to pin to the first line regardless of message length
Replaced all raw <div class="alert alert-*"> with the shared <Alert> component across LoginForm, RegisterForm, TagsDisplaySection, BadgeOverview, ForgotPassword, and MyTeams — giving them consistent shadow, spacing, and typography
Browser alert() / window.alert() calls in MyTeams, SearchMapView, and TeamEditForm replaced with styled toasts
Global toast context & success message reliability fix
Root cause: A socket-triggered GET /api/teams/my-teams refetch after a team-application approval would occasionally remove the team from the current pagination page, unmounting TeamCard and everything inside it. By the time setSuccess(...) was called (~650 ms later, after getTeamById completed), the component was dead and React silently dropped the state update — the success toast never appeared.

Fix: Introduced ToastContext at the AppLayout root, above all pages and modals. Any component — even one that is about to unmount — can call useToast() and the toast will still render, because ToastProvider cannot be unmounted by data-driven re-renders.

Additional improvements shipped alongside:

TeamApplicationsModal and TeamInvitesModal migrated from local success state to useToast
TeamInvitationDetailsModal: success toasts added for all four accept/decline variants
TeamApplicationDetailsModal: local success Alert + setTimeout(onClose, 3000) replaced with useToast; modal now closes immediately after cancel
ScreenAlert key now includes a successId counter so the Alert always remounts — even when the message text is identical to the previous toast — preventing the React bail-out that caused repeated same-type actions to show nothing
Files changed
34 files · +1934 / −899 lines