### PR TITLE
Polish search input pill layout and icons

### DIFF
--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -619,18 +619,19 @@ const BooleanSearchInput = ({
         : {}),
   };
   const pillBaseClassName =
-    "inline-grid h-[1.375rem] grid-cols-[0.625rem_minmax(0,auto)_0.625rem] items-center gap-1 rounded-lg px-2.5 py-0 text-xs font-medium leading-[1.1] transition-opacity hover:opacity-80";
+    "inline-grid min-h-[1.375rem] max-w-full grid-cols-[0.625rem_minmax(0,1fr)_0.625rem] items-start gap-1 rounded-lg px-[5px] py-[3px] text-xs font-medium leading-[1.1] transition-opacity hover:opacity-80";
   const advancedIndicatorClassName = isCompactLayout
     ? "inline-flex h-3.5 w-3.5 items-center justify-center rounded-full p-0 text-[0.625rem] font-medium leading-none text-white transition-opacity hover:opacity-80"
     : "inline-flex h-[1.125rem] items-center justify-center rounded-lg px-2 py-0 text-xs font-medium leading-[1.1] text-white transition-opacity hover:opacity-80";
   const pillIconClassName =
-    "flex h-2.5 w-2.5 items-center justify-center overflow-hidden [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:shrink-0";
+    "mt-[0.0625rem] flex h-2.5 w-2.5 items-center justify-center overflow-hidden [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:shrink-0";
   const pillSvgClassName = "h-2.5 w-2.5";
-  const pillLabelClassName = "min-w-0 whitespace-nowrap text-left leading-[1.1]";
+  const pillLabelClassName =
+    "min-w-0 max-w-full whitespace-normal break-words text-left leading-[1.1] [overflow-wrap:anywhere]";
   const pillCloseClassName =
-    "flex h-2.5 w-2.5 items-center justify-center overflow-hidden [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:shrink-0";
+    "mt-[0.0625rem] flex h-2.5 w-2.5 items-center justify-center overflow-hidden [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:shrink-0";
   const pillTooltipClassName =
