### PR TITLE
Refactor/refactor components

### DIFF
--- a/src/components/badges/BadgeAwardModal.jsx
+++ b/src/components/badges/BadgeAwardModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
 import {
   Award,
   Send,
@@ -17,6 +17,8 @@ import {
   FlaskConical,
   // Badge icons
   MessageCircle,
+  Calendar,
+  MapPin,
 } from "lucide-react";
 import {
   CATEGORY_COLORS,
@@ -38,6 +40,7 @@ import { tagService } from "../../services/tagService";
 import { useBadges, useSharedTeamsForAward } from "../../hooks/useBadgeQueries";
 import { useUserTags } from "../../hooks/useUserQueries";
 import { DEMO_PROFILE_TOOLTIP } from "../../utils/userHelpers";
+import { format } from "date-fns";
 
 /**
  * BadgeAwardModal Component
@@ -94,6 +97,9 @@ const BadgeAwardModal = ({
   awardeeAvatar,
   awardeeBio,
   awardeeIsDemo,
+  awardeeCity = null,
+  awardeeCountry = null,
+  awardeeJoinedAt = null,
   onUserClick,
   onAwardComplete,
 }) => {
@@ -120,6 +126,12 @@ const BadgeAwardModal = ({
   const [showTagSearch, setShowTagSearch] = useState(false);
   const tagSearchRef = useRef(null);
   const tagSearchTimerRef = useRef(null);
+  const nameContainerRef = useRef(null);
+  const nameProbeRef = useRef(null);
+  const dateRef = useRef(null);
+  const [dateIsNarrow, setDateIsNarrow] = useState(false);
+  const dateIsNarrowRef = useRef(false);
+  dateIsNarrowRef.current = dateIsNarrow;
   const {
     data: badges = EMPTY_QUERY_ARRAY,
     error: badgesError,
@@ -159,6 +171,16 @@ const BadgeAwardModal = ({
   const getAbbreviatedName = () => {
     return (awardeeFirstName || "").split(" ")[0] || awardeeUsername || "User";
   };
+
+  const locationText = [awardeeCity, awardeeCountry].filter(Boolean).join(", ");
+  const joinedDateText = (() => {
+    if (!awardeeJoinedAt) return null;
+    try {
+      return format(new Date(awardeeJoinedAt), "MMM d, yyyy");
+    } catch {
+      return null;
+    }
+  })();
 
   useEffect(() => {
     setAwardeeTags(fetchedAwardeeTags);
@@ -268,6 +290,30 @@ const BadgeAwardModal = ({
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
+
+  useLayoutEffect(() => {
+    const container = nameContainerRef.current;
+    const probe = nameProbeRef.current;
+    if (!container || !probe) return;
+
+    const update = () => {
+      const first = awardeeFirstName || "";
+      const last = awardeeLastName || "";
+      const full = `${first} ${last}`.trim();
+      const displayName = full || awardeeUsername || "User";
+      const dateEl = dateRef.current;
+      const reservedWidth =
+        dateIsNarrowRef.current && dateEl ? dateEl.offsetWidth + 16 : 0;
+      probe.textContent = displayName;
+      setDateIsNarrow(probe.scrollWidth > container.clientWidth - reservedWidth);
+    };
+
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(container);
+    if (dateRef.current) resizeObserver.observe(dateRef.current);
+    update();
+    return () => resizeObserver.disconnect();
+  }, [awardeeFirstName, awardeeLastName, awardeeUsername]);
 
   // Group badges by category
   const badgesByCategory = badges.reduce((acc, badge) => {
@@ -445,9 +491,28 @@ const BadgeAwardModal = ({
 
         {/* Awardee info */}
         {!success && (
-          <div className="flex items-start space-x-3 mb-3">
-            {onUserClick ? (
-              <Tooltip content="View profile" position="bottom" wrapperClassName="block">
+          <div className="relative flex items-start justify-between gap-4 mb-5">
+            <div className="flex min-w-0 flex-1 items-start space-x-4">
+              {onUserClick ? (
+                <Tooltip content="View profile" position="bottom" wrapperClassName="block">
+                  <UserAvatar
+                    user={{
+                      avatar_url: awardeeAvatar,
+                      avatarUrl: awardeeAvatar,
+                      first_name: awardeeFirstName,
+                      last_name: awardeeLastName,
+                      username: awardeeUsername,
+                    }}
+                    sizeClass="w-12 h-12"
+                    initialsClassName="text-xl font-medium"
+                    clickable
+                    onClick={() => onUserClick(awardeeId)}
+                    title="View profile"
+                    showDemoOverlay={awardeeIsDemo}
+                    demoOverlayTextClassName="text-[8px]"
+                  />
+                </Tooltip>
+              ) : (
                 <UserAvatar
                   user={{
                     avatar_url: awardeeAvatar,
@@ -457,69 +522,82 @@ const BadgeAwardModal = ({
                     username: awardeeUsername,
                   }}
                   sizeClass="w-12 h-12"
-                  clickable
-                  onClick={() => onUserClick(awardeeId)}
-                  title="View profile"
+                  initialsClassName="text-xl font-medium"
                   showDemoOverlay={awardeeIsDemo}
                   demoOverlayTextClassName="text-[8px]"
-                  demoOverlayTextTranslateClassName="-translate-y-[3px]"
                 />
-              </Tooltip>
-            ) : (
-              <UserAvatar
-                user={{
-                  avatar_url: awardeeAvatar,
-                  avatarUrl: awardeeAvatar,
-                  first_name: awardeeFirstName,
-                  last_name: awardeeLastName,
-                  username: awardeeUsername,
-                }}
-                sizeClass="w-12 h-12"
-                showDemoOverlay={awardeeIsDemo}
-                demoOverlayTextClassName="text-[8px]"
-                demoOverlayTextTranslateClassName="-translate-y-[3px]"
-              />
-            )}
-
-            <div className="flex-1 min-w-0">
-              {onUserClick ? (
-                <Tooltip content="View profile" position="bottom" wrapperClassName="block">
-                  <h4
-                    className="font-medium text-base-content cursor-pointer hover:text-primary transition-colors leading-[120%] mb-[0.2em]"
-                    onClick={() => onUserClick(awardeeId)}
-                  >
-                    {getDisplayName()}
-                  </h4>
-                </Tooltip>
-              ) : (
-                <h4 className="font-medium text-base-content leading-[120%] mb-[0.2em]">
-                  {getDisplayName()}
-                </h4>
               )}
 
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-0">
-                {onUserClick ? (
-                  <Tooltip content="View profile" position="bottom" wrapperClassName="inline-flex">
-                    <p
-                      className="text-sm text-base-content/70 cursor-pointer hover:text-primary transition-colors"
-                      onClick={() => onUserClick(awardeeId)}
-                    >
-                      @{awardeeUsername}
-                    </p>
-                  </Tooltip>
-                ) : (
-                  <p className="text-sm text-base-content/70">@{awardeeUsername}</p>
-                )}
-                {awardeeIsDemo && (
-                  <Tooltip
-                    content={DEMO_PROFILE_TOOLTIP}
-                    wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+              <div className="flex-1 min-w-0">
+                <h4
+                  ref={nameContainerRef}
+                  className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative"
+                >
+                  {onUserClick ? (
+                    <Tooltip content="View profile" position="bottom" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
+                      <span onClick={() => onUserClick(awardeeId)}>{getDisplayName()}</span>
+                    </Tooltip>
+                  ) : (
+                    <span>{getDisplayName()}</span>
+                  )}
+                  <span
+                    ref={nameProbeRef}
+                    className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium"
+                    aria-hidden="true"
                   >
-                    <FlaskConical size={12} className="flex-shrink-0" />
-                  </Tooltip>
-                )}
+                    {getDisplayName()}
+                  </span>
+                </h4>
+
+                <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs" style={{ maxHeight: "2.1em" }}>
+                  {onUserClick ? (
+                    <Tooltip content="View profile" position="bottom" wrapperClassName="inline-flex">
+                      <p
+                        className="text-base-content/70 cursor-pointer hover:text-primary transition-colors"
+                        onClick={() => onUserClick(awardeeId)}
+                      >
+                        @{awardeeUsername}
+                      </p>
+                    </Tooltip>
+                  ) : (
+                    <p className="text-base-content/70">@{awardeeUsername}</p>
+                  )}
+                  {dateIsNarrow && joinedDateText && (
+                    <div className="flex shrink-0 items-center gap-1 text-base-content/60">
+                      <Calendar size={10} className="shrink-0" />
+                      <span className="leading-[1.05] whitespace-nowrap">{joinedDateText}</span>
+                    </div>
+                  )}
+                  {locationText && (
+                    <Tooltip
+                      content={locationText}
+                      wrapperClassName="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden"
+                    >
+                      <MapPin size={10} className="shrink-0 text-base-content/60" />
+                      <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">{locationText}</span>
+                    </Tooltip>
+                  )}
+                  {awardeeIsDemo && (
+                    <Tooltip
+                      content={DEMO_PROFILE_TOOLTIP}
+                      wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+                    >
+                      <FlaskConical size={12} className="flex-shrink-0" />
+                    </Tooltip>
+                  )}
+                </div>
               </div>
             </div>
+
+            {joinedDateText && (
+              <div
+                ref={dateRef}
+                className={`flex items-center text-xs text-base-content/60 whitespace-nowrap flex-shrink-0${dateIsNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
+              >
+                <Calendar size={12} className="mr-1" />
+                <span>{joinedDateText}</span>
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/badges/BadgeAwardModal.jsx
+++ b/src/components/badges/BadgeAwardModal.jsx
@@ -502,6 +502,7 @@ const BadgeAwardModal = ({
                       first_name: awardeeFirstName,
                       last_name: awardeeLastName,
                       username: awardeeUsername,
+                      is_synthetic: awardeeIsDemo,
                     }}
                     sizeClass="w-12 h-12"
                     initialsClassName="text-xl font-medium"
@@ -520,6 +521,7 @@ const BadgeAwardModal = ({
                     first_name: awardeeFirstName,
                     last_name: awardeeLastName,
                     username: awardeeUsername,
+                    is_synthetic: awardeeIsDemo,
                   }}
                   sizeClass="w-12 h-12"
                   initialsClassName="text-xl font-medium"

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -22,12 +22,12 @@ import {
 import { Link } from "react-router-dom";
 import Tooltip from "../common/Tooltip";
 import { CountBadge } from "../common/NotificationBadge";
-import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
+import { isSyntheticTeam } from "../../utils/userHelpers";
 import { formatRelativeChatTimestamp, formatShortRelativeChatTimestamp } from "../../utils/dateHelpers";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import UserAvatar from "../users/UserAvatar";
-import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import TeamAvatar from "../teams/TeamAvatar";
 import {
   DELETED_USER_DISPLAY_NAME,
   getDisplayName as getDeletedUserDisplayName,
@@ -689,38 +689,13 @@ const ConversationList = ({
                   }
                 >
                   {isTeam ? (
-                    <div className="w-14 h-14 rounded-full relative overflow-hidden">
-                      {getTeamAvatarUrl(conversationData) ? (
-                        <img
-                          src={getTeamAvatarUrl(conversationData)}
-                          alt={displayName}
-                          className="object-cover w-full h-full rounded-full"
-                          onError={(e) => {
-                            e.target.style.display = "none";
-                            const fallback =
-                              e.target.parentElement.querySelector(
-                                ".avatar-fallback",
-                              );
-                            if (fallback) fallback.style.display = "flex";
-                          }}
-                        />
-                      ) : null}
-                      <div
-                        className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                        style={{
-                          display: getTeamAvatarUrl(conversationData)
-                            ? "none"
-                            : "flex",
-                        }}
-                      >
-                        <span className="text-xl font-medium">
-                          {getTeamInitials(conversationData)}
-                        </span>
-                      </div>
-                      {isSyntheticTeam(conversationData) && (
-                        <DemoAvatarOverlay textClassName="text-[8px]" />
-                      )}
-                    </div>
+                    <TeamAvatar
+                      team={conversationData}
+                      sizeClass="w-14 h-14"
+                      initialsClassName="text-xl font-medium"
+                      showDemoOverlay={isSyntheticTeam(conversationData)}
+                      demoOverlayTextClassName="text-[8px]"
+                    />
                   ) : (
                     <UserAvatar
                       user={isFormerPartner ? null : conversationData}

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -106,13 +106,13 @@ const PersonRequestCard = ({
   const fullName = getDisplayName();
   const abbrevName = user ? formatDisplayName(user) : fullName;
   const [displayedName, setDisplayedName] = useState(fullName);
-  const displayedNameRef = useRef(fullName);
-  displayedNameRef.current = displayedName;
+  const [isOverflow, setIsOverflow] = useState(false);
+  const isOverflowRef = useRef(false);
+  isOverflowRef.current = isOverflow;
   const forceNarrowRef = useRef(forceNarrow);
   forceNarrowRef.current = forceNarrow;
 
   useLayoutEffect(() => {
-    if (fullName === abbrevName) { setDisplayedName(fullName); return; }
     const container = nameContainerRef.current;
     const probe = probeRef.current;
     if (!container || !probe) return;
@@ -120,11 +120,13 @@ const PersonRequestCard = ({
       // Date is absolute (out of flow) when either this card or any sibling card is narrow.
       // Subtract its width + gap back so the measurement is always against the same
       // effective width, preventing oscillation.
-      const isDateAbsolute = displayedNameRef.current !== fullName || forceNarrowRef.current;
+      const isDateAbsolute = isOverflowRef.current || forceNarrowRef.current;
       const dateEl = dateRef.current;
-      const dateReservedWidth = isDateAbsolute && dateEl ? dateEl.offsetWidth + 16 : 0; // 16 = space-x-4 gap
+      const dateReservedWidth = isDateAbsolute && dateEl ? dateEl.offsetWidth + 16 : 0;
       probe.textContent = fullName;
-      setDisplayedName(probe.scrollWidth <= container.clientWidth - dateReservedWidth ? fullName : abbrevName);
+      const overflows = probe.scrollWidth > container.clientWidth - dateReservedWidth;
+      setIsOverflow(overflows);
+      setDisplayedName(overflows && fullName !== abbrevName ? abbrevName : fullName);
     };
     const ro = new ResizeObserver(update);
     ro.observe(container);
@@ -132,8 +134,8 @@ const PersonRequestCard = ({
     return () => ro.disconnect();
   }, [fullName, abbrevName]);
 
-  const isNarrow = displayedName !== fullName;
-  const dateIsNarrow = isNarrow || forceNarrow;
+  const isNarrow = isOverflow;
+  const dateIsNarrow = isOverflow || forceNarrow;
 
   // Report narrow state to parent for cross-card sync
   useEffect(() => { onNarrowChange?.(isNarrow); }, [isNarrow]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -143,100 +145,103 @@ const PersonRequestCard = ({
   return (
     <div className="bg-base-200/30 rounded-lg border border-base-300 p-4">
       {/* User Info Header */}
-      <div className="flex items-start space-x-4 mb-4 relative">
-        {/* Avatar */}
-        <Tooltip
-          content={clickable ? "View profile" : undefined}
-          wrapperClassName={`avatar ${clickableStyles}`}
-        >
-          <div className="w-12 h-12 rounded-full relative overflow-hidden" onClick={handleUserClick}>
-            {avatarUrl ? (
-              <img
-                src={avatarUrl}
-                alt={user?.username || "User"}
-                className="object-cover w-full h-full rounded-full"
-                onError={(e) => {
-                  e.target.style.display = "none";
-                  const fallback =
-                    e.target.parentElement.querySelector(".avatar-fallback");
-                  if (fallback) fallback.style.display = "flex";
+      <div className="relative flex items-start justify-between gap-4 mb-4">
+        <div className="flex min-w-0 flex-1 items-start space-x-4">
+          {/* Avatar */}
+          <Tooltip
+            content={clickable ? "View profile" : undefined}
+            wrapperClassName={`avatar ${clickableStyles}`}
+          >
+            <div className="w-12 h-12 rounded-full relative overflow-hidden" onClick={handleUserClick}>
+              {avatarUrl ? (
+                <img
+                  src={avatarUrl}
+                  alt={user?.username || "User"}
+                  className="object-cover w-full h-full rounded-full"
+                  onError={(e) => {
+                    e.target.style.display = "none";
+                    const fallback =
+                      e.target.parentElement.querySelector(".avatar-fallback");
+                    if (fallback) fallback.style.display = "flex";
+                  }}
+                />
+              ) : null}
+              {/* Fallback initials */}
+              <div
+                className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+                style={{
+                  display: avatarUrl ? "none" : "flex",
                 }}
-              />
-            ) : null}
-            {/* Fallback initials */}
-            <div
-              className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-              style={{
-                display: avatarUrl ? "none" : "flex",
-              }}
-            >
-              <span className="text-xl font-medium">
-                {getUserInitials(user)}
-              </span>
+              >
+                <span className="text-xl font-medium">
+                  {getUserInitials(user)}
+                </span>
+              </div>
+              {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[8px]" />}
             </div>
-            {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[8px]" />}
-          </div>
-        </Tooltip>
+          </Tooltip>
 
-        {/* Name and Details */}
-        <div className="flex-1 min-w-0">
-          <h4 ref={nameContainerRef} className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative">
-            {clickable ? (
-              <Tooltip content="View profile" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
-                <span onClick={handleUserClick}>{displayedName}</span>
-              </Tooltip>
-            ) : (
-              displayedName
-            )}
-            <span ref={probeRef} className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium" aria-hidden="true" />
-          </h4>
-
-          {(dateIsNarrow || showUsername || (showLocation && (user?.city || user?.country || getPostalCode())) || sublineExtra || showDemoProfile) && (
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs" style={{ maxHeight: "2.1em" }}>
-              {dateIsNarrow ? (
-                <div className="flex shrink-0 items-center gap-1 text-base-content/60">
-                  <Calendar size={10} className="shrink-0" />
-                  <span className="leading-[1.05] whitespace-nowrap">{formatDate()}</span>
-                </div>
-              ) : showUsername && (
-                clickable ? (
-                  <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
-                    <Tooltip content="View profile" wrapperClassName="block truncate leading-[1.05] text-base-content/70 cursor-pointer hover:text-primary transition-colors">
-                      <span onClick={handleUserClick}>@{user.username}</span>
-                    </Tooltip>
-                  </div>
-                ) : (
-                  <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
-                    <span className="block truncate leading-[1.05] text-base-content/70">@{user.username}</span>
-                  </div>
-                )
-              )}
-              {showLocation && (user?.city || user?.country || getPostalCode()) && (
-                <div className="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden">
-                  <MapPin size={10} className="text-base-content/60 shrink-0" />
-                  <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">
-                    {formatListLocation(user, { isRemote: user?.is_remote || user?.isRemote }).short || getPostalCode()}
-                  </span>
-                </div>
-              )}
-              {sublineExtra}
-              {showDemoProfile && (
-                <Tooltip
-                  content={DEMO_PROFILE_TOOLTIP}
-                  wrapperClassName="flex shrink-0 items-center gap-0.5 text-base-content/50"
-                >
-                  <FlaskConical size={10} className="flex-shrink-0" />
+          {/* Name and Details */}
+          <div className="flex-1 min-w-0">
+            <h4 ref={nameContainerRef} className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative">
+              {clickable ? (
+                <Tooltip content="View profile" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
+                  <span onClick={handleUserClick}>{displayedName}</span>
                 </Tooltip>
+              ) : (
+                displayedName
               )}
-            </div>
-          )}
+              <span ref={probeRef} className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium" aria-hidden="true" />
+            </h4>
+
+            {(showUsername || dateIsNarrow || (showLocation && (user?.city || user?.country || getPostalCode())) || sublineExtra || showDemoProfile) && (
+              <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs" style={{ maxHeight: "2.1em" }}>
+                {showUsername && (
+                  clickable ? (
+                    <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
+                      <Tooltip content="View profile" wrapperClassName="block truncate leading-[1.05] text-base-content/70 cursor-pointer hover:text-primary transition-colors">
+                        <span onClick={handleUserClick}>@{user.username}</span>
+                      </Tooltip>
+                    </div>
+                  ) : (
+                    <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
+                      <span className="block truncate leading-[1.05] text-base-content/70">@{user.username}</span>
+                    </div>
+                  )
+                )}
+                {dateIsNarrow && (
+                  <div className="flex shrink-0 items-center gap-1 text-base-content/60">
+                    <Calendar size={10} className="shrink-0" />
+                    <span className="leading-[1.05] whitespace-nowrap">{formatDate()}</span>
+                  </div>
+                )}
+                {showLocation && (user?.city || user?.country || getPostalCode()) && (
+                  <div className="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden">
+                    <MapPin size={10} className="text-base-content/60 shrink-0" />
+                    <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">
+                      {formatListLocation(user, { isRemote: user?.is_remote || user?.isRemote }).short || getPostalCode()}
+                    </span>
+                  </div>
+                )}
+                {sublineExtra}
+                {showDemoProfile && (
+                  <Tooltip
+                    content={DEMO_PROFILE_TOOLTIP}
+                    wrapperClassName="flex shrink-0 items-center gap-0.5 text-base-content/50"
+                  >
+                    <FlaskConical size={10} className="flex-shrink-0" />
+                  </Tooltip>
+                )}
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Date - top right; absolute (out of flow) when narrow so subline gets full width,
             but still rendered so its width can be measured for stable name-fit calculation */}
         <div
           ref={dateRef}
-          className={`flex items-center text-xs text-base-content/60 flex-shrink-0${dateIsNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
+          className={`flex items-center text-xs text-base-content/60 whitespace-nowrap flex-shrink-0${dateIsNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
         >
           <Calendar size={12} className="mr-1" />
           <span>{formatDate()}</span>

--- a/src/components/teams/TeamApplicationModal.jsx
+++ b/src/components/teams/TeamApplicationModal.jsx
@@ -1,4 +1,5 @@
 import React, { lazy, Suspense, useState, useEffect } from "react";
+import { format } from "date-fns";
 import {
   Send,
   Users,
@@ -10,6 +11,7 @@ import {
   FlaskConical,
   ChevronRight,
   ChevronUp,
+  Calendar,
 } from "lucide-react";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { teamService } from "../../services/teamService";
@@ -331,6 +333,11 @@ const TeamApplicationModal = ({
   const teamLocation = getTeamLocation();
   const teamIsRemote = displayTeam?.isRemote ?? displayTeam?.is_remote;
   const showDemoTeam = isSyntheticTeam(displayTeam);
+  const teamCreatedAtRaw = displayTeam?.created_at ?? displayTeam?.createdAt ?? null;
+  const teamCreatedAtText = (() => {
+    if (!teamCreatedAtRaw) return null;
+    try { return format(new Date(teamCreatedAtRaw), "MMM d, yyyy"); } catch { return null; }
+  })();
   const shouldShowRolePicker =
     loadingRoles || vacantRoles.length > 0 || isRoleSectionExpanded;
   const roleAvailabilityLabel =
@@ -438,6 +445,13 @@ const TeamApplicationModal = ({
                 </CardMetaRow>
               </div>
             </div>
+
+            {teamCreatedAtText && (
+              <div className="flex items-center text-xs text-base-content/60 whitespace-nowrap flex-shrink-0">
+                <Calendar size={12} className="mr-1" />
+                <span>{teamCreatedAtText}</span>
+              </div>
+            )}
           </div>
 
           {displayTeam?.description && (

--- a/src/components/teams/TeamAvatar.jsx
+++ b/src/components/teams/TeamAvatar.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import { getTeamInitials, isSyntheticTeam } from "../../utils/userHelpers";
+
+const TeamAvatar = ({
+  team,
+  sizeClass = "w-14 h-14",
+  className = "",
+  clickable = false,
+  onClick,
+  title,
+  initialsClassName = "text-xl font-medium",
+  showDemoOverlay = false,
+  demoOverlayTextClassName = "text-[8px]",
+  demoOverlayTextTranslateClassName = "-translate-y-[2px]",
+}) => {
+  const avatarUrl =
+    team?.teamavatar_url ||
+    team?.teamavatarUrl ||
+    team?.avatar_url ||
+    team?.avatarUrl ||
+    null;
+  const teamName = team?.name || "Team";
+  const showSyntheticOverlay = showDemoOverlay && isSyntheticTeam(team);
+
+  return (
+    <div
+      className={`${clickable ? "cursor-pointer hover:opacity-80 transition-opacity" : ""} ${className}`}
+      onClick={clickable ? onClick : undefined}
+      title={title}
+    >
+      <div className={`${sizeClass} rounded-full relative overflow-hidden`}>
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={teamName}
+            className="object-cover w-full h-full rounded-full"
+            onError={(e) => {
+              e.target.style.display = "none";
+              const fallback =
+                e.target.parentElement.querySelector(".avatar-fallback");
+              if (fallback) fallback.style.display = "flex";
+            }}
+          />
+        ) : null}
+
+        <div
+          className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
+          style={{ display: avatarUrl ? "none" : "flex" }}
+        >
+          <span className={initialsClassName}>
+            {getTeamInitials(team)}
+          </span>
+        </div>
+
+        {showSyntheticOverlay && (
+          <DemoAvatarOverlay
+            textClassName={demoOverlayTextClassName}
+            textTranslateClassName={demoOverlayTextTranslateClassName}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TeamAvatar;

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -30,7 +30,7 @@ import Alert from "../common/Alert";
 import { format } from "date-fns";
 import InlineUserLink from "../users/InlineUserLink";
 import { useHydratedRole } from "../../hooks/useHydratedRole";
-import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import TeamAvatar from "./TeamAvatar";
 import { DEMO_TEAM_TOOLTIP, isSyntheticTeam } from "../../utils/userHelpers";
 import { useAuth } from "../../contexts/AuthContext";
 import {
@@ -265,34 +265,6 @@ const TeamInvitationDetailsModal = ({
       console.error("Error formatting date:", error);
       return "Unknown date";
     }
-  };
-
-  const getTeamAvatar = () => {
-    return (
-      team.teamavatar_url ||
-      team.teamavatarUrl ||
-      team.avatar_url ||
-      team.avatarUrl ||
-      null
-    );
-  };
-
-  // Get team initials from name (e.g., "Urban Gardeners Berlin" → "UGB")
-  const getTeamInitials = () => {
-    const name = team?.name;
-    if (!name || typeof name !== "string") return "?";
-
-    const words = name.trim().split(/\s+/);
-
-    if (words.length === 1) {
-      return name.slice(0, 2).toUpperCase();
-    }
-
-    return words
-      .slice(0, 3)
-      .map((word) => word.charAt(0))
-      .join("")
-      .toUpperCase();
   };
 
   const getMemberCount = () => {
@@ -723,40 +695,14 @@ const TeamInvitationDetailsModal = ({
             onClick={handleTeamClick}
           >
             <Tooltip content="Click to view team details" wrapperClassName="avatar">
-              <div className="w-12 h-12 rounded-full relative overflow-hidden">
-                {getTeamAvatar() ? (
-                  <img
-                    src={getTeamAvatar()}
-                    alt={team.name || "Team"}
-                    className="object-cover w-full h-full rounded-full"
-                    onError={(e) => {
-                      e.target.style.display = "none";
-                      const fallback =
-                        e.target.parentElement.querySelector(
-                          ".avatar-fallback",
-                        );
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                ) : null}
-
-                {/* Fallback initials */}
-                <div
-                  className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                  style={{ display: getTeamAvatar() ? "none" : "flex" }}
-                >
-                  <span className="text-xl font-medium">
-                    {getTeamInitials()}
-                  </span>
-                </div>
-
-                {isSyntheticTeam(team) && (
-                  <DemoAvatarOverlay
-                    textClassName="text-[8px]"
-                    textTranslateClassName="-translate-y-[2px]"
-                  />
-                )}
-              </div>
+              <TeamAvatar
+                team={team}
+                sizeClass="w-12 h-12"
+                initialsClassName="text-xl font-medium"
+                showDemoOverlay={isSyntheticTeam(team)}
+                demoOverlayTextClassName="text-[8px]"
+                demoOverlayTextTranslateClassName="-translate-y-[2px]"
+              />
             </Tooltip>
 
             <div className="flex-1 min-w-0">

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useMemo, useCallback, useLayoutEffect, useRef } from "react";
 import {
   Users,
   Send,
@@ -13,6 +13,7 @@ import {
   FlaskConical,
   ChevronRight,
   ChevronUp,
+  Calendar,
 } from "lucide-react";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
@@ -45,6 +46,7 @@ import {
   normalizeNumericId,
   numericIdsMatch,
 } from "../../utils/teamRequestUtils";
+import { format } from "date-fns";
 
 const normalizeId = normalizeNumericId;
 const idsMatch = numericIdsMatch;
@@ -227,6 +229,9 @@ const TeamInviteModal = ({
   inviteeAvatar,
   inviteeBio,
   inviteeIsSynthetic = false,
+  inviteeCity = null,
+  inviteeCountry = null,
+  inviteeJoinedAt = null,
   prefillTeamId = null,
   prefillRoleId = null,
   prefillTeamName = null,
@@ -264,6 +269,12 @@ const TeamInviteModal = ({
   const [selectedTeamForModal, setSelectedTeamForModal] = useState(null);
   const [selectedTeamInvitations, setSelectedTeamInvitations] = useState([]);
   const [selectedTeamApplications, setSelectedTeamApplications] = useState([]);
+  const nameContainerRef = useRef(null);
+  const nameProbeRef = useRef(null);
+  const dateRef = useRef(null);
+  const [dateIsNarrow, setDateIsNarrow] = useState(false);
+  const dateIsNarrowRef = useRef(false);
+  dateIsNarrowRef.current = dateIsNarrow;
 
   // Fetch teams where user can invite
   useEffect(() => {
@@ -587,6 +598,7 @@ const TeamInviteModal = ({
       first_name: inviteeFirstName,
       last_name: inviteeLastName,
       username: inviteeUsername || inviteeName,
+      avatar_url: inviteeAvatar || null,
       is_synthetic: inviteeIsSynthetic,
       isSynthetic: inviteeIsSynthetic,
     };
@@ -843,6 +855,30 @@ const TeamInviteModal = ({
       setIsTeamSectionExpanded(false);
     }
   }, [isOpen, selectedTeamId, vacantRoles, loadingRoles]);
+
+  useLayoutEffect(() => {
+    const container = nameContainerRef.current;
+    const probe = nameProbeRef.current;
+    if (!container || !probe) return;
+
+    const update = () => {
+      const first = inviteeFirstName || "";
+      const last = inviteeLastName || "";
+      const full = `${first} ${last}`.trim();
+      const displayName = full || inviteeName || inviteeUsername || "Unknown User";
+      const dateEl = dateRef.current;
+      const reservedWidth =
+        dateIsNarrowRef.current && dateEl ? dateEl.offsetWidth + 16 : 0;
+      probe.textContent = displayName;
+      setDateIsNarrow(probe.scrollWidth > container.clientWidth - reservedWidth);
+    };
+
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(container);
+    if (dateRef.current) resizeObserver.observe(dateRef.current);
+    update();
+    return () => resizeObserver.disconnect();
+  }, [inviteeFirstName, inviteeLastName, inviteeName, inviteeUsername]);
 
   const prefillContextNote = useMemo(() => {
     if (!idsMatch(selectedTeamId, normalizedPrefillTeamId)) return null;
@@ -1220,6 +1256,15 @@ const TeamInviteModal = ({
     (!selectedTeamRequiresRole || selectedRoleId !== null);
   const inviteeUser = getInviteeUserObject();
   const showInviteeDemoProfile = isSyntheticUser(inviteeUser);
+  const locationText = [inviteeCity, inviteeCountry].filter(Boolean).join(", ");
+  const joinedDateText = (() => {
+    if (!inviteeJoinedAt) return null;
+    try {
+      return format(new Date(inviteeJoinedAt), "MMM d, yyyy");
+    } catch {
+      return null;
+    }
+  })();
   const handleRoleSectionToggle = () => {
     setIsRoleSectionExpanded((isExpanded) => {
       if (isExpanded && isRoleSelectionRequired) {
@@ -1440,49 +1485,83 @@ const TeamInviteModal = ({
 
         <div className="space-y-5">
           {/* Invitee info */}
-          <div className="flex items-start space-x-3 mb-3">
-            <Tooltip content="View profile" position="bottom" wrapperClassName="block">
-              <UserAvatar
-                user={inviteeUser}
-                sizeClass="w-12 h-12"
-                clickable
-                onClick={() => handleUserClick(inviteeId)}
-                title="View profile"
-                showDemoOverlay={showInviteeDemoProfile}
-                demoOverlayTextClassName="text-[8px]"
-                demoOverlayTextTranslateClassName="-translate-y-[3px]"
-              />
-            </Tooltip>
-
-            <div className="flex-1 min-w-0">
+          <div className="relative flex items-start justify-between gap-4 mb-5">
+            <div className="flex min-w-0 flex-1 items-start space-x-4">
               <Tooltip content="View profile" position="bottom" wrapperClassName="block">
-                <h4
-                  className="font-medium text-base-content cursor-pointer hover:text-primary transition-colors leading-[120%] mb-[0.2em]"
+                <UserAvatar
+                  user={inviteeUser}
+                  sizeClass="w-12 h-12"
+                  initialsClassName="text-xl font-medium"
+                  clickable
                   onClick={() => handleUserClick(inviteeId)}
-                >
-                  {getInviteeDisplayName()}
-                </h4>
+                  title="View profile"
+                  showDemoOverlay={showInviteeDemoProfile}
+                  demoOverlayTextClassName="text-[8px]"
+                />
               </Tooltip>
 
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-0">
-                <Tooltip content="View profile" position="bottom" wrapperClassName="inline-flex">
-                  <p
-                    className="text-sm text-base-content/70 cursor-pointer hover:text-primary transition-colors"
-                    onClick={() => handleUserClick(inviteeId)}
-                  >
-                    @{getUsername()}
-                  </p>
-                </Tooltip>
-                {showInviteeDemoProfile && (
-                  <Tooltip
-                    content={DEMO_PROFILE_TOOLTIP}
-                    wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
-                  >
-                    <FlaskConical size={12} className="flex-shrink-0" />
+              <div className="flex-1 min-w-0">
+                <h4
+                  ref={nameContainerRef}
+                  className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative"
+                >
+                  <Tooltip content="View profile" position="bottom" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
+                    <span onClick={() => handleUserClick(inviteeId)}>{getInviteeDisplayName()}</span>
                   </Tooltip>
-                )}
+                  <span
+                    ref={nameProbeRef}
+                    className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium"
+                    aria-hidden="true"
+                  >
+                    {getInviteeDisplayName()}
+                  </span>
+                </h4>
+
+                <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs" style={{ maxHeight: "2.1em" }}>
+                  <Tooltip content="View profile" position="bottom" wrapperClassName="inline-flex">
+                    <p
+                      className="text-base-content/70 cursor-pointer hover:text-primary transition-colors"
+                      onClick={() => handleUserClick(inviteeId)}
+                    >
+                      @{getUsername()}
+                    </p>
+                  </Tooltip>
+                  {dateIsNarrow && joinedDateText && (
+                    <div className="flex shrink-0 items-center gap-1 text-base-content/60">
+                      <Calendar size={10} className="shrink-0" />
+                      <span className="leading-[1.05] whitespace-nowrap">{joinedDateText}</span>
+                    </div>
+                  )}
+                  {locationText && (
+                    <Tooltip
+                      content={locationText}
+                      wrapperClassName="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden"
+                    >
+                      <MapPin size={10} className="shrink-0 text-base-content/60" />
+                      <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">{locationText}</span>
+                    </Tooltip>
+                  )}
+                  {showInviteeDemoProfile && (
+                    <Tooltip
+                      content={DEMO_PROFILE_TOOLTIP}
+                      wrapperClassName="flex items-center gap-0.5 text-base-content/50 text-xs"
+                    >
+                      <FlaskConical size={12} className="flex-shrink-0" />
+                    </Tooltip>
+                  )}
+                </div>
               </div>
             </div>
+
+            {joinedDateText && (
+              <div
+                ref={dateRef}
+                className={`flex items-center text-xs text-base-content/60 whitespace-nowrap flex-shrink-0${dateIsNarrow ? " absolute opacity-0 pointer-events-none" : ""}`}
+              >
+                <Calendar size={12} className="mr-1" />
+                <span>{joinedDateText}</span>
+              </div>
+            )}
           </div>
 
           {/* Bio if available */}

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -570,10 +570,10 @@ const VacantRoleCard = ({
     if (is_remote) return "Remote";
     return formatLocation(normalizeLocationData(role), {
       displayType: "full",
-      showPostalCode: true,
-      showState: true,
+      showPostalCode: false,
+      showState: false,
       showCountry: true,
-      showCountryCode: viewMode !== "card" && viewMode !== "mini",
+      showCountryCode: false,
     }) || null;
   };
 
@@ -1451,14 +1451,14 @@ const VacantRoleCard = ({
                   {locationText}
                 </CardMetaItem>
               )}
-              {showDistance && (
-                <CardMetaItem icon={Ruler} nowrap>
-                  {Math.round(rawDistanceKm)} km away
-                </CardMetaItem>
-              )}
               {!is_remote && max_distance_km && (
                 <CardMetaItem icon={CircleDot} tone="muted" nowrap>
                   {max_distance_km} km
+                </CardMetaItem>
+              )}
+              {showDistance && (
+                <CardMetaItem icon={Ruler} nowrap>
+                  {Math.round(rawDistanceKm)} km away
                 </CardMetaItem>
               )}
               {demoRoleMetaItem}
@@ -1470,15 +1470,14 @@ const VacantRoleCard = ({
                   {locationText}
                 </CardMetaItem>
               )}
-
-              {showDistance && (
-                <CardMetaItem icon={Ruler} nowrap>
-                  {Math.round(rawDistanceKm)} km away
-                </CardMetaItem>
-              )}
               {!is_remote && max_distance_km && (
                 <CardMetaItem icon={CircleDot} tone="muted" nowrap>
                   {max_distance_km} km
+                </CardMetaItem>
+              )}
+              {showDistance && (
+                <CardMetaItem icon={Ruler} nowrap>
+                  {Math.round(rawDistanceKm)} km away
                 </CardMetaItem>
               )}
               {demoRoleMetaItem}

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -45,6 +45,7 @@ import {
 import Button from "../common/Button";
 import Tooltip from "../common/Tooltip";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import UserAvatar from "../users/UserAvatar";
 import CardMetaItem from "../common/CardMetaItem";
 import CardMetaRow from "../common/CardMetaRow";
 import TeamApplicationButton from "./TeamApplicationButton";
@@ -1279,8 +1280,6 @@ const VacantRoleDetailsModal = ({
   const filledRoleCompactDisplayName = filledRoleUser
     ? formatDisplayName(filledRoleUser)
     : filledRoleDisplayName;
-  const filledRoleAvatarUrl =
-    filledRoleUser?.avatarUrl ?? filledRoleUser?.avatar_url ?? null;
   const filledAt =
     displayRole.filledAt ??
     displayRole.filled_at ??
@@ -1809,36 +1808,21 @@ const VacantRoleDetailsModal = ({
             {isFilledRole ? (
               <Tooltip content={filledRoleUser?.id ? `Click to view ${filledRoleDisplayName || "this user"}'s profile` : undefined}>
               <div
-                className={`w-20 h-20 rounded-full relative overflow-hidden ${filledRoleUser?.id ? "cursor-pointer" : ""}`}
-                onClick={filledRoleUser?.id ? handleFilledUserClick : undefined}
                 role={filledRoleUser?.id ? "button" : undefined}
                 tabIndex={filledRoleUser?.id ? 0 : undefined}
                 onKeyDown={filledRoleUser?.id ? (e) => { if (e.key === "Enter" || e.key === " ") handleFilledUserClick(); } : undefined}
               >
-                {filledRoleAvatarUrl ? (
-                  <img
-                    src={filledRoleAvatarUrl}
-                    alt={filledRoleDisplayName || roleName}
-                    className="object-cover w-full h-full rounded-full"
-                    onError={(e) => {
-                      e.target.style.display = "none";
-                      const fallback =
-                        e.target.parentElement.querySelector(".avatar-fallback");
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                ) : null}
-                <div
-                  className="avatar-fallback bg-[var(--color-primary-focus)] text-white rounded-full w-full h-full flex items-center justify-center absolute inset-0"
-                  style={{ display: filledRoleAvatarUrl ? "none" : "flex" }}
-                >
-                  <span className="text-2xl font-semibold">
-                    {filledRoleUser
-                      ? getUserInitials(filledRoleUser)
-                      : getRoleInitials()}
-                  </span>
-                </div>
-                {demoAvatarOverlay}
+                <UserAvatar
+                  user={filledRoleUser}
+                  sizeClass="w-20 h-20"
+                  clickable={!!filledRoleUser?.id}
+                  onClick={handleFilledUserClick}
+                  initialsClassName="text-2xl font-semibold"
+                  showDemoOverlay={!!demoAvatarOverlay}
+                  demoOverlayTextClassName="text-[9px]"
+                  demoOverlayTextTranslateClassName="-translate-y-[4px]"
+                  fallbackText={!filledRoleUser ? getRoleInitials() : undefined}
+                />
               </div>
               </Tooltip>
             ) : effectivePct !== null ? (
@@ -2469,18 +2453,9 @@ const VacantRoleDetailsModal = ({
                     applicantProfile.last_name ??
                     "";
                   const username = applicantProfile.username ?? "";
-                  const avatarUrl =
-                    applicantProfile.avatarUrl ??
-                    applicantProfile.avatar_url ??
-                    null;
                   const displayName = firstName && lastName
                     ? `${firstName} ${lastName}`
                     : firstName || lastName || username || "Unknown";
-                  const initials = firstName && lastName
-                    ? `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase()
-                    : (firstName || lastName || username || "?")
-                        .charAt(0)
-                        .toUpperCase();
                   const applicationRoleMatch = application.role || {};
                   const applicantScore =
                     applicantMatch?.matchScore ??
@@ -2533,27 +2508,13 @@ const VacantRoleDetailsModal = ({
                         }}
                       >
                         <div className="avatar relative">
-                          <div className="w-14 h-14 rounded-full relative overflow-hidden">
-                            {avatarUrl ? (
-                              <img
-                                src={avatarUrl}
-                                alt={displayName}
-                                className="object-cover w-full h-full rounded-full"
-                                onError={(e) => {
-                                  e.target.style.display = "none";
-                                  const fallback =
-                                    e.target.parentElement.querySelector(".avatar-fallback");
-                                  if (fallback) fallback.style.display = "flex";
-                                }}
-                              />
-                            ) : null}
-                            <div
-                              className="avatar-fallback placeholder bg-[var(--color-primary-focus)] text-primary-content rounded-full w-full h-full absolute inset-0 flex items-center justify-center"
-                              style={{ display: avatarUrl ? "none" : "flex" }}
-                            >
-                              <span className="text-xl">{initials}</span>
-                            </div>
-                          </div>
+                          <UserAvatar
+                            user={applicantProfile}
+                            sizeClass="w-14 h-14"
+                            initialsClassName="text-xl"
+                            showDemoOverlay={isSyntheticUser(applicantProfile)}
+                            demoOverlayTextClassName="text-[8px]"
+                          />
                           {ApplicantMatchIcon && (
                             <div
                               className={`absolute -top-0.5 -left-0.5 w-[14px] h-[14px] rounded-full ring-2 ring-white flex items-center justify-center ${applicantMatchTier.bg}`}
@@ -2675,18 +2636,9 @@ const VacantRoleDetailsModal = ({
                     inviteeProfile.last_name ??
                     "";
                   const username = inviteeProfile.username ?? "";
-                  const avatarUrl =
-                    inviteeProfile.avatarUrl ??
-                    inviteeProfile.avatar_url ??
-                    null;
                   const displayName = firstName && lastName
                     ? `${firstName} ${lastName}`
                     : firstName || lastName || username || "Unknown";
-                  const initials = firstName && lastName
-                    ? `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase()
-                    : (firstName || lastName || username || "?")
-                        .charAt(0)
-                        .toUpperCase();
                   const invitationRoleMatch = invitation.role || {};
                   const inviteeScore =
                     inviteeMatch?.matchScore ??
@@ -2739,27 +2691,13 @@ const VacantRoleDetailsModal = ({
                         }}
                       >
                         <div className="avatar relative">
-                          <div className="w-14 h-14 rounded-full relative overflow-hidden">
-                            {avatarUrl ? (
-                              <img
-                                src={avatarUrl}
-                                alt={displayName}
-                                className="object-cover w-full h-full rounded-full"
-                                onError={(e) => {
-                                  e.target.style.display = "none";
-                                  const fallback =
-                                    e.target.parentElement.querySelector(".avatar-fallback");
-                                  if (fallback) fallback.style.display = "flex";
-                                }}
-                              />
-                            ) : null}
-                            <div
-                              className="avatar-fallback placeholder bg-[var(--color-primary-focus)] text-primary-content rounded-full w-full h-full absolute inset-0 flex items-center justify-center"
-                              style={{ display: avatarUrl ? "none" : "flex" }}
-                            >
-                              <span className="text-xl">{initials}</span>
-                            </div>
-                          </div>
+                          <UserAvatar
+                            user={inviteeProfile}
+                            sizeClass="w-14 h-14"
+                            initialsClassName="text-xl"
+                            showDemoOverlay={isSyntheticUser(inviteeProfile)}
+                            demoOverlayTextClassName="text-[8px]"
+                          />
                           {InviteeMatchIcon && (
                             <div
                               className={`absolute -top-0.5 -left-0.5 w-[14px] h-[14px] rounded-full ring-2 ring-white flex items-center justify-center ${inviteeMatchTier.bg}`}

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -933,6 +933,9 @@ const UserDetailsModal = ({
           inviteeAvatar={user.avatar_url || user.avatarUrl}
           inviteeBio={user.bio}
           inviteeIsSynthetic={user.is_synthetic ?? user.isSynthetic}
+          inviteeCity={user.city}
+          inviteeCountry={user.country}
+          inviteeJoinedAt={user.created_at || user.createdAt}
           prefillTeamId={invitationPrefillTeamId}
           prefillRoleId={invitationPrefillRoleId}
           prefillTeamName={invitationPrefillTeamName}
@@ -976,6 +979,9 @@ const UserDetailsModal = ({
           awardeeAvatar={user.avatar_url || user.avatarUrl}
           awardeeBio={user.bio}
           awardeeIsDemo={!!(user.is_synthetic ?? user.isSynthetic)}
+          awardeeCity={user.city}
+          awardeeCountry={user.country}
+          awardeeJoinedAt={user.created_at || user.createdAt}
           onAwardComplete={() => {
             queryClient.invalidateQueries({
               queryKey: userProfileQueryKey(user.id),

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -27,16 +27,15 @@ import Tooltip from "../components/common/Tooltip";
 import { CountBadge } from "../components/common/NotificationBadge";
 import { uploadToImageKit } from "../config/imagekit";
 import UserAvatar from "../components/users/UserAvatar";
-import DemoAvatarOverlay from "../components/users/DemoAvatarOverlay";
+import TeamAvatar from "../components/teams/TeamAvatar";
 import TeamDetailsModal from "../components/teams/TeamDetailsModal";
 import UserDetailsModal from "../components/users/UserDetailsModal";
-import { getTeamInitials, isSyntheticTeam } from "../utils/userHelpers";
+import { isSyntheticTeam } from "../utils/userHelpers";
 import { formatDisplayName } from "../utils/nameFormatters";
 import {
   formatRelativeChatTimestamp,
   normalizeTimestampToDate,
 } from "../utils/dateHelpers";
-import { getTeamAvatarUrl } from "../utils/chatEntityResolvers";
 import { getMessageConversationTarget } from "../utils/messageNotificationUtils";
 
 const getConversationPartnerId = (conversation) =>
@@ -3145,31 +3144,16 @@ const Chat = () => {
                         position="bottom"
                         wrapperClassName="inline-flex items-center flex-shrink-0"
                       >
-                        <div
-                          className="w-10 h-10 rounded-full relative overflow-hidden cursor-pointer hover:opacity-80 transition-opacity"
-                          onClick={handleHeaderTeamClick}
-                        >
-                          {getTeamAvatarUrl(teamData) ? (
-                            <img
-                              src={getTeamAvatarUrl(teamData)}
-                              alt={teamData.name}
-                              className="object-cover w-full h-full rounded-full"
-                              onError={(e) => {
-                                e.target.style.display = "none";
-                                const fallback = e.target.parentElement.querySelector(".avatar-fallback");
-                                if (fallback) fallback.style.display = "flex";
-                              }}
-                            />
-                          ) : null}
-                          <div
-                            className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                            style={{ display: getTeamAvatarUrl(teamData) ? "none" : "flex" }}
-                          >
-                            <span className="text-sm font-medium">{getTeamInitials(teamData)}</span>
-                          </div>
-                          {isSyntheticTeam(teamData) && (
-                            <DemoAvatarOverlay textClassName="text-[7px]" />
-                          )}
+                        <div className="relative">
+                          <TeamAvatar
+                            team={teamData}
+                            sizeClass="w-10 h-10"
+                            clickable={true}
+                            onClick={handleHeaderTeamClick}
+                            initialsClassName="text-sm font-medium"
+                            showDemoOverlay={isSyntheticTeam(teamData)}
+                            demoOverlayTextClassName="text-[7px]"
+                          />
                           {(activeConversation?.unreadCount || activeConversation?.unread_count) > 0 && (
                             <CountBadge
                               count={activeConversation.unreadCount ?? activeConversation.unread_count}

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   Search,
   X,
+  FlaskConical,
 } from "lucide-react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import PageContainer from "../components/layout/PageContainer";
@@ -30,7 +31,7 @@ import UserAvatar from "../components/users/UserAvatar";
 import TeamAvatar from "../components/teams/TeamAvatar";
 import TeamDetailsModal from "../components/teams/TeamDetailsModal";
 import UserDetailsModal from "../components/users/UserDetailsModal";
-import { isSyntheticTeam } from "../utils/userHelpers";
+import { isSyntheticTeam, isSyntheticUser, DEMO_PROFILE_TOOLTIP, DEMO_TEAM_TOOLTIP } from "../utils/userHelpers";
 import { formatDisplayName } from "../utils/nameFormatters";
 import {
   formatRelativeChatTimestamp,
@@ -3216,6 +3217,14 @@ const Chat = () => {
                                 ? `Team Chat with ${teamData.members.length} ${teamData.members.length === 1 ? "Member" : "Members"}`
                                 : "Team Chat"}
                             </span>
+                            {isSyntheticTeam(teamData) && (
+                              <Tooltip
+                                content={DEMO_TEAM_TOOLTIP}
+                                wrapperClassName="flex items-center gap-0.5 text-base-content/50 flex-shrink-0"
+                              >
+                                <FlaskConical size={10} className="flex-shrink-0" />
+                              </Tooltip>
+                            )}
                           </div>
                           {conversationUpdatedAt && (
                             <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
@@ -3228,6 +3237,14 @@ const Chat = () => {
                           <div className="flex items-center gap-1.5 min-w-0">
                             <User size={12} className="flex-shrink-0" />
                             <span className="truncate">DM Chat</span>
+                            {isSyntheticUser(conversationPartner) && (
+                              <Tooltip
+                                content={DEMO_PROFILE_TOOLTIP}
+                                wrapperClassName="flex items-center gap-0.5 text-base-content/50 flex-shrink-0"
+                              >
+                                <FlaskConical size={10} className="flex-shrink-0" />
+                              </Tooltip>
+                            )}
                           </div>
                           {conversationUpdatedAt && (
                             <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">


### PR DESCRIPTION
## Summary

This PR consolidates frontend refactors, UI polish, contact/support flow additions, and privacy/security-facing improvements across Lomir. It introduces shared components for repeated card/avatar/match-score patterns, improves location formatting across cards and modals, adds the public contact page, and tightens several registration, profile, map, chat, and team-detail experiences.

## What changed

- Added a new `/contact` page with email contact form, optional file attachments, optional Turnstile verification, success toast handling, and in-app chat routing for authenticated users when `VITE_LOMIR_CONTACT_USER_ID` is configured.
- Self-hosted Roboto font files and wired them through `@font-face` to avoid loading Google Fonts from an external CDN.
- Refactored repeated UI patterns into shared components/hooks:
  - `TeamAvatar`
  - `ListViewRow`
  - `MatchScoreOverlay`
  - expanded `MatchScoreSection`
  - `useTeamAwardModals`
- Unified team/user/vacant-role card layouts, avatar fallbacks, demo overlays, match-score display, and list-row metadata.
- Improved location handling with normalized district/city/state/country data, country codes, German postal-code fallbacks, Berlin/Frankfurt district mapping, and reusable list-location formatting.
- Polished search and map result displays, including stale open-role count fixes, location truncation, standardized icon sizing, better match indicators, and card/list responsiveness.
- Improved profile and detail modal headers with clearer location/date/demo indicators and better responsive behavior.
- Enhanced registration validation feedback, field error animation, username/email availability UX, and verification-related messaging.
- Updated chat/contact-related UI, including contact routing, conversation list polish, event/message display tweaks, and demo indicators.
- Updated README documentation for the contact page, privacy behavior, self-hosted fonts, routes, location privacy, and related environment variables.

## Testing

- `npm run build` passes.
- Build completed with existing Vite warnings about large chunks and `VacantRoleDetailsModal.jsx` being both statically and dynamically imported.