### PR TITLE
Security/api security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Contact the project owner for a demo login, or register a new account with a val
 - **Best Match Sorting** — Weighted matching algorithm scores teams and roles against your profile (tags 40%, badges 30%, distance 30%)
 - **Map View** — Leaflet-powered map with custom markers for teams, users, and roles; popups with detail cards; distance-based filtering and proximity sorting
 - **Team Management** — Create teams, manage members and roles, post vacant roles, handle applications and invitations with role-specific targeting; My Teams uses the same responsive sort and result-view controls as search
-- **User Profiles** — Customizable profiles with interest tags, badges, avatar uploads (ImageKit), and geocoded location
+- **User Profiles** — Customizable profiles with interest tags, badges, avatar uploads (ImageKit), and geocoded location; profile header shows city and country code; non-public profiles are protected — non-owners and non-teammates see only the username and avatar ("This profile is private")
 - **Real-Time Chat** — Direct and team group messaging with typing indicators, read receipts, file/image sharing, @mentions, reply threading, and rich system event messages (Socket.IO)
 - **Badge System** — Browse 30 badges across 5 color-coded categories; award badges to teammates with reasons and team context
 - **Notifications** — In-app notification center for invitations, applications, badge awards, and role updates
 - **Account Deletion** — Multi-step account deletion with impact preview, automatic team ownership transfer, and graceful "Former Lomir User" handling across chat, badges, and notifications
 - **Demo Data Indicators** — Synthetic/seed data is visually labeled with FlaskConical icons and "DEMO" avatar overlays so users can distinguish test content from real data
 - **Contact Page** — Email contact form with optional file attachments (up to 5 files, 25 MB each — images, PDF, Word, Excel, PPT, TXT, ZIP); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; success toast on submit
-- **Security** — Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), and self-service password reset from the login form
+- **Security** — Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; real-time email and username availability feedback during registration; unverified accounts are automatically deleted after 24 hours
 
 ---
 
@@ -143,7 +143,8 @@ Lomir-frontend/
 │   │   ├── searchPageHelpers.js    # Helper functions for SearchPage (not a page itself)
 │   │   ├── MyTeams.jsx             # User's teams, invitations, applications
 │   │   ├── Profile.jsx             # User profile editing
-│   │   ├── PublicProfile.jsx       # Profile placeholder for deleted/missing users
+│   │   ├── PublicProfile.jsx       # Other users' public profiles; shows "private" message for
+│   │   │                           #   limited-access profiles; placeholder for deleted users
 │   │   ├── Register.jsx            # Multi-step registration with CAPTCHA
 │   │   ├── Login.jsx
 │   │   ├── Chat.jsx                # Direct + team messaging with file sharing
@@ -160,8 +161,9 @@ Lomir-frontend/
 │   │   ├── auth/                   # Login/register forms, TurnstileWidget
 │   │   ├── teams/                  # Team cards, detail modals, vacant roles,
 │   │   │                           #   applications, invitations, member management
-│   │   ├── users/                  # User cards, detail modals, InlineUserLink,
-│   │   │                           #   UserAvatar, DemoAvatarOverlay, deleted user handling
+│   │   ├── users/                  # User cards, detail modals, InlineUserLink, UserAvatar,
+│   │   │                           #   UserProfileHeaderSection (avatar + name + location header),
+│   │   │                           #   DemoAvatarOverlay, deleted user handling
 │   │   ├── badges/                 # Badge display, awarding, category modals, AwardCard
 │   │   ├── tags/                   # Tag input, display, and selection
 │   │   ├── chat/                   # Chat UI, message bubbles, file/image previews,
@@ -224,7 +226,9 @@ Lomir-frontend/
 │   │   ├── matchHelpers.js         # Shared match score helpers (weights, render cascade)
 │   │   ├── matchScoreUtils.js      # Match tier color coding (green/yellow/orange)
 │   │   ├── payloadExtractors.js    # Role/team payload field extractors shared across components
-│   │   ├── locationUtils.js        # Haversine distance calculation
+│   │   ├── locationUtils.js        # Haversine distance, formatLocation / normalizeLocationData
+│   │   │                           #   (de-duplicated city/district/state/country display,
+│   │   │                           #   postal-code city fallback, Berlin district lookup)
 │   │   ├── vacantRoleUtils.js      # Role status helpers (filled, closed, open) + display labels
 │   │   ├── teamRequestUtils.js     # Invitation + application helper functions (build card data, labels)
 │   │   ├── eventPreview.js         # Parse + format chat system event messages for previews and toasts
@@ -264,7 +268,7 @@ Lomir-frontend/
 | `/search` | Search | Find teams, users, and roles; Boolean search input; shared result-view toggle; advanced filtering by tags, badges, distance |
 | `/teams/my-teams` | My Teams | Teams you belong to, pending invitations and applications; shared sort and result-view controls |
 | `/profile` | Profile | Edit your profile, tags, avatar, and location |
-| `/profile/:id` | Public Profile | View any user's profile; shows placeholder for deleted/missing users |
+| `/profile/:id` | Public Profile | View any user's profile; shows "private" message for non-public profiles; placeholder for deleted users |
 | `/chat` | Chat | Direct messages and team group chat with file/image sharing, @mentions, and reply threading |
 | `/badges` | Badges | Browse all 30 badges across 5 categories |
 | `/settings` | Settings | Change password and delete account |
@@ -284,7 +288,9 @@ The search page supports multiple sort and filter modes:
 
 **Best Match scoring** uses the backend matching engine (tag overlap 40%, badge overlap 30%, distance 30%) and falls back to client-side profile overlap calculations when backend scores aren't available.
 