-    "inline-flex z-10 hover:z-[500] focus-within:z-[500]";
+    "inline-flex max-w-full min-w-0 z-10 hover:z-[500] focus-within:z-[500]";
   const renderPillTooltipContent = (Icon, filterName, removeAction) => (
     <span className="inline-flex flex-wrap items-center gap-y-0.5">
       <span>{getRemoveActionParts(removeAction).firstWord}</span>
@@ -724,7 +725,7 @@ const BooleanSearchInput = ({
       : null;
     const pillSign = labelParts.sign || shortLabelParts?.sign;
     const criteriaPillClassName = `${pillBaseClassName}${
-      pillSign ? " grid-cols-[auto_minmax(0,auto)_0.625rem]" : ""
+      pillSign ? " grid-cols-[auto_minmax(0,1fr)_0.625rem]" : ""
     }`;
     const renderLeadingIcon = (iconNode, ariaHidden = false) => (
       <span

--- a/src/components/BooleanSearchInput.jsx
+++ b/src/components/BooleanSearchInput.jsx
@@ -120,6 +120,11 @@ const getCriteriaPillIcon = (pill) => {
   }
 };
 
+const getFocusAreaPillIcon = (pill) =>
+  SUPERCATEGORY_ICONS[pill.supercategory] ||
+  SUPERCATEGORY_ICONS[pill.category] ||
+  Layers;
+
 const getCriteriaFilterType = (pill) => {
   if (pill.type === "role") return "searchTerm";
   if (pill.key === "sort") return "sort";
@@ -614,14 +619,16 @@ const BooleanSearchInput = ({
         : {}),
   };
   const pillBaseClassName =
-    "inline-grid grid-cols-[0.625rem_minmax(0,auto)_0.625rem] items-start gap-1 rounded-lg px-2.5 py-[0.1875rem] text-xs font-medium leading-[1.1] transition-opacity hover:opacity-80";
+    "inline-grid h-[1.375rem] grid-cols-[0.625rem_minmax(0,auto)_0.625rem] items-center gap-1 rounded-lg px-2.5 py-0 text-xs font-medium leading-[1.1] transition-opacity hover:opacity-80";
   const advancedIndicatorClassName = isCompactLayout
     ? "inline-flex h-3.5 w-3.5 items-center justify-center rounded-full p-0 text-[0.625rem] font-medium leading-none text-white transition-opacity hover:opacity-80"
     : "inline-flex h-[1.125rem] items-center justify-center rounded-lg px-2 py-0 text-xs font-medium leading-[1.1] text-white transition-opacity hover:opacity-80";
-  const pillIconClassName = "flex h-[1.1em] w-2.5 items-center justify-center";
+  const pillIconClassName =
+    "flex h-2.5 w-2.5 items-center justify-center overflow-hidden [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:shrink-0";
   const pillSvgClassName = "h-2.5 w-2.5";
-  const pillLabelClassName = "min-w-0 text-left leading-[1.1]";
-  const pillCloseClassName = "flex h-[1.1em] w-2.5 items-center justify-center";
+  const pillLabelClassName = "min-w-0 whitespace-nowrap text-left leading-[1.1]";
+  const pillCloseClassName =
+    "flex h-2.5 w-2.5 items-center justify-center overflow-hidden [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:shrink-0";
   const pillTooltipClassName =
     "inline-flex z-10 hover:z-[500] focus-within:z-[500]";
   const renderPillTooltipContent = (Icon, filterName, removeAction) => (
@@ -691,10 +698,19 @@ const BooleanSearchInput = ({
     });
 
   const renderFocusAreaPill = (pill) => {
+    const FocusAreaIcon = getFocusAreaPillIcon(pill);
+
     return renderColoredFilterPill({
       pill,
       color: FOCUS_GREEN,
-      icon: <Tag size={10} strokeWidth={3} className={pillSvgClassName} />,
+      icon: (
+        <FocusAreaIcon
+          size={10}
+          strokeWidth={3}
+          className={pillSvgClassName}
+          aria-hidden="true"
+        />
+      ),
       onRemove: onRemoveFocusAreaPill,
       TooltipIcon: Tag,
       removeAction: "Remove Focus Area",
@@ -765,10 +781,16 @@ const BooleanSearchInput = ({
             className={`${criteriaPillClassName} border border-amber-400 bg-amber-50 text-amber-700 transition-colors hover:border-amber-500 hover:bg-amber-100 hover:opacity-100`}
             aria-label={ariaLabel}
           >
-            {renderLeadingIcon(<UserSearch size={12} className={pillSvgClassName} />)}
+            {renderLeadingIcon(
+              <UserSearch
+                size={10}
+                strokeWidth={3}
+                className={pillSvgClassName}
+              />,
+            )}
             {pillLabelNode}
             <span className={pillCloseClassName} aria-hidden="true">
-              <X size={10} strokeWidth={2.5} className={pillSvgClassName} />
+              <X size={10} strokeWidth={3} className={pillSvgClassName} />
             </span>
           </button>
         </Tooltip>
@@ -788,10 +810,12 @@ const BooleanSearchInput = ({
             className={`${criteriaPillClassName} border border-slate-400 bg-slate-50 text-slate-600 transition-colors hover:border-slate-500 hover:bg-slate-100 hover:opacity-100`}
             aria-label={ariaLabel}
           >
-            {renderLeadingIcon(<Users size={12} className={pillSvgClassName} />)}
+            {renderLeadingIcon(
+              <Users size={10} strokeWidth={3} className={pillSvgClassName} />,
+            )}
             {pillLabelNode}
             <span className={pillCloseClassName} aria-hidden="true">
-              <X size={10} strokeWidth={2.5} className={pillSvgClassName} />
+              <X size={10} strokeWidth={3} className={pillSvgClassName} />
             </span>
           </button>
         </Tooltip>
@@ -814,8 +838,8 @@ const BooleanSearchInput = ({
           {renderLeadingIcon(
             CriteriaIcon ? (
               <CriteriaIcon
-                size={12}
-                strokeWidth={2.5}
+                size={10}
+                strokeWidth={3}
                 className={pillSvgClassName}
               />
             ) : null,
@@ -823,7 +847,7 @@ const BooleanSearchInput = ({
           )}
           {pillLabelNode}
           <span className={pillCloseClassName} aria-hidden="true">
-            <X size={10} strokeWidth={2.5} className={pillSvgClassName} />
+            <X size={10} strokeWidth={3} className={pillSvgClassName} />
           </span>
         </button>
       </Tooltip>

--- a/src/components/layout/PageContainer.jsx
+++ b/src/components/layout/PageContainer.jsx
@@ -28,7 +28,7 @@ const PageContainer = ({
           <div className="flex flex-col sm:flex-row sm:items-start justify-between mb-6">
             <div className={titleAlignment === "center" ? "w-full text-center" : ""}>
               {title && (
-                <h1 className="text-2xl sm:text-3xl font-medium text-primary mb-1">
+                <h1 className="text-2xl sm:text-3xl font-medium leading-[110%] text-primary mb-1">
                   {title}
                 </h1>
               )}

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -284,6 +284,7 @@ const SearchPage = () => {
         cat.tags?.forEach((tag) => {
           lookup[Number(tag.id)] = {
             ...tag,
+            category: cat.name,
             supercategory: supercat.name,
           };
         });
@@ -291,6 +292,20 @@ const SearchPage = () => {
     });
     return lookup;
   }, [structuredTags]);
+
+  const resolveTagWithTaxonomy = useCallback(
+    (tag) => {
+      const id = Number(tag?.id ?? tag?.tag_id ?? tag?.tagId);
+      if (!Number.isFinite(id)) return tag;
+
+      return {
+        ...structuredTagLookup[id],
+        ...tag,
+        id,
+      };
+    },
+    [structuredTagLookup],
+  );
 
   // ===== SORTING STATE =====
   const [sortBy, setSortBy] = useState(() => {
@@ -1047,6 +1062,8 @@ const SearchPage = () => {
     key: `tag-${id}`,
     id,
     label: filterTagMap[id]?.name || `Tag ${id}`,
+    category: filterTagMap[id]?.category || "",
+    supercategory: filterTagMap[id]?.supercategory || "",
   }));
 
   const badgePills = filterBadgeIds
@@ -1212,6 +1229,44 @@ const SearchPage = () => {
     });
     setFilterTagMap(map);
   }, [location.search, structuredTagLookup]);
+
+  useEffect(() => {
+    if (
+      filterTagIds.length === 0 ||
+      Object.keys(structuredTagLookup).length === 0
+    ) {
+      return;
+    }
+
+    setFilterTagMap((prev) => {
+      let changed = false;
+      const next = { ...prev };
+
+      filterTagIds.forEach((id) => {
+        const taxonomyTag = structuredTagLookup[id];
+        if (!taxonomyTag) return;
+
+        const current = next[id];
+        if (
+          current?.category === taxonomyTag.category &&
+          current?.supercategory === taxonomyTag.supercategory
+        ) {
+          return;
+        }
+
+        next[id] = {
+          ...taxonomyTag,
+          ...current,
+          id,
+          category: current?.category || taxonomyTag.category,
+          supercategory: current?.supercategory || taxonomyTag.supercategory,
+        };
+        changed = true;
+      });
+
+      return changed ? next : prev;
+    });
+  }, [filterTagIds, structuredTagLookup]);
 
   useEffect(() => {
     if (!showSortDropdown) {
@@ -1618,10 +1673,11 @@ const SearchPage = () => {
   };
 
   const handleAddTagFilter = (tag) => {
-    const id = Number(tag.id);
-    if (filterTagIds.includes(id)) return;
+    const id = Number(tag?.id ?? tag?.tag_id ?? tag?.tagId);
+    if (!Number.isFinite(id) || filterTagIds.includes(id)) return;
+    const resolvedTag = resolveTagWithTaxonomy(tag);
     setFilterTagIds((prev) => [...prev, id]);
-    setFilterTagMap((prev) => ({ ...prev, [id]: tag }));
+    setFilterTagMap((prev) => ({ ...prev, [id]: resolvedTag }));
     setCurrentPage(1);
   };
 
@@ -1666,6 +1722,7 @@ const SearchPage = () => {
 
       const tags = (Array.isArray(rawTags) ? rawTags : rawTags?.data || [])
         .filter((t) => !filterTagIds.includes(Number(t.id)))
+        .map(resolveTagWithTaxonomy)
         .slice(0, 8);
 
       const q = trimmed.toLowerCase();
@@ -1679,7 +1736,7 @@ const SearchPage = () => {
 
       return { tags, badges };
     },
-    [allBadges, filterTagIds, filterBadgeIds],
+    [allBadges, filterTagIds, filterBadgeIds, resolveTagWithTaxonomy],
   );
 
   const handleActivePillRemove = (pillKey) => {


### PR DESCRIPTION
Description
This PR refines the search page’s filter pills inside the search input for better visual consistency and narrow-viewport behavior.

Changes

Replaces the generic focus-area pill icon with the matching category/supercategory icon.
Keeps the focus-area tooltip icon as the familiar tag icon.
Enriches selected focus-area filters with category and supercategory metadata, including URL-loaded tag filters and search suggestions.
Normalizes pill icon sizing, stroke weight, text weight, and close icon styling across badge, focus-area, and criteria pills.
Allows long pill labels to wrap within the pill border on narrow viewports.
Aligns pill icons to the first text line when labels wrap.
Updates shared page titles to use 110% line-height.
Testing

npm run build
git diff --check

Notes
Build passes with the existing Vite chunk-size/dynamic-import warnings.