### PR TITLE
Refactor/cleanup

### DIFF
--- a/src/components/badges/BadgeAwardModal.jsx
+++ b/src/components/badges/BadgeAwardModal.jsx
@@ -32,15 +32,12 @@ import Modal from "../common/Modal";
 import Button from "../common/Button";
 import Alert from "../common/Alert";
 import Tooltip from "../common/Tooltip";
-import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import UserAvatar from "../users/UserAvatar";
 import { badgeService } from "../../services/badgeService";
 import { tagService } from "../../services/tagService";
 import { useBadges, useSharedTeamsForAward } from "../../hooks/useBadgeQueries";
 import { useUserTags } from "../../hooks/useUserQueries";
-import {
-  getUserInitials,
-  DEMO_PROFILE_TOOLTIP,
-} from "../../utils/userHelpers";
+import { DEMO_PROFILE_TOOLTIP } from "../../utils/userHelpers";
 
 /**
  * BadgeAwardModal Component
@@ -451,65 +448,37 @@ const BadgeAwardModal = ({
           <div className="flex items-start space-x-3 mb-3">
             {onUserClick ? (
               <Tooltip content="View profile" position="bottom" wrapperClassName="block">
-                <div
-                  className="avatar cursor-pointer hover:opacity-80 transition-opacity"
+                <UserAvatar
+                  user={{
+                    avatar_url: awardeeAvatar,
+                    avatarUrl: awardeeAvatar,
+                    first_name: awardeeFirstName,
+                    last_name: awardeeLastName,
+                    username: awardeeUsername,
+                  }}
+                  sizeClass="w-12 h-12"
+                  clickable
                   onClick={() => onUserClick(awardeeId)}
-                >
-                  <div className="w-12 h-12 rounded-full relative overflow-hidden">
-                    {awardeeAvatar ? (
-                      <img
-                        src={awardeeAvatar}
-                        alt={awardeeUsername}
-                        className="object-cover w-full h-full rounded-full"
-                        onError={(e) => {
-                          e.target.style.display = "none";
-                          const fallback = e.target.parentElement.querySelector(".avatar-fallback");
-                          if (fallback) fallback.style.display = "flex";
-                        }}
-                      />
-                    ) : null}
-                    <div
-                      className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                      style={{ display: awardeeAvatar ? "none" : "flex" }}
-                    >
-                      <span className="text-lg font-medium">
-                        {getUserInitials({ first_name: awardeeFirstName, last_name: awardeeLastName, username: awardeeUsername })}
-                      </span>
-                    </div>
-                    {awardeeIsDemo && (
-                      <DemoAvatarOverlay textClassName="text-[8px]" textTranslateClassName="-translate-y-[3px]" />
-                    )}
-                  </div>
-                </div>
+                  title="View profile"
+                  showDemoOverlay={awardeeIsDemo}
+                  demoOverlayTextClassName="text-[8px]"
+                  demoOverlayTextTranslateClassName="-translate-y-[3px]"
+                />
               </Tooltip>
             ) : (
-              <div className="avatar">
-                <div className="w-12 h-12 rounded-full relative overflow-hidden">
-                  {awardeeAvatar ? (
-                    <img
-                      src={awardeeAvatar}
-                      alt={awardeeUsername}
-                      className="object-cover w-full h-full rounded-full"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        const fallback = e.target.parentElement.querySelector(".avatar-fallback");
-                        if (fallback) fallback.style.display = "flex";
-                      }}
-                    />
-                  ) : null}
-                  <div
-                    className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                    style={{ display: awardeeAvatar ? "none" : "flex" }}
-                  >
-                    <span className="text-lg font-medium">
-                      {getUserInitials({ first_name: awardeeFirstName, last_name: awardeeLastName, username: awardeeUsername })}
-                    </span>
-                  </div>
-                  {awardeeIsDemo && (
-                    <DemoAvatarOverlay textClassName="text-[8px]" textTranslateClassName="-translate-y-[3px]" />
-                  )}
-                </div>
-              </div>
+              <UserAvatar
+                user={{
+                  avatar_url: awardeeAvatar,
+                  avatarUrl: awardeeAvatar,
+                  first_name: awardeeFirstName,
+                  last_name: awardeeLastName,
+                  username: awardeeUsername,
+                }}
+                sizeClass="w-12 h-12"
+                showDemoOverlay={awardeeIsDemo}
+                demoOverlayTextClassName="text-[8px]"
+                demoOverlayTextTranslateClassName="-translate-y-[3px]"
+              />
             )}
 
             <div className="flex-1 min-w-0">

--- a/src/components/badges/BadgesDisplaySection.jsx
+++ b/src/components/badges/BadgesDisplaySection.jsx
@@ -91,7 +91,7 @@ const BadgesDisplaySection = ({
   const pillCount = (badges || []).length;
 
   const titleSummary = totalCredits > 0 ? (
-    <span className="min-w-0 text-sm font-normal text-base-content/60 whitespace-nowrap">
+    <span className="min-w-0 text-sm font-normal text-base-content/60 whitespace-normal sm:whitespace-nowrap">
       ({totalCredits} ct. in {pillCount} {pillCount === 1 ? 'area' : 'areas'})
     </span>
   ) : null;
@@ -100,16 +100,18 @@ const BadgesDisplaySection = ({
     <div className="flex items-start gap-2 mb-3">
       <Award size={18} className="mt-0.5 text-primary flex-shrink-0" />
       <div className="min-w-0 flex-1">
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
-          <div className="min-w-0 flex flex-wrap items-baseline gap-x-1 gap-y-0.5">
-            <h3 className="font-medium leading-5 whitespace-nowrap">{title}</h3>
-            {titleSummary}
-          </div>
-          {headerRight && (
-            <div className="flex items-center justify-end gap-2 text-right whitespace-nowrap">
-              {headerRight}
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-x-3 gap-y-0.5">
+            <div className="min-w-0 flex flex-wrap items-baseline gap-x-1 gap-y-0.5">
+              <h3 className="font-medium leading-[1.1] break-words sm:whitespace-nowrap">{title}</h3>
+              {titleSummary}
             </div>
-          )}
+            {headerRight && (
+              <div className="shrink-0">
+                {headerRight}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/common/ListViewRow.jsx
+++ b/src/components/common/ListViewRow.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { MapPin, Globe, Tag, Award, Ruler } from "lucide-react";
+import Tooltip from "./Tooltip";
+
+const ListViewRow = ({
+  locationText,
+  locationTooltip,
+  isRemote = false,
+  distance = null,
+  tagsSummary,
+  tagsTooltip,
+  badgesSummary,
+  badgesTooltip,
+  actionSlot = null,
+  locationVisibilityClassName = "flex",
+  locationWidthClassName = "",
+  locationInsetClassName = "",
+  tagsWidthClassName = "",
+  badgesWidthClassName = "",
+  locationBreakpoint = "sm",
+  className = "",
+}) => {
+  const LocationIcon = isRemote ? Globe : MapPin;
+  const shortBreakpointClass = locationBreakpoint === "md" ? "md:hidden" : "sm:hidden";
+  const fullBreakpointClass = locationBreakpoint === "md" ? "hidden md:block" : "hidden sm:block";
+
+  return (
+    <div className={`flex items-stretch ${className}`}>
+      <div
+        className={`box-border ${locationVisibilityClassName} w-24 flex-shrink-0 items-center gap-3 overflow-hidden sm:w-56 ${locationWidthClassName} ${locationInsetClassName}`}
+      >
+        {distance != null && (
+          <div className="hidden w-16 flex-shrink-0 overflow-hidden md:block">
+            <div className="text-xs text-base-content flex items-center gap-1 overflow-hidden">
+              <Tooltip content={`${Math.round(distance)} km away from you`}>
+                <div className="flex items-center gap-1">
+                  <Ruler size={9} className="flex-shrink-0" />
+                  <span className="whitespace-nowrap">{Math.round(distance)} km</span>
+                </div>
+              </Tooltip>
+            </div>
+          </div>
+        )}
+
+        {locationText && (
+          <div className="min-w-0 text-xs text-base-content/60 flex items-center gap-1 overflow-hidden">
+            <Tooltip
+              content={locationTooltip || locationText}
+              wrapperClassName="flex min-w-0 w-full items-center overflow-hidden"
+            >
+              <div className="flex min-w-0 w-full items-center gap-1 overflow-hidden">
+                <LocationIcon size={9} className="flex-shrink-0" />
+                <span className={`min-w-0 flex-1 truncate ${shortBreakpointClass}`}>
+                  {locationText}
+                </span>
+                <span className={`min-w-0 flex-1 truncate ${fullBreakpointClass}`}>
+                  {locationTooltip || locationText}
+                </span>
+              </div>
+            </Tooltip>
+          </div>
+        )}
+      </div>
+
+      <div
+        className={`hidden w-52 flex-shrink-0 text-xs text-base-content/60 lg:flex items-center gap-1 overflow-hidden ${tagsWidthClassName}`}
+      >
+        {tagsSummary && (
+          <Tooltip
+            content={tagsTooltip || tagsSummary}
+            wrapperClassName="flex items-center gap-1 min-w-0 overflow-hidden w-full"
+          >
+            <Tag size={9} className="flex-shrink-0" />
+            <span className="truncate">{tagsSummary}</span>
+          </Tooltip>
+        )}
+      </div>
+
+      <div
+        className={`hidden w-48 flex-shrink-0 text-xs text-base-content/60 xl:flex items-center gap-1 overflow-hidden ${badgesWidthClassName}`}
+      >
+        {badgesSummary && (
+          <Tooltip
+            content={badgesTooltip || badgesSummary}
+            wrapperClassName="flex items-center gap-1 min-w-0 overflow-hidden w-full"
+          >
+            <Award size={9} className="flex-shrink-0" />
+            <span className="truncate">{badgesSummary}</span>
+          </Tooltip>
+        )}
+      </div>
+
+      {actionSlot && (
+        <div className="w-20 flex-shrink-0 flex items-center justify-end gap-2">
+          {actionSlot}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ListViewRow;

--- a/src/components/common/LocationDistanceTagsRow.jsx
+++ b/src/components/common/LocationDistanceTagsRow.jsx
@@ -67,7 +67,7 @@ const TruncatedList = ({ items, icon: Icon, compact = false }) => {
 
   return (
     <div
-      className={`flex items-start leading-snug text-base-content/70 ${compact ? "text-xs" : "text-sm"}`}
+      className={`flex items-start leading-[110%] text-base-content/70 ${compact ? "text-xs" : "text-sm"}`}
     >
       <Icon size={compact ? 10 : 13} className="mr-1 flex-shrink-0 mt-0.5" />
       <span ref={spanRef}>{displayText}</span>

--- a/src/components/common/LocationSection.jsx
+++ b/src/components/common/LocationSection.jsx
@@ -64,7 +64,7 @@ const LocationSection = ({
   if (compact) {
     return (
       <div
-        className={`flex flex-wrap items-start leading-snug text-sm text-base-content/70 ${className} ${iconSize < 16 ? "gap-x-2 gap-y-1" : "gap-x-3 gap-y-2"}`}
+        className={`flex flex-wrap items-start leading-[110%] text-sm text-base-content/70 ${className} ${iconSize < 16 ? "gap-x-2 gap-y-1" : "gap-x-3 gap-y-2"}`}
       >
         {/* Location info */}
         <div className="flex items-start">
