### PR TITLE
Feature/delete unregistered accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Contact the project owner for a demo login, or register a new account with a val
 - **Notifications** — In-app notification center for invitations, applications, badge awards, and role updates
 - **Account Deletion** — Multi-step account deletion with impact preview, automatic team ownership transfer, and graceful "Former Lomir User" handling across chat, badges, and notifications
 - **Demo Data Indicators** — Synthetic/seed data is visually labeled with FlaskConical icons and "DEMO" avatar overlays so users can distinguish test content from real data
-- **Security** — Cloudflare Turnstile CAPTCHA on registration (feature-flagged), enforced password policy (min 8 chars, letter + number), and self-service password reset from the login form
+- **Contact Page** — Email contact form with optional file attachments (up to 5 files, 25 MB each — images, PDF, Word, Excel, PPT, TXT, ZIP); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; success toast on submit
+- **Security** — Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), and self-service password reset from the login form
 
 ---
 
@@ -97,6 +98,9 @@ VITE_IMAGEKIT_URL_ENDPOINT=https://ik.imagekit.io/<your-id>
 
 # Cloudflare Turnstile (optional for local dev — if unset, CAPTCHA is not shown)
 # VITE_TURNSTILE_SITE_KEY=<turnstile-site-key>
+
+# Contact page — set to a Lomir user ID to route authenticated users to in-app chat
+# VITE_LOMIR_CONTACT_USER_ID=<lomir-team-user-id>
 ```
 
 > Get the ImageKit values from the project owner.
@@ -146,6 +150,7 @@ Lomir-frontend/
 │   │   ├── ForgotPassword.jsx
 │   │   ├── ResetPassword.jsx
 │   │   ├── VerifyEmail.jsx
+│   │   ├── Contact.jsx             # Contact form with file attachments + in-app chat routing
 │   │   └── DesignSystem.jsx        # Dev-only component playground
 │   ├── components/
 │   │   ├── BooleanSearchInput.jsx  # Textarea-based Boolean search input with operator helpers
@@ -261,6 +266,7 @@ Lomir-frontend/
 | `/chat` | Chat | Direct messages and team group chat with file/image sharing, @mentions, and reply threading |
 | `/badges` | Badges | Browse all 30 badges across 5 categories |
 | `/settings` | Settings | Change password and delete account |
+| `/contact` | Contact | Email form with file attachments; authenticated users with a contact user ID configured are routed to in-app chat |
 
 ---
 

--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -777,8 +777,7 @@ const RegisterForm = () => {
               <span className="font-medium">{formData.email}</span>
             </p>
             <p className="text-sm text-base-content/60 mb-6">
-              Please click the link in the email to verify your account. The
-              link will expire in 24 hours.
+              Please click the link in the email to verify your account. The link will expire in <strong>24 hours</strong> — if you don't verify within this time, your registration will be automatically deleted and you'll need to sign up again.
             </p>
 
             {resendMessage && (

--- a/src/pages/VerifyEmail.jsx
+++ b/src/pages/VerifyEmail.jsx
@@ -79,7 +79,17 @@ const VerifyEmail = () => {
     if (status === "verifying") return "Please wait a moment.";
     if (status === "success")
       return "Your account is now active. You can log in with your credentials.";
-    return message;
+    if (status === "info")
+      return "Your account may already be verified. Try logging in.";
+    return (
+      <>
+        {message}
+        <br />
+        <span className="text-sm mt-2 block">
+          If your verification link has expired, your registration may have been removed. You can sign up again with the same email address.
+        </span>
+      </>
+    );
   };
 
   return (


### PR DESCRIPTION
Summary
Contact page — New public /contact route with an API-based email form (replaces the old mailto: approach). Supports up to 5 file attachments per submission (images, PDF, Word, Excel, PPT, TXT, ZIP; 25 MB per file — matching chat upload limits). Authenticated users with VITE_LOMIR_CONTACT_USER_ID configured are shown an in-app chat option instead. Optional Cloudflare Turnstile CAPTCHA. On success, the form collapses and fires a viewport-centered toast consistent with the rest of the app.
User profile header — City and country now shown below the username in the profile header.
Registration UX — Improved validation feedback and alert rendering; users are now informed about the 24-hour email verification deadline at sign-up and in the verification email.
Password reset — Restored the "Forgot password?" link that was missing from the login form.
Footer — Added a Contact link.
README — Updated with the new contact page, env var, project structure, and key pages.
Test plan
 Submit the contact form as a guest — confirm email arrives with correct fields and any attached files
 Submit as an authenticated user without VITE_LOMIR_CONTACT_USER_ID set — confirm the email form is shown
 Submit as an authenticated user with VITE_LOMIR_CONTACT_USER_ID set — confirm the in-app chat card is shown alongside the email form
 Attach more than 5 files — confirm the button disappears after the 5th
 Attach a file over 25 MB or an unsupported type — confirm the error message
 Successful submission — confirm toast appears, form collapses back to the card view, fields are cleared
 Register a new account — confirm the 24-hour verification notice is visible and the verification email mentions the deadline
 Use the "Forgot password?" link from the login form — confirm it works end-to-end