### PR TITLE
Adjust email verification action button widths

### DIFF
--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -412,13 +412,13 @@ const RegisterForm = () => {
             )}
 
             <div className="flex flex-col gap-2 w-full">
-              <Link to="/login" className="btn btn-primary w-full">
+              <Link to="/login" className="btn btn-primary w-fit self-center px-6">
                 Go to Login
               </Link>
 
               <button
                 type="button"
-                className="btn btn-ghost btn-sm"
+                className="btn btn-ghost btn-sm w-fit self-center px-4"
                 onClick={handleResendVerification}
                 disabled={resendStatus === "sending" || resendCooldown > 0}
               >


### PR DESCRIPTION
**Summary**
Adjusts the email verification success screen action buttons in RegisterForm.jsx.
Makes both “Go to Login” and “Resend verification email” fit their content width instead of stretching full-width.
Centers both actions for a cleaner confirmation screen layout.

**Testing**
Ran npm run build successfully.
Existing Vite warnings remain unchanged: large bundle warning and VacantRoleDetailsModal.jsx mixed static/dynamic import warning.