@@ -121,15 +121,17 @@ const LocationSection = ({
     <div className={className}>
       {/* Title row - icon and title together */}
       {shouldShowTitle && (
-        <div className="flex items-center justify-between mb-2">
-          <div className="flex items-center">
-            <IconComponent
-              size={18}
-              className="mr-2 text-primary flex-shrink-0"
-            />
-            <h3 className="font-medium">{title}</h3>
+        <div className="flex items-start gap-2 mb-1">
+          <IconComponent
+            size={18}
+            className="mt-0.5 text-primary flex-shrink-0"
+          />
+          <div className="min-w-0 flex-1 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-x-3 gap-y-0.5">
+            <h3 className="font-medium leading-[1.1]">{title}</h3>
+            {resolvedHeaderRight && (
+              <div className="shrink-0">{resolvedHeaderRight}</div>
+            )}
           </div>
-          {resolvedHeaderRight}
         </div>
       )}
 
@@ -153,6 +155,7 @@ const LocationSection = ({
                 showPostalCode: true,
                 showState: true,
                 showCountry: true,
+                showCountryCode,
               })}
             </span>
           </div>

--- a/src/components/common/MatchScoreOverlay.jsx
+++ b/src/components/common/MatchScoreOverlay.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import Tooltip from "./Tooltip";
+
+const MatchScoreOverlay = ({
+  matchTier,
+  tooltipText,
+  sizeClassName = "w-5 h-5",
+  iconSize = 10,
+  iconClassName = "text-white",
+  positionClassName = "absolute -top-0.5 -left-0.5 z-10",
+  className = "",
+  style,
+  strokeWidth = 2.5,
+}) => {
+  if (!matchTier) {
+    return null;
+  }
+
+  const overlay = (
+    <div
+      aria-label={tooltipText}
+      className={[
+        "rounded-full ring-2 ring-white flex items-center justify-center",
+        matchTier.bg,
+        sizeClassName,
+        positionClassName,
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={style}
+    >
+      <matchTier.Icon
+        size={iconSize}
+        className={iconClassName}
+        strokeWidth={strokeWidth}
+      />
+    </div>
+  );
+
+  if (!tooltipText) {
+    return overlay;
+  }
+
+  return <Tooltip content={tooltipText}>{overlay}</Tooltip>;
+};
+
+export default MatchScoreOverlay;

--- a/src/components/common/MatchScoreSection.jsx
+++ b/src/components/common/MatchScoreSection.jsx
@@ -81,6 +81,8 @@ const MatchScoreSection = ({
   matchDetails,
   comparisonLabel = null,
   roleLabel = null,
+  headline: headlineProp = null,
+  headlineTooltip = null,
 }) => {
   if (matchScore == null) return null;
 
@@ -127,15 +129,6 @@ const MatchScoreSection = ({
     totalBadgeCount > 0 && sharedBadgeCount !== null
       ? Math.round((sharedBadgeCount / totalBadgeCount) * 100)
       : null;
-  const summaryParts = [];
-
-  if (sharedTagCount > 0) {
-    summaryParts.push(pluralize(sharedTagCount, "shared focus area"));
-  }
-  if (sharedBadgeCount > 0) {
-    summaryParts.push(pluralize(sharedBadgeCount, "shared badge"));
-  }
-
   // ── Headline text ─────────────────────────────────────────
   const comparisonSuffix = comparisonLabel
     ? ` of you and ${comparisonLabel}`
@@ -150,18 +143,74 @@ const MatchScoreSection = ({
         ? `the ${normalizedRoleLabel}`
         : `the ${normalizedRoleLabel} role`
     : null;
+  // ── Headline title (overridable via headlineProp) ────────────
   let headline;
-  if (normalizedMatchType === "role_match" && formattedRoleLabel) {
+  if (headlineProp) {
+    headline = headlineProp;
+  } else if (normalizedMatchType === "role_match" && formattedRoleLabel) {
     headline = `${tier.pct}% matching score of ${comparisonLabel || "this person"} with ${formattedRoleLabel}`;
   } else if (normalizedMatchType === "role_match") {
     headline = comparisonLabel
       ? `${tier.pct}% match of your profile with ${comparisonLabel}`
       : `${tier.pct}% match of your profile`;
   } else {
-    headline =
-      summaryParts.length > 0
-        ? `${tier.pct}% profile match${comparisonSuffix} — ${summaryParts.join(", ")}`
-        : `${tier.pct}% profile match${comparisonSuffix}`;
+    headline = `${tier.pct}% profile match${comparisonSuffix}`;
+  }
+
+  // ── Detail line (always computed from matchDetails) ───────────
+  let detailLine = null;
+  if (normalizedMatchType === "role_match" && formattedRoleLabel) {
+    const roleItems = [];
+    if (totalTagCount > 0 && sharedTagCount !== null)
+      roleItems.push(`${sharedTagCount} of ${totalTagCount} required focus areas`);
+    if (totalBadgeCount > 0 && sharedBadgeCount !== null)
+      roleItems.push(`${sharedBadgeCount} of ${totalBadgeCount} badges`);
+    const roleLocationHint =
+      distPct === 100 ? "within the role's location radius" :
+      distPct === 25  ? "up to 20 km beyond the role's radius" :
+      distPct === 0   ? "outside the role's location radius" :
+      null;
+    const roleParts = roleItems.length > 0 ? [roleItems.join(", ") + " met"] : [];
+    if (roleLocationHint) roleParts.push(roleLocationHint);
+    if (roleParts.length > 0) detailLine = roleParts.join(", ");
+  } else if (normalizedMatchType === "role_match") {
+    const commonItems = [];
+    if (totalTagCount > 0 && sharedTagCount !== null)
+      commonItems.push(`${sharedTagCount} of ${totalTagCount} focus areas`);
+    if (totalBadgeCount > 0 && sharedBadgeCount !== null)
+      commonItems.push(`${sharedBadgeCount} of ${totalBadgeCount} badges`);
+    const locationHint =
+      distPct === 100 ? "same location or remote-friendly team" :
+      distPct >= 75   ? "within 100 km of each other" :
+      distPct >= 50   ? "within 300 km of each other" :
+      distPct >= 25   ? "within 1000 km of each other" :
+      distPct === 0   ? "locations too far apart" :
+      null;
+    if (commonItems.length > 0 && locationHint) {
+      detailLine = `${commonItems.join(", ")} in common and ${locationHint}`;
+    } else if (commonItems.length > 0) {
+      detailLine = `${commonItems.join(", ")} in common`;
+    } else if (locationHint) {
+      detailLine = locationHint.charAt(0).toUpperCase() + locationHint.slice(1);
+    }
+  } else {
+    const commonItems = [];
+    if (sharedTagCount > 0) commonItems.push(pluralize(sharedTagCount, "focus area"));
+    if (sharedBadgeCount > 0) commonItems.push(pluralize(sharedBadgeCount, "badge"));
+    const locationHint =
+      distPct === 100 ? "same location or remote-friendly team" :
+      distPct >= 75   ? "within 100 km of each other" :
+      distPct >= 50   ? "within 300 km of each other" :
+      distPct >= 25   ? "within 1000 km of each other" :
+      distPct === 0   ? "locations too far apart" :
+      null;
+    if (commonItems.length > 0 && locationHint) {
+      detailLine = `${commonItems.join(", ")} in common and ${locationHint}`;
+    } else if (commonItems.length > 0) {
+      detailLine = `${commonItems.join(", ")} in common`;
+    } else if (locationHint) {
+      detailLine = locationHint.charAt(0).toUpperCase() + locationHint.slice(1);
+    }
   }
 
   // ── Progress bar rows ─────────────────────────────────────
@@ -170,15 +219,22 @@ const MatchScoreSection = ({
       label: "Location",
       icon: MapPin,
       value: distPct ?? 0,
-      tooltip: (
-        <>
-          Location factors into the score with {LOCATION_WEIGHT}%.
-          <br />
-          Remote teams = 100%. Same city = 100%. Within 100 km = 75%.
-          <br />
-          Within 300 km = 50%. Within 1000 km = 25%. Farther away = 0%.
-        </>
-      ),
+      tooltip:
+        normalizedMatchType === "role_match" ? (
+          <>
+            Location factors into the score with {LOCATION_WEIGHT}%.
+            <br />
+            Within the role's radius = 100%. Up to 20 km beyond = 25%. Farther = 0%.
+          </>
+        ) : (
+          <>
+            Location factors into the score with {LOCATION_WEIGHT}%.
+            <br />
+            Remote teams = 100%. Same city = 100%. Within 100 km = 75%.
+            <br />
+            Within 300 km = 50%. Within 1000 km = 25%. Farther away = 0%.
+          </>
+        ),
     },
     {
       label: "Focus Areas",
@@ -227,33 +283,50 @@ const MatchScoreSection = ({
   ];
 
   return (
-    <div className="rounded-xl p-4 bg-base-200/50 border border-base-300">
+    <div className={`rounded-xl p-4 border leading-[110%] ${tier.bgTint} ${tier.borderTint}`}>
       {/* Headline */}
-      <div className="flex items-start gap-2 mb-3">
-        <Icon size={16} className={`mt-0.5 flex-shrink-0 ${tier.text}`} />
-        <span className={`min-w-0 text-sm font-semibold ${tier.text}`}>{headline}</span>
+      <div className="flex items-start gap-1 mb-3">
+        <Icon size={14} className={`mt-0.5 flex-shrink-0 ${tier.text}`} />
+        <div className="min-w-0">
+          {headlineTooltip ? (
+            <Tooltip content={headlineTooltip} wrapperClassName="inline">
+              <span className={`text-sm leading-[110%] font-semibold ${tier.text}`}>
+                {headline}{detailLine ? ":" : ""}
+              </span>
+            </Tooltip>
+          ) : (
+            <span className={`text-sm leading-[110%] font-semibold ${tier.text}`}>
+              {headline}{detailLine ? ":" : ""}
+            </span>
+          )}
+          {detailLine && (
+            <span className={`text-sm leading-[110%] font-semibold ${tier.text}`}>
+              {" "}{detailLine}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* Per-dimension bars */}
       <div className="space-y-2">
         {rows.map(({ label, value, icon, tooltip }) => (
           <div key={label} className="flex items-center gap-2">
-            <Tooltip content={tooltip}>
-              <span className="text-xs text-base-content/60 w-24 flex-shrink-0 flex items-center gap-1 cursor-help">
+            <Tooltip content={tooltip} wrapperClassName="w-24 flex-shrink-0">
+              <span className="text-sm leading-[110%] text-base-content/60 flex items-center gap-1 cursor-help whitespace-nowrap">
                 {React.createElement(icon, {
-                  size: 12,
+                  size: 14,
                   className: "flex-shrink-0",
                 })}
                 {label}
               </span>
             </Tooltip>
-            <div className="flex-1 h-1.5 bg-base-200 rounded-full overflow-hidden">
+            <div className={`flex-1 h-1.5 rounded-full overflow-hidden ${tier.bgMid}`}>
               <div
                 className={`h-full rounded-full transition-all duration-500 ${tier.bg}`}
                 style={{ width: `${value}%` }}
               />
             </div>
-            <span className="text-xs font-medium text-base-content/60 w-8 text-right">
+            <span className="text-sm leading-[110%] font-medium text-base-content/60 w-8 text-right">
               {value}%
             </span>
           </div>

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -11,6 +11,7 @@ import {
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import { formatDisplayName } from "../../utils/nameFormatters";
+import { formatListLocation } from "../../utils/locationUtils";
 
 /**
  * PersonRequestCard Component
@@ -214,7 +215,7 @@ const PersonRequestCard = ({
                 <div className="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden">
                   <MapPin size={10} className="text-base-content/60 shrink-0" />
                   <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">
-                    {[user?.city, user?.country].filter(Boolean).join(", ") || getPostalCode()}
+                    {formatListLocation(user, { isRemote: user?.is_remote || user?.isRemote }).short || getPostalCode()}
                   </span>
                 </div>
               )}

--- a/src/components/tags/TagsDisplaySection.jsx
+++ b/src/components/tags/TagsDisplaySection.jsx
@@ -479,18 +479,18 @@ const TagsDisplaySection = ({
       <div className="flex items-start gap-2 mb-3">
         <Tag size={18} className="mt-0.5 text-primary flex-shrink-0" />
         <div className="min-w-0 flex-1">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 flex-1 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 flex-1 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-x-3 gap-y-0.5">
               <div className="min-w-0 flex flex-wrap items-baseline gap-x-1 gap-y-0.5">
-                <h3 className="font-medium leading-5 whitespace-nowrap">{title}</h3>
+                <h3 className="font-medium leading-[1.1] break-words sm:whitespace-nowrap">{title}</h3>
                 {totalCredits > 0 && (
-                  <span className="min-w-0 text-sm font-normal text-base-content/60 whitespace-nowrap">
+                  <span className="min-w-0 text-sm font-normal text-base-content/60 whitespace-normal sm:whitespace-nowrap">
                     ({totalCredits} ct. in {pillCount} {pillCount === 1 ? 'area' : 'areas'})
                   </span>
                 )}
               </div>
               {headerRight && (
-                <div className="flex items-center justify-end gap-2 text-right whitespace-nowrap">
+                <div className="shrink-0">
                   {headerRight}
                 </div>
               )}

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -37,6 +37,7 @@ import Alert from "../common/Alert";
 import ConfirmModal from "../common/ConfirmModal";
 import NotificationBadge from "../common/NotificationBadge";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
+import MatchScoreOverlay from "../common/MatchScoreOverlay";
 import TeamApplicationsModal from "./TeamApplicationsModal";
 import { format } from "date-fns";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
@@ -2257,15 +2258,13 @@ const TeamCard = ({
       );
     } else {
       matchOverlay = (
-        <div
-          className={`absolute -top-0.5 -left-0.5 rounded-full ring-2 ring-white flex items-center justify-center ${matchTier.bg} ${viewMode === "list" ? "w-[14px] h-[14px]" : "w-5 h-5"}`}
-        >
-          <matchTier.Icon
-            size={viewMode === "list" ? 7 : 10}
-            className="text-white"
-            strokeWidth={2.5}
-          />
-        </div>
+        <MatchScoreOverlay
+          matchTier={matchTier}
+          tooltipText={matchTooltipText}
+          sizeClassName={viewMode === "list" ? "w-[14px] h-[14px]" : "w-5 h-5"}
+          iconSize={viewMode === "list" ? 7 : 10}
+          positionClassName="absolute -top-0.5 -left-0.5 z-10"
+        />
       );
     }
   }

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -2786,10 +2786,10 @@ const TeamCard = ({
                     />
                   </span>
                 ) : (
-                  <span className="flex items-center gap-1">
+                  <span className="flex items-start gap-1">
                     <UserSearch
                       size={viewMode === "mini" ? 10 : 13}
-                      className="text-orange-500 flex-shrink-0"
+                      className="text-orange-500 flex-shrink-0 mt-0.5"
                     />
                     <span className="leading-[1.05]">{teamInvitationRoleName}</span>
                   </span>
@@ -2828,10 +2828,10 @@ const TeamCard = ({
                     />
                   </span>
                 ) : (
-                  <span className="flex items-center gap-1">
+                  <span className="flex items-start gap-1">
                     <UserSearch
                       size={viewMode === "mini" ? 10 : 13}
-                      className="text-orange-500 flex-shrink-0"
+                      className="text-orange-500 flex-shrink-0 mt-0.5"
                     />
                     <span className="leading-[1.05]">{teamApplicationRoleName}</span>
                   </span>
@@ -2857,7 +2857,7 @@ const TeamCard = ({
                   </span>
                 ) : (
                   <span
-                    className="flex items-center gap-1 cursor-pointer"
+                    className="flex items-start gap-1 cursor-pointer"
                     onClick={(e) => {
                       e.stopPropagation();
                       setIsModalOpen(true);
@@ -2865,7 +2865,7 @@ const TeamCard = ({
                   >
                     <Users
                       size={viewMode === "mini" ? 10 : 13}
-                      className="text-primary flex-shrink-0"
+                      className="text-primary flex-shrink-0 mt-0.5"
                     />
                     <span className="leading-[1.05]">{teamData._teamName}</span>
                   </span>
@@ -3021,12 +3021,12 @@ const TeamCard = ({
         }
         headerClassName={
           viewMode === "mini"
-            ? `!p-4 sm:!p-5 ${activeFilters.showLocation || activeFilters.showTags || activeFilters.showBadges ? "!pb-4" : "!pb-0"}`
+            ? "!p-4 sm:!p-5 !pb-4 sm:!pb-5"
             : ""
         }
         imageWrapperClassName={viewMode === "mini" ? "mb-0 pb-0" : ""}
         titleClassName={
-          viewMode === "mini" ? "text-base mb-0.5 leading-[110%]" : ""
+          viewMode === "mini" ? "text-base mb-0 leading-[110%]" : ""
         }
         marginClassName="mb-0"
         imageOverlay={avatarOverlay}

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -43,7 +43,11 @@ import { format } from "date-fns";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
-import { calculateDistanceKm, normalizeLocationData } from "../../utils/locationUtils";
+import {
+  calculateDistanceKm,
+  formatListLocation,
+  normalizeLocationData,
+} from "../../utils/locationUtils";
 import {
   extractListPayload,
   extractProfilePayload,
@@ -2295,15 +2299,10 @@ const TeamCard = ({
   // ============ LIST VIEW ============
 
   if (viewMode === "list") {
-    const teamLocation = normalizeLocationData(teamData);
-    const locationText =
-      teamData.is_remote || teamData.isRemote
-        ? "Remote"
-        : [teamData.city, teamLocation.countryName].filter(Boolean).join(", ");
-    const locationTextShort =
-      teamData.is_remote || teamData.isRemote
-        ? "Remote"
-        : ([teamData.city, teamLocation.countryCode].filter(Boolean).join(", ") || locationText);
+    const { short: locationTextShort, full: locationText } =
+      formatListLocation(teamData, {
+        isRemote: teamData.is_remote || teamData.isRemote,
+      });
     const distance = teamData.distance_km ?? teamData.distanceKm;
     const showDistance =
       !hideDistanceInfo &&

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -37,6 +37,7 @@ import Alert from "../common/Alert";
 import ConfirmModal from "../common/ConfirmModal";
 import NotificationBadge from "../common/NotificationBadge";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
+import ListViewRow from "../common/ListViewRow";
 import MatchScoreOverlay from "../common/MatchScoreOverlay";
 import TeamApplicationsModal from "./TeamApplicationsModal";
 import { format } from "date-fns";
@@ -2501,69 +2502,22 @@ const TeamCard = ({
           imageInnerOverlay={demoAvatarOverlay}
           listEdgeRounding={!disableListEdgeRounding}
       >
-          <div
-            className={`box-border ${listLocationVisibilityClassName} w-24 flex-shrink-0 items-center gap-3 overflow-hidden sm:w-56 ${listLocationWidthClassName} ${listLocationInsetClassName}`}
-          >
-            {showDistance && (
-              <div className="hidden w-16 flex-shrink-0 overflow-hidden md:block">
-                <div className="text-xs text-base-content flex items-center gap-1 overflow-hidden">
-                  <Tooltip content={`${Math.round(distance)} km away from you`}>
-                    <div className="flex items-center gap-1">
-                      <Ruler size={9} className="flex-shrink-0" />
-                      <span className="whitespace-nowrap">{Math.round(distance)} km</span>
-                    </div>
-                  </Tooltip>
-                </div>
-              </div>
-            )}
-            {locationText && (
-              <div className="min-w-0 text-xs text-base-content/60 flex items-center gap-1 overflow-hidden">
-                <Tooltip
-                  content={locationText}
-                  wrapperClassName="flex min-w-0 w-full items-center overflow-hidden"
-                >
-                  <div className="flex min-w-0 w-full items-center gap-1 overflow-hidden">
-                    {teamData.is_remote || teamData.isRemote ? (
-                      <Globe size={9} className="flex-shrink-0" />
-                    ) : (
-                      <MapPin size={9} className="flex-shrink-0" />
-                    )}
-                    {listLocationShortBreakpoint === "md" ? (
-                      <>
-                        <span className="min-w-0 flex-1 truncate md:hidden">{locationTextShort}</span>
-                        <span className="min-w-0 flex-1 truncate hidden md:block">{locationText}</span>
-                      </>
-                    ) : (
-                      <>
-                        <span className="min-w-0 flex-1 truncate sm:hidden">{locationTextShort}</span>
-                        <span className="min-w-0 flex-1 truncate hidden sm:block">{locationText}</span>
-                      </>
-                    )}
-                  </div>
-                </Tooltip>
-              </div>
-            )}
-          </div>
-          <div
-            className={`hidden w-52 flex-shrink-0 text-xs text-base-content/60 lg:flex items-center gap-1 overflow-hidden ${listTagsWidthClassName}`}
-          >
-            {tagsSummary && (
-              <Tooltip content={tagNames.join(", ")} wrapperClassName="flex items-center gap-1 min-w-0 overflow-hidden w-full">
-                <Tag size={9} className="flex-shrink-0" />
-                <span className="truncate">{tagsSummary}</span>
-              </Tooltip>
-            )}
-          </div>
-          <div
-            className={`hidden w-48 flex-shrink-0 text-xs text-base-content/60 xl:flex items-center gap-1 overflow-hidden ${listBadgesWidthClassName}`}
-          >
-            {badgesSummary && (
-              <Tooltip content={badgeNames.join(", ")} wrapperClassName="flex items-center gap-1 min-w-0 overflow-hidden w-full">
-                <Award size={9} className="flex-shrink-0" />
-                <span className="truncate">{badgesSummary}</span>
-              </Tooltip>
-            )}
-          </div>
+          <ListViewRow
+            locationText={locationTextShort}
+            locationTooltip={locationText}
+            isRemote={teamData.is_remote || teamData.isRemote}
+            distance={showDistance ? Math.round(distance) : null}
+            tagsSummary={tagsSummary}
+            tagsTooltip={tagNames.join(", ")}
+            badgesSummary={badgesSummary}
+            badgesTooltip={badgeNames.join(", ")}
+            locationVisibilityClassName={listLocationVisibilityClassName}
+            locationWidthClassName={listLocationWidthClassName}
+            locationInsetClassName={listLocationInsetClassName}
+            tagsWidthClassName={listTagsWidthClassName}
+            badgesWidthClassName={listBadgesWidthClassName}
+            locationBreakpoint={listLocationShortBreakpoint}
+          />
           {shouldReserveMyTeamsActionSlot && (
             <div className="w-20 flex-shrink-0 flex items-center justify-end gap-2">
               {(effectiveVariant === "invitation" || isRoleInvitationVariant) && (
@@ -2758,7 +2712,7 @@ const TeamCard = ({
         title={cardTitle}
         subtitle={
           <span
-            className={`mt-0.5 flex max-h-[2.75em] overflow-hidden items-center flex-wrap leading-snug text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-px w-full" : "text-sm gap-x-1.5 gap-y-px"}`}
+            className={`mt-0.5 flex max-h-[2.75em] overflow-hidden items-center flex-wrap leading-[110%] text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-px w-full" : "text-sm gap-x-1.5 gap-y-px"}`}
           >
             {scoreSubtitleItem}
             {isRoleVariant && getFormattedDate() && (

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -2290,22 +2290,7 @@ const TeamCard = ({
     ? DEMO_ROLE_TOOLTIP
     : DEMO_TEAM_TOOLTIP;
   const demoAvatarOverlay = showDemoIndicator ? (
-    <DemoAvatarOverlay
-      textClassName={
-        viewMode === "list"
-          ? "text-[5px]"
-          : viewMode === "mini"
-            ? "text-[9px]"
-            : "text-[10px]"
-      }
-      textTranslateClassName={
-        viewMode === "list"
-          ? "-translate-y-[2px]"
-          : viewMode === "mini"
-            ? "-translate-y-[4px]"
-            : "-translate-y-[4px]"
-      }
-    />
+    <DemoAvatarOverlay viewMode={viewMode} />
   ) : null;
 
   // ============ LIST VIEW ============

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -1875,13 +1875,13 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
                           </Tooltip>
                         )}
 
-                      {((teamDateIsNarrow && getTeamCreatedDate()) || isSyntheticTeam(team)) && (
-                        <span className="flex items-center gap-3 flex-shrink-0">
-                          {teamDateIsNarrow && getTeamCreatedDate() && (
+                      {(getTeamCreatedDate() || isSyntheticTeam(team)) && (
+                        <span className="flex items-center gap-1.5 flex-shrink-0">
+                          {getTeamCreatedDate() && (
                             <Tooltip
                               content={`Created on ${getTeamCreatedDate().full}`}
                               position="bottom"
-                              wrapperClassName="flex items-center text-base-content/70 flex-shrink-0 cursor-help"
+                              wrapperClassName={`items-center text-base-content/70 flex-shrink-0 cursor-help ${teamDateIsNarrow ? "flex" : "flex sm:hidden"}`}
                             >
                               <Calendar size={14} className="mr-1" />
                               <span>{getTeamCreatedDate().narrow}</span>
@@ -1892,8 +1892,8 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
                               content={DEMO_TEAM_TOOLTIP}
                               wrapperClassName="flex items-start text-base-content/50"
                             >
-                              <FlaskConical size={14} className={`flex-shrink-0 mt-px${teamDateIsNarrow ? "" : " mr-0.5"}`} />
-                              {!teamDateIsNarrow && <span className="leading-[1.15]">Demo Team</span>}
+                              <FlaskConical size={14} className={`flex-shrink-0 mt-px${teamDateIsNarrow ? "" : " sm:mr-0.5"}`} />
+                              {!teamDateIsNarrow && <span className="hidden sm:inline leading-[1.15]">Demo Team</span>}
                             </Tooltip>
                           )}
                         </span>
@@ -1903,7 +1903,7 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
                   {getTeamCreatedDate() && (
                     <div
                       ref={teamDateRef}
-                      className={`flex-shrink-0${teamDateIsNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
+                      className={`flex-shrink-0${teamDateIsNarrow ? " absolute opacity-0 pointer-events-none" : " hidden sm:block"}`}
                     >
                       <Tooltip
                         content={`Created on ${getTeamCreatedDate().full}`}

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -1941,6 +1941,7 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
                     entityType="team"
                     distance={showHighlightsForContext ? effectiveTeamDistanceKm : null}
                     showDefaultHeaderRight={showHighlightsForContext}
+                    showCountryCode={false}
                   />
 
                   {/* Team Focus Areas */}
@@ -1970,14 +1971,14 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
                           return (
                             <span className="flex items-center gap-1.5 text-sm text-success">
                               <MatchIcon size={14} className="flex-shrink-0" />
-                              <span>{matchCount}/{total} in common</span>
+                              <span>{matchCount}/{total} matching</span>
                             </span>
                           );
                         }
                         return (
                           <span className="flex items-center gap-1.5 text-sm text-slate-500">
                             <X size={14} className="flex-shrink-0" />
-                            <span>None in common</span>
+                            <span className="leading-[1.1]">None matching</span>
                           </span>
                         );
                       })() : null}
@@ -2007,14 +2008,14 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
                           return (
                             <span className="flex items-center gap-1.5 text-sm text-success">
                               <MatchIcon size={14} className="flex-shrink-0" />
-                              <span>{matchCount}/{total} in common</span>
+                              <span>{matchCount}/{total} matching</span>
                             </span>
                           );
                         }
                         return (
                           <span className="flex items-center gap-1.5 text-sm text-slate-500">
                             <X size={14} className="flex-shrink-0" />
-                            <span>None in common</span>
+                            <span className="leading-[1.1]">None matching</span>
                           </span>
                         );
                       })() : null}

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -22,6 +22,7 @@ import CardMetaRow from "../common/CardMetaRow";
 import RoleBadgePill from "../common/RoleBadgePill";
 import Tooltip from "../common/Tooltip";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import UserAvatar from "../users/UserAvatar";
 import UserDetailsModal from "../users/UserDetailsModal";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import TeamInvitesModal from "../teams/TeamInvitesModal";
@@ -31,7 +32,6 @@ import {
   DEMO_PROFILE_TOOLTIP,
   DEMO_ROLE_TOOLTIP,
   DEMO_TEAM_TOOLTIP,
-  getUserInitials,
   isSyntheticUser,
   isSyntheticRole,
   isSyntheticTeam,
@@ -1442,44 +1442,16 @@ const TeamInviteModal = ({
           {/* Invitee info */}
           <div className="flex items-start space-x-3 mb-3">
             <Tooltip content="View profile" position="bottom" wrapperClassName="block">
-              <div
-                className="avatar cursor-pointer hover:opacity-80 transition-opacity"
+              <UserAvatar
+                user={inviteeUser}
+                sizeClass="w-12 h-12"
+                clickable
                 onClick={() => handleUserClick(inviteeId)}
-              >
-                <div className="w-12 h-12 rounded-full relative overflow-hidden">
-                  {inviteeAvatar ? (
-                    <img
-                      src={inviteeAvatar}
-                      alt={getUsername()}
-                      className="object-cover w-full h-full rounded-full"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        const fallback =
-                          e.target.parentElement.querySelector(
-                            ".avatar-fallback"
-                          );
-                        if (fallback) fallback.style.display = "flex";
-                      }}
-                    />
-                  ) : null}
-                  <div
-                    className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                    style={{
-                      display: inviteeAvatar ? "none" : "flex",
-                    }}
-                  >
-                    <span className="text-lg font-medium">
-                      {getUserInitials(inviteeUser)}
-                    </span>
-                  </div>
-                  {showInviteeDemoProfile && (
-                    <DemoAvatarOverlay
-                      textClassName="text-[8px]"
-                      textTranslateClassName="-translate-y-[3px]"
-                    />
-                  )}
-                </div>
-              </div>
+                title="View profile"
+                showDemoOverlay={showInviteeDemoProfile}
+                demoOverlayTextClassName="text-[8px]"
+                demoOverlayTextTranslateClassName="-translate-y-[3px]"
+              />
             </Tooltip>
 
             <div className="flex-1 min-w-0">

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -15,7 +15,7 @@ import { formatDisplayName } from "../../utils/nameFormatters";
 import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import Tooltip from "../common/Tooltip";
-import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import UserAvatar from "../users/UserAvatar";
 import { DEMO_PROFILE_TOOLTIP, isSyntheticUser } from "../../utils/userHelpers";
 
 const getTeamMemberId = (member) =>
@@ -172,36 +172,14 @@ const TeamMembersSection = ({
               key={memberId}
               className="flex items-start bg-green-50 rounded-xl shadow p-4 gap-4 transition-all duration-200 hover:bg-green-100 hover:shadow-md"
             >
-              <div className="avatar">
-                <div className="rounded-full w-14 h-14 relative overflow-hidden">
-                  {memberAvatarUrl ? (
-                    <img
-                      src={memberAvatarUrl}
-                      alt={member.username}
-                      className="object-cover w-full h-full rounded-full"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        const fallback =
-                          e.target.parentElement.querySelector(
-                            ".avatar-fallback",
-                          );
-                        if (fallback) fallback.style.display = "flex";
-                      }}
-                    />
-                  ) : null}
-                  <div
-                    className="avatar-fallback placeholder bg-[var(--color-primary-focus)] text-primary-content rounded-full w-full h-full absolute inset-0 flex items-center justify-center"
-                    style={{ display: memberAvatarUrl ? "none" : "flex" }}
-                  >
-                    <span className="text-xl">
-                      {anonymize ? "PP" : getMemberInitials(member)}
-                    </span>
-                  </div>
-                  {showDemoAvatarOverlay && (
-                    <DemoAvatarOverlay textClassName="text-[8px]" />
-                  )}
-                </div>
-              </div>
+              <UserAvatar
+                user={member}
+                sizeClass="w-14 h-14"
+                showDemoOverlay={showDemoAvatarOverlay}
+                demoOverlayTextClassName="text-[8px]"
+                fallbackText={anonymize ? "PP" : undefined}
+                initialsClassName="text-xl"
+              />
 
               <div className="flex-1 min-w-0 pt-[1px]">
                 <div className="flex flex-col">

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -12,6 +12,7 @@ import RoleBadgeDropdown from "./RoleBadgeDropdown";
 import ScreenAlert from "../common/ScreenAlert";
 import { teamService } from "../../services/teamService";
 import { formatDisplayName } from "../../utils/nameFormatters";
+import { formatListLocation } from "../../utils/locationUtils";
 import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import Tooltip from "../common/Tooltip";
@@ -316,11 +317,15 @@ const TeamMembersSection = ({
 
                   {shouldShowMemberMetaRow && (
                     <CardMetaRow>
-                      {!anonymize && (member.city || member.country) && (
-                        <CardMetaItem icon={MapPin}>
-                          {[member.city, member.country].filter(Boolean).join(", ")}
-                        </CardMetaItem>
-                      )}
+                      {!anonymize && (() => {
+                        const memberLocationText = formatListLocation(member, {
+                          isRemote: member.is_remote || member.isRemote,
+                        }).short;
+
+                        return memberLocationText ? (
+                          <CardMetaItem icon={MapPin}>{memberLocationText}</CardMetaItem>
+                        ) : null;
+                      })()}
 
                       {!anonymize && member.distance_km != null && (
                         <CardMetaItem icon={Ruler} tone="muted" nowrap>

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -29,6 +29,7 @@ import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
+import ListViewRow from "../common/ListViewRow";
 import MatchScoreOverlay from "../common/MatchScoreOverlay";
 import Tooltip from "../common/Tooltip";
 import {
@@ -1054,64 +1055,16 @@ const VacantRoleCard = ({
           }
           className={status !== "open" ? "opacity-70" : ""}
         >
-          <div className="flex w-24 flex-shrink-0 items-center gap-3 overflow-hidden sm:w-56">
-            {showDistance && (
-              <div className="hidden w-16 flex-shrink-0 overflow-hidden md:block">
-                <div className="text-xs text-base-content flex items-center gap-1 overflow-hidden">
-                  <Tooltip content={`${roundedDistanceKm} km away from you`}>
-                    <div className="flex items-center gap-1">
-                      <Ruler size={9} className="flex-shrink-0" />
-                      <span className="whitespace-nowrap">
-                        {roundedDistanceKm} km
-                      </span>
-                    </div>
-                  </Tooltip>
-                </div>
-              </div>
-            )}
-            {locationText && (
-              <div className="min-w-0 text-xs text-base-content/60 flex items-center gap-1 overflow-hidden">
-                <Tooltip
-                  content={locationText}
-                  wrapperClassName="flex min-w-0 w-full items-center overflow-hidden"
-                >
-                  <div className="flex min-w-0 w-full items-center gap-1 overflow-hidden">
-                    {is_remote ? (
-                      <Globe size={9} className="flex-shrink-0" />
-                    ) : (
-                      <MapPin size={9} className="flex-shrink-0" />
-                    )}
-                    <span className="min-w-0 flex-1 truncate sm:hidden">{locationTextShort}</span>
-                    <span className="min-w-0 flex-1 truncate hidden sm:block">{locationText}</span>
-                  </div>
-                </Tooltip>
-              </div>
-            )}
-          </div>
-
-          <div className="hidden w-52 flex-shrink-0 text-xs text-base-content/60 lg:flex items-center gap-1 overflow-hidden">
-            {tagsSummary && (
-              <Tooltip
-                content={tagNames.join(", ")}
-                wrapperClassName="flex items-center gap-1 min-w-0 overflow-hidden w-full"
-              >
-                <Tag size={9} className="flex-shrink-0" />
-                <span className="truncate">{tagsSummary}</span>
-              </Tooltip>
-            )}
-          </div>
-
-          <div className="hidden w-48 flex-shrink-0 text-xs text-base-content/60 xl:flex items-center gap-1 overflow-hidden">
-            {badgesSummary && (
-              <Tooltip
-                content={badgeNames.join(", ")}
-                wrapperClassName="flex items-center gap-1 min-w-0 overflow-hidden w-full"
-              >
-                <Award size={9} className="flex-shrink-0" />
-                <span className="truncate">{badgesSummary}</span>
-              </Tooltip>
-            )}
-          </div>
+          <ListViewRow
+            locationText={locationTextShort}
+            locationTooltip={locationText}
+            isRemote={is_remote}
+            distance={showDistance ? roundedDistanceKm : null}
+            tagsSummary={tagsSummary}
+            tagsTooltip={tagNames.join(", ")}
+            badgesSummary={badgesSummary}
+            badgesTooltip={badgeNames.join(", ")}
+          />
         </Card>
         {detailsModal}
       </>
@@ -1121,7 +1074,7 @@ const VacantRoleCard = ({
   if (usesSharedSearchCard) {
     const searchCardSubtitle = (
       <span
-        className={`mt-0.5 flex max-h-[2.75em] overflow-hidden text-base-content/70 leading-snug ${
+        className={`mt-0.5 flex max-h-[2.75em] overflow-hidden text-base-content/70 leading-[110%] ${
           isMiniView
             ? "items-center flex-wrap text-xs gap-x-1 gap-y-px w-full"
             : "items-center flex-wrap text-sm gap-x-1.5 gap-y-px"

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -1127,12 +1127,12 @@ const VacantRoleCard = ({
           }
           headerClassName={
             viewMode === "mini"
-              ? `!p-4 sm:!p-5 ${miniHasContent ? "!pb-4" : "!pb-0"}`
+              ? "!p-4 sm:!p-5 !pb-4 sm:!pb-5"
               : ""
           }
           imageWrapperClassName={viewMode === "mini" ? "mb-0 pb-0" : ""}
           titleClassName={
-            viewMode === "mini" ? "text-base mb-0.5 leading-[110%]" : ""
+            viewMode === "mini" ? "text-base mb-0 leading-[110%]" : ""
           }
           marginClassName="mb-0"
           imageOverlay={
@@ -1177,7 +1177,7 @@ const VacantRoleCard = ({
               }`}
             >
               <Users
-                size={viewMode === "mini" ? 12 : 16}
+                size={viewMode === "mini" ? 10 : 13}
                 className="mr-1 flex-shrink-0 mt-0.5"
               />
               <span className="min-w-0 whitespace-normal break-words">

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -39,6 +39,7 @@ import {
   isSyntheticUser,
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import UserAvatar from "../users/UserAvatar";
 import { resolveFilledRoleUser } from "../../utils/vacantRoleUtils";
 import {
   getMatchTier,
@@ -999,34 +1000,10 @@ const VacantRoleCard = ({
     />
   );
   const demoAvatarOverlay = isSyntheticRole(role) ? (
-    <DemoAvatarOverlay
-      textClassName={
-        viewMode === "list"
-          ? "text-[5px]"
-          : viewMode === "mini"
-            ? "text-[9px]"
-            : "text-[10px]"
-      }
-      textTranslateClassName={
-        viewMode === "list"
-          ? "-translate-y-[2px]"
-          : viewMode === "mini"
-            ? "-translate-y-[4px]"
-            : "-translate-y-[4px]"
-      }
-    />
+    <DemoAvatarOverlay viewMode={viewMode} />
   ) : null;
   const compactDemoAvatarOverlay = isSyntheticRole(role) ? (
-    <DemoAvatarOverlay
-      textClassName={isMiniView ? "text-[6px]" : "text-[7px]"}
-      textTranslateClassName="-translate-y-[3px]"
-    />
-  ) : null;
-  const compactFilledUserDemoAvatarOverlay = isSyntheticUser(filledUser) ? (
-    <DemoAvatarOverlay
-      textClassName={isMiniView ? "text-[6px]" : "text-[7px]"}
-      textTranslateClassName="-translate-y-[3px]"
-    />
+    <DemoAvatarOverlay viewMode={isMiniView ? "compact-mini" : "compact"} />
   ) : null;
 
   if (viewMode === "list") {
@@ -1283,32 +1260,15 @@ const VacantRoleCard = ({
         } ${notificationHighlight ? "role-card-highlight" : ""}`}
       >
         {isFilled && filledUser ? (
-            <div className="avatar">
-              <div className={`${avatarSizeClass} rounded-full relative overflow-hidden`}>
-                {filledUserAvatarUrl ? (
-                  <img
-                    src={filledUserAvatarUrl}
-                    alt={filledUserDisplayName || "Filled role"}
-                    className="object-cover w-full h-full rounded-full"
-                    onError={(e) => {
-                      e.target.style.display = "none";
-                      const fallback =
-                        e.target.parentElement.querySelector(".avatar-fallback");
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                ) : null}
-                <div
-                  className="avatar-fallback bg-[var(--color-primary-focus)] text-white flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                  style={{ display: filledUserAvatarUrl ? "none" : "flex" }}
-                >
-                  <span className={`${avatarTextClass} font-medium`}>
-                    {getUserInitials(filledUser)}
-                  </span>
-                </div>
-                {compactFilledUserDemoAvatarOverlay ?? compactDemoAvatarOverlay}
-                {miniMatchOverlay}
-              </div>
+            <div className="relative">
+              <UserAvatar
+                user={filledUser}
+                sizeClass={avatarSizeClass}
+                showDemoOverlay={isSyntheticUser(filledUser)}
+                demoOverlayTextClassName={isMiniView ? "text-[6px]" : "text-[7px]"}
+                demoOverlayTextTranslateClassName="-translate-y-[3px]"
+              />
+              {miniMatchOverlay}
             </div>
           ) : hasMatchScore && !isMiniView ? (
             <Tooltip content={getMatchTooltip()}>

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -52,6 +52,7 @@ import { useAuth } from "../../contexts/AuthContext";
 import { format } from "date-fns";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import {
+  formatListLocation,
   formatLocation,
   normalizeLocationData,
 } from "../../utils/locationUtils";
@@ -998,10 +999,10 @@ const VacantRoleCard = ({
 
   if (viewMode === "list") {
     const roundedDistanceKm = showDistance ? Math.round(rawDistanceKm) : null;
-    const roleLocationNorm = normalizeLocationData(role);
-    const locationTextShort = is_remote
-      ? "Remote"
-      : ([roleLocationNorm.city, roleLocationNorm.countryCode].filter(Boolean).join(", ") || locationText);
+    const { short: locationTextShort, full: locationText } = formatListLocation(
+      role,
+      { isRemote: is_remote },
+    );
     const visibleTags = tagNames.slice(0, 3);
     const remainingTagCount = tagNames.length - visibleTags.length;
     const tagsSummary =

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -29,6 +29,7 @@ import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
+import MatchScoreOverlay from "../common/MatchScoreOverlay";
 import Tooltip from "../common/Tooltip";
 import {
   DEMO_PROFILE_TOOLTIP,
@@ -900,26 +901,15 @@ const VacantRoleCard = ({
     if (!matchTier) return null;
 
     return (
-      <Tooltip content={getMatchTooltip()}>
-        <div
-          aria-label={getMatchTooltip()}
-          className="absolute -top-0.5 -left-0.5 z-10 rounded-full ring-2 ring-white flex items-center justify-center text-white"
-          style={{
-            width: `${size}px`,
-            height: `${size}px`,
-          }}
-        >
-          <div
-            className={`w-full h-full rounded-full flex items-center justify-center ${matchTier.bg}`}
-          >
-            <matchTier.Icon
-              size={iconSize}
-              className="text-white"
-              strokeWidth={2.5}
-            />
-          </div>
-        </div>
-      </Tooltip>
+      <MatchScoreOverlay
+        matchTier={matchTier}
+        tooltipText={getMatchTooltip()}
+        iconSize={iconSize}
+        sizeClassName=""
+        className=""
+        positionClassName="absolute -top-0.5 -left-0.5 z-10"
+        style={{ width: `${size}px`, height: `${size}px` }}
+      />
     );
   };
   const searchResultTypeOverlay = showSearchResultTypeOverlay ? (

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -89,6 +89,7 @@ import {
   computeRoleUserMatch,
 } from "../../utils/matchHelpers";
 import { formatDisplayName } from "../../utils/nameFormatters";
+import MatchScoreSection from "../common/MatchScoreSection";
 import { resolveFilledRoleUser } from "../../utils/vacantRoleUtils";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
 import { useTeamModalSafe } from "../../contexts/TeamModalContext";
@@ -1261,6 +1262,13 @@ const VacantRoleDetailsModal = ({
     return fallbackName ? fallbackName.split(/\s+/)[0] : null;
   })();
   const comparisonPossessive = toPossessive(comparisonShortName);
+  const compactComparisonName =
+    comparisonUser && comparisonShortName
+      ? formatDisplayName(comparisonUser)
+      : comparisonShortName;
+  const compactComparisonPossessive = isComparisonSelf
+    ? "your"
+    : toPossessive(compactComparisonName);
   const filledRoleUser = isFilledRole
     ? comparisonUser || resolvedFilledUser
     : null;
@@ -1328,6 +1336,16 @@ const VacantRoleDetailsModal = ({
       ? getMatchTier(effectiveMatchScore)
       : null;
   const MatchTierIcon = matchTier?.Icon ?? null;
+  const matchHeadline = effectivePct !== null
+    ? (isFilledRole
+      ? `${effectivePct}% matching score for ${filledRoleCompactDisplayName || "this member"} with this role`
+      : `${effectivePct}% match with ${compactComparisonPossessive} profile`)
+    : null;
+  const matchHeadlineTooltip = effectivePct !== null
+    ? (isFilledRole
+      ? `${effectivePct}% matching score for ${filledRoleDisplayName || "this member"} with this role`
+      : `${effectivePct}% match with ${comparisonPossessive} profile`)
+    : null;
   const handleFilledUserClick = () => {
     const filledUserId = filledRoleUser?.id;
     if (filledUserId && userModal?.openUserModal) {
@@ -2059,146 +2077,15 @@ const VacantRoleDetailsModal = ({
             </div>
           )}
 
-        {effectiveMatchScore !== null &&
-          effectiveMatchScore !== undefined &&
-          (() => {
-            const pct = Math.round(effectiveMatchScore * 100);
-            const tagPct = Math.round(
-              (effectiveMatchDetails?.tagScore ??
-                effectiveMatchDetails?.tag_score ??
-                0) * 100,
-            );
-            const badgePct = Math.round(
-              (effectiveMatchDetails?.badgeScore ??
-                effectiveMatchDetails?.badge_score ??
-                0) * 100,
-            );
-            const distPct = Math.round(
-              (effectiveMatchDetails?.distanceScore ??
-                effectiveMatchDetails?.distance_score ??
-                0) * 100,
-            );
-            const compactComparisonName =
-              comparisonUser && comparisonShortName
-                ? formatDisplayName(comparisonUser)
-                : comparisonShortName;
-            const compactComparisonPossessive =
-              isComparisonSelf
-                ? "your"
-                : toPossessive(compactComparisonName);
-            const matchSummaryText = isFilledRole
-              ? `${pct}% matching score for ${filledRoleCompactDisplayName || "this member"} with this role`
-              : `${pct}% match with ${compactComparisonPossessive} profile`;
-            const fullMatchSummaryText = isFilledRole
-              ? `${pct}% matching score for ${filledRoleDisplayName || "this member"} with this role`
-              : `${pct}% match with ${comparisonPossessive} profile`;
-
-            const tierColor = {
-              bg: "bg-base-200/50",
-              border: "border-base-300",
-              text: matchTier?.text ?? "text-base-content/70",
-            };
-
-            return (
-              <div
-                className={`rounded-xl p-4 ${tierColor.bg} border ${tierColor.border}`}
-              >
-                <div className="flex min-w-0 items-start gap-2 mb-3">
-                  {MatchTierIcon ? (
-                    <MatchTierIcon size={16} className={`${tierColor.text} mt-px flex-shrink-0`} />
-                  ) : null}
-                  <Tooltip
-                    content={fullMatchSummaryText}
-                    wrapperClassName="min-w-0"
-                  >
-                    <span className={`block min-w-0 overflow-hidden text-sm font-semibold leading-[115%] [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] ${tierColor.text}`}>
-                      {matchSummaryText}
-                    </span>
-                  </Tooltip>
-                </div>
-
-                <div className="space-y-2">
-                  {[
-                    {
-                      label: "Location",
-                      value: distPct,
-                      icon: MapPin,
-                      tooltip: (
-                        <>
-                          Location factors into the score with 30%.
-                          <br />
-                          Within the role's radius = 100%. Up to 20 km beyond =
-                          25%. Farther = 0%.
-                        </>
-                      ),
-                    },
-                    {
-                      label: "Focus Areas",
-                      value: tagPct,
-                      icon: Tag,
-                      tooltip: (
-                        <>
-                          Focus Areas factor into the score with 40%.
-                          <br />
-                          {effectiveMatchDetails?.matchingTags ??
-                            effectiveMatchDetails?.matching_tags ??
-                            0}{" "}
-                          out of{" "}
-                          {effectiveMatchDetails?.totalRequiredTags ??
-                            effectiveMatchDetails?.total_required_tags ??
-                            0}{" "}
-                          required focus areas met.
-                        </>
-                      ),
-                    },
-                    {
-                      label: "Badges",
-                      value: badgePct,
-                      icon: Award,
-                      tooltip: (
-                        <>
-                          Badges factor into the score with 30%.
-                          <br />
-                          {effectiveMatchDetails?.matchingBadges ??
-                            effectiveMatchDetails?.matching_badges ??
-                            0}{" "}
-                          out of{" "}
-                          {effectiveMatchDetails?.totalRequiredBadges ??
-                            effectiveMatchDetails?.total_required_badges ??
-                            0}{" "}
-                          required badges met.
-                        </>
-                      ),
-                    },
-                  ].map((row) => {
-                    const IconComponent = row.icon;
-
-                    return (
-                      <div key={row.label} className="flex items-center gap-2">
-                        <Tooltip content={row.tooltip}>
-                          <span className="text-xs text-base-content/60 w-24 flex-shrink-0 flex items-center gap-1 cursor-help">
-                            <IconComponent size={12} className="flex-shrink-0" />
-                            {row.label}
-                          </span>
-                        </Tooltip>
-                        <div className="flex-1 h-1.5 bg-base-200 rounded-full overflow-hidden">
-                          <div
-                            className={`h-full rounded-full transition-all duration-500 ${
-                              matchTier?.bg ?? "bg-slate-400"
-                            }`}
-                            style={{ width: `${Math.max(0, row.value)}%` }}
-                          />
-                        </div>
-                        <span className="text-xs font-medium text-base-content/60 w-8 text-right">
-                          {row.value}%
-                        </span>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })()}
+        {effectiveMatchScore !== null && effectiveMatchScore !== undefined && (
+          <MatchScoreSection
+            matchScore={effectiveMatchScore}
+            matchType="role_match"
+            matchDetails={effectiveMatchDetails}
+            headline={matchHeadline}
+            headlineTooltip={matchHeadlineTooltip !== matchHeadline ? matchHeadlineTooltip : null}
+          />
+        )}
 
         {locationText && (
           <div>

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -25,6 +25,7 @@ import {
   XCircle,
   CheckCircle,
   PenLine,
+  Minus,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import {
@@ -1250,9 +1251,15 @@ const VacantRoleDetailsModal = ({
     comparisonUserId != null &&
     currentUser?.id != null &&
     String(comparisonUserId) === String(currentUser.id);
-  const comparisonShortName = isComparisonSelf
-    ? null
-    : comparisonFirstName || comparisonDisplayName;
+  const comparisonShortName = (() => {
+    if (isComparisonSelf) return null;
+
+    const firstName = comparisonFirstName?.trim().split(/\s+/)[0];
+    if (firstName) return firstName;
+
+    const fallbackName = comparisonDisplayName?.trim();
+    return fallbackName ? fallbackName.split(/\s+/)[0] : null;
+  })();
   const comparisonPossessive = toPossessive(comparisonShortName);
   const filledRoleUser = isFilledRole
     ? comparisonUser || resolvedFilledUser
@@ -1415,6 +1422,7 @@ const VacantRoleDetailsModal = ({
       showPostalCode: true,
       showState: true,
       showCountry: true,
+      showCountryCode: false,
     }) || null;
   };
 
@@ -1428,6 +1436,7 @@ const VacantRoleDetailsModal = ({
     const locationLabel = formatLocation(normalizeLocationData(person), {
       displayType: "short",
       showCountry: true,
+      showCountryCode: false,
     });
 
     if (locationLabel) return locationLabel;
@@ -2193,14 +2202,14 @@ const VacantRoleDetailsModal = ({
 
         {locationText && (
           <div>
-            <div className="flex items-start gap-2 mb-2">
+            <div className="flex items-start gap-2 mb-1">
               {isRemote ? (
                 <Globe size={18} className="mt-0.5 text-primary flex-shrink-0" />
               ) : (
                 <MapPin size={18} className="mt-0.5 text-primary flex-shrink-0" />
               )}
-              <div className="min-w-0 flex-1 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
-                <h3 className="font-medium leading-5">
+              <div className="min-w-0 flex-1 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-x-3 gap-y-0.5">
+                <h3 className="font-medium leading-[1.1]">
                   <span className="sm:hidden">Location</span>
                   <span className="hidden sm:inline">Location Preference</span>
                 </h3>
@@ -2234,7 +2243,24 @@ const VacantRoleDetailsModal = ({
                       status = (
                         <span className="flex items-center gap-1.5 text-sm text-slate-500">
                           <X size={14} className="flex-shrink-0" />
-                          <span>{locationMismatchText}</span>
+                          <span className="leading-[1.1]">{locationMismatchText}</span>
+                        </span>
+                      );
+                    }
+                  } else if (comparisonUser) {
+                    const userHasLocation = normalizeLocationData(comparisonUser).hasLocation;
+                    if (!userHasLocation) {
+                      status = (
+                        <span className="flex items-center gap-1.5 text-sm text-slate-500">
+                          <X size={14} className="flex-shrink-0" />
+                          <span className="leading-[1.1]">No location set</span>
+                        </span>
+                      );
+                    } else {
+                      status = (
+                        <span className="flex items-center gap-1.5 text-sm text-slate-500">
+                          <Minus size={14} className="flex-shrink-0" />
+                          <span className="leading-[1.1]">Location not compared</span>
                         </span>
                       );
                     }
@@ -2242,16 +2268,12 @@ const VacantRoleDetailsModal = ({
 
                   if (!status) return null;
 
-                  return (
-                    <div className="flex items-center justify-end gap-2 text-right whitespace-nowrap">
-                      {status}
-                    </div>
-                  );
+                  return <div className="shrink-0">{status}</div>;
                 })()}
               </div>
             </div>
 
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm text-base-content/70">
               <span className="min-w-0">{locationText}</span>
               {!isRemote && maxDistanceKm && (
                 <span className="flex items-center gap-1 text-base-content/50 whitespace-nowrap">
@@ -2268,43 +2290,43 @@ const VacantRoleDetailsModal = ({
 
         {/* Desired Focus Areas */}
         <div>
-          <div className="flex items-start justify-between gap-3 mb-2">
-            <div className="flex items-start gap-2 min-w-0">
-              <Tag size={18} className="mt-0.5 text-primary flex-shrink-0" />
-              <h3 className="font-medium leading-5">
+          <div className="flex items-start gap-2 mb-2">
+            <Tag size={18} className="mt-0.5 text-primary flex-shrink-0" />
+            <div className="min-w-0 flex-1 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-x-3 gap-y-0.5">
+              <h3 className="font-medium leading-[1.1]">
                 <span className="sm:hidden">Focus Areas</span>
                 <span className="hidden sm:inline">Desired Focus Areas</span>
               </h3>
-            </div>
-            {shouldShowComparisonSummary && tags.length > 0 && (() => {
-              const matchCount = tags.filter((t) => {
-                const tagId = Number(t.tagId ?? t.tag_id ?? t.id);
-                return userTagMap.has(tagId);
-              }).length;
-              const total = tags.length;
-              if (matchCount > 0) {
-                const MatchIcon = matchCount === total ? CheckCheck : Check;
-                const compactLabel =
-                  matchCount === total
-                    ? "All in common"
-                    : `${matchCount}/${total} in common`;
-                return (
-                  <span className="flex items-center gap-1.5 text-sm text-success">
-                    <MatchIcon size={14} className="flex-shrink-0" />
-                    <span className="sm:hidden">{compactLabel}</span>
-                    <span className="hidden sm:inline">
-                      {matchCount}/{total} in common{summarySuffix}
+              {shouldShowComparisonSummary && tags.length > 0 && (() => {
+                const matchCount = tags.filter((t) => {
+                  const tagId = Number(t.tagId ?? t.tag_id ?? t.id);
+                  return userTagMap.has(tagId);
+                }).length;
+                const total = tags.length;
+                if (matchCount > 0) {
+                  const MatchIcon = matchCount === total ? CheckCheck : Check;
+                  const compactLabel =
+                    matchCount === total
+                      ? "All matching"
+                      : `${matchCount}/${total} matching`;
+                  return (
+                    <span className="flex items-center gap-1.5 text-sm text-success shrink-0">
+                      <MatchIcon size={14} className="flex-shrink-0" />
+                      <span className="break-words sm:hidden">{compactLabel}{summarySuffix}</span>
+                      <span className="hidden break-words sm:inline">
+                        {matchCount}/{total} matching{summarySuffix}
+                      </span>
                     </span>
+                  );
+                }
+                return (
+                  <span className="flex items-center gap-1.5 text-sm text-slate-500 shrink-0">
+                    <X size={14} className="flex-shrink-0" />
+                    <span className="leading-[1.1]">None matching{summarySuffix}</span>
                   </span>
                 );
-              }
-              return (
-                <span className="flex items-center gap-1.5 text-sm text-slate-500">
-                  <X size={14} className="flex-shrink-0" />
-                  <span>None in common{summarySuffix}</span>
-                </span>
-              );
-            })()}
+              })()}
+            </div>
           </div>
 
           {tags.length > 0 ? (
@@ -2409,43 +2431,43 @@ const VacantRoleDetailsModal = ({
 
         {/* Desired Badges */}
         <div>
-          <div className="flex items-start justify-between gap-3 mb-2">
-            <div className="flex items-start gap-2 min-w-0">
-              <Award size={18} className="mt-0.5 text-primary flex-shrink-0" />
-              <h3 className="font-medium leading-5">
+          <div className="flex items-start gap-2 mb-2">
+            <Award size={18} className="mt-0.5 text-primary flex-shrink-0" />
+            <div className="min-w-0 flex-1 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-x-3 gap-y-0.5">
+              <h3 className="font-medium leading-[1.1]">
                 <span className="sm:hidden">Badges</span>
                 <span className="hidden sm:inline">Desired Badges</span>
               </h3>
-            </div>
-            {shouldShowComparisonSummary && badges.length > 0 && (() => {
-              const matchCount = badges.filter((b) => {
-                const badgeKey = (b.name ?? b.badgeName ?? b.badge_name ?? "").trim().toLowerCase();
-                return userBadgeMap.has(badgeKey);
-              }).length;
-              const total = badges.length;
-              if (matchCount > 0) {
-                const MatchIcon = matchCount === total ? CheckCheck : Check;
-                const compactLabel =
-                  matchCount === total
-                    ? "All in common"
-                    : `${matchCount}/${total} in common`;
-                return (
-                  <span className="flex items-center gap-1.5 text-sm text-success">
-                    <MatchIcon size={14} className="flex-shrink-0" />
-                    <span className="sm:hidden">{compactLabel}</span>
-                    <span className="hidden sm:inline">
-                      {matchCount}/{total} in common{summarySuffix}
+              {shouldShowComparisonSummary && badges.length > 0 && (() => {
+                const matchCount = badges.filter((b) => {
+                  const badgeKey = (b.name ?? b.badgeName ?? b.badge_name ?? "").trim().toLowerCase();
+                  return userBadgeMap.has(badgeKey);
+                }).length;
+                const total = badges.length;
+                if (matchCount > 0) {
+                  const MatchIcon = matchCount === total ? CheckCheck : Check;
+                  const compactLabel =
+                    matchCount === total
+                      ? "All matching"
+                      : `${matchCount}/${total} matching`;
+                  return (
+                    <span className="flex items-center gap-1.5 text-sm text-success shrink-0">
+                      <MatchIcon size={14} className="flex-shrink-0" />
+                      <span className="break-words sm:hidden">{compactLabel}{summarySuffix}</span>
+                      <span className="hidden break-words sm:inline">
+                        {matchCount}/{total} matching{summarySuffix}
+                      </span>
                     </span>
+                  );
+                }
+                return (
+                  <span className="flex items-center gap-1.5 text-sm text-slate-500 shrink-0">
+                    <X size={14} className="flex-shrink-0" />
+                    <span className="leading-[1.1]">None matching{summarySuffix}</span>
                   </span>
                 );
-              }
-              return (
-                <span className="flex items-center gap-1.5 text-sm text-slate-500">
-                  <X size={14} className="flex-shrink-0" />
-                  <span>None in common{summarySuffix}</span>
-                </span>
-              );
-            })()}
+              })()}
+            </div>
           </div>
 
           {badges.length > 0 ? (

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -2019,7 +2019,7 @@ const VacantRoleDetailsModal = ({
               )}
 
               {(rolePostedDate || isSyntheticRole(displayRole)) && (
-                <span className="flex items-center gap-3 flex-shrink-0">
+                <span className="flex items-center gap-1.5 flex-shrink-0">
                   {rolePostedDate && (
                     <Tooltip
                       content={`${rolePostedDate.label} ${rolePostedDate.full}`}

--- a/src/components/users/DemoAvatarOverlay.jsx
+++ b/src/components/users/DemoAvatarOverlay.jsx
@@ -1,9 +1,38 @@
 import React from "react";
 
+const VIEW_MODE_SIZES = {
+  list: {
+    textClassName: "text-[5px]",
+    textTranslateClassName: "-translate-y-[2px]",
+  },
+  mini: {
+    textClassName: "text-[9px]",
+    textTranslateClassName: "-translate-y-[4px]",
+  },
+  card: {
+    textClassName: "text-[10px]",
+    textTranslateClassName: "-translate-y-[4px]",
+  },
+  compact: {
+    textClassName: "text-[7px]",
+    textTranslateClassName: "-translate-y-[3px]",
+  },
+  "compact-mini": {
+    textClassName: "text-[6px]",
+    textTranslateClassName: "-translate-y-[3px]",
+  },
+};
+
 const DemoAvatarOverlay = ({
-  textClassName = "text-[10px]",
-  textTranslateClassName = "-translate-y-[2px]",
+  viewMode,
+  textClassName: textClassNameOverride,
+  textTranslateClassName: textTranslateClassNameOverride,
 }) => {
+  const preset = viewMode ? VIEW_MODE_SIZES[viewMode] || VIEW_MODE_SIZES.card : null;
+  const textClassName = textClassNameOverride || preset?.textClassName || "text-[8px]";
+  const textTranslateClassName =
+    textTranslateClassNameOverride || preset?.textTranslateClassName || "-translate-y-[2px]";
+
   return (
     <div className="absolute inset-0 z-10 pointer-events-none">
       <div className="absolute inset-x-0 bottom-0 h-[30%] bg-gradient-to-t from-black/55 to-transparent" />

--- a/src/components/users/UserAvatar.jsx
+++ b/src/components/users/UserAvatar.jsx
@@ -18,6 +18,7 @@ const UserAvatar = ({
   title,
   iconSize = 12,
   initialsClassName = "text-[10px] font-medium",
+  fallbackText,
   showDemoOverlay = false,
   demoOverlayTextClassName = "text-[7px]",
   demoOverlayTextTranslateClassName = "-translate-y-[2px]",
@@ -63,7 +64,9 @@ const UserAvatar = ({
           {isFormerUser ? (
             <User size={iconSize} />
           ) : (
-            <span className={initialsClassName}>{getUserInitials(user)}</span>
+            <span className={initialsClassName}>
+              {fallbackText ?? getUserInitials(user)}
+            </span>
           )}
         </div>
 

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -219,22 +219,7 @@ const UserCard = ({
         });
 
   const demoAvatarOverlay = isSyntheticUser(user) ? (
-    <DemoAvatarOverlay
-      textClassName={
-        viewMode === "list"
-          ? "text-[5px]"
-          : viewMode === "mini"
-            ? "text-[9px]"
-            : "text-[10px]"
-      }
-      textTranslateClassName={
-        viewMode === "list"
-          ? "-translate-y-[2px]"
-          : viewMode === "mini"
-            ? "-translate-y-[4px]"
-            : "-translate-y-[4px]"
-      }
-    />
+    <DemoAvatarOverlay viewMode={viewMode} />
   ) : null;
 
   // ============ LIST VIEW ============

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -26,7 +26,11 @@ import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import MatchScoreOverlay from "../common/MatchScoreOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
-import { formatLocation, normalizeLocationData } from "../../utils/locationUtils";
+import {
+  formatListLocation,
+  formatLocation,
+  normalizeLocationData,
+} from "../../utils/locationUtils";
 
 /**
  * UserCard Component
@@ -227,12 +231,10 @@ const UserCard = ({
 
   // ============ LIST VIEW ============
   if (viewMode === "list") {
-    const listLocationText = user.is_remote || user.isRemote
-      ? "Remote"
-      : [userLocation.city, userLocation.countryName].filter(Boolean).join(", ");
-    const listLocationTextShort = user.is_remote || user.isRemote
-      ? "Remote"
-      : ([userLocation.city, userLocation.countryCode].filter(Boolean).join(", ") || listLocationText);
+    const { short: listLocationTextShort, full: listLocationText } =
+      formatListLocation(user, {
+        isRemote: user.is_remote || user.isRemote,
+      });
 
     const distance = user.distanceKm ?? user.distance_km;
     const showDistance = distance != null && distance < 999999 && !(user.is_remote || user.isRemote);

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -23,6 +23,7 @@ import {
 import DemoAvatarOverlay from "./DemoAvatarOverlay";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
+import MatchScoreOverlay from "../common/MatchScoreOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import { formatLocation, normalizeLocationData } from "../../utils/locationUtils";
@@ -189,11 +190,13 @@ const UserCard = ({
     const badgeIconSize =
       viewMode === "list" ? 7 : 10;
     matchOverlay = (
-      <div
-        className={`absolute -top-0.5 -left-0.5 rounded-full ring-2 ring-white flex items-center justify-center ${matchTier.bg} ${badgeSize}`}
-      >
-        <matchTier.Icon size={badgeIconSize} className="text-white" strokeWidth={2.5} />
-      </div>
+      <MatchScoreOverlay
+        matchTier={matchTier}
+        tooltipText={matchTooltipText}
+        sizeClassName={badgeSize}
+        iconSize={badgeIconSize}
+        positionClassName="absolute -top-0.5 -left-0.5 z-10"
+      />
     );
   }
 

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -23,6 +23,7 @@ import {
 import DemoAvatarOverlay from "./DemoAvatarOverlay";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
+import ListViewRow from "../common/ListViewRow";
 import MatchScoreOverlay from "../common/MatchScoreOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
@@ -304,49 +305,16 @@ const UserCard = ({
         imageOverlay={avatarOverlay}
         imageInnerOverlay={demoAvatarOverlay}
       >
-        <div className="flex w-24 flex-shrink-0 items-center gap-3 overflow-hidden sm:w-56">
-          <div className="hidden w-16 flex-shrink-0 overflow-hidden md:block">
-            {showDistance && (
-              <div className="text-xs text-base-content flex items-center gap-1 overflow-hidden">
-                <Tooltip content={`${Math.round(distance)} km away from you`}>
-                  <div className="flex items-center gap-1">
-                    <Ruler size={9} className="flex-shrink-0" />
-                    <span className="whitespace-nowrap">{Math.round(distance)} km</span>
-                  </div>
-                </Tooltip>
-              </div>
-            )}
-          </div>
-          {listLocationText && (
-            <div className="min-w-0 flex-1 text-xs text-base-content/60 flex items-center gap-1 overflow-hidden">
-              <Tooltip content={locationText || listLocationText} wrapperClassName="flex items-center gap-1 min-w-0 overflow-hidden w-full">
-                {user.is_remote || user.isRemote ? (
-                  <Globe size={9} className="flex-shrink-0" />
-                ) : (
-                  <MapPin size={9} className="flex-shrink-0" />
-                )}
-                <span className="truncate sm:hidden">{listLocationTextShort}</span>
-                <span className="truncate hidden sm:block">{listLocationText}</span>
-              </Tooltip>
-            </div>
-          )}
-        </div>
-        <div className="hidden w-52 flex-shrink-0 text-xs text-base-content/60 lg:flex items-center gap-1 overflow-hidden">
-          {tagsSummary && (
-            <Tooltip content={tagNames.join(", ")} wrapperClassName="flex items-center gap-1 min-w-0 overflow-hidden w-full">
-              <Tag size={9} className="flex-shrink-0" />
-              <span className="truncate">{tagsSummary}</span>
-            </Tooltip>
-          )}
-        </div>
-        <div className="hidden w-48 flex-shrink-0 text-xs text-base-content/60 xl:flex items-center gap-1 overflow-hidden">
-          {badgesSummary && (
-            <Tooltip content={badgeNames.join(", ")} wrapperClassName="flex items-center gap-1 min-w-0 overflow-hidden w-full">
-              <Award size={9} className="flex-shrink-0" />
-              <span className="truncate">{badgesSummary}</span>
-            </Tooltip>
-          )}
-        </div>
+        <ListViewRow
+          locationText={listLocationTextShort}
+          locationTooltip={listLocationText}
+          isRemote={user.is_remote || user.isRemote}
+          distance={showDistance ? Math.round(distance) : null}
+          tagsSummary={tagsSummary}
+          tagsTooltip={tagNames.join(", ")}
+          badgesSummary={badgesSummary}
+          badgesTooltip={badgeNames.join(", ")}
+        />
       </Card>
     );
   }
@@ -357,7 +325,7 @@ const UserCard = ({
       title={displayName()}
       subtitle={
         <span
-          className={`mt-0.5 flex max-h-[2.75em] items-center flex-wrap overflow-hidden leading-snug text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-px w-full" : "text-sm gap-x-1.5 gap-y-px"}`}
+          className={`mt-0.5 flex max-h-[2.75em] items-center flex-wrap overflow-hidden leading-[110%] text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-px w-full" : "text-sm gap-x-1.5 gap-y-px"}`}
         >
           {scoreSubtitleItem}
           {user.username && <span>@{user.username}</span>}

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -393,12 +393,12 @@ const UserCard = ({
       }
       headerClassName={
         viewMode === "mini"
-          ? `!p-4 sm:!p-5 ${activeFilters.showLocation || activeFilters.showTags || activeFilters.showBadges ? "!pb-4" : "!pb-0"}`
+          ? "!p-4 sm:!p-5 !pb-4 sm:!pb-5"
           : ""
       }
       imageWrapperClassName={viewMode === "mini" ? "mb-0 pb-0" : ""}
       titleClassName={
-        viewMode === "mini" ? "text-base mb-0.5 leading-[110%]" : ""
+        viewMode === "mini" ? "text-base mb-0 leading-[110%]" : ""
       }
       marginClassName="mb-0"
       imageOverlay={avatarOverlay}

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -782,6 +782,7 @@ const UserDetailsModal = ({
               className=""
               distance={showMatchHighlights ? effectiveDistanceKm : null}
               headerRight={roleMatchLocationHeaderRight}
+              showCountryCode={false}
             />
 
             {/* Focus Areas */}
@@ -825,14 +826,14 @@ const UserDetailsModal = ({
                   return (
                     <span className="flex items-center gap-1.5 text-sm text-success">
                       <MatchIcon size={14} className="flex-shrink-0" />
-                      <span>{matchCount}/{total} in common</span>
+                      <span>{matchCount}/{total} matching</span>
                     </span>
                   );
                 }
                 return (
                   <span className="flex items-center gap-1.5 text-sm text-slate-500">
                     <X size={14} className="flex-shrink-0" />
-                    <span>None in common</span>
+                    <span className="leading-[1.1]">None matching</span>
                   </span>
                 );
               })()}
@@ -889,14 +890,14 @@ const UserDetailsModal = ({
                   return (
                     <span className="flex items-center gap-1.5 text-sm text-success">
                       <MatchIcon size={14} className="flex-shrink-0" />
-                      <span>{matchCount}/{total} in common</span>
+                      <span>{matchCount}/{total} matching</span>
                     </span>
                   );
                 }
                 return (
                   <span className="flex items-center gap-1.5 text-sm text-slate-500">
                     <X size={14} className="flex-shrink-0" />
-                    <span>None in common</span>
+                    <span className="leading-[1.1]">None matching</span>
                   </span>
                 );
               })()}

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -14,7 +14,7 @@ import {
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "./DemoAvatarOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
-import { getCountryCode, normalizeLocationData } from "../../utils/locationUtils";
+import { formatListLocation, normalizeLocationData } from "../../utils/locationUtils";
 import { format } from "date-fns";
 
 /**
@@ -102,9 +102,8 @@ const UserProfileHeaderSection = ({
 
   const displayName = getDisplayName();
   const location = normalizeLocationData(user);
-  const countryCode = getCountryCode(location.country);
   const headerLocationText = location.hasLocation
-    ? [location.city, countryCode || location.country].filter(Boolean).join(", ")
+    ? formatListLocation(user, { isRemote: location.isRemote }).short
     : "";
 
   useLayoutEffect(() => {

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -5,7 +5,6 @@ import {
   EyeClosed,
   Calendar,
   FlaskConical,
-  MapPin,
 } from "lucide-react";
 import {
   DEMO_PROFILE_TOOLTIP,
@@ -14,7 +13,6 @@ import {
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "./DemoAvatarOverlay";
 import { getMatchTier } from "../../utils/matchScoreUtils";
-import { formatListLocation, normalizeLocationData } from "../../utils/locationUtils";
 import { format } from "date-fns";
 
 /**
@@ -101,11 +99,6 @@ const UserProfileHeaderSection = ({
   };
 
   const displayName = getDisplayName();
-  const location = normalizeLocationData(user);
-  const headerLocationText = location.hasLocation
-    ? formatListLocation(user, { isRemote: location.isRemote }).short
-    : "";
-
   useLayoutEffect(() => {
     const container = titleContainerRef.current;
     const probe = titleProbeRef.current;
@@ -183,13 +176,6 @@ const UserProfileHeaderSection = ({
         </h1>
         <div className="flex items-center flex-wrap gap-x-3 gap-y-0.5 text-sm leading-[110%]">
           <span className="text-base-content/70">@{user?.username}</span>
-          {headerLocationText && (
-            <span className="flex items-center text-base-content/70">
-              <MapPin size={14} className="mr-1 flex-shrink-0" />
-              <span>{headerLocationText}</span>
-            </span>
-          )}
-
           {/* Visibility Indicator - Only show for own profile */}
           {shouldShowVisibilityIndicator() && (
             <div className="flex items-center text-base-content/70">
@@ -206,13 +192,13 @@ const UserProfileHeaderSection = ({
               )}
             </div>
           )}
-          {((dateIsNarrow && getMemberSinceDate()) || isSyntheticUser(user)) && (
-            <span className="flex items-center gap-3 flex-shrink-0">
-              {dateIsNarrow && getMemberSinceDate() && (
+          {(getMemberSinceDate() || isSyntheticUser(user)) && (
+            <span className="flex items-center gap-1.5 flex-shrink-0">
+              {getMemberSinceDate() && (
                 <Tooltip
                   content={`Joined Lomir on ${getMemberSinceDate().full}`}
                   position="bottom"
-                  wrapperClassName="flex items-center text-base-content/70 flex-shrink-0 cursor-help"
+                  wrapperClassName={`items-center text-base-content/70 flex-shrink-0 cursor-help ${dateIsNarrow ? "flex" : "flex sm:hidden"}`}
                 >
                   <Calendar size={14} className="mr-1" />
                   <span>{getMemberSinceDate().short}</span>
@@ -223,8 +209,8 @@ const UserProfileHeaderSection = ({
                   content={DEMO_PROFILE_TOOLTIP}
                   wrapperClassName="flex items-start text-base-content/50"
                 >
-                  <FlaskConical size={14} className={`flex-shrink-0 mt-px${dateIsNarrow ? "" : " mr-0.5"}`} />
-                  {!dateIsNarrow && <span className="leading-[1.15]">Demo Profile</span>}
+                  <FlaskConical size={14} className={`flex-shrink-0 mt-px${dateIsNarrow ? "" : " sm:mr-0.5"}`} />
+                  {!dateIsNarrow && <span className="hidden sm:inline leading-[1.15]">Demo Profile</span>}
                 </Tooltip>
               )}
             </span>
@@ -236,7 +222,7 @@ const UserProfileHeaderSection = ({
       {getMemberSinceDate() && (
         <div
           ref={dateRef}
-          className={`flex-shrink-0${dateIsNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
+          className={`flex-shrink-0${dateIsNarrow ? " absolute opacity-0 pointer-events-none" : " hidden sm:block"}`}
         >
           <Tooltip
             content={`Joined Lomir on ${getMemberSinceDate().full}`}

--- a/src/hooks/useTeamAwardModals.js
+++ b/src/hooks/useTeamAwardModals.js
@@ -1,0 +1,332 @@
+import { useState, useCallback } from "react";
+import { teamService } from "../services/teamService";
+
+/**
+ * useTeamAwardModals
+ *
+ * Team-scoped parallel of useAwardModals.
+ * Fetches badge awards for ALL team members (restricted to team focus-area tags)
+ * and feeds them to TagAwardsModal / SupercategoryAwardsModal / BadgeCategoryModal.
+ *
+ * @param {string|number} teamId - The team whose focus-area awards to fetch
+ * @returns {Object} Modal state, handlers, closers, and props-spreaders
+ */
+
+/**
+ * Robustly unwrap an API response to get the data rows array.
+ */
+const unwrapRows = (response) => {
+  const payload =
+    response?.success !== undefined
+      ? response
+      : response?.data?.success !== undefined
+        ? response.data
+        : (response?.data ?? response);
+
+  const rows = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : [];
+
+  return rows;
+};
+
+const useTeamAwardModals = (teamId) => {
+  // ========= Tag Awards Modal state =========
+  const [tagAwardsModal, setTagAwardsModal] = useState({
+    isOpen: false,
+    tagName: null,
+    dominantBadgeCategory: null,
+    totalCredits: 0,
+  });
+  const [tagAwards, setTagAwards] = useState([]);
+  const [tagAwardsLoading, setTagAwardsLoading] = useState(false);
+
+  // ========= Supercategory Awards Modal state =========
+  const [supercategoryModal, setSupercategoryModal] = useState({
+    isOpen: false,
+    supercategory: null,
+    tags: [],
+    totalCredits: 0,
+  });
+  const [supercategoryAwards, setSupercategoryAwards] = useState([]);
+  const [supercategoryLoading, setSupercategoryLoading] = useState(false);
+
+  // ========= Badge Category Modal state (NEW) =========
+  const [badgeCategoryModal, setBadgeCategoryModal] = useState({
+    isOpen: false,
+    category: null,
+    color: null,
+    badges: [],
+    totalCredits: 0,
+    focusedBadgeName: null,
+  });
+  const [detailedBadgeAwards, setDetailedBadgeAwards] = useState([]);
+  const [badgeModalLoading, setBadgeModalLoading] = useState(false);
+
+  // ========= Shared fetch helper (focus-area filtered awards) =========
+
+  const fetchTeamAwards = useCallback(async () => {
+    if (!teamId) return [];
+    try {
+      const response = await teamService.getTeamBadgeAwards(teamId);
+      return unwrapRows(response);
+    } catch (error) {
+      console.error("Error fetching team badge awards:", error);
+      return [];
+    }
+  }, [teamId]);
+
+  /** Fetch ALL badge awards for team members (not filtered by focus areas).
+   *  Used by badge category / badge pill drill-downs. */
+  const fetchAllTeamBadgeAwards = useCallback(async () => {
+    if (!teamId) return [];
+    try {
+      const response = await teamService.getTeamMemberBadgeAwards(teamId);
+      return unwrapRows(response);
+    } catch (error) {
+      console.error("Error fetching all team member badge awards:", error);
+      return [];
+    }
+  }, [teamId]);
+
+  // ========= Tag & Supercategory Handlers (unchanged) =========
+
+  /** Click a credited tag pill → open TagAwardsModal */
+  const handleTagClick = useCallback(
+    async (tag) => {
+      setTagAwardsModal({
+        isOpen: true,
+        tagName: tag.name,
+        dominantBadgeCategory:
+          tag.dominantBadgeCategory || tag.dominant_badge_category,
+        totalCredits: tag.badgeCredits || tag.badge_credits || 0,
+      });
+      setTagAwardsLoading(true);
+
+      try {
+        const rows = await fetchTeamAwards();
+
+        const filtered = rows.filter((award) => {
+          const awardTagName = award.tagName ?? award.tag_name;
+          return awardTagName === tag.name;
+        });
+
+        setTagAwards(filtered);
+      } catch (error) {
+        console.error("Error filtering tag awards:", error);
+        setTagAwards([]);
+      } finally {
+        setTagAwardsLoading(false);
+      }
+    },
+    [fetchTeamAwards],
+  );
+
+  /** Click a supercategory icon → open SupercategoryAwardsModal */
+  const handleSupercategoryClick = useCallback(
+    async (supercategory, groupTags) => {
+      const totalCredits = groupTags.reduce(
+        (sum, t) => sum + (t.badgeCredits || t.badge_credits || 0),
+        0,
+      );
+
+      setSupercategoryModal({
+        isOpen: true,
+        supercategory,
+        tags: groupTags,
+        totalCredits,
+      });
+      setSupercategoryLoading(true);
+
+      try {
+        const rows = await fetchTeamAwards();
+
+        const tagNames = new Set(groupTags.map((t) => t.name));
+
+        const filtered = rows.filter((award) => {
+          const awardTagName = award.tagName ?? award.tag_name;
+          return awardTagName && tagNames.has(awardTagName);
+        });
+
+        setSupercategoryAwards(filtered);
+      } catch (error) {
+        console.error("Error filtering supercategory awards:", error);
+        setSupercategoryAwards([]);
+      } finally {
+        setSupercategoryLoading(false);
+      }
+    },
+    [fetchTeamAwards],
+  );
+
+  // ========= Badge Category & Badge Pill Handlers (NEW) =========
+
+  /** Click a badge category icon → open BadgeCategoryModal for entire category */
+  const handleBadgeCategoryClick = useCallback(
+    async (category, color, badges, totalCredits) => {
+      setBadgeCategoryModal({
+        isOpen: true,
+        category,
+        color,
+        badges,
+        totalCredits,
+        focusedBadgeName: null,
+      });
+      setBadgeModalLoading(true);
+
+      try {
+        const rows = await fetchAllTeamBadgeAwards();
+
+        const categoryAwards = rows.filter((award) => {
+          const c =
+            award.badgeCategory ??
+            award.badge_category ??
+            award.category ??
+            award.badge_category_name;
+          return String(c ?? "").trim() === String(category ?? "").trim();
+        });
+
+        setDetailedBadgeAwards(categoryAwards);
+      } catch (error) {
+        console.error("Error fetching detailed badge awards:", error);
+        setDetailedBadgeAwards([]);
+      } finally {
+        setBadgeModalLoading(false);
+      }
+    },
+    [fetchAllTeamBadgeAwards],
+  );
+
+  /** Click an individual badge pill → open BadgeCategoryModal focused on that badge */
+  const handleBadgeClick = useCallback(
+    async (badge, category, color) => {
+      const badgeCredits = badge.total_credits ?? badge.totalCredits ?? 0;
+
+      setBadgeCategoryModal({
+        isOpen: true,
+        category,
+        color,
+        badges: [badge],
+        totalCredits: badgeCredits,
+        focusedBadgeName: badge.name,
+      });
+      setBadgeModalLoading(true);
+
+      try {
+        const rows = await fetchAllTeamBadgeAwards();
+
+        const badgeAwards = rows.filter((award) => {
+          const awardBadgeName =
+            award.badgeName ?? award.badge_name ?? award.name;
+          return (
+            String(awardBadgeName ?? "").trim() ===
+            String(badge.name ?? "").trim()
+          );
+        });
+
+        setDetailedBadgeAwards(badgeAwards);
+      } catch (error) {
+        console.error("Error fetching badge awards:", error);
+        setDetailedBadgeAwards([]);
+      } finally {
+        setBadgeModalLoading(false);
+      }
+    },
+    [fetchAllTeamBadgeAwards],
+  );
+
+  // ========= Closers =========
+
+  const closeTagAwardsModal = useCallback(() => {
+    setTagAwardsModal({
+      isOpen: false,
+      tagName: null,
+      dominantBadgeCategory: null,
+      totalCredits: 0,
+    });
+    setTagAwards([]);
+  }, []);
+
+  const closeSupercategoryModal = useCallback(() => {
+    setSupercategoryModal({
+      isOpen: false,
+      supercategory: null,
+      tags: [],
+      totalCredits: 0,
+    });
+    setSupercategoryAwards([]);
+  }, []);
+
+  const closeBadgeCategoryModal = useCallback(() => {
+    setBadgeCategoryModal({
+      isOpen: false,
+      category: null,
+      color: null,
+      badges: [],
+      totalCredits: 0,
+      focusedBadgeName: null,
+    });
+    setDetailedBadgeAwards([]);
+  }, []);
+
+  // ========= Props-spreader objects (for cleaner JSX) =========
+
+  /** Spread onto <TagAwardsModal ... /> */
+  const tagAwardsModalProps = {
+    isOpen: tagAwardsModal.isOpen,
+    onClose: closeTagAwardsModal,
+    tagName: tagAwardsModal.tagName,
+    dominantBadgeCategory: tagAwardsModal.dominantBadgeCategory,
+    totalCredits: tagAwardsModal.totalCredits,
+    awards: tagAwards,
+    loading: tagAwardsLoading,
+    entityType: "team",
+  };
+
+  /** Spread onto <SupercategoryAwardsModal ... /> */
+  const supercategoryModalProps = {
+    isOpen: supercategoryModal.isOpen,
+    onClose: closeSupercategoryModal,
+    supercategory: supercategoryModal.supercategory,
+    tags: supercategoryModal.tags,
+    totalCredits: supercategoryModal.totalCredits,
+    awards: supercategoryAwards,
+    loading: supercategoryLoading,
+    entityType: "team",
+  };
+
+  /** Spread onto <BadgeCategoryModal ... /> (NEW) */
+  const badgeCategoryModalProps = {
+    isOpen: badgeCategoryModal.isOpen,
+    onClose: closeBadgeCategoryModal,
+    category: badgeCategoryModal.category,
+    color: badgeCategoryModal.color,
+    badges: badgeCategoryModal.badges,
+    totalCredits: badgeCategoryModal.totalCredits,
+    detailedAwards: detailedBadgeAwards,
+    loading: badgeModalLoading,
+    focusedBadgeName: badgeCategoryModal.focusedBadgeName,
+  };
+
+  return {
+    // Handlers (wire to TagsDisplaySection & BadgesDisplaySection)
+    handleTagClick,
+    handleSupercategoryClick,
+    handleBadgeCategoryClick,
+    handleBadgeClick,
+
+    // Closers (if needed individually)
+    closeTagAwardsModal,
+    closeSupercategoryModal,
+    closeBadgeCategoryModal,
+
+    // Props-spreader objects (for JSX)
+    tagAwardsModalProps,
+    supercategoryModalProps,
+    badgeCategoryModalProps,
+  };
+};
+
+export default useTeamAwardModals;

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -738,6 +738,30 @@ export const formatLocation = (locationData, options = {}) => {
 };
 
 /**
+ * Format location for list-style display.
+ *
+ * Returns a compact short string (city, country code) and a full string
+ * (city, country name) while preserving the existing "Remote" behavior.
+ *
+ * @param {Object} entity - Entity with location fields (raw or normalized)
+ * @param {Object} options
+ * @param {boolean} options.isRemote - Whether the entity is remote
+ * @returns {{ short: string, full: string }} Short and full location strings
+ */
+export const formatListLocation = (entity, { isRemote = false } = {}) => {
+  if (isRemote) {
+    return { short: "Remote", full: "Remote" };
+  }
+
+  const normalized = normalizeLocationData(entity);
+  const full = [normalized.city, normalized.countryName].filter(Boolean).join(", ");
+  const short =
+    [normalized.city, normalized.countryCode].filter(Boolean).join(", ") || full;
+
+  return { short, full };
+};
+
+/**
  * Check if location data has changed between two objects
  * Used to determine if geocoding is needed
  *

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -450,6 +450,26 @@ const FRANKFURT_POSTAL_CODE_DISTRICTS = {
   65936: "Nied",
 };
 
+const DE_CITY_COORDS = [
+  { pattern: /^10\d{3}$|^11\d{3}$|^12\d{3}$|^13\d{3}$|^14[01]\d{2}$/, city: "Berlin", state: "Berlin", lat: 52.52, lng: 13.405 },
+  { pattern: /^60\d{3}$|^6[1-5]\d{3}$/, city: "Frankfurt am Main", state: "Hessen", lat: 50.1109, lng: 8.6821 },
+  { pattern: /^8[01]\d{3}$/, city: "München", state: "Bayern", lat: 48.1351, lng: 11.582 },
+  { pattern: /^86\d{3}$/, city: "Augsburg", state: "Bayern", lat: 48.3705, lng: 10.8978 },
+  { pattern: /^2[012]\d{3}$/, city: "Hamburg", state: "Hamburg", lat: 53.5511, lng: 9.9937 },
+  { pattern: /^5[01]\d{3}$/, city: "Köln", state: "Nordrhein-Westfalen", lat: 50.9333, lng: 6.95 },
+  { pattern: /^7[01]\d{3}$/, city: "Stuttgart", state: "Baden-Württemberg", lat: 48.7758, lng: 9.1829 },
+  { pattern: /^40\d{3}$/, city: "Düsseldorf", state: "Nordrhein-Westfalen", lat: 51.2217, lng: 6.7762 },
+  { pattern: /^44\d{3}$/, city: "Dortmund", state: "Nordrhein-Westfalen", lat: 51.5136, lng: 7.4653 },
+  { pattern: /^45\d{3}$/, city: "Essen", state: "Nordrhein-Westfalen", lat: 51.4556, lng: 7.0116 },
+  { pattern: /^28\d{3}$/, city: "Bremen", state: "Bremen", lat: 53.0793, lng: 8.8017 },
+  { pattern: /^30\d{3}$/, city: "Hannover", state: "Niedersachsen", lat: 52.3759, lng: 9.732 },
+  { pattern: /^90\d{3}$/, city: "Nürnberg", state: "Bayern", lat: 49.4521, lng: 11.0767 },
+  { pattern: /^04\d{3}$/, city: "Leipzig", state: "Sachsen", lat: 51.3397, lng: 12.3731 },
+  { pattern: /^01\d{3}$/, city: "Dresden", state: "Sachsen", lat: 51.0504, lng: 13.7373 },
+  { pattern: /^48\d{3}$/, city: "Münster", state: "Nordrhein-Westfalen", lat: 51.9607, lng: 7.6261 },
+  { pattern: /^09\d{3}$/, city: "Chemnitz", state: "Sachsen", lat: 50.8278, lng: 12.9214 },
+];
+
 export const deriveLocationFromPostalCode = (postalCode, country) => {
   const code = normalizePostalCode(postalCode);
   if (!code) return {};
@@ -464,11 +484,9 @@ export const deriveLocationFromPostalCode = (postalCode, country) => {
       state: "Berlin",
       country: "Germany",
       district: berlinDistrict,
+      latitude: 52.52,
+      longitude: 13.405,
     };
-  }
-
-  if (/^10\d{3}$|^11\d{3}$|^12\d{3}$|^13\d{3}$|^14[01]\d{2}$/.test(code)) {
-    return { city: "Berlin", state: "Berlin", country: "Germany" };
   }
 
   const frankfurtDistrict = FRANKFURT_POSTAL_CODE_DISTRICTS[code];
@@ -478,11 +496,20 @@ export const deriveLocationFromPostalCode = (postalCode, country) => {
       state: "Hessen",
       country: "Germany",
       district: frankfurtDistrict,
+      latitude: 50.1109,
+      longitude: 8.6821,
     };
   }
 
-  if (/^60\d{3}$|^65\d{3}$/.test(code)) {
-    return { city: "Frankfurt am Main", state: "Hessen", country: "Germany" };
+  const cityMatch = DE_CITY_COORDS.find((entry) => entry.pattern.test(code));
+  if (cityMatch) {
+    return {
+      city: cityMatch.city,
+      state: cityMatch.state,
+      country: "Germany",
+      latitude: cityMatch.lat,
+      longitude: cityMatch.lng,
+    };
   }
 
   return {};
@@ -569,6 +596,7 @@ export const normalizeLocationData = (entity) => {
     entity.role_location?.lat,
     entity.roleLocation?.latitude,
     entity.roleLocation?.lat,
+    derivedLocation.latitude,
   ) ?? null;
   const longitude = firstPresent(
     entity.longitude,
@@ -583,6 +611,7 @@ export const normalizeLocationData = (entity) => {
     entity.roleLocation?.longitude,
     entity.roleLocation?.lng,
     entity.roleLocation?.lon,
+    derivedLocation.longitude,
   ) ?? null;
   const isRemote = entity.is_remote === true || entity.isRemote === true;
 

--- a/src/utils/matchScoreUtils.js
+++ b/src/utils/matchScoreUtils.js
@@ -17,6 +17,9 @@ export function getMatchTier(score) {
       pct,
       Icon: Sparkles,
       bg: "bg-orange-500",
+      bgMid: "bg-orange-800/30",
+      bgTint: "bg-orange-50",
+      borderTint: "border-orange-500",
       text: "text-orange-500",
       label: "Great match",
     };
@@ -25,6 +28,9 @@ export function getMatchTier(score) {
       pct,
       Icon: TrendingUp,
       bg: "bg-success",
+      bgMid: "bg-[#036b0c]/30",
+      bgTint: "bg-green-50",
+      borderTint: "border-success",
       text: "text-success",
       label: "Good match",
     };
@@ -32,6 +38,9 @@ export function getMatchTier(score) {
     pct,
     Icon: TrendingDown,
     bg: "bg-slate-400",
+    bgMid: "bg-slate-400/30",
+    bgTint: "bg-slate-50",
+    borderTint: "border-slate-400",
     text: "text-slate-400",
     label: "Low match",
   };


### PR DESCRIPTION
Summary
Unified match score card into a single shared MatchScoreSection component used by all detail modals (user, team, role) — design changes now propagate everywhere from one place
Match score card polish: tier-based color system for bar fills/tracks/backgrounds/borders, 110% leading throughout, structured headline with contextual detail line showing focus areas, badges, and location ("X of Y in common and within 100 km")
Extracted shared utilities: MatchScoreOverlay component, formatListLocation utility, consolidated DemoAvatarOverlay presets
Responsive detail modal headers: date badge moves from the top-right corner into the subline on narrow viewports across all three modal types; "Demo" label collapses to icon-only on mobile
Test plan
 Open a user, team, and role detail modal — match score card should render consistently with tier colors (orange ≥80%, green ≥50%, slate <50%)
 Verify headline detail line appears on all card types including filled-role cards in VacantRoleDetailsModal
 Narrow the browser to mobile width — date should appear in the subline, not push it left
 Check that "Demo Profile / Demo Team" label collapses to icon-only on small screens
 Verify no location text in user modal header (only in the dedicated Location section below)