-**Map view** renders all results on a Leaflet map with color-coded markers. Clicking a marker shows a popup with the team/user/role card. Distance indicators show how far each result is from your location.
+**Map view** renders all results on a Leaflet map with color-coded markers. Clicking a marker shows a popup with the team/user/role card. Distance indicators show how far each result is from your location. Map markers use approximate coordinates (~11km precision) returned by the backend — exact user locations are never sent to the client.
+
+**Distance on role cards** — Vacant role cards and mini-cards show a distance indicator (km) when search results include proximity data.
 
 ---
 

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -1553,9 +1553,9 @@ const MessageDisplay = ({
     const fromTeam = resolveUserIdFromTeamMembers(name);
     if (fromTeam) return fromTeam;
 
-    // 2) fallback: backend search (your endpoint currently returns placeholder [])
+    // 2) fallback: backend search
     const res = await userService.searchUsers(name);
-    const users = res?.data?.data || [];
+    const users = res?.data?.data?.users || [];
 
     if (users.length === 1) return users[0].id;
 

--- a/src/components/common/LocationSection.jsx
+++ b/src/components/common/LocationSection.jsx
@@ -78,7 +78,7 @@ const LocationSection = ({
               {formatLocation(location, {
                 displayType: "full",
                 showPostalCode: true,
-                showState: false,
+                showState: true,
                 showCountry: true,
               })}
             </span>

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -53,7 +53,11 @@ import {
   isSyntheticTeam,
   isSyntheticUser,
 } from "../../utils/userHelpers";
-import { getCountryCode, getCountryDisplayName } from "../../utils/locationUtils";
+import {
+  formatLocation,
+  getCountryCode,
+  normalizeLocationData,
+} from "../../utils/locationUtils";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import Tooltip from "../common/Tooltip";
 
@@ -126,10 +130,15 @@ const CITY_COORDINATE_FALLBACKS = {
   bogotá: { lat: 4.711, lng: -74.0721 },
   "bogotá dc": { lat: 4.711, lng: -74.0721 },
   "bogotá d.c.": { lat: 4.711, lng: -74.0721 },
+  cologne: { lat: 50.938, lng: 6.960 },
   frankfurt: { lat: 50.1109, lng: 8.6821 },
   "frankfurt am main": { lat: 50.1109, lng: 8.6821 },
+  hamburg: { lat: 53.550, lng: 9.993 },
   johannesburg: { lat: -26.2041, lng: 28.0473 },
+  köln: { lat: 50.938, lng: 6.960 },
   madrid: { lat: 40.4168, lng: -3.7038 },
+  münchen: { lat: 48.137, lng: 11.576 },
+  munich: { lat: 48.137, lng: 11.576 },
   toronto: { lat: 43.6532, lng: -79.3832 },
 };
 const DEMO_PROFILE_LOCATION_FALLBACKS = {
@@ -213,6 +222,7 @@ const isValidCoordinate = (lat, lng) =>
 const getLatLng = (item) => {
   const lat = toNumber(firstPresent(
     item?.latitude,
+    item?.approximate_latitude,
     item?.lat,
     item?.location?.latitude,
     item?.roleLocation?.latitude,
@@ -220,6 +230,7 @@ const getLatLng = (item) => {
   ));
   const lng = toNumber(firstPresent(
     item?.longitude,
+    item?.approximate_longitude,
     item?.lng,
     item?.lon,
     item?.location?.longitude,
@@ -411,6 +422,15 @@ const inferCityFromPostalCode = (value) => {
   if (postalCode === "2000") return "Johannesburg";
   if (/^28\d{3}$/.test(postalCode)) return "Madrid";
   if (/^M\d[A-Z]\s?\d[A-Z]\d$/.test(postalCode)) return "Toronto";
+  // 5-digit German postal codes — map numeric ranges to major cities
+  if (/^\d{5}$/.test(postalCode)) {
+    const n = parseInt(postalCode, 10);
+    if (n >= 10115 && n <= 14199) return "Berlin";
+    if (n >= 20095 && n <= 22769) return "Hamburg";
+    if (n >= 50667 && n <= 51149) return "Cologne";
+    if (n >= 60311 && n <= 65936) return "Frankfurt";
+    if (n >= 80331 && n <= 81929) return "München";
+  }
   return null;
 };
 
@@ -475,14 +495,20 @@ const getLocationLabel = (item) => {
     item.user?.state,
     item.role?.state,
   );
-  const countryLabel = country
-    ? getCountryDisplayName(getCountryCode(country) ?? country)
-    : inferredCountryCode
-      ? getCountryDisplayName(inferredCountryCode)
-      : null;
-  const parts = [city, state, countryLabel].filter(Boolean);
+  const locationLabel = formatLocation(
+    normalizeLocationData({
+      ...item,
+      city,
+      state,
+      country: country || inferredCountryCode,
+    }),
+    {
+      displayType: "short",
+      showState: true,
+    },
+  );
 
-  return parts.length > 0 ? parts.join(", ") : LOCATION_NOT_AVAILABLE;
+  return locationLabel || LOCATION_NOT_AVAILABLE;
 };
 
 const getItemCountryCode = (item) => {
@@ -1001,6 +1027,7 @@ const normalizeMapPoint = (
   const type = getMapPointType(item);
   const lat = toNumber(firstPresent(
     item.latitude,
+    item.approximate_latitude,
     item.lat,
     item.location?.latitude,
     item.roleLocation?.latitude,
@@ -1008,6 +1035,7 @@ const normalizeMapPoint = (
   ));
   const lng = toNumber(firstPresent(
     item.longitude,
+    item.approximate_longitude,
     item.lng,
     item.lon,
     item.location?.longitude,

--- a/src/components/teams/CreateVacantRoleModal.jsx
+++ b/src/components/teams/CreateVacantRoleModal.jsx
@@ -234,6 +234,7 @@ const CreateVacantRoleModal = ({
         postal_code: formData.isRemote ? null : formData.postalCode || null,
         city: formData.isRemote ? null : formData.city || null,
         state: formData.isRemote ? null : formData.state || null,
+        district: formData.isRemote ? null : formData.district || null,
         country: formData.isRemote ? null : formData.country || null,
         max_distance_km: formData.isRemote
           ? null

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -498,12 +498,19 @@ const TeamDetailsModal = ({
         console.error("Error fetching team details:", err);
         // Only show error if we don't have any data to display
         if (!team) {
-          setNotification({
-            type: "error",
-            message:
-              "Server error: " +
-              (err.response?.data?.error || err.message || "Unknown error"),
-          });
+          if (err.response?.status === 404) {
+            setNotification({
+              type: "error",
+              message: "Team not found or you don't have access to it.",
+            });
+          } else {
+            setNotification({
+              type: "error",
+              message:
+                "Server error: " +
+                (err.response?.data?.error || err.message || "Unknown error"),
+            });
+          }
         }
         return null;
       } finally {
@@ -1119,6 +1126,7 @@ const TeamDetailsModal = ({
           : formData.postalCode?.trim() || null,
         city: isRemoteBoolean ? null : formData.city?.trim() || null,
         state: isRemoteBoolean ? null : formData.state?.trim() || null,
+        district: isRemoteBoolean ? null : formData.district?.trim() || null,
         country: isRemoteBoolean ? null : formData.country?.trim() || null,
       };
 

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -49,6 +49,10 @@ import { teamService } from "../../services/teamService";
 import { useAuth } from "../../contexts/AuthContext";
 import { format } from "date-fns";
 import { formatDisplayName } from "../../utils/nameFormatters";
+import {
+  formatLocation,
+  normalizeLocationData,
+} from "../../utils/locationUtils";
 
 const userPendingApplicationsCache = new Map();
 const userReceivedInvitationsCache = new Map();
@@ -560,8 +564,12 @@ const VacantRoleCard = ({
 
   const getLocationText = () => {
     if (is_remote) return "Remote";
-    const parts = [city, country].filter(Boolean);
-    return parts.length > 0 ? parts.join(", ") : null;
+    return formatLocation(normalizeLocationData(role), {
+      displayType: "full",
+      showPostalCode: true,
+      showState: true,
+      showCountry: true,
+    }) || null;
   };
 
   const locationText = getLocationText();
@@ -817,18 +825,27 @@ const VacantRoleCard = ({
     </Tooltip>
   ) : null;
   const miniLocationSubtitleItem =
-    isMiniView && !activeFilters.showLocation && locationText ? (
-      <span className="inline-flex min-w-0 items-center gap-0.5 leading-none">
-        {is_remote ? (
-          <>
-            <Globe size={10} className="flex-shrink-0" />
-            <span className="leading-[1.05]">{locationText}</span>
-          </>
-        ) : (
-          <>
-            <MapPin size={10} className="flex-shrink-0" />
-            <span className="leading-[1.05]">{locationText}</span>
-          </>
+    isMiniView &&
+    !activeFilters.showLocation &&
+    (locationText || showDistance) ? (
+      <span className="inline-flex min-w-0 items-center gap-1 leading-none">
+        {locationText && (
+          <span className="inline-flex min-w-0 items-center gap-0.5">
+            {is_remote ? (
+              <Globe size={10} className="flex-shrink-0" />
+            ) : (
+              <MapPin size={10} className="flex-shrink-0" />
+            )}
+            <span className="min-w-0 truncate leading-[1.05]">
+              {locationText}
+            </span>
+          </span>
+        )}
+        {showDistance && (
+          <span className="inline-flex items-center gap-0.5 whitespace-nowrap text-base-content">
+            <Ruler size={10} className="flex-shrink-0" />
+            <span>{Math.round(rawDistanceKm)} km</span>
+          </span>
         )}
       </span>
     ) : null;
@@ -1208,6 +1225,7 @@ const VacantRoleCard = ({
           <LocationDistanceTagsRow
             entity={role}
             entityType="team"
+            distance={showDistance ? rawDistanceKm : null}
             tags={viewMode === "mini" && !activeFilters.showTags ? null : tagNames}
             badges={
               viewMode === "mini" && !activeFilters.showBadges
@@ -1474,6 +1492,12 @@ const VacantRoleCard = ({
                     <span className="truncate">{locationText}</span>
                   </span>
                 )}
+                {showDistance && (
+                  <span className="flex items-center gap-1 text-base-content">
+                    <Ruler size={10} className="shrink-0" />
+                    <span>{Math.round(rawDistanceKm)} km away</span>
+                  </span>
+                )}
                 {!is_remote && max_distance_km && (
                   <span className="flex items-center gap-1 text-base-content/50">
                     <CircleDot size={10} className="shrink-0" />
@@ -1482,7 +1506,7 @@ const VacantRoleCard = ({
                 )}
                 {demoRoleMetaItem}
               </div>
-            ) : locationText || (!is_remote && max_distance_km) || demoRoleMetaItem ? (
+            ) : locationText || showDistance || (!is_remote && max_distance_km) || demoRoleMetaItem ? (
               <div className="mt-0.5 flex max-h-[2.1em] flex-wrap items-center gap-2 overflow-hidden text-xs text-base-content/60">
                 {locationText && (
                   <span className="flex items-center gap-1 min-w-0">
@@ -1495,6 +1519,12 @@ const VacantRoleCard = ({
                   </span>
                 )}
 
+                {showDistance && (
+                  <span className="flex items-center gap-1 text-base-content">
+                    <Ruler size={10} className="shrink-0" />
+                    <span>{Math.round(rawDistanceKm)} km away</span>
+                  </span>
+                )}
                 {!is_remote && max_distance_km && (
                   <span className="flex items-center gap-1 text-base-content/50">
                     <CircleDot size={10} className="shrink-0" />
@@ -1512,6 +1542,11 @@ const VacantRoleCard = ({
                   {locationText}
                 </CardMetaItem>
               )}
+              {showDistance && (
+                <CardMetaItem icon={Ruler} nowrap>
+                  {Math.round(rawDistanceKm)} km away
+                </CardMetaItem>
+              )}
               {!is_remote && max_distance_km && (
                 <CardMetaItem icon={CircleDot} tone="muted" nowrap>
                   {max_distance_km} km
@@ -1519,7 +1554,7 @@ const VacantRoleCard = ({
               )}
               {demoRoleMetaItem}
             </CardMetaRow>
-          ) : locationText || (!is_remote && max_distance_km) || demoRoleMetaItem ? (
+          ) : locationText || showDistance || (!is_remote && max_distance_km) || demoRoleMetaItem ? (
             <CardMetaRow>
               {locationText && (
                 <CardMetaItem icon={is_remote ? Globe : MapPin}>
@@ -1527,6 +1562,11 @@ const VacantRoleCard = ({
                 </CardMetaItem>
               )}
 
+              {showDistance && (
+                <CardMetaItem icon={Ruler} nowrap>
+                  {Math.round(rawDistanceKm)} km away
+                </CardMetaItem>
+              )}
               {!is_remote && max_distance_km && (
                 <CardMetaItem icon={CircleDot} tone="muted" nowrap>
                   {max_distance_km} km

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -1409,8 +1409,13 @@ const VacantRoleDetailsModal = ({
 
   const getLocationText = () => {
     if (isRemote) return "Remote — no geographic preference";
-    const parts = [city, state, country].filter(Boolean);
-    return parts.length > 0 ? parts.join(", ") : null;
+
+    return formatLocation(normalizeLocationData(displayRole), {
+      displayType: "full",
+      showPostalCode: true,
+      showState: true,
+      showCountry: true,
+    }) || null;
   };
 
   const getPersonLocationText = (person, fallbackDistanceKm = null) => {

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -25,6 +25,7 @@ import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
+import { formatLocation, normalizeLocationData } from "../../utils/locationUtils";
 
 /**
  * UserCard Component
@@ -206,6 +207,16 @@ const UserCard = ({
   ) : (
     matchOverlay
   );
+  const userLocation = normalizeLocationData(user);
+  const locationText =
+    user.is_remote || user.isRemote
+      ? "Remote"
+      : formatLocation(userLocation, {
+          displayType: "short",
+          showState: true,
+          showCountry: true,
+        });
+
   const demoAvatarOverlay = isSyntheticUser(user) ? (
     <DemoAvatarOverlay
       textClassName={
@@ -227,10 +238,6 @@ const UserCard = ({
 
   // ============ LIST VIEW ============
   if (viewMode === "list") {
-    const locationText =
-      user.is_remote || user.isRemote
-        ? "Remote"
-        : [user.city, user.country].filter(Boolean).join(", ");
     const distance = user.distanceKm ?? user.distance_km;
     const showDistance = distance != null && distance < 999999 && !(user.is_remote || user.isRemote);
 
@@ -380,7 +387,7 @@ const UserCard = ({
           )}
           {viewMode === "mini" &&
             !activeFilters.showLocation &&
-            (user.is_remote || user.isRemote || user.city || user.country) && (
+            locationText && (
               <span className="flex items-start">
                 {user.is_remote || user.isRemote ? (
                   <Globe size={12} className="mr-0.5 flex-shrink-0 mt-0.5" />
@@ -388,9 +395,7 @@ const UserCard = ({
                   <MapPin size={12} className="mr-0.5 flex-shrink-0 mt-0.5" />
                 )}
                 <span>
-                  {user.is_remote || user.isRemote
-                    ? "Remote"
-                    : [user.city, user.country].filter(Boolean).join(", ")}
+                  {locationText}
                 </span>
               </span>
             )}

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -10,6 +10,7 @@ import BadgeCategoryModal from "../badges/BadgeCategoryModal";
 import TagAwardsModal from "../badges/TagAwardsModal";
 import UserProfileHeaderSection from "./UserProfileHeaderSection";
 import { messageService } from "../../services/messageService";
+import { geocodingService } from "../../services/geocodingService";
 import { userService } from "../../services/userService";
 import {
   useUserBadges,
@@ -196,6 +197,14 @@ const UserDetailsModal = ({
     setLoading(viewedUserProfileQuery.isLoading);
   }, [viewedUserProfileQuery.isLoading]);
 
+  // Force a fresh fetch whenever this modal opens so that privacy access level
+  // is always evaluated against the current auth state (avoids stale cache).
+  useEffect(() => {
+    if (isOpen && userId) {
+      queryClient.invalidateQueries({ queryKey: userProfileQueryKey(userId) });
+    }
+  }, [isOpen, userId, queryClient]);
+
   useEffect(() => {
     if (!isOpen || !userId) return;
     if (!viewedUserProfileQuery.data) return;
@@ -262,6 +271,62 @@ const UserDetailsModal = ({
     console.error("Error fetching user tags:", viewedUserTagsQuery.error);
     setUserTags([]);
   }, [viewedUserTagsQuery.error]);
+
+  // Enrich postal-code-only locations with city, district, and state.
+  // The geocoding service has an in-memory cache so repeated lookups are free.
+  useEffect(() => {
+    if (!user) return;
+    const postalCode = user.postal_code || user.postalCode;
+    if (!postalCode) return;
+
+    const hasAllLocationDetails =
+      user.city &&
+      user.state &&
+      (user.district || user.suburb || user.borough || user.cityDistrict);
+    if (hasAllLocationDetails) return;
+
+    const country = user.country; // may be null; geocodingService.detectCountryCode will fall back
+    geocodingService
+      .getLocationFromPostalCode(postalCode, country || null)
+      .then((locationInfo) => {
+        if (!locationInfo) return;
+        setUser((prev) => {
+          if (!prev) return prev;
+
+          const nextDistrict =
+            prev.district ||
+            locationInfo.district ||
+            locationInfo.suburb ||
+            locationInfo.borough ||
+            locationInfo.cityDistrict;
+          const nextUser = {
+            ...prev,
+            city: prev.city || locationInfo.city,
+            state: prev.state || locationInfo.state,
+            country: prev.country || locationInfo.country,
+            district: nextDistrict,
+          };
+
+          return nextUser.city === prev.city &&
+            nextUser.state === prev.state &&
+            nextUser.country === prev.country &&
+            nextUser.district === prev.district
+            ? prev
+            : nextUser;
+        });
+      })
+      .catch(() => {}); // silently fail — location falls back to known profile fields
+  }, [
+    user?.id,
+    user?.postal_code,
+    user?.postalCode,
+    user?.city,
+    user?.state,
+    user?.district,
+    user?.suburb,
+    user?.borough,
+    user?.cityDistrict,
+  ]);
 
   // Resolve CURRENT user's tags/badges for overlap highlighting (not the viewed user's)
   useEffect(() => {
@@ -677,6 +742,12 @@ const UserDetailsModal = ({
               For comprehensive profile editing, you'll be redirected to the
               full profile page.
             </p>
+          </div>
+        ) : (!ownProfile && (user?.profileAccess === "limited" || user?.profile_access === "limited")) ? (
+          // PRIVATE PROFILE - non-owner, non-teammate viewing a private account
+          <div className="text-center text-base-content/60 py-8">
+            <p className="text-lg font-medium">{user.username}</p>
+            <p className="text-sm mt-2">This profile is private.</p>
           </div>
         ) : (
           // VIEW MODE - User profile information

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -886,6 +886,7 @@ const Profile = () => {
           country: formData.country,
           // Pick up geocoded state & coordinates from the API response
           state: response.data?.state ?? user.state,
+          district: response.data?.district ?? user.district,
           latitude: response.data?.latitude ?? user.latitude,
           longitude: response.data?.longitude ?? user.longitude,
           // Use the avatar URL from ImageKit if we uploaded a new image,
@@ -973,6 +974,7 @@ const Profile = () => {
     postalCode: displayUser.postalCode || "",
     city: displayUser.city || "",
     state: displayUser.state || "",
+    district: displayUser.district || "",
     country: displayUser.country || "",
   };
   const hasProfileLocation = Boolean(

--- a/src/pages/PublicProfile.jsx
+++ b/src/pages/PublicProfile.jsx
@@ -112,6 +112,8 @@ const PublicProfile = () => {
     );
   }
 
+  const isPrivateProfile = user?.profileAccess === "limited" || user?.profile_access === "limited";
+
   return (
     <PageContainer title="Profile" variant="transparent" frame={false}>
       <div className="flex justify-center">
@@ -134,22 +136,30 @@ const PublicProfile = () => {
               </div>
             </div>
 
-            <div className="space-y-2 text-center">
-              <h2 className="text-sm font-medium uppercase tracking-[0.12em] text-base-content/50">
-                Bio
-              </h2>
-              <p className="text-base-content/75">
-                {bio || "This user has not added a bio yet."}
-              </p>
-            </div>
+            {isPrivateProfile ? (
+              <div className="text-center text-base-content/60 py-4">
+                <p className="text-sm">This profile is private.</p>
+              </div>
+            ) : (
+              <>
+                <div className="space-y-2 text-center">
+                  <h2 className="text-sm font-medium uppercase tracking-[0.12em] text-base-content/50">
+                    Bio
+                  </h2>
+                  <p className="text-base-content/75">
+                    {bio || "This user has not added a bio yet."}
+                  </p>
+                </div>
 
-            <BadgesDisplaySection
-              title="Badges"
-              badges={badges}
-              emptyMessage={badgeEmptyMessage}
-              groupByCategory={true}
-              showCredits={true}
-            />
+                <BadgesDisplaySection
+                  title="Badges"
+                  badges={badges}
+                  emptyMessage={badgeEmptyMessage}
+                  groupByCategory={true}
+                  showCredits={true}
+                />
+              </>
+            )}
 
             <div className="flex justify-center">
               <Button variant="ghost" onClick={() => navigate(-1)}>

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -231,6 +231,7 @@ export const teamService = {
         : toNullOrTrimmed(teamData.postal_code ?? teamData.postalCode);
       const city = isRemote ? null : toNullOrTrimmed(teamData.city);
       const state = isRemote ? null : toNullOrTrimmed(teamData.state);
+      const district = isRemote ? null : toNullOrTrimmed(teamData.district);
       const country = isRemote ? null : toNullOrTrimmed(teamData.country);
 
       const dataToSend = {
@@ -240,6 +241,7 @@ export const teamService = {
         postal_code,
         city,
         state,
+        district,
         country,
       };
 

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -38,7 +38,9 @@ export const userService = {
     ).then(normalizeUserPayload),
 
   searchUsers: (query) =>
-    api.get(`/api/users?search=${encodeURIComponent(query)}`),
+    api.get("/api/search/global", {
+      params: { searchType: "users", query },
+    }),
 
   /**
    * Updates user details. Keeps the verbose error block because we want the

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -193,14 +193,280 @@ export const getCountryCode = (countryName) => {
 const firstPresent = (...values) =>
   values.find((value) => value !== null && value !== undefined && value !== "");
 
+const normalizePostalCode = (value) =>
+  value === null || value === undefined ? "" : String(value).trim().toUpperCase();
+
+const normalizeLocationKey = (value) =>
+  value === null || value === undefined
+    ? ""
+    : String(value)
+        .trim()
+        .toLowerCase()
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "");
+
+const sameLocationPart = (left, right) =>
+  normalizeLocationKey(left) === normalizeLocationKey(right);
+
+const appendUniqueLocationPart = (parts, value) => {
+  if (!value) return;
+  if (!parts.some((part) => sameLocationPart(part, value))) {
+    parts.push(value);
+  }
+};
+
+const BERLIN_POSTAL_CODE_DISTRICTS = {
+  10115: "Mitte",
+  10117: "Mitte",
+  10119: "Mitte",
+  10178: "Mitte",
+  10179: "Mitte",
+  10243: "Friedrichshain",
+  10245: "Friedrichshain",
+  10247: "Friedrichshain",
+  10249: "Friedrichshain",
+  10315: "Lichtenberg",
+  10317: "Lichtenberg",
+  10318: "Karlshorst",
+  10319: "Friedrichsfelde",
+  10365: "Lichtenberg",
+  10367: "Lichtenberg",
+  10369: "Lichtenberg",
+  10405: "Prenzlauer Berg",
+  10407: "Prenzlauer Berg",
+  10409: "Prenzlauer Berg",
+  10435: "Prenzlauer Berg",
+  10437: "Prenzlauer Berg",
+  10439: "Prenzlauer Berg",
+  10551: "Moabit",
+  10553: "Moabit",
+  10555: "Moabit",
+  10557: "Tiergarten",
+  10559: "Moabit",
+  10585: "Charlottenburg",
+  10587: "Charlottenburg",
+  10589: "Charlottenburg",
+  10623: "Charlottenburg",
+  10625: "Charlottenburg",
+  10627: "Charlottenburg",
+  10629: "Charlottenburg",
+  10707: "Wilmersdorf",
+  10709: "Wilmersdorf",
+  10711: "Halensee",
+  10713: "Wilmersdorf",
+  10715: "Wilmersdorf",
+  10717: "Wilmersdorf",
+  10719: "Charlottenburg",
+  10777: "Schöneberg",
+  10779: "Schöneberg",
+  10781: "Schöneberg",
+  10783: "Schöneberg",
+  10785: "Tiergarten",
+  10787: "Schöneberg",
+  10789: "Charlottenburg",
+  10823: "Schöneberg",
+  10825: "Schöneberg",
+  10827: "Schöneberg",
+  10829: "Schöneberg",
+  10961: "Kreuzberg",
+  10963: "Kreuzberg",
+  10965: "Kreuzberg",
+  10967: "Kreuzberg",
+  10969: "Kreuzberg",
+  10997: "Kreuzberg",
+  10999: "Kreuzberg",
+  12043: "Neukölln",
+  12045: "Neukölln",
+  12047: "Neukölln",
+  12049: "Neukölln",
+  12051: "Neukölln",
+  12053: "Neukölln",
+  12055: "Neukölln",
+  12057: "Neukölln",
+  12059: "Neukölln",
+  12101: "Tempelhof",
+  12103: "Tempelhof",
+  12105: "Tempelhof",
+  12107: "Tempelhof",
+  12109: "Tempelhof",
+  12157: "Steglitz",
+  12159: "Friedenau",
+  12161: "Friedenau",
+  12163: "Steglitz",
+  12165: "Steglitz",
+  12167: "Steglitz",
+  12169: "Steglitz",
+  12203: "Lichterfelde",
+  12205: "Lichterfelde",
+  12207: "Lichterfelde",
+  12209: "Lichterfelde",
+  12247: "Lankwitz",
+  12249: "Lankwitz",
+  12277: "Marienfelde",
+  12279: "Marienfelde",
+  12305: "Lichtenrade",
+  12307: "Lichtenrade",
+  12309: "Lichtenrade",
+  12347: "Britz",
+  12349: "Buckow",
+  12351: "Buckow",
+  12353: "Buckow",
+  12355: "Rudow",
+  12357: "Rudow",
+  12359: "Britz",
+  12435: "Alt-Treptow",
+  12437: "Baumschulenweg",
+  12439: "Niederschöneweide",
+  12459: "Oberschöneweide",
+  12487: "Johannisthal",
+  12489: "Adlershof",
+  12524: "Altglienicke",
+  12526: "Bohnsdorf",
+  12527: "Grünau",
+  12555: "Köpenick",
+  12557: "Köpenick",
+  12559: "Köpenick",
+  12587: "Friedrichshagen",
+  12589: "Rahnsdorf",
+  12619: "Kaulsdorf",
+  12621: "Kaulsdorf",
+  12623: "Mahlsdorf",
+  12627: "Hellersdorf",
+  12629: "Hellersdorf",
+  12679: "Marzahn",
+  12681: "Marzahn",
+  12683: "Biesdorf",
+  12685: "Marzahn",
+  12687: "Marzahn",
+  12689: "Marzahn",
+  13051: "Wartenberg",
+  13053: "Hohenschönhausen",
+  13055: "Hohenschönhausen",
+  13057: "Hohenschönhausen",
+  13059: "Wartenberg",
+  13086: "Weißensee",
+  13088: "Weißensee",
+  13089: "Heinersdorf",
+  13125: "Buch",
+  13127: "Pankow",
+  13129: "Blankenburg",
+  13156: "Niederschönhausen",
+  13158: "Rosenthal",
+  13159: "Blankenfelde",
+  13187: "Pankow",
+  13189: "Pankow",
+  13347: "Wedding",
+  13349: "Wedding",
+  13351: "Wedding",
+  13353: "Wedding",
+  13355: "Gesundbrunnen",
+  13357: "Gesundbrunnen",
+  13359: "Gesundbrunnen",
+  13403: "Reinickendorf",
+  13405: "Reinickendorf",
+  13407: "Reinickendorf",
+  13409: "Reinickendorf",
+  13435: "Märkisches Viertel",
+  13437: "Wittenau",
+  13439: "Märkisches Viertel",
+  13465: "Frohnau",
+  13467: "Hermsdorf",
+  13469: "Waidmannslust",
+  13503: "Heiligensee",
+  13505: "Konradshöhe",
+  13507: "Tegel",
+  13509: "Tegel",
+  13581: "Spandau",
+  13583: "Spandau",
+  13585: "Spandau",
+  13587: "Hakenfelde",
+  13589: "Falkenhagener Feld",
+  13591: "Staaken",
+  13593: "Wilhelmstadt",
+  13595: "Wilhelmstadt",
+  13597: "Spandau",
+  13599: "Haselhorst",
+  13627: "Charlottenburg",
+  13629: "Siemensstadt",
+  14050: "Westend",
+  14052: "Westend",
+  14053: "Westend",
+  14055: "Westend",
+  14057: "Charlottenburg",
+  14059: "Charlottenburg",
+  14089: "Kladow",
+  14109: "Wannsee",
+  14129: "Nikolassee",
+  14163: "Zehlendorf",
+  14165: "Zehlendorf",
+  14167: "Zehlendorf",
+  14169: "Zehlendorf",
+  14193: "Grunewald",
+  14195: "Dahlem",
+  14197: "Wilmersdorf",
+  14199: "Wilmersdorf",
+};
+
+const FRANKFURT_POSTAL_CODE_DISTRICTS = {
+  60308: "Westend-Süd",
+  60310: "Innenstadt",
+  60311: "Innenstadt",
+  60313: "Innenstadt",
+  60329: "Bahnhofsviertel",
+  60389: "Nordend-Ost",
+  65933: "Griesheim",
+  65934: "Höchst",
+  65936: "Nied",
+};
+
+export const deriveLocationFromPostalCode = (postalCode, country) => {
+  const code = normalizePostalCode(postalCode);
+  if (!code) return {};
+
+  const countryCode = getCountryCode(country) || (country ? String(country).toUpperCase() : null);
+  if (countryCode && countryCode !== "DE") return {};
+
+  const berlinDistrict = BERLIN_POSTAL_CODE_DISTRICTS[code];
+  if (berlinDistrict) {
+    return {
+      city: "Berlin",
+      state: "Berlin",
+      country: "Germany",
+      district: berlinDistrict,
+    };
+  }
+
+  if (/^10\d{3}$|^11\d{3}$|^12\d{3}$|^13\d{3}$|^14[01]\d{2}$/.test(code)) {
+    return { city: "Berlin", state: "Berlin", country: "Germany" };
+  }
+
+  const frankfurtDistrict = FRANKFURT_POSTAL_CODE_DISTRICTS[code];
+  if (frankfurtDistrict) {
+    return {
+      city: "Frankfurt am Main",
+      state: "Hessen",
+      country: "Germany",
+      district: frankfurtDistrict,
+    };
+  }
+
+  if (/^60\d{3}$|^65\d{3}$/.test(code)) {
+    return { city: "Frankfurt am Main", state: "Hessen", country: "Germany" };
+  }
+
+  return {};
+};
+
 export const normalizeLocationData = (entity) => {
   if (!entity) {
     return {
       postalCode: null,
+      district: null,
       city: null,
       state: null,
       country: null,
       countryName: null,
+      countryCode: null,
       latitude: null,
       longitude: null,
       isRemote: false,
@@ -218,24 +484,51 @@ export const normalizeLocationData = (entity) => {
     entity.roleLocation?.postal_code,
     entity.roleLocation?.postalCode,
   ) ?? null;
-  const city = firstPresent(
-    entity.city,
-    entity.location?.city,
-    entity.role_location?.city,
-    entity.roleLocation?.city,
-  ) ?? null;
-  const state = firstPresent(
-    entity.state,
-    entity.location?.state,
-    entity.role_location?.state,
-    entity.roleLocation?.state,
-  ) ?? null;
   const country = firstPresent(
     entity.country,
     entity.location?.country,
     entity.role_location?.country,
     entity.roleLocation?.country,
   ) ?? null;
+  const derivedLocation = deriveLocationFromPostalCode(postalCode, country);
+  const city = firstPresent(
+    entity.city,
+    entity.location?.city,
+    entity.role_location?.city,
+    entity.roleLocation?.city,
+    derivedLocation.city,
+  ) ?? null;
+  const state = firstPresent(
+    entity.state,
+    entity.location?.state,
+    entity.role_location?.state,
+    entity.roleLocation?.state,
+    derivedLocation.state,
+  ) ?? null;
+  const district = firstPresent(
+    entity.district,
+    entity.suburb,
+    entity.borough,
+    entity.cityDistrict,
+    entity.city_district,
+    entity.location?.district,
+    entity.location?.suburb,
+    entity.location?.borough,
+    entity.location?.cityDistrict,
+    entity.location?.city_district,
+    entity.role_location?.district,
+    entity.role_location?.suburb,
+    entity.role_location?.borough,
+    entity.role_location?.cityDistrict,
+    entity.role_location?.city_district,
+    entity.roleLocation?.district,
+    entity.roleLocation?.suburb,
+    entity.roleLocation?.borough,
+    entity.roleLocation?.cityDistrict,
+    entity.roleLocation?.city_district,
+    derivedLocation.district,
+  ) ?? null;
+  const countryCode = getCountryCode(country);
   const latitude = firstPresent(
     entity.latitude,
     entity.lat,
@@ -263,14 +556,16 @@ export const normalizeLocationData = (entity) => {
   const isRemote = entity.is_remote === true || entity.isRemote === true;
 
   // Determine if we have any location data
-  const hasLocation = isRemote || !!(city || postalCode || state || country);
+  const hasLocation = isRemote || !!(district || city || postalCode || state || country);
 
   return {
     postalCode,
+    district,
     city,
     state,
     country,
     countryName: getCountryDisplayName(country),
+    countryCode,
     latitude,
     longitude,
     isRemote,
@@ -322,6 +617,7 @@ export const locationsHaveDifferentKnownParts = (source, target) => {
  * @param {boolean} options.showPostalCode - Include postal code in output
  * @param {boolean} options.showState - Include state/region in output
  * @param {boolean} options.showCountry - Include country in output
+ * @param {boolean} options.showCountryCode - Include ISO country code in output
  * @returns {string} Formatted location string
  */
 export const formatLocation = (locationData, options = {}) => {
@@ -330,52 +626,80 @@ export const formatLocation = (locationData, options = {}) => {
     showPostalCode = false,
     showState = false,
     showCountry = true,
+    showCountryCode = true,
   } = options;
 
-  const { postalCode, city, state, countryName } = locationData;
+  const { postalCode, district, city, state, countryName, countryCode } = locationData;
 
-  if (!city && !postalCode && !state && !countryName) {
+  if (!district && !city && !postalCode && !state && !countryName && !countryCode) {
     return "";
   }
+
+  const appendCountryParts = () => {
+    if (!showCountry) return;
+    appendUniqueLocationPart(parts, countryName);
+    if (showCountryCode && countryCode && !sameLocationPart(countryCode, countryName)) {
+      appendUniqueLocationPart(parts, countryCode);
+    }
+  };
 
   const parts = [];
 
   switch (displayType) {
     case "city-only":
-      if (city) parts.push(city);
+      appendUniqueLocationPart(parts, district || city);
       break;
 
     case "full":
-      // Full format: postal code + city, state, country
-      if (showPostalCode && postalCode && city) {
+      // Full format: postal code + district/city, state, country
+      if (showPostalCode && postalCode && district) {
+        parts.push(`${postalCode} ${district}`);
+        appendUniqueLocationPart(parts, city);
+      } else if (showPostalCode && postalCode && city) {
         parts.push(`${postalCode} ${city}`);
+      } else if (district) {
+        parts.push(district);
+        appendUniqueLocationPart(parts, city);
       } else if (city) {
         parts.push(city);
       } else if (postalCode) {
         parts.push(postalCode);
       }
 
-      if (showState && state) {
-        parts.push(state);
+      if (
+        showState &&
+        state &&
+        !sameLocationPart(state, city) &&
+        !sameLocationPart(state, district)
+      ) {
+        appendUniqueLocationPart(parts, state);
       }
 
-      if (showCountry && countryName) {
-        parts.push(countryName);
-      }
+      appendCountryParts();
       break;
 
     case "short":
     default:
-      // Short format: city, country
-      if (city) {
+      // Short format: district/city, optional state, country
+      if (district) {
+        parts.push(district);
+        appendUniqueLocationPart(parts, city);
+      } else if (city) {
         parts.push(city);
       } else if (postalCode) {
         parts.push(postalCode);
       }
 
-      if (showCountry && countryName) {
-        parts.push(countryName);
+      if (
+        showState &&
+        state &&
+        !sameLocationPart(state, city) &&
+        !sameLocationPart(state, district)
+      ) {
+        appendUniqueLocationPart(parts, state);
       }
+
+      appendCountryParts();
       break;
   }
 
@@ -456,6 +780,7 @@ export default {
   COUNTRY_NAME_TO_CODE,
   getCountryDisplayName,
   getCountryCode,
+  deriveLocationFromPostalCode,
   normalizeLocationData,
   formatLocation,
   hasLocationChanged,


### PR DESCRIPTION
Summary
This branch brings together several independent features and a security hardening pass that were developed sequentially off main. The core theme is tightening the auth/registration flow, improving user privacy, and enriching location display across the app.

Security & Privacy
Private profile protection — The backend now returns profile_access: "limited" for profiles viewed by non-owners and non-teammates. UserDetailsModal and PublicProfile detect this flag and render a "This profile is private" message instead of leaking any profile data. UserDetailsModal also invalidates its React Query cache on every open so the access check is always evaluated against the current auth state, not a stale cache.
Approximate coordinates — Search results now carry approximate_latitude / approximate_longitude (backend-rounded to ~11 km). SearchMapView reads these fields for map placement; exact GPS coordinates are never sent to the frontend.
userService.searchUsers endpoint fix — Previously called the defunct /api/users?search=... endpoint (the hardened getUsers ignores search params). Now routes to /api/search/global?searchType=users&query=... and the @mention name-resolution fallback in MessageDisplay reads res.data.data.users to match the search response shape.
Contact Page (/contact)
New public contact page with an email form and optional Cloudflare Turnstile CAPTCHA (feature-flagged via VITE_TURNSTILE_SITE_KEY)
Up to 5 file attachments per submission (25 MB each — images, PDF, Word, Excel, PPT, TXT, ZIP)
Authenticated users with VITE_LOMIR_CONTACT_USER_ID configured are redirected to in-app chat instead of the form
On submit, the form collapses and a success toast is shown
Registration & Auth
Real-time availability checks — Email and username fields in RegisterForm now perform debounced backend availability checks as the user types, showing inline feedback before form submission
Improved validation UX — Field errors animate in, the shared Alert component supports multi-line content via children, and form-level errors are cleared on field change
Auto-delete of unverified accounts — Accounts not verified within 24 hours are automatically deleted by the backend. VerifyEmail now shows a contextual message when a link has expired ("your registration may have been removed; you can sign up again with the same email address")
Forgot-password link restored — The login form correctly links to /forgot-password with a self-service reset flow
Self-hosted Fonts (GDPR)
Roboto woff2 files (weights 300 / 400 / 500 / 700) served from public/fonts/ with @font-face declarations in index.css
index.html no longer loads anything from Google's CDN — eliminates the third-party font request that could log user IPs
Location Display
New formatLocation and normalizeLocationData utilities in locationUtils.js build smart, de-duplicated location strings (city → district → state → country with fallback logic and accent-insensitive deduplication)
Berlin postal code → district lookup table (200+ codes) for richer location display when only a postal code is stored
UserDetailsModal enriches postal-code-only profiles on-the-fly via geocodingService (in-memory cache, silent failure)
UserCard, UserProfileHeaderSection, VacantRoleCard, VacantRoleDetailsModal, and SearchMapView all updated to use formatLocation / normalizeLocationData instead of ad-hoc city + country concatenation
Distance on role cards — VacantRoleCard and its mini-card layout now show a distance indicator (km) alongside location when distance_km is present in search results
README
Updated to reflect all of the above: features list, Security bullet, Search & Matching section, project structure (locationUtils.js, PublicProfile.jsx, users/ component list), and Key Pages table.

Test plan
 Registration: type an already-taken email → inline "already in use" error appears before submit
 Registration: complete sign-up → email arrives, verify link works; verify expired-link message is shown for old links
 Login: forgot-password link opens /forgot-password and reset email arrives
 Contact form: submit without attachment; submit with attachment; submit as authenticated user with contact ID set (→ routed to chat)
 Search results: map markers render; clicking a marker shows the popup with card
 Search results: role card shows distance when proximity sort is active
 Private profile: view a non-public user's profile modal → shows "This profile is private"
 Own profile: editing and saving still works, location fields update correctly
 Public profile page (/profile/:id) for a private user: shows "This profile is private"
 @mention in chat: clicking a mention resolves the user (fallback search now uses correct endpoint)
 Browser network tab: no requests to fonts.googleapis.com or fonts.gstatic.com
 npm run build passes with no errors