### PR TITLE
feat: Redesign contact page with auth-aware layout and backend form submission

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import backgroundImage from "./assets/images/Gradient-peach-yellow-violet-invert
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import Settings from "./pages/Settings";
+import Contact from "./pages/Contact";
 
 function AppLayout() {
   const location = useLocation();
@@ -67,6 +68,7 @@ function AppLayout() {
                 <Route path="/register" element={<Register />} />
                 <Route path="/verify-email" element={<VerifyEmail />} />
                 <Route path="/badges" element={<BadgeOverview />} />
+                <Route path="/contact" element={<Contact />} />
                 <Route
                   path="/garden"
                   element={<Placeholder pageName="Project Garden" />}

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Footer = () => {
   return (
@@ -11,7 +12,7 @@ const Footer = () => {
         <div className="flex space-x-6 mt-2">
           <a href="#" className="text-base-content hover:text-primary-focus rounded-full px-4 py-1">Terms</a>
           <a href="#" className="text-base-content hover:text-primary-focus rounded-full px-4 py-1">Privacy</a>
-          <a href="#" className="text-base-content hover:text-primary-focus rounded-full px-4 py-1">Contact</a>
+          <Link to="/contact" className="text-base-content hover:text-primary-focus rounded-full px-4 py-1">Contact</Link>
         </div>
       </div>
     </footer>

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -5,6 +5,7 @@ import {
   EyeClosed,
   Calendar,
   FlaskConical,
+  MapPin,
 } from "lucide-react";
 import {
   DEMO_PROFILE_TOOLTIP,
@@ -13,6 +14,7 @@ import {
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "./DemoAvatarOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
+import { getCountryCode, normalizeLocationData } from "../../utils/locationUtils";
 import { format } from "date-fns";
 
 /**
@@ -99,6 +101,11 @@ const UserProfileHeaderSection = ({
   };
 
   const displayName = getDisplayName();
+  const location = normalizeLocationData(user);
+  const countryCode = getCountryCode(location.country);
+  const headerLocationText = location.hasLocation
+    ? [location.city, countryCode || location.country].filter(Boolean).join(", ")
+    : "";
 
   useLayoutEffect(() => {
     const container = titleContainerRef.current;
@@ -177,6 +184,12 @@ const UserProfileHeaderSection = ({
         </h1>
         <div className="flex items-center flex-wrap gap-x-3 gap-y-0.5 text-sm leading-[110%]">
           <span className="text-base-content/70">@{user?.username}</span>
+          {headerLocationText && (
+            <span className="flex items-center text-base-content/70">
+              <MapPin size={14} className="mr-1 flex-shrink-0" />
+              <span>{headerLocationText}</span>
+            </span>
+          )}
 
           {/* Visibility Indicator - Only show for own profile */}
           {shouldShowVisibilityIndicator() && (

--- a/src/index.css
+++ b/src/index.css
@@ -640,6 +640,7 @@ body {
   border: 2px solid transparent;
   border-radius: 9999px;
   padding: 0.25rem 0.5rem;
+  line-height: 1.1;
   transition: all var(--transition-speed-normal);
 }
 

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -3,7 +3,9 @@ import { Link, useNavigate } from "react-router-dom";
 import {
   Mail,
   MessageCircle,
+  Paperclip,
   Send,
+  X,
 } from "lucide-react";
 import Alert from "../components/common/Alert";
 import Button from "../components/common/Button";
@@ -42,7 +44,32 @@ const Contact = () => {
   const [statusMessage, setStatusMessage] = useState("");
   const [turnstileToken, setTurnstileToken] = useState(null);
   const [isEmailFormOpen, setIsEmailFormOpen] = useState(false);
+  const [attachments, setAttachments] = useState([]);
+  const ATTACHMENT_MAX_FILES = 5;
   const turnstileRef = useRef(null);
+  const fileInputRef = useRef(null);
+
+  const ATTACHMENT_MAX_MB = 25;
+  const ATTACHMENT_MAX_BYTES = ATTACHMENT_MAX_MB * 1024 * 1024;
+  const ATTACHMENT_ALLOWED_TYPES = [
+    // Images (matches chatImage)
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    // Documents (matches chatFile)
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "text/csv",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "text/plain",
+    "application/zip",
+    "application/x-rar-compressed",
+  ];
 
   const canUseInAppContact =
     isAuthenticated && Boolean(LOMIR_CONTACT_USER_ID);
@@ -91,6 +118,45 @@ const Contact = () => {
     setTurnstileToken(null);
   };
 
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+
+    if (!file) return;
+
+    if (!ATTACHMENT_ALLOWED_TYPES.includes(file.type)) {
+      setErrors((prev) => ({
+        ...prev,
+        attachment: "File type not supported. Accepted: images, PDF, Word, Excel, PowerPoint, TXT, ZIP",
+      }));
+      return;
+    }
+
+    if (file.size > ATTACHMENT_MAX_BYTES) {
+      setErrors((prev) => ({
+        ...prev,
+        attachment: `File must be ${ATTACHMENT_MAX_MB} MB or smaller.`,
+      }));
+      return;
+    }
+
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next.attachment;
+      return next;
+    });
+    setAttachments((prev) => [...prev, file]);
+  };
+
+  const removeAttachment = (index) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next.attachment;
+      return next;
+    });
+  };
+
   const handleSubmit = async (event) => {
     event.preventDefault();
 
@@ -102,13 +168,26 @@ const Contact = () => {
     setStatusMessage("");
 
     try {
-      const response = await api.post("/api/contact", {
-        name: formValues.name.trim(),
-        email: formValues.email.trim(),
-        topic: formValues.topic,
-        message: formValues.message.trim(),
-        ...(hasTurnstile ? { turnstile_token: turnstileToken } : {}),
-      });
+      let body;
+      if (attachments.length > 0) {
+        body = new FormData();
+        body.append("name", formValues.name.trim());
+        body.append("email", formValues.email.trim());
+        body.append("topic", formValues.topic);
+        body.append("message", formValues.message.trim());
+        if (hasTurnstile) body.append("turnstile_token", turnstileToken);
+        attachments.forEach((file) => body.append("attachments", file));
+      } else {
+        body = {
+          name: formValues.name.trim(),
+          email: formValues.email.trim(),
+          topic: formValues.topic,
+          message: formValues.message.trim(),
+          ...(hasTurnstile ? { turnstile_token: turnstileToken } : {}),
+        };
+      }
+
+      const response = await api.post("/api/contact", body);
 
       setStatus("success");
       setStatusMessage(
@@ -116,6 +195,7 @@ const Contact = () => {
           "Thanks, your message has been sent to the Lomir team.",
       );
       setFormValues(initialFormValues);
+      setAttachments([]);
       resetTurnstile();
     } catch (error) {
       console.error("Contact form submission error:", error);
@@ -293,17 +373,69 @@ const Contact = () => {
               required
               className="mb-0"
             >
-              <textarea
-                id="contact-message"
-                className={`textarea textarea-bordered min-h-40 w-full resize-y ${
-                  errors.message ? "textarea-error" : ""
-                }`}
-                value={formValues.message}
-                onChange={(event) => updateField("message", event.target.value)}
-                placeholder="Tell us what is on your mind"
-                disabled={isSubmitting}
-              />
+              <div className="relative">
+                <textarea
+                  id="contact-message"
+                  className={`textarea textarea-bordered min-h-40 w-full resize-y pb-10 ${
+                    errors.message ? "textarea-error" : ""
+                  }`}
+                  value={formValues.message}
+                  onChange={(event) => updateField("message", event.target.value)}
+                  placeholder="Tell us what is on your mind"
+                  disabled={isSubmitting}
+                />
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  className="hidden"
+                  accept=".jpg,.jpeg,.png,.gif,.webp,.pdf,.doc,.docx,.xls,.xlsx,.csv,.ppt,.pptx,.txt,.zip,.rar"
+                  onChange={handleFileChange}
+                  disabled={isSubmitting}
+                />
+                {attachments.length < ATTACHMENT_MAX_FILES && (
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isSubmitting}
+                    className="absolute bottom-2 right-2 btn btn-ghost btn-xs gap-1 px-2 text-base-content/40 hover:text-base-content/70"
+                  >
+                    <Paperclip size={13} />
+                    Attach file
+                  </button>
+                )}
+              </div>
             </FormGroup>
+
+            {(attachments.length > 0 || errors.attachment) && (
+              <div className="space-y-1.5">
+                {attachments.map((file, index) => (
+                  <div
+                    key={index}
+                    className="flex items-center gap-2 rounded-lg border border-base-300 bg-base-200/50 px-3 py-2 text-sm"
+                  >
+                    <Paperclip size={14} className="shrink-0 text-base-content/60" />
+                    <span className="min-w-0 truncate text-base-content/80">
+                      {file.name}
+                    </span>
+                    <span className="shrink-0 text-base-content/50">
+                      ({(file.size / 1024).toFixed(0)} KB)
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removeAttachment(index)}
+                      disabled={isSubmitting}
+                      className="btn btn-ghost btn-xs ml-auto shrink-0 p-0.5"
+                      aria-label="Remove attachment"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                ))}
+                {errors.attachment && (
+                  <p className="text-xs text-error">{errors.attachment}</p>
+                )}
+              </div>
+            )}
 
             <div className="pt-3 flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
               <div className="sm:pt-0">
@@ -348,7 +480,7 @@ const Contact = () => {
         </form>
 
         {!isAuthenticated && (
-          <div className="mt-6 rounded-lg bg-base-100/60 p-4 text-sm text-base-content/70">
+          <div className="mt-6 rounded-lg bg-base-100/60 text-sm text-base-content/70">
             <p>
               Already part of Lomir?{" "}
               <Link to="/login" className="link link-primary">

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -13,6 +13,7 @@ import Card from "../components/common/Card";
 import FormGroup from "../components/common/FormGroup";
 import TurnstileWidget from "../components/common/TurnstileWidget";
 import { useAuth } from "../contexts/AuthContext";
+import { useToast } from "../contexts/ToastContext";
 import api from "../services/api";
 
 const LOMIR_CONTACT_USER_ID = (
@@ -36,6 +37,7 @@ const topicOptions = [
 const Contact = () => {
   const navigate = useNavigate();
   const { isAuthenticated } = useAuth();
+  const showToast = useToast();
   const hasTurnstile = Boolean(import.meta.env.VITE_TURNSTILE_SITE_KEY);
 
   const [formValues, setFormValues] = useState(initialFormValues);
@@ -189,13 +191,15 @@ const Contact = () => {
 
       const response = await api.post("/api/contact", body);
 
-      setStatus("success");
-      setStatusMessage(
+      showToast(
         response.data?.message ||
           "Thanks, your message has been sent to the Lomir team.",
       );
       setFormValues(initialFormValues);
       setAttachments([]);
+      setStatus("idle");
+      setStatusMessage("");
+      setIsEmailFormOpen(false);
       resetTurnstile();
     } catch (error) {
       console.error("Contact form submission error:", error);
@@ -291,14 +295,6 @@ const Contact = () => {
         className="h-full"
         marginClassName="mb-0"
       >
-        {status === "success" && (
-          <Alert
-            type="success"
-            message={statusMessage}
-            className="mb-5 w-full shadow-sm"
-          />
-        )}
-
         {status === "error" && (
           <Alert
             type="error"

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,11 +1,21 @@
-import { useState } from "react";
-import { Mail, MessageCircle, Send, ShieldCheck } from "lucide-react";
+import { useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import {
+  Mail,
+  MessageCircle,
+  Send,
+} from "lucide-react";
 import Alert from "../components/common/Alert";
 import Button from "../components/common/Button";
 import Card from "../components/common/Card";
 import FormGroup from "../components/common/FormGroup";
+import TurnstileWidget from "../components/common/TurnstileWidget";
+import { useAuth } from "../contexts/AuthContext";
+import api from "../services/api";
 
-const CONTACT_EMAIL = import.meta.env.VITE_CONTACT_EMAIL || "contact@lomir.app";
+const LOMIR_CONTACT_USER_ID = (
+  import.meta.env.VITE_LOMIR_CONTACT_USER_ID || ""
+).trim();
 
 const initialFormValues = {
   name: "",
@@ -22,9 +32,20 @@ const topicOptions = [
 ];
 
 const Contact = () => {
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+  const hasTurnstile = Boolean(import.meta.env.VITE_TURNSTILE_SITE_KEY);
+
   const [formValues, setFormValues] = useState(initialFormValues);
   const [errors, setErrors] = useState({});
-  const [messageSent, setMessageSent] = useState(false);
+  const [status, setStatus] = useState("idle");
+  const [statusMessage, setStatusMessage] = useState("");
+  const [turnstileToken, setTurnstileToken] = useState(null);
+  const [isEmailFormOpen, setIsEmailFormOpen] = useState(false);
+  const turnstileRef = useRef(null);
+
+  const canUseInAppContact =
+    isAuthenticated && Boolean(LOMIR_CONTACT_USER_ID);
 
   const updateField = (field, value) => {
     setFormValues((currentValues) => ({
@@ -35,7 +56,8 @@ const Contact = () => {
       ...currentErrors,
       [field]: "",
     }));
-    setMessageSent(false);
+    setStatus("idle");
+    setStatusMessage("");
   };
 
   const validateForm = () => {
@@ -56,63 +78,156 @@ const Contact = () => {
       nextErrors.message = "Message is required";
     }
 
+    if (hasTurnstile && !turnstileToken) {
+      nextErrors.turnstile = "Please complete the CAPTCHA verification";
+    }
+
     setErrors(nextErrors);
     return Object.keys(nextErrors).length === 0;
   };
 
-  const handleSubmit = (event) => {
+  const resetTurnstile = () => {
+    turnstileRef.current?.reset();
+    setTurnstileToken(null);
+  };
+
+  const handleSubmit = async (event) => {
     event.preventDefault();
 
     if (!validateForm()) {
       return;
     }
 
-    const subject = `Lomir contact: ${formValues.topic}`;
-    const body = [
-      `Name: ${formValues.name.trim()}`,
-      `Email: ${formValues.email.trim()}`,
-      `Topic: ${formValues.topic}`,
-      "",
-      formValues.message.trim(),
-    ].join("\n");
+    setStatus("submitting");
+    setStatusMessage("");
 
-    window.location.href = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
-      subject,
-    )}&body=${encodeURIComponent(body)}`;
-    setMessageSent(true);
+    try {
+      const response = await api.post("/api/contact", {
+        name: formValues.name.trim(),
+        email: formValues.email.trim(),
+        topic: formValues.topic,
+        message: formValues.message.trim(),
+        ...(hasTurnstile ? { turnstile_token: turnstileToken } : {}),
+      });
+
+      setStatus("success");
+      setStatusMessage(
+        response.data?.message ||
+          "Thanks, your message has been sent to the Lomir team.",
+      );
+      setFormValues(initialFormValues);
+      resetTurnstile();
+    } catch (error) {
+      console.error("Contact form submission error:", error);
+      setStatus("error");
+      setStatusMessage(
+        error.response?.data?.message ||
+          "Something went wrong while sending your message. Please try again.",
+      );
+      resetTurnstile();
+    }
   };
 
-  return (
-    <div className="max-w-5xl mx-auto space-y-6">
-      <section className="background-opacity rounded-xl shadow-soft px-6 py-10 sm:px-8 text-center">
-        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
-          <Mail size={30} />
-        </div>
-        <h1 className="text-3xl sm:text-4xl font-medium tracking-tight text-primary">
-          Contact Lomir
-        </h1>
-        <p className="mx-auto mt-3 max-w-2xl text-base-content/75">
-          Questions, feedback, account help, or privacy requests can all start
-          here. We will get your message to the right place.
-        </p>
-      </section>
+  const handleTurnstileVerify = (token) => {
+    setTurnstileToken(token);
+    setErrors((currentErrors) => {
+      if (!currentErrors.turnstile) {
+        return currentErrors;
+      }
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(280px,0.9fr)] items-start">
+      const remainingErrors = { ...currentErrors };
+      delete remainingErrors.turnstile;
+      return remainingErrors;
+    });
+  };
+
+  const renderContactForm = () => {
+    const isSubmitting = status === "submitting";
+    const emailSubtitle = isAuthenticated
+      ? "We will reply by email."
+      : "We will reply by email. Create an account for direct in-app messaging with the Lomir team.";
+
+    if (!isEmailFormOpen) {
+      return (
         <Card
-          title="Send us a message"
-          subtitle="Use your email client to send a prepared message to the Lomir team."
           hoverable={false}
           truncateContent={false}
+          contentClassName="pt-4 sm:pt-7"
+          className="h-full"
+          marginClassName="mb-0"
         >
-          {messageSent && (
-            <Alert
-              type="success"
-              message="Your email client should open with the message ready to send."
-              className="mb-5 w-full shadow-sm"
-            />
-          )}
+          <div className="flex gap-3">
+            <div className="avatar placeholder relative">
+              <div className="rounded-full w-12 h-12 relative flex items-center justify-center overflow-hidden">
+                <Send size={28} className="text-primary" />
+              </div>
+            </div>
 
-          <form onSubmit={handleSubmit} className="space-y-1">
+            <div className="min-w-0 flex-1">
+              <h3 className="font-medium text-[var(--color-primary-focus)] leading-[120%] mb-1 text-lg">
+                Send us a message
+              </h3>
+              <p className="max-h-[2.75em] overflow-hidden">
+                {emailSubtitle}
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-auto flex justify-end pt-6">
+            <Button
+              type="button"
+              variant="primary"
+              icon={<Mail size={16} />}
+              className="w-full sm:w-auto"
+              onClick={() => setIsEmailFormOpen(true)}
+            >
+              Compose Email
+            </Button>
+          </div>
+
+          {!isAuthenticated && (
+            <div className="mt-6 rounded-lg bg-base-100/60 text-left text-sm text-base-content/70 sm:text-right">
+              <p>
+                Already part of Lomir?{" "}
+                <Link to="/login" className="link link-primary">
+                  Log in
+                </Link>{" "}
+                to contact us through the app chat.
+              </p>
+            </div>
+          )}
+        </Card>
+      );
+    }
+
+    return (
+      <Card
+        title="Send us a message"
+        subtitle={emailSubtitle}
+        hoverable={false}
+        truncateContent={false}
+        imageSize="small"
+        imageReplacement={<Send size={28} className="text-primary" />}
+        className="h-full"
+        marginClassName="mb-0"
+      >
+        {status === "success" && (
+          <Alert
+            type="success"
+            message={statusMessage}
+            className="mb-5 w-full shadow-sm"
+          />
+        )}
+
+        {status === "error" && (
+          <Alert
+            type="error"
+            message={statusMessage}
+            className="mb-5 w-full shadow-sm"
+          />
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
             <div className="grid gap-4 sm:grid-cols-2">
               <FormGroup
                 label="Name"
@@ -130,6 +245,7 @@ const Contact = () => {
                   value={formValues.name}
                   onChange={(event) => updateField("name", event.target.value)}
                   placeholder="Your name"
+                  disabled={isSubmitting}
                 />
               </FormGroup>
 
@@ -149,6 +265,7 @@ const Contact = () => {
                   value={formValues.email}
                   onChange={(event) => updateField("email", event.target.value)}
                   placeholder="you@example.com"
+                  disabled={isSubmitting}
                 />
               </FormGroup>
             </div>
@@ -159,6 +276,7 @@ const Contact = () => {
                 className="select select-bordered w-full"
                 value={formValues.topic}
                 onChange={(event) => updateField("topic", event.target.value)}
+                disabled={isSubmitting}
               >
                 {topicOptions.map((topic) => (
                   <option key={topic} value={topic}>
@@ -181,76 +299,148 @@ const Contact = () => {
                   errors.message ? "textarea-error" : ""
                 }`}
                 value={formValues.message}
-                onChange={(event) =>
-                  updateField("message", event.target.value)
-                }
+                onChange={(event) => updateField("message", event.target.value)}
                 placeholder="Tell us what is on your mind"
+                disabled={isSubmitting}
               />
             </FormGroup>
 
-            <div className="pt-3">
-              <Button
-                type="submit"
-                variant="primary"
-                icon={<Send size={16} />}
-                className="w-full sm:w-auto"
-              >
-                Prepare Email
-              </Button>
+            <div className="pt-3 flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+              <div className="sm:pt-0">
+                <Button
+                  type="submit"
+                  variant="primary"
+                  icon={!isSubmitting ? <Send size={16} /> : null}
+                  className="w-full sm:w-auto"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? (
+                    <>
+                      <span className="loading loading-spinner loading-sm"></span>
+                      Sending...
+                    </>
+                  ) : (
+                    "Send Message"
+                  )}
+                </Button>
+              </div>
+
+              {hasTurnstile && (
+                <div className="form-control w-full sm:w-auto sm:items-end">
+                  <div className="flex justify-center sm:justify-end">
+                    <TurnstileWidget
+                      ref={turnstileRef}
+                      onVerify={handleTurnstileVerify}
+                      onExpire={() => setTurnstileToken(null)}
+                      onError={() => setTurnstileToken(null)}
+                    />
+                  </div>
+                  {errors.turnstile && (
+                    <label className="label justify-center sm:justify-end">
+                      <span className="label-text-alt text-error">
+                        {errors.turnstile}
+                      </span>
+                    </label>
+                  )}
+                </div>
+              )}
             </div>
-          </form>
-        </Card>
+        </form>
 
-        <div className="space-y-4">
-          <Card
-            title="Direct email"
-            subtitle="Prefer a blank email? Write to us directly."
-            hoverable={false}
-            truncateContent={false}
-            marginClassName="mb-0"
-            imageReplacement={<Mail size={26} className="text-primary" />}
-          >
-            <a
-              href={`mailto:${CONTACT_EMAIL}`}
-              className="link link-primary break-all text-sm sm:text-base"
-            >
-              {CONTACT_EMAIL}
-            </a>
-          </Card>
-
-          <Card
-            title="Account and privacy"
-            subtitle="For profile, email, deletion, or data questions."
-            hoverable={false}
-            truncateContent={false}
-            marginClassName="mb-0"
-            imageReplacement={
-              <ShieldCheck size={26} className="text-primary" />
-            }
-          >
-            <p className="text-base-content/75">
-              Include the email address connected to your Lomir account so we
-              can help faster.
+        {!isAuthenticated && (
+          <div className="mt-6 rounded-lg bg-base-100/60 p-4 text-sm text-base-content/70">
+            <p>
+              Already part of Lomir?{" "}
+              <Link to="/login" className="link link-primary">
+                Log in
+              </Link>{" "}
+              to contact us through the app chat.
             </p>
-          </Card>
+          </div>
+        )}
+      </Card>
+    );
+  };
 
-          <Card
-            title="Feedback"
-            subtitle="Ideas, bugs, or rough edges are welcome."
-            hoverable={false}
-            truncateContent={false}
-            marginClassName="mb-0"
-            imageReplacement={
-              <MessageCircle size={26} className="text-primary" />
-            }
-          >
-            <p className="text-base-content/75">
-              Tell us what you were trying to do and where the app surprised
-              you.
+  const renderAuthenticatedContact = () => {
+    return (
+      <Card
+        hoverable={false}
+        truncateContent={false}
+        contentClassName="pt-4 sm:pt-7"
+        className="h-full"
+        marginClassName="mb-0"
+      >
+        <div className="mb-5 flex gap-3">
+          <div className="avatar placeholder relative">
+            <div className="rounded-full w-12 h-12 relative flex items-center justify-center overflow-hidden">
+              <MessageCircle size={28} className="text-primary" />
+            </div>
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <h3 className="font-medium text-[var(--color-primary-focus)] leading-[120%] mb-1 text-lg">
+              Talk to the Lomir Team
+            </h3>
+            <p className="max-h-[2.75em] overflow-hidden">
+              Use your Lomir account to reach us directly in the app.
             </p>
-          </Card>
+          </div>
         </div>
-      </div>
+
+        <p className="text-base-content/75">
+          The Lomir Team account is available for account questions, privacy
+          requests, feedback, and anything that needs a little human context.
+        </p>
+
+        <div className="mt-auto flex justify-end pt-6">
+          <Button
+            type="button"
+            variant="primary"
+            icon={<MessageCircle size={16} />}
+            className="w-full sm:w-auto"
+            onClick={() =>
+              navigate(`/chat/${LOMIR_CONTACT_USER_ID}?type=direct`)
+            }
+          >
+            Send Chat Message
+          </Button>
+        </div>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6">
+      <section className="background-opacity rounded-xl shadow-soft px-6 py-10 sm:px-8 text-center">
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <Mail size={30} />
+        </div>
+        <h1 className="text-3xl sm:text-4xl font-medium tracking-tight text-primary">
+          Contact Lomir
+        </h1>
+        <p className="mx-auto mt-3 max-w-2xl text-base-content/75">
+          Questions, feedback, account help, or privacy requests can all start here.
+          <br />
+          We will get your message to the right place.
+        </p>
+      </section>
+
+      {canUseInAppContact ? (
+        <div
+          className={
+            isEmailFormOpen
+              ? "grid gap-5"
+              : "grid gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)] lg:items-stretch"
+          }
+        >
+          {renderAuthenticatedContact()}
+
+          {renderContactForm()}
+        </div>
+      ) : (
+        <div className="grid gap-5">{renderContactForm()}</div>
+      )}
     </div>
   );
 };

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,0 +1,258 @@
+import { useState } from "react";
+import { Mail, MessageCircle, Send, ShieldCheck } from "lucide-react";
+import Alert from "../components/common/Alert";
+import Button from "../components/common/Button";
+import Card from "../components/common/Card";
+import FormGroup from "../components/common/FormGroup";
+
+const CONTACT_EMAIL = import.meta.env.VITE_CONTACT_EMAIL || "contact@lomir.app";
+
+const initialFormValues = {
+  name: "",
+  email: "",
+  topic: "General question",
+  message: "",
+};
+
+const topicOptions = [
+  "General question",
+  "Account support",
+  "Privacy request",
+  "Feedback",
+];
+
+const Contact = () => {
+  const [formValues, setFormValues] = useState(initialFormValues);
+  const [errors, setErrors] = useState({});
+  const [messageSent, setMessageSent] = useState(false);
+
+  const updateField = (field, value) => {
+    setFormValues((currentValues) => ({
+      ...currentValues,
+      [field]: value,
+    }));
+    setErrors((currentErrors) => ({
+      ...currentErrors,
+      [field]: "",
+    }));
+    setMessageSent(false);
+  };
+
+  const validateForm = () => {
+    const nextErrors = {};
+    const trimmedEmail = formValues.email.trim();
+
+    if (!formValues.name.trim()) {
+      nextErrors.name = "Name is required";
+    }
+
+    if (!trimmedEmail) {
+      nextErrors.email = "Email is required";
+    } else if (!/\S+@\S+\.\S+/.test(trimmedEmail)) {
+      nextErrors.email = "Please enter a valid email address";
+    }
+
+    if (!formValues.message.trim()) {
+      nextErrors.message = "Message is required";
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    const subject = `Lomir contact: ${formValues.topic}`;
+    const body = [
+      `Name: ${formValues.name.trim()}`,
+      `Email: ${formValues.email.trim()}`,
+      `Topic: ${formValues.topic}`,
+      "",
+      formValues.message.trim(),
+    ].join("\n");
+
+    window.location.href = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
+      subject,
+    )}&body=${encodeURIComponent(body)}`;
+    setMessageSent(true);
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6">
+      <section className="background-opacity rounded-xl shadow-soft px-6 py-10 sm:px-8 text-center">
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <Mail size={30} />
+        </div>
+        <h1 className="text-3xl sm:text-4xl font-medium tracking-tight text-primary">
+          Contact Lomir
+        </h1>
+        <p className="mx-auto mt-3 max-w-2xl text-base-content/75">
+          Questions, feedback, account help, or privacy requests can all start
+          here. We will get your message to the right place.
+        </p>
+      </section>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(280px,0.9fr)] items-start">
+        <Card
+          title="Send us a message"
+          subtitle="Use your email client to send a prepared message to the Lomir team."
+          hoverable={false}
+          truncateContent={false}
+        >
+          {messageSent && (
+            <Alert
+              type="success"
+              message="Your email client should open with the message ready to send."
+              className="mb-5 w-full shadow-sm"
+            />
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-1">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormGroup
+                label="Name"
+                htmlFor="contact-name"
+                error={errors.name}
+                required
+                className="mb-0"
+              >
+                <input
+                  id="contact-name"
+                  type="text"
+                  className={`input input-bordered w-full ${
+                    errors.name ? "input-error" : ""
+                  }`}
+                  value={formValues.name}
+                  onChange={(event) => updateField("name", event.target.value)}
+                  placeholder="Your name"
+                />
+              </FormGroup>
+
+              <FormGroup
+                label="Email"
+                htmlFor="contact-email"
+                error={errors.email}
+                required
+                className="mb-0"
+              >
+                <input
+                  id="contact-email"
+                  type="email"
+                  className={`input input-bordered w-full ${
+                    errors.email ? "input-error" : ""
+                  }`}
+                  value={formValues.email}
+                  onChange={(event) => updateField("email", event.target.value)}
+                  placeholder="you@example.com"
+                />
+              </FormGroup>
+            </div>
+
+            <FormGroup label="Topic" htmlFor="contact-topic" className="mb-0">
+              <select
+                id="contact-topic"
+                className="select select-bordered w-full"
+                value={formValues.topic}
+                onChange={(event) => updateField("topic", event.target.value)}
+              >
+                {topicOptions.map((topic) => (
+                  <option key={topic} value={topic}>
+                    {topic}
+                  </option>
+                ))}
+              </select>
+            </FormGroup>
+
+            <FormGroup
+              label="Message"
+              htmlFor="contact-message"
+              error={errors.message}
+              required
+              className="mb-0"
+            >
+              <textarea
+                id="contact-message"
+                className={`textarea textarea-bordered min-h-40 w-full resize-y ${
+                  errors.message ? "textarea-error" : ""
+                }`}
+                value={formValues.message}
+                onChange={(event) =>
+                  updateField("message", event.target.value)
+                }
+                placeholder="Tell us what is on your mind"
+              />
+            </FormGroup>
+
+            <div className="pt-3">
+              <Button
+                type="submit"
+                variant="primary"
+                icon={<Send size={16} />}
+                className="w-full sm:w-auto"
+              >
+                Prepare Email
+              </Button>
+            </div>
+          </form>
+        </Card>
+
+        <div className="space-y-4">
+          <Card
+            title="Direct email"
+            subtitle="Prefer a blank email? Write to us directly."
+            hoverable={false}
+            truncateContent={false}
+            marginClassName="mb-0"
+            imageReplacement={<Mail size={26} className="text-primary" />}
+          >
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className="link link-primary break-all text-sm sm:text-base"
+            >
+              {CONTACT_EMAIL}
+            </a>
+          </Card>
+
+          <Card
+            title="Account and privacy"
+            subtitle="For profile, email, deletion, or data questions."
+            hoverable={false}
+            truncateContent={false}
+            marginClassName="mb-0"
+            imageReplacement={
+              <ShieldCheck size={26} className="text-primary" />
+            }
+          >
+            <p className="text-base-content/75">
+              Include the email address connected to your Lomir account so we
+              can help faster.
+            </p>
+          </Card>
+
+          <Card
+            title="Feedback"
+            subtitle="Ideas, bugs, or rough edges are welcome."
+            hoverable={false}
+            truncateContent={false}
+            marginClassName="mb-0"
+            imageReplacement={
+              <MessageCircle size={26} className="text-primary" />
+            }
+          >
+            <p className="text-base-content/75">
+              Tell us what you were trying to do and where the app surprised
+              you.
+            </p>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Contact;


### PR DESCRIPTION
Redesigns the contact page into a two-tier experience based on authentication state. Logged-in users get an in-app messaging option via the Lomir Team account (user 355) alongside an email contact form. Non-logged-in visitors see the email contact form with a prompt to create an account for direct messaging. The form now submits to the backend (POST /api/contact) instead of using mailto: links.
Changes
src/pages/Contact.jsx

Auth-aware layout using useAuth() to detect login state
Logged-in view: "Talk to the Lomir Team" card with a button that navigates to /chat/{LOMIR_CONTACT_USER_ID}?type=direct for direct messaging
Collapsible "Send us a message" email form available for all visitors (logged-in and not)
Form submits via POST /api/contact instead of opening a mailto: link
Turnstile CAPTCHA integration using the same pattern as RegisterForm.jsx
File attachment support (up to 5 files, 25 MB limit, validated file types)
Form validation for required fields (name, email, message)
Loading, success, and error states with Alert component
Lomir Team user ID read from VITE_LOMIR_CONTACT_USER_ID env var — falls back to form-only view if unset

src/components/layout/Footer.jsx

Contact link updated from <a href="#"> to <Link to="/contact"> using React Router

.env

Added VITE_LOMIR_CONTACT_USER_ID=355

Deployment notes

Add VITE_LOMIR_CONTACT_USER_ID=355 to Vercel environment variables
Requires the backend POST /api/contact endpoint to be deployed first

