### PR TITLE
Private profile anonymization + match score component cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,23 +158,38 @@ Lomir-frontend/
 │   ├── components/
 │   │   ├── BooleanSearchInput.jsx  # Textarea-based Boolean search input with operator helpers
 │   │   ├── SearchHelp.jsx          # Search Tips popup panel
-│   │   ├── auth/                   # Login/register forms, TurnstileWidget
-│   │   ├── teams/                  # Team cards, detail modals, vacant roles,
-│   │   │                           #   applications, invitations, member management
-│   │   ├── users/                  # User cards, detail modals, InlineUserLink, UserAvatar,
+│   │   ├── auth/                   # LoginForm, RegisterForm
+│   │   ├── teams/                  # TeamCard, TeamDetailsModal, TeamAvatar, TeamEditForm,
+│   │   │                           #   TeamFocusAreaSection, TeamMembersSection, TeamRoleManager,
+│   │   │                           #   VacantRoleCard, VacantRoleDetailsModal, VacantRolesSection,
+│   │   │                           #   CreateTeamModal, CreateVacantRoleModal, RoleBadgeDropdown,
+│   │   │                           #   TeamApplicationButton, TeamApplicationModal,
+│   │   │                           #   TeamApplicationsModal, TeamApplicationDetailsModal,
+│   │   │                           #   TeamInviteModal, TeamInvitesModal,
+│   │   │                           #   TeamInvitationDetailsModal, RequestRoleCard
+│   │   ├── users/                  # UserCard, UserDetailsModal, UserAvatar,
 │   │   │                           #   UserProfileHeaderSection (avatar + name + location header),
-│   │   │                           #   DemoAvatarOverlay, deleted user handling
+│   │   │                           #   UserBioSection, InlineUserLink, DemoAvatarOverlay,
+│   │   │                           #   DeletedUserProfilePlaceholder
 │   │   ├── badges/                 # Badge display, awarding, category modals, AwardCard
 │   │   ├── tags/                   # Tag input, display, and selection
 │   │   ├── chat/                   # Chat UI, message bubbles, file/image previews,
 │   │   │                           #   MentionDropdown, MessageText (mentions + URLs),
 │   │   │                           #   reply previews, system event messages
 │   │   ├── search/                 # SearchMapView (Leaflet map with markers/popups)
-│   │   ├── common/                 # Shared UI: Button, Card, Modal, Alert, Pagination,
-│   │   │                           #   ImageUploader, LocationInput, TurnstileWidget,
-│   │   │                           #   FilterSortOptionButton, ResultViewToggle,
-│   │   │                           #   PersonRequestCard, RequestListModal, Tooltip...
-│   │   └── layout/                 # Navbar, Footer, PageContainer, Grid, Section
+│   │   ├── common/                 # Shared UI primitives and composed widgets:
+│   │   │                           #   Button, Card, Modal, Alert, Pagination, Tooltip,
+│   │   │                           #   Input, Select, Checkbox, Dropdown, FormGroup,
+│   │   │                           #   FormSectionDivider, DataDisplay, InfoCard, Placeholder,
+│   │   │                           #   ImageUploader, LocationInput, LocationDisplay,
+│   │   │                           #   LocationSection, LocationModeToggle, CountrySelect,
+│   │   │                           #   TurnstileWidget, FilterSortOptionButton, ResultViewToggle,
+│   │   │                           #   ListViewRow, CardMetaItem, CardMetaRow, RoleBadgePill,
+│   │   │                           #   MatchScoreOverlay, MatchScoreSubtitle, MatchScoreSection,
+│   │   │                           #   SearchResultTypeOverlay, NotificationBadge,
+│   │   │                           #   PersonRequestCard, RequestListModal, SendMessageButton,
+│   │   │                           #   VisibilityToggle, ScreenAlert, ConfirmModal
+│   │   └── layout/                 # Navbar, Footer, PageContainer, ProtectedRoute, Grid, Section
 │   ├── contexts/
 │   │   ├── AuthContext.jsx         # Authentication state + JWT management
 │   │   ├── UserModalContext.jsx    # Global user detail modal stack
@@ -215,7 +230,8 @@ Lomir-frontend/
 │   │   ├── useMyTeamsSort.js       # Sort state for MyTeams page
 │   │   ├── useClientPagination.js  # Client-side pagination state for lists
 │   │   ├── useSocketEvents.js      # Subscribe to a set of Socket.IO events with React-safe cleanup
-│   │   ├── useAwardModals.js       # Badge award modal state management
+│   │   ├── useAwardModals.js       # Badge award modal state management (user profile context)
+│   │   ├── useTeamAwardModals.js   # Badge award modal state management (team context)
 │   │   └── useTheme.js             # Theme toggle state
 │   ├── utils/
 │   │   ├── formatters.js           # camelCase ↔ snake_case conversion (used by api.js interceptors)
@@ -225,6 +241,7 @@ Lomir-frontend/
 │   │   ├── teamMatchUtils.js       # Team/role match scoring + overlap calculations
 │   │   ├── matchHelpers.js         # Shared match score helpers (weights, render cascade)
 │   │   ├── matchScoreUtils.js      # Match tier color coding (green/yellow/orange)
+│   │   ├── listSummaryUtils.js     # extractNames + summarizeList for tag/badge summary strings
 │   │   ├── payloadExtractors.js    # Role/team payload field extractors shared across components
 │   │   ├── locationUtils.js        # Haversine distance, formatLocation / normalizeLocationData
 │   │   │                           #   (de-duplicated city/district/state/country display,
@@ -239,7 +256,7 @@ Lomir-frontend/
 │   │   ├── dateHelpers.js          # Date formatting utilities
 │   │   ├── debounce.js             # Generic debounce utility
 │   │   ├── badgeIconUtils.jsx      # Badge icon component resolution by category
-│   │   └── Colors.js              # Shared color constants for badge categories and UI accents
+│   │   └── Colors.js               # Shared color constants for badge categories and UI accents
 │   ├── constants/
 │   │   ├── badgeConstants.js       # Badge category metadata (names, colors, icons)
 │   │   ├── uiText.js               # Shared UI strings

--- a/src/components/badges/AwardCard.jsx
+++ b/src/components/badges/AwardCard.jsx
@@ -16,6 +16,8 @@ import {
 } from "lucide-react";
 import Tooltip from "../common/Tooltip";
 import InlineUserLink from "../users/InlineUserLink";
+import { useAuth } from "../../contexts/AuthContext";
+import { useUserProfile } from "../../hooks/useUserQueries";
 import { useTeamModalSafe } from "../../contexts/TeamModalContext";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
 import { getBadgeIcon } from "../../utils/badgeIconUtils";
@@ -31,6 +33,34 @@ import {
 } from "../../utils/deletedUser";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import { getDisplayName } from "../../utils/userHelpers";
+
+const normalizeBooleanFlag = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes"].includes(normalized)) return true;
+    if (["false", "0", "no"].includes(normalized)) return false;
+  }
+  return null;
+};
+
+const firstPresent = (...values) =>
+  values.find((value) => value !== undefined && value !== null);
+
+const idsMatch = (firstId, secondId) => {
+  if (firstId === undefined || firstId === null) return false;
+  if (secondId === undefined || secondId === null) return false;
+  return String(firstId).trim() === String(secondId).trim();
+};
+
+const getProfilePublicStatus = (profile) =>
+  firstPresent(
+    profile?.isPublic,
+    profile?.is_public,
+    profile?.profileIsPublic,
+    profile?.profile_is_public,
+  );
 
 /**
  * AwardCard
@@ -74,6 +104,8 @@ const AwardCard = ({
   onDeleteAward = null,
   isBadgeHidden = false,
   badgeActionLoadingKey = null,
+  subjectUserId = null,
+  canViewPrivateAwardees = false,
 }) => {
   const mutedBadgeColor = "#6B7280";
   const mutedCardBackground = "#F3F4F6";
@@ -96,6 +128,7 @@ const AwardCard = ({
     ? `0 0 12px ${isBadgeHidden ? "#9CA3AF66" : `${catColor}66`}`
     : undefined;
   const childTeamModalZIndex = useChildModalZIndex();
+  const { user: currentUser } = useAuth();
 
   // --- Normalize fields (camelCase + snake_case) ---
   const awardId = award?.awardId || award?.award_id || award?.id || null;
@@ -160,30 +193,130 @@ const AwardCard = ({
   const tagName = award?.tagName ?? award?.tag_name ?? null;
 
   // --- Awarded BY (bottom row) ---
-  const awardedByUserId = award?.awardedByUserId || award?.awarded_by_user_id;
+  const awardedBySource =
+    award?.awardedBy ??
+    award?.awarded_by ??
+    award?.awardedByUser ??
+    award?.awarded_by_user ??
+    award?.awarder ??
+    award?.awarderUser ??
+    award?.awarder_user ??
+    {};
+  const awardedByUserId =
+    award?.awardedByUserId ??
+    award?.awarded_by_user_id ??
+    awardedBySource?.id ??
+    awardedBySource?.userId ??
+    awardedBySource?.user_id ??
+    null;
   const awardedByFirstName =
-    award?.awardedByFirstName || award?.awarded_by_first_name;
+    award?.awardedByFirstName ??
+    award?.awarded_by_first_name ??
+    awardedBySource?.firstName ??
+    awardedBySource?.first_name ??
+    null;
   const awardedByLastName =
-    award?.awardedByLastName || award?.awarded_by_last_name;
+    award?.awardedByLastName ??
+    award?.awarded_by_last_name ??
+    awardedBySource?.lastName ??
+    awardedBySource?.last_name ??
+    null;
   const awardedByUsername =
-    award?.awardedByUsername || award?.awarded_by_username;
+    award?.awardedByUsername ??
+    award?.awarded_by_username ??
+    awardedBySource?.username ??
+    null;
   const awardedByAvatarUrl =
-    award?.awardedByAvatarUrl || award?.awarded_by_avatar_url;
+    award?.awardedByAvatarUrl ??
+    award?.awarded_by_avatar_url ??
+    awardedBySource?.avatarUrl ??
+    awardedBySource?.avatar_url ??
+    null;
   const awardedByIsSynthetic =
-    award?.awardedByIsSynthetic ?? award?.awarded_by_is_synthetic ?? false;
-
-  const awardedByUser = {
-    id: awardedByUserId,
-    first_name: awardedByFirstName,
-    last_name: awardedByLastName,
-    username: awardedByUsername,
-    avatar_url: awardedByAvatarUrl,
-    is_synthetic: awardedByIsSynthetic,
-  };
+    award?.awardedByIsSynthetic ??
+    award?.awarded_by_is_synthetic ??
+    awardedBySource?.isSynthetic ??
+    awardedBySource?.is_synthetic ??
+    false;
+  const awardedByIsPublic =
+    firstPresent(
+      award?.awardedByIsPublic,
+      award?.awarded_by_is_public,
+      award?.awarderIsPublic,
+      award?.awarder_is_public,
+      award?.awardedByPublic,
+      award?.awarded_by_public,
+      award?.awarderPublic,
+      award?.awarder_public,
+      award?.awardedByProfileIsPublic,
+      award?.awarded_by_profile_is_public,
+      award?.awarderProfileIsPublic,
+      award?.awarder_profile_is_public,
+      awardedBySource?.isPublic,
+      awardedBySource?.is_public,
+      awardedBySource?.profile?.isPublic,
+      awardedBySource?.profile?.is_public,
+    );
+  const awardedByIsPrivate =
+    firstPresent(
+      award?.awardedByIsPrivate,
+      award?.awarded_by_is_private,
+      award?.awarderIsPrivate,
+      award?.awarder_is_private,
+      award?.awardedByPrivate,
+      award?.awarded_by_private,
+      award?.awarderPrivate,
+      award?.awarder_private,
+      award?.awardedByProfileIsPrivate,
+      award?.awarded_by_profile_is_private,
+      award?.awarderProfileIsPrivate,
+      award?.awarder_profile_is_private,
+      awardedBySource?.isPrivate,
+      awardedBySource?.is_private,
+      awardedBySource?.profile?.isPrivate,
+      awardedBySource?.profile?.is_private,
+    );
+  const awardedByVisibility = firstPresent(
+    award?.awardedByVisibility,
+    award?.awarded_by_visibility,
+    award?.awarderVisibility,
+    award?.awarder_visibility,
+    award?.awardedByProfileVisibility,
+    award?.awarded_by_profile_visibility,
+    award?.awarderProfileVisibility,
+    award?.awarder_profile_visibility,
+    awardedBySource?.visibility,
+    awardedBySource?.profileVisibility,
+    awardedBySource?.profile_visibility,
+    awardedBySource?.profile?.visibility,
+  );
+  const awardedByHasExplicitPrivacy = Boolean(
+    awardedByIsPublic !== undefined ||
+      awardedByIsPrivate !== undefined ||
+      awardedByVisibility !== undefined,
+  );
+  const awarderIsFormerUser = !awardedByUserId && !awardedByUsername;
 
   // --- Awarded TO / Awardee (title row — team context) ---
+  const awardedToSource =
+    award?.awardedTo ??
+    award?.awarded_to ??
+    award?.awardedToUser ??
+    award?.awarded_to_user ??
+    award?.awardee ??
+    award?.awardeeUser ??
+    award?.awardee_user ??
+    {};
   const awardedToUserId =
-    award?.awardedToUserId || award?.awarded_to_user_id || null;
+    firstPresent(
+      award?.awardedToUserId,
+      award?.awarded_to_user_id,
+      award?.awardeeUserId,
+      award?.awardee_user_id,
+      awardedToSource?.id,
+      awardedToSource?.userId,
+      awardedToSource?.user_id,
+    ) ?? null;
   const awardedToFirstName =
     award?.awardedToFirstName || award?.awarded_to_first_name || null;
   const awardedToLastName =
@@ -194,12 +327,173 @@ const AwardCard = ({
     award?.awardedToAvatarUrl || award?.awarded_to_avatar_url || null;
   const awardedToIsSynthetic =
     award?.awardedToIsSynthetic ?? award?.awarded_to_is_synthetic ?? false;
+  const awardedToIsPublic = firstPresent(
+    award?.awardedToIsPublic,
+    award?.awarded_to_is_public,
+    award?.awardeeIsPublic,
+    award?.awardee_is_public,
+    award?.awardedToPublic,
+    award?.awarded_to_public,
+    award?.awardeePublic,
+    award?.awardee_public,
+    award?.awardedToProfileIsPublic,
+    award?.awarded_to_profile_is_public,
+    award?.awardeeProfileIsPublic,
+    award?.awardee_profile_is_public,
+    awardedToSource?.isPublic,
+    awardedToSource?.is_public,
+    awardedToSource?.profile?.isPublic,
+    awardedToSource?.profile?.is_public,
+  );
+  const awardedToIsPrivate = firstPresent(
+    award?.awardedToIsPrivate,
+    award?.awarded_to_is_private,
+    award?.awardeeIsPrivate,
+    award?.awardee_is_private,
+    award?.awardedToPrivate,
+    award?.awarded_to_private,
+    award?.awardeePrivate,
+    award?.awardee_private,
+    award?.awardedToProfileIsPrivate,
+    award?.awarded_to_profile_is_private,
+    award?.awardeeProfileIsPrivate,
+    award?.awardee_profile_is_private,
+    awardedToSource?.isPrivate,
+    awardedToSource?.is_private,
+    awardedToSource?.profile?.isPrivate,
+    awardedToSource?.profile?.is_private,
+  );
+  const awardedToVisibility = firstPresent(
+    award?.awardedToVisibility,
+    award?.awarded_to_visibility,
+    award?.awardeeVisibility,
+    award?.awardee_visibility,
+    award?.awardedToProfileVisibility,
+    award?.awarded_to_profile_visibility,
+    award?.awardeeProfileVisibility,
+    award?.awardee_profile_visibility,
+    awardedToSource?.visibility,
+    awardedToSource?.profileVisibility,
+    awardedToSource?.profile_visibility,
+    awardedToSource?.profile?.visibility,
+  );
+  const awardedToHasExplicitPrivacy = Boolean(
+    awardedToIsPublic !== undefined ||
+      awardedToIsPrivate !== undefined ||
+      awardedToVisibility !== undefined,
+  );
 
   const hasAwardeeInfo = Boolean(awardedToUserId);
+  const recipientUserId = firstPresent(awardedToUserId, subjectUserId);
+  const viewerIsRecipient = idsMatch(currentUser?.id, recipientUserId);
+  const viewerCanSeeAwardee = viewerIsRecipient || canViewPrivateAwardees;
+  const shouldFetchAwarderPrivacy = Boolean(
+    awardedByUserId &&
+      !viewerIsRecipient &&
+      !awardedByHasExplicitPrivacy &&
+      !awarderIsFormerUser,
+  );
+  const {
+    data: resolvedAwarderProfile = null,
+    isLoading: awarderPrivacyLoading = false,
+  } = useUserProfile(awardedByUserId, {
+    enabled: shouldFetchAwarderPrivacy,
+  });
+  const resolvedAwarderIsPublic = getProfilePublicStatus(resolvedAwarderProfile);
+  const shouldFetchAwardeePrivacy = Boolean(
+    awardedToUserId &&
+      !viewerCanSeeAwardee &&
+      !awardedToHasExplicitPrivacy,
+  );
+  const {
+    data: resolvedAwardeeProfile = null,
+    isLoading: awardeePrivacyLoading = false,
+  } = useUserProfile(awardedToUserId, {
+    enabled: shouldFetchAwardeePrivacy,
+  });
+  const resolvedAwardeeIsPublic = getProfilePublicStatus(resolvedAwardeeProfile);
+  const awardedByVisibilityValue =
+    typeof awardedByVisibility === "string"
+      ? awardedByVisibility.trim().toLowerCase()
+      : null;
+  const awardedToVisibilityValue =
+    typeof awardedToVisibility === "string"
+      ? awardedToVisibility.trim().toLowerCase()
+      : null;
+  const explicitAwarderProfileIsPrivate =
+    normalizeBooleanFlag(awardedByIsPublic) === false ||
+    normalizeBooleanFlag(awardedByIsPrivate) === true ||
+    ["private", "hidden", "anonymous"].includes(awardedByVisibilityValue);
+  const awarderProfileIsPrivate =
+    !awarderIsFormerUser &&
+    (explicitAwarderProfileIsPrivate ||
+      (!viewerIsRecipient &&
+      !awardedByHasExplicitPrivacy &&
+      (awarderPrivacyLoading ||
+          normalizeBooleanFlag(resolvedAwarderIsPublic) !== true)));
+  const shouldAnonymizeAwarder = awarderProfileIsPrivate && !viewerIsRecipient;
+  const explicitAwardeeProfileIsPrivate =
+    normalizeBooleanFlag(awardedToIsPublic) === false ||
+    normalizeBooleanFlag(awardedToIsPrivate) === true ||
+    ["private", "hidden", "anonymous"].includes(awardedToVisibilityValue);
+  const awardeeProfileIsPrivate =
+    explicitAwardeeProfileIsPrivate ||
+    (!viewerCanSeeAwardee &&
+      !awardedToHasExplicitPrivacy &&
+      (awardeePrivacyLoading ||
+        normalizeBooleanFlag(resolvedAwardeeIsPublic) !== true));
+  const shouldAnonymizeAwardee =
+    awardeeProfileIsPrivate && !viewerCanSeeAwardee;
+  const awardedByDisplayIsPublic = shouldAnonymizeAwarder
+    ? false
+    : awarderProfileIsPrivate
+      ? true
+      : awardedByIsPublic;
+  const awardedByDisplayIsPrivate = shouldAnonymizeAwarder
+    ? true
+    : awarderProfileIsPrivate
+      ? false
+      : awardedByIsPrivate;
+  const awardedByUser = {
+    id: awardedByUserId,
+    first_name: awardedByFirstName,
+    last_name: awardedByLastName,
+    username: awardedByUsername,
+    avatar_url: awardedByAvatarUrl,
+    is_synthetic: awardedByIsSynthetic,
+    is_public: awardedByDisplayIsPublic,
+    isPublic: awardedByDisplayIsPublic,
+    is_private: awardedByDisplayIsPrivate,
+    isPrivate: awardedByDisplayIsPrivate,
+  };
+  const awardedToDisplayIsPublic = shouldAnonymizeAwardee
+    ? false
+    : awardeeProfileIsPrivate
+      ? true
+      : awardedToIsPublic;
+  const awardedToDisplayIsPrivate = shouldAnonymizeAwardee
+    ? true
+    : awardeeProfileIsPrivate
+      ? false
+      : awardedToIsPrivate;
+  const awardedToUser = {
+    id: awardedToUserId,
+    first_name: awardedToFirstName,
+    last_name: awardedToLastName,
+    username: awardedToUsername,
+    avatar_url: shouldAnonymizeAwardee ? null : awardedToAvatarUrl,
+    is_synthetic: awardedToIsSynthetic,
+    is_public: awardedToDisplayIsPublic,
+    isPublic: awardedToDisplayIsPublic,
+    is_private: awardedToDisplayIsPrivate,
+    isPrivate: awardedToDisplayIsPrivate,
+  };
 
-  const awarderName = awardedByFirstName
-    ? `${awardedByFirstName}${awardedByLastName ? ` ${awardedByLastName}` : ""}`
-    : awardedByUsername || getDeletedUserDisplayName(awardedByUser);
+  const awarderName = shouldAnonymizeAwarder
+    ? "Private Profile"
+    : awardedByFirstName
+      ? `${awardedByFirstName}${awardedByLastName ? ` ${awardedByLastName}` : ""}`
+      : awardedByUsername || getDeletedUserDisplayName(awardedByUser);
   const isDeletedAwarder = !awardedByUserId || isDeletedUser(awardedByUser);
 
   // --- Team modal integration (global fallback) ---
@@ -395,7 +689,7 @@ const AwardCard = ({
           </div>
 
           {/* ── Subline ── */}
-          <div className="mt-1 flex max-h-[2.5em] min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 overflow-hidden text-xs leading-tight text-base-content/60">
+          <div className="mt-1 flex max-h-[2.5em] min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 overflow-hidden text-xs leading-[110%] text-base-content/60">
             {/* Awarded by (team context only — awarder name, clickable) */}
             {hasAwardeeInfo && (
               <span className="flex items-center gap-1 min-w-0">
@@ -406,7 +700,10 @@ const AwardCard = ({
                 <span className="flex-shrink-0">awarded by</span>
                 <Tooltip
                   content={
-                    awardedByUserId && canOpenUser && !isDeletedAwarder
+                    awardedByUserId &&
+                    canOpenUser &&
+                    !isDeletedAwarder &&
+                    !shouldAnonymizeAwarder
                       ? "View profile"
                       : null
                   }
@@ -415,15 +712,21 @@ const AwardCard = ({
                   <span
                     className={[
                       "truncate font-medium",
-                      isDeletedAwarder
+                      isDeletedAwarder || shouldAnonymizeAwarder
                         ? "text-base-content/50"
                         : "text-base-content/70",
-                      awardedByUserId && canOpenUser && !isDeletedAwarder
+                      awardedByUserId &&
+                      canOpenUser &&
+                      !isDeletedAwarder &&
+                      !shouldAnonymizeAwarder
                         ? "cursor-pointer hover:text-primary transition-colors"
                         : "",
                     ].join(" ")}
                     onClick={
-                      awardedByUserId && canOpenUser && !isDeletedAwarder
+                      awardedByUserId &&
+                      canOpenUser &&
+                      !isDeletedAwarder &&
+                      !shouldAnonymizeAwarder
                         ? () => openUser(awardedByUserId)
                         : undefined
                     }
@@ -618,31 +921,26 @@ const AwardCard = ({
                 <span className="hidden sm:inline">Awarded </span>to
               </>
             }
-            user={{
-              id: awardedToUserId,
-              first_name: awardedToFirstName,
-              last_name: awardedToLastName,
-              username: awardedToUsername,
-              avatar_url: awardedToAvatarUrl,
-              is_synthetic: awardedToIsSynthetic,
-            }}
+            user={awardedToUser}
             displayName={
-              <>
-                <span className="hidden sm:inline">
-                  {getDisplayName({
-                    first_name: awardedToFirstName,
-                    last_name: awardedToLastName,
-                    username: awardedToUsername,
-                  })}
-                </span>
-                <span className="sm:hidden">
-                  {formatDisplayName({
-                    first_name: awardedToFirstName,
-                    last_name: awardedToLastName,
-                    username: awardedToUsername,
-                  })}
-                </span>
-              </>
+              shouldAnonymizeAwardee ? undefined : (
+                <>
+                  <span className="hidden sm:inline">
+                    {getDisplayName({
+                      first_name: awardedToFirstName,
+                      last_name: awardedToLastName,
+                      username: awardedToUsername,
+                    })}
+                  </span>
+                  <span className="sm:hidden">
+                    {formatDisplayName({
+                      first_name: awardedToFirstName,
+                      last_name: awardedToLastName,
+                      username: awardedToUsername,
+                    })}
+                  </span>
+                </>
+              )
             }
             onOpenUser={openUser}
           />
@@ -654,16 +952,6 @@ const AwardCard = ({
               </>
             }
             user={awardedByUser}
-            displayName={
-              <>
-                <span className="hidden sm:inline">
-                  {getDisplayName(awardedByUser)}
-                </span>
-                <span className="sm:hidden">
-                  {formatDisplayName(awardedByUser)}
-                </span>
-              </>
-            }
             onOpenUser={openUser}
           />
         )}

--- a/src/components/badges/BadgeCategoryModal.jsx
+++ b/src/components/badges/BadgeCategoryModal.jsx
@@ -35,6 +35,8 @@ const BadgeCategoryModal = ({
   badgeActionLoadingKey = null,
   hiddenAwardIds = [],
   showHiddenBadgeAwards = false,
+  subjectUserId = null,
+  canViewPrivateAwardees = false,
 }) => {
   // Team details modal state (for AwardCard team clicks)
   const [selectedTeamForDetails, setSelectedTeamForDetails] = useState(null);
@@ -323,6 +325,8 @@ const BadgeCategoryModal = ({
                         onDeleteAward={onDeleteAward}
                         isBadgeHidden={isAwardHidden(award)}
                         badgeActionLoadingKey={badgeActionLoadingKey}
+                        subjectUserId={subjectUserId}
+                        canViewPrivateAwardees={canViewPrivateAwardees}
                         highlighted={
                           !!highlightBadgeName &&
                           (

--- a/src/components/badges/SupercategoryAwardsModal.jsx
+++ b/src/components/badges/SupercategoryAwardsModal.jsx
@@ -33,6 +33,8 @@ const SupercategoryAwardsModal = ({
   badgeActionLoadingKey = null,
   hiddenAwardIds = [],
   showHiddenBadgeAwards = false,
+  subjectUserId = null,
+  canViewPrivateAwardees = false,
 }) => {
   // Internal TeamDetailsModal state (so the team click works even if parent doesn’t manage it)
   const [selectedTeamForDetails, setSelectedTeamForDetails] = useState(null);
@@ -273,6 +275,8 @@ const SupercategoryAwardsModal = ({
                               onDeleteAward={onDeleteAward}
                               isBadgeHidden={isAwardHidden(award)}
                               badgeActionLoadingKey={badgeActionLoadingKey}
+                              subjectUserId={subjectUserId}
+                              canViewPrivateAwardees={canViewPrivateAwardees}
                               highlighted={
                                 !!highlightBadgeName &&
                                 (

--- a/src/components/badges/TagAwardsModal.jsx
+++ b/src/components/badges/TagAwardsModal.jsx
@@ -46,6 +46,8 @@ const TagAwardsModal = ({
   badgeActionLoadingKey = null,
   hiddenAwardIds = [],
   showHiddenBadgeAwards = false,
+  subjectUserId = null,
+  canViewPrivateAwardees = false,
 }) => {
   // Internal TeamDetailsModal state (mirrors SupercategoryAwardsModal)
   const [selectedTeamForDetails, setSelectedTeamForDetails] = useState(null);
@@ -286,6 +288,8 @@ const TagAwardsModal = ({
                               onDeleteAward={onDeleteAward}
                               isBadgeHidden={isAwardHidden(normalizedAward)}
                               badgeActionLoadingKey={badgeActionLoadingKey}
+                              subjectUserId={subjectUserId}
+                              canViewPrivateAwardees={canViewPrivateAwardees}
                               highlighted={
                                 !!highlightBadgeName &&
                                 (

--- a/src/components/common/MatchScoreOverlay.jsx
+++ b/src/components/common/MatchScoreOverlay.jsx
@@ -3,6 +3,7 @@ import Tooltip from "./Tooltip";
 
 const MatchScoreOverlay = ({
   matchTier,
+  icon: IconOverride,
   tooltipText,
   sizeClassName = "w-5 h-5",
   iconSize = 10,
@@ -15,6 +16,8 @@ const MatchScoreOverlay = ({
   if (!matchTier) {
     return null;
   }
+
+  const Icon = IconOverride || matchTier.Icon;
 
   const overlay = (
     <div
@@ -30,7 +33,7 @@ const MatchScoreOverlay = ({
         .join(" ")}
       style={style}
     >
-      <matchTier.Icon
+      <Icon
         size={iconSize}
         className={iconClassName}
         strokeWidth={strokeWidth}

--- a/src/components/common/MatchScoreSubtitle.jsx
+++ b/src/components/common/MatchScoreSubtitle.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Tooltip from "./Tooltip";
+
+const MatchScoreSubtitle = ({ matchTier, tooltipText, iconSize = 12 }) => {
+  if (!matchTier) return null;
+
+  return (
+    <Tooltip content={tooltipText}>
+      <span className="inline-flex items-center gap-0.5 whitespace-nowrap leading-none flex-shrink-0">
+        <matchTier.Icon
+          size={iconSize}
+          className={`${matchTier.text} flex-shrink-0`}
+        />
+        <span className="text-base-content">{matchTier.pct}%</span>
+      </span>
+    </Tooltip>
+  );
+};
+
+export default MatchScoreSubtitle;

--- a/src/components/common/PersonRequestCard.jsx
+++ b/src/components/common/PersonRequestCard.jsx
@@ -5,13 +5,12 @@ import Tooltip from "./Tooltip";
 import {
   DEMO_PROFILE_TOOLTIP,
   getDisplayName as getUserDisplayName,
-  getUserAvatarUrl,
-  getUserInitials,
   isSyntheticUser,
 } from "../../utils/userHelpers";
-import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import UserAvatar from "../users/UserAvatar";
 import { formatDisplayName } from "../../utils/nameFormatters";
 import { formatListLocation } from "../../utils/locationUtils";
+import { isPrivateProfileUser } from "../../utils/teamRequestUtils";
 
 /**
  * PersonRequestCard Component
@@ -35,6 +34,7 @@ import { formatListLocation } from "../../utils/locationUtils";
  * @param {React.ReactNode} props.footerLeft - Content for the left side of the footer (e.g., inviter info)
  * @param {boolean} props.clickable - Whether user elements are clickable (default: true)
  * @param {boolean} props.showLocation - Whether to show location info (default: true)
+ * @param {boolean} props.privateProfile - Whether to render this user as a private profile
  */
 const PersonRequestCard = ({
   user,
@@ -52,11 +52,32 @@ const PersonRequestCard = ({
   showLocation = true,
   onNarrowChange,
   forceNarrow = false,
+  privateProfile,
 }) => {
   // ============ Helper Functions ============
+  const isPrivateUser = privateProfile ?? isPrivateProfileUser(user);
+  const displayUser = isPrivateUser
+    ? {
+        ...(user ?? {}),
+        first_name: "Private",
+        firstName: "Private",
+        last_name: "Profile",
+        lastName: "Profile",
+        username: null,
+        avatar_url: null,
+        avatarUrl: null,
+        is_public: false,
+        isPublic: false,
+        is_private: true,
+        isPrivate: true,
+      }
+    : user;
+  const effectiveClickable = clickable && !isPrivateUser;
 
   // Get display name
   const getDisplayName = () => {
+    if (isPrivateUser) return "Private Profile";
+
     const displayName = getUserDisplayName(user);
     return displayName === "Unknown" ? "Unknown User" : displayName;
   };
@@ -80,31 +101,31 @@ const PersonRequestCard = ({
 
   // Handle click on user elements
   const handleUserClick = () => {
-    if (clickable && onUserClick && user?.id) {
+    if (effectiveClickable && onUserClick && user?.id) {
       onUserClick(user.id);
     }
   };
 
   // Clickable styles
-  const clickableStyles = clickable
+  const clickableStyles = effectiveClickable
     ? "cursor-pointer hover:opacity-80 transition-opacity"
     : "";
 
-  const clickableTextStyles = clickable
-    ? "cursor-pointer hover:text-primary transition-colors"
-    : "";
   const showUsername =
+    !isPrivateUser &&
     user?.username &&
     (getDisplayName() !== user.username || isSyntheticUser(user));
-  const showDemoProfile = isSyntheticUser(user);
-  const avatarUrl = getUserAvatarUrl(user);
+  const showDemoProfile = !isPrivateUser && isSyntheticUser(user);
 
   // ============ Adaptive name (full → abbreviated → CSS truncate) ============
   const nameContainerRef = useRef(null);
   const probeRef = useRef(null);
   const dateRef = useRef(null);
   const fullName = getDisplayName();
-  const abbrevName = user ? formatDisplayName(user) : fullName;
+  const abbrevName = displayUser ? formatDisplayName(displayUser) : fullName;
+  const hasLocation =
+    !isPrivateUser &&
+    (user?.city || user?.country || getPostalCode());
   const [displayedName, setDisplayedName] = useState(fullName);
   const [isOverflow, setIsOverflow] = useState(false);
   const isOverflowRef = useRef(false);
@@ -149,42 +170,25 @@ const PersonRequestCard = ({
         <div className="flex min-w-0 flex-1 items-start space-x-4">
           {/* Avatar */}
           <Tooltip
-            content={clickable ? "View profile" : undefined}
+            content={effectiveClickable ? "View profile" : undefined}
             wrapperClassName={`avatar ${clickableStyles}`}
           >
-            <div className="w-12 h-12 rounded-full relative overflow-hidden" onClick={handleUserClick}>
-              {avatarUrl ? (
-                <img
-                  src={avatarUrl}
-                  alt={user?.username || "User"}
-                  className="object-cover w-full h-full rounded-full"
-                  onError={(e) => {
-                    e.target.style.display = "none";
-                    const fallback =
-                      e.target.parentElement.querySelector(".avatar-fallback");
-                    if (fallback) fallback.style.display = "flex";
-                  }}
-                />
-              ) : null}
-              {/* Fallback initials */}
-              <div
-                className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                style={{
-                  display: avatarUrl ? "none" : "flex",
-                }}
-              >
-                <span className="text-xl font-medium">
-                  {getUserInitials(user)}
-                </span>
-              </div>
-              {isSyntheticUser(user) && <DemoAvatarOverlay textClassName="text-[8px]" />}
-            </div>
+            <UserAvatar
+              user={displayUser}
+              sizeClass="w-12 h-12"
+              initialsClassName="text-xl font-medium"
+              clickable={effectiveClickable}
+              onClick={handleUserClick}
+              privateProfile={isPrivateUser}
+              showDemoOverlay={showDemoProfile}
+              demoOverlayTextClassName="text-[8px]"
+            />
           </Tooltip>
 
           {/* Name and Details */}
           <div className="flex-1 min-w-0">
             <h4 ref={nameContainerRef} className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative">
-              {clickable ? (
+              {effectiveClickable ? (
                 <Tooltip content="View profile" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
                   <span onClick={handleUserClick}>{displayedName}</span>
                 </Tooltip>
@@ -194,10 +198,10 @@ const PersonRequestCard = ({
               <span ref={probeRef} className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium" aria-hidden="true" />
             </h4>
 
-            {(showUsername || dateIsNarrow || (showLocation && (user?.city || user?.country || getPostalCode())) || sublineExtra || showDemoProfile) && (
+            {(showUsername || dateIsNarrow || (showLocation && hasLocation) || sublineExtra || showDemoProfile) && (
               <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs" style={{ maxHeight: "2.1em" }}>
                 {showUsername && (
-                  clickable ? (
+                  effectiveClickable ? (
                     <div className="min-w-0 flex-[0_1_auto] overflow-hidden">
                       <Tooltip content="View profile" wrapperClassName="block truncate leading-[1.05] text-base-content/70 cursor-pointer hover:text-primary transition-colors">
                         <span onClick={handleUserClick}>@{user.username}</span>
@@ -215,7 +219,7 @@ const PersonRequestCard = ({
                     <span className="leading-[1.05] whitespace-nowrap">{formatDate()}</span>
                   </div>
                 )}
-                {showLocation && (user?.city || user?.country || getPostalCode()) && (
+                {showLocation && hasLocation && (
                   <div className="flex min-w-0 max-w-[calc(100%-1.5rem)] flex-[0_1_auto] items-center gap-1 overflow-hidden">
                     <MapPin size={10} className="text-base-content/60 shrink-0" />
                     <span className="min-w-0 truncate text-base-content/60 leading-[1.05]">
@@ -249,7 +253,7 @@ const PersonRequestCard = ({
       </div>
 
       {/* Bio if available */}
-      {user?.bio && (
+      {!isPrivateUser && user?.bio && (
         <div className="mb-5 text-sm text-base-content/80">
           <p className="line-clamp-2">{user.bio}</p>
         </div>

--- a/src/components/teams/TeamApplicationDetailsModal.jsx
+++ b/src/components/teams/TeamApplicationDetailsModal.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useToast } from "../../contexts/ToastContext";
 import {
   Calendar,
@@ -20,7 +20,7 @@ import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import InlineUserLink from "../users/InlineUserLink";
 import VacantRoleCard from "./VacantRoleCard";
-import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import TeamAvatar from "./TeamAvatar";
 import {
   DEMO_TEAM_TOOLTIP,
   isSyntheticTeam,
@@ -28,10 +28,127 @@ import {
 import Alert from "../common/Alert";
 import { format } from "date-fns";
 import { useHydratedRole } from "../../hooks/useHydratedRole";
+import { teamService } from "../../services/teamService";
+import { useAuth } from "../../contexts/AuthContext";
 import {
   extractRoleMatchData,
+  getMemberUserId,
+  idsMatch,
+  isExistingMemberStatus,
   normalizeBoolean,
 } from "../../utils/teamRequestUtils";
+
+const EMPTY_OBJECT = {};
+
+const firstDefined = (...values) =>
+  values.find((value) => value !== undefined);
+
+const firstPresent = (...values) =>
+  values.find(
+    (value) => value !== undefined && value !== null && value !== "",
+  );
+
+const hasValue = (value) =>
+  value !== undefined && value !== null && value !== "";
+
+const isApplicantExistingTeamMember = ({ application, team, currentUser }) => {
+  const applicantId =
+    application?.applicant?.id ??
+    application?.user?.id ??
+    application?.applicantId ??
+    application?.applicant_id ??
+    application?.userId ??
+    application?.user_id ??
+    currentUser?.id ??
+    null;
+
+  if (!team || applicantId === null || applicantId === undefined) return false;
+
+  const directFlags = [
+    application?.isInternalRoleApplication,
+    application?.is_internal_role_application,
+    application?.isInternal,
+    application?.is_internal,
+    application?.isApplicantMember,
+    application?.is_applicant_member,
+    application?.applicantIsMember,
+    application?.applicant_is_member,
+    application?.alreadyMember,
+    application?.already_member,
+    application?.isExistingMember,
+    application?.is_existing_member,
+    application?.existingMember,
+    application?.existing_member,
+    application?.currentUserIsMember,
+    application?.current_user_is_member,
+    team?.isApplicantMember,
+    team?.is_applicant_member,
+    team?.applicantIsMember,
+    team?.applicant_is_member,
+    team?.alreadyMember,
+    team?.already_member,
+    team?.isExistingMember,
+    team?.is_existing_member,
+    team?.existingMember,
+    team?.existing_member,
+    team?.currentUserIsMember,
+    team?.current_user_is_member,
+  ];
+
+  if (directFlags.some((flag) => normalizeBoolean(flag) === true)) {
+    return true;
+  }
+
+  const membershipStatuses = [
+    application?.applicantMembershipStatus,
+    application?.applicant_membership_status,
+    application?.membershipStatus,
+    application?.membership_status,
+    application?.applicantStatus,
+    application?.applicant_status,
+    team?.applicantMembershipStatus,
+    team?.applicant_membership_status,
+    team?.membershipStatus,
+    team?.membership_status,
+    team?.applicantStatus,
+    team?.applicant_status,
+  ];
+
+  if (membershipStatuses.some(isExistingMemberStatus)) {
+    return true;
+  }
+
+  if (idsMatch(team?.owner_id ?? team?.ownerId, applicantId)) {
+    return true;
+  }
+
+  const memberCollections = [
+    team?.members,
+    team?.teamMembers,
+    team?.team_members,
+  ].filter(Array.isArray);
+
+  if (
+    memberCollections.some((members) =>
+      members.some((member) => idsMatch(getMemberUserId(member), applicantId)),
+    )
+  ) {
+    return true;
+  }
+
+  const memberIdLists = [
+    team?.memberIds,
+    team?.member_ids,
+    team?.memberUserIds,
+    team?.member_user_ids,
+    team?.teamMemberIds,
+    team?.team_member_ids,
+  ].filter(Array.isArray);
+
+  return memberIdLists.some((memberIds) =>
+    memberIds.some((memberId) => idsMatch(memberId, applicantId)),
+  );
+};
 
 /**
  * TeamApplicationDetailsModal Component
@@ -47,6 +164,8 @@ const TeamApplicationDetailsModal = ({
   onSendReminder,
   notificationHighlight = false,
 }) => {
+  const { user: currentUser } = useAuth();
+
   // ============ State ============
   const showToast = useToast();
   const loading = false;
@@ -55,54 +174,242 @@ const TeamApplicationDetailsModal = ({
   const [isTeamDetailsOpen, setIsTeamDetailsOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+  const [hydratedTeam, setHydratedTeam] = useState(null);
+  const teamHeaderRowRef = useRef(null);
   const teamNameContainerRef = useRef(null);
   const teamNameProbeRef = useRef(null);
   const teamDateRef = useRef(null);
   const [teamDateIsNarrow, setTeamDateIsNarrow] = useState(false);
-  const teamDateIsNarrowRef = useRef(false);
-  teamDateIsNarrowRef.current = teamDateIsNarrow;
 
   // ============ Helpers ============
 
   // Get team data from application
-  const baseTeam = application?.team || {};
+  const baseTeam = application?.team || EMPTY_OBJECT;
+  const effectiveTeamId =
+    baseTeam?.id ??
+    baseTeam?.teamId ??
+    baseTeam?.team_id ??
+    application?.teamId ??
+    application?.team_id ??
+    null;
+  const sourceTeam = hydratedTeam
+    ? { ...baseTeam, ...hydratedTeam }
+    : baseTeam;
   const syntheticTeamFlag =
-    baseTeam?.is_synthetic ??
-    baseTeam?.isSynthetic ??
+    sourceTeam?.is_synthetic ??
+    sourceTeam?.isSynthetic ??
     application?.team_is_synthetic ??
     application?.teamIsSynthetic;
   const team = {
-    ...baseTeam,
+    ...sourceTeam,
+    id: firstPresent(
+      sourceTeam?.id,
+      sourceTeam?.teamId,
+      sourceTeam?.team_id,
+      application?.teamId,
+      application?.team_id,
+    ),
+    name: firstPresent(
+      sourceTeam?.name,
+      application?.teamName,
+      application?.team_name,
+    ),
+    current_members_count: firstDefined(
+      sourceTeam?.current_members_count,
+      sourceTeam?.currentMembersCount,
+      application?.team_current_members_count,
+      application?.teamCurrentMembersCount,
+    ),
+    currentMembersCount: firstDefined(
+      sourceTeam?.currentMembersCount,
+      sourceTeam?.current_members_count,
+      application?.teamCurrentMembersCount,
+      application?.team_current_members_count,
+    ),
+    member_count: firstDefined(
+      sourceTeam?.member_count,
+      sourceTeam?.memberCount,
+      application?.team_member_count,
+      application?.teamMemberCount,
+    ),
+    memberCount: firstDefined(
+      sourceTeam?.memberCount,
+      sourceTeam?.member_count,
+      application?.teamMemberCount,
+      application?.team_member_count,
+    ),
+    members_count: firstDefined(
+      sourceTeam?.members_count,
+      sourceTeam?.membersCount,
+      application?.team_members_count,
+      application?.teamMembersCount,
+    ),
+    membersCount: firstDefined(
+      sourceTeam?.membersCount,
+      sourceTeam?.members_count,
+      application?.teamMembersCount,
+      application?.team_members_count,
+    ),
+    max_members: firstDefined(
+      sourceTeam?.max_members,
+      sourceTeam?.maxMembers,
+      application?.team_max_members,
+      application?.teamMaxMembers,
+    ),
+    maxMembers: firstDefined(
+      sourceTeam?.maxMembers,
+      sourceTeam?.max_members,
+      application?.teamMaxMembers,
+      application?.team_max_members,
+    ),
+    city: firstPresent(sourceTeam?.city, application?.team_city),
+    country: firstPresent(sourceTeam?.country, application?.team_country),
+    location: firstPresent(sourceTeam?.location, application?.team_location),
+    postal_code: firstPresent(
+      sourceTeam?.postal_code,
+      sourceTeam?.postalCode,
+      application?.team_postal_code,
+      application?.teamPostalCode,
+    ),
+    postalCode: firstPresent(
+      sourceTeam?.postalCode,
+      sourceTeam?.postal_code,
+      application?.teamPostalCode,
+      application?.team_postal_code,
+    ),
+    is_remote: firstDefined(
+      sourceTeam?.is_remote,
+      sourceTeam?.isRemote,
+      application?.team_is_remote,
+      application?.teamIsRemote,
+    ),
+    isRemote: firstDefined(
+      sourceTeam?.isRemote,
+      sourceTeam?.is_remote,
+      application?.teamIsRemote,
+      application?.team_is_remote,
+    ),
     is_synthetic:
-      baseTeam?.is_synthetic ?? baseTeam?.isSynthetic ?? syntheticTeamFlag,
+      sourceTeam?.is_synthetic ?? sourceTeam?.isSynthetic ?? syntheticTeamFlag,
     isSynthetic:
-      baseTeam?.isSynthetic ?? baseTeam?.is_synthetic ?? syntheticTeamFlag,
+      sourceTeam?.isSynthetic ?? sourceTeam?.is_synthetic ?? syntheticTeamFlag,
   };
   const teamName = team.name || "Unknown Team";
 
+  useEffect(() => {
+    if (!isOpen) {
+      setHydratedTeam(null);
+      return;
+    }
+
+    if (!effectiveTeamId) return;
+
+    const hasMemberCount =
+      [
+        baseTeam?.current_members_count,
+        baseTeam?.currentMembersCount,
+        baseTeam?.member_count,
+        baseTeam?.memberCount,
+        baseTeam?.members_count,
+        baseTeam?.membersCount,
+        application?.team_current_members_count,
+        application?.teamCurrentMembersCount,
+        application?.team_member_count,
+        application?.teamMemberCount,
+        application?.team_members_count,
+        application?.teamMembersCount,
+      ].some((value) => value !== undefined) ||
+      Array.isArray(baseTeam?.members);
+    const hasMaxMembers = [
+      baseTeam?.max_members,
+      baseTeam?.maxMembers,
+      application?.team_max_members,
+      application?.teamMaxMembers,
+    ].some((value) => value !== undefined);
+    const hasLocation = [
+      baseTeam?.city,
+      baseTeam?.country,
+      baseTeam?.location,
+      baseTeam?.postal_code,
+      baseTeam?.postalCode,
+      application?.team_city,
+      application?.team_country,
+      application?.team_location,
+      application?.team_postal_code,
+      application?.teamPostalCode,
+    ].some(hasValue);
+    const hasRemoteFlag = [
+      baseTeam?.is_remote,
+      baseTeam?.isRemote,
+      application?.team_is_remote,
+      application?.teamIsRemote,
+    ].some((value) => value !== undefined);
+    const hasSyntheticFlag = [
+      baseTeam?.is_synthetic,
+      baseTeam?.isSynthetic,
+      application?.team_is_synthetic,
+      application?.teamIsSynthetic,
+    ].some((value) => value !== undefined);
+
+    if (
+      hasMemberCount &&
+      hasMaxMembers &&
+      (hasLocation || hasRemoteFlag) &&
+      hasSyntheticFlag
+    ) {
+      setHydratedTeam(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchTeamDetails = async () => {
+      try {
+        const response = await teamService.getTeamById(effectiveTeamId);
+        if (cancelled) return;
+        setHydratedTeam(response?.data ?? response ?? null);
+      } catch (err) {
+        console.warn(
+          "Could not fetch team details for application details modal:",
+          err,
+        );
+        if (!cancelled) setHydratedTeam(null);
+      }
+    };
+
+    fetchTeamDetails();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, effectiveTeamId, application, baseTeam]);
+
   useLayoutEffect(() => {
+    const row = teamHeaderRowRef.current;
     const container = teamNameContainerRef.current;
     const probe = teamNameProbeRef.current;
-    if (!container || !probe) return;
+    if (!row || !container || !probe) return;
 
     const update = () => {
-      const dateEl = teamDateRef.current;
-      const reservedWidth =
-        teamDateIsNarrowRef.current && dateEl ? dateEl.offsetWidth + 16 : 0;
-
       probe.textContent = teamName;
+      const rowWidth = row.clientWidth;
+      const shouldCollapseForRowWidth = rowWidth > 0 && rowWidth < 520;
+      const shouldCollapseForTitle =
+        probe.scrollWidth > container.clientWidth;
+
       setTeamDateIsNarrow(
-        probe.scrollWidth > container.clientWidth - reservedWidth,
+        shouldCollapseForRowWidth || shouldCollapseForTitle,
       );
     };
 
     const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(row);
     resizeObserver.observe(container);
     if (teamDateRef.current) resizeObserver.observe(teamDateRef.current);
     update();
 
     return () => resizeObserver.disconnect();
-  }, [teamName]);
+  }, [isOpen, teamName]);
   const roleId = application?.role?.id ?? application?.roleId ?? null;
   const teamId = team?.id ?? null;
   const {
@@ -147,41 +454,14 @@ const TeamApplicationDetailsModal = ({
     }
   };
 
-  // Get team avatar
-  const getTeamAvatar = () => {
-    return (
-      team.teamavatar_url ||
-      team.teamavatarUrl ||
-      team.avatar_url ||
-      team.avatarUrl ||
-      null
-    );
-  };
-
-  // Get team initials from name (e.g., "Urban Gardeners Berlin" → "UGB")
-  const getTeamInitials = () => {
-    const name = team?.name;
-    if (!name || typeof name !== "string") return "?";
-
-    const words = name.trim().split(/\s+/);
-
-    if (words.length === 1) {
-      return name.slice(0, 2).toUpperCase();
-    }
-
-    return words
-      .slice(0, 3)
-      .map((word) => word.charAt(0))
-      .join("")
-      .toUpperCase();
-  };
-
   const getMemberCount = () => {
     return (
       team.current_members_count ??
       team.currentMembersCount ??
       team.member_count ??
       team.memberCount ??
+      team.members_count ??
+      team.membersCount ??
       team.members?.length ??
       0
     );
@@ -210,6 +490,21 @@ const TeamApplicationDetailsModal = ({
           : fallbackLocation,
     };
   };
+
+  const hasTeamMemberCountData =
+    [
+      team.current_members_count,
+      team.currentMembersCount,
+      team.member_count,
+      team.memberCount,
+      team.members_count,
+      team.membersCount,
+    ].some((value) => value !== undefined) ||
+    Array.isArray(team.members);
+  const hasTeamMaxMemberData =
+    team.max_members !== undefined || team.maxMembers !== undefined;
+  const showTeamMemberCapacity =
+    hasTeamMemberCountData && hasTeamMaxMemberData;
 
   const handleTeamClick = () => {
     if (team?.id) setIsTeamDetailsOpen(true);
@@ -268,6 +563,11 @@ const TeamApplicationDetailsModal = ({
 
   const isInternalRoleApplication =
     application?.isInternalRoleApplication ?? application?.is_internal_role_application ?? false;
+  const applicantAlreadyTeamMember = isApplicantExistingTeamMember({
+    application,
+    team,
+    currentUser,
+  });
   const hasRoleApplication = !!(
     application?.role ||
     application?.roleId ||
@@ -427,47 +727,24 @@ const TeamApplicationDetailsModal = ({
         )}
 
         {/* Top row: Team info (left, clickable) + Date (right) */}
-        <div className="relative flex items-start justify-between gap-4 mb-5">
+        <div
+          ref={teamHeaderRowRef}
+          className="relative flex items-start justify-between gap-4 mb-5"
+        >
           {/* Team info */}
           <div
             className="flex min-w-0 flex-1 items-start space-x-4 cursor-pointer hover:opacity-80 transition-opacity"
             onClick={handleTeamClick}
           >
             <Tooltip content="Click to view team details" wrapperClassName="avatar">
-              <div className="w-12 h-12 rounded-full relative overflow-hidden">
-                {getTeamAvatar() ? (
-                  <img
-                    src={getTeamAvatar()}
-                    alt={team.name || "Team"}
-                    className="object-cover w-full h-full rounded-full"
-                    onError={(e) => {
-                      e.target.style.display = "none";
-                      const fallback =
-                        e.target.parentElement.querySelector(
-                          ".avatar-fallback"
-                        );
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                ) : null}
-
-                {/* Fallback initials */}
-                <div
-                  className="avatar-fallback bg-[var(--color-primary-focus)] text-primary-content flex items-center justify-center w-full h-full rounded-full absolute inset-0"
-                  style={{ display: getTeamAvatar() ? "none" : "flex" }}
-                >
-                  <span className="text-xl font-medium">
-                    {getTeamInitials()}
-                  </span>
-                </div>
-
-                {isSyntheticTeam(team) && (
-                  <DemoAvatarOverlay
-                    textClassName="text-[8px]"
-                    textTranslateClassName="-translate-y-[2px]"
-                  />
-                )}
-              </div>
+              <TeamAvatar
+                team={team}
+                sizeClass="w-12 h-12"
+                initialsClassName="text-xl font-medium"
+                showDemoOverlay={isSyntheticTeam(team)}
+                demoOverlayTextClassName="text-[8px]"
+                demoOverlayTextTranslateClassName="-translate-y-[2px]"
+              />
             </Tooltip>
 
             <div className="flex-1 min-w-0">
@@ -501,15 +778,17 @@ const TeamApplicationDetailsModal = ({
                     </span>
                   </div>
                 )}
-                <Tooltip
-                  content="Team members"
-                  wrapperClassName="flex shrink-0 items-center gap-1 text-base-content/70"
-                >
-                  <Users size={10} className="shrink-0 text-primary" />
-                  <span className="leading-[1.05] whitespace-nowrap">
-                    {getMemberCount()}/{getMaxMembers()}
-                  </span>
-                </Tooltip>
+                {showTeamMemberCapacity && (
+                  <Tooltip
+                    content="Team members"
+                    wrapperClassName="flex shrink-0 items-center gap-1 text-base-content/70"
+                  >
+                    <Users size={10} className="shrink-0 text-primary" />
+                    <span className="leading-[1.05] whitespace-nowrap">
+                      {getMemberCount()}/{getMaxMembers()}
+                    </span>
+                  </Tooltip>
+                )}
                 {teamLocationDetails.locationText && (
                   <Tooltip
                     content={teamLocationDetails.locationText}
@@ -525,7 +804,7 @@ const TeamApplicationDetailsModal = ({
                     </span>
                   </Tooltip>
                 )}
-                {isInternalRoleApplication && (
+                {applicantAlreadyTeamMember && (
                   <Tooltip
                     content="You are already a member of this team"
                     wrapperClassName="flex min-w-0 overflow-hidden items-center gap-0.5 text-base-content/70"

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -22,6 +22,7 @@ import {
   getRequestUserLabel,
   getRequestUserId,
   getRequestRoleId,
+  isPrivateProfileUser,
   isRequestForUser,
 } from "../../utils/teamRequestUtils";
 
@@ -395,6 +396,8 @@ const TeamApplicationsModal = ({
           "applicant",
           currentUser?.id,
         );
+        const applicantIsPrivate =
+          isPrivateProfileUser(application.applicant) && !isSelfApplication;
         const isInternalRoleApplication = Boolean(
           application?.isInternalRoleApplication ??
             application?.is_internal_role_application ??
@@ -462,6 +465,7 @@ const TeamApplicationsModal = ({
           >
             <PersonRequestCard
               user={application.applicant}
+              privateProfile={applicantIsPrivate}
               date={getRequestDateValue(application)}
               onNarrowChange={(narrow) => setNarrowMap((prev) => {
                 if ((prev[String(application.id)] ?? false) === narrow) return prev;
@@ -506,15 +510,16 @@ const TeamApplicationsModal = ({
                       }
                       allowedStatusActions={["filled", "open"]}
                       statusActionLoading={statusUpdatingRoleId === roleId}
-                      viewAsUserId={application.applicant?.id}
-                      viewAsUser={application.applicant}
+                      viewAsUserId={applicantIsPrivate ? null : application.applicant?.id}
+                      viewAsUser={applicantIsPrivate ? null : application.applicant}
                     />
                 ) : null
               }
               extraContent={
                 <>
                   {/* User Tags/Skills if available */}
-                  {application.applicant?.tags &&
+                  {!applicantIsPrivate &&
+                    application.applicant?.tags &&
                     application.applicant.tags.length > 0 && (
                       <div className="mb-4">
                         <h5 className="font-medium text-sm text-base-content/80 mb-2">

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -39,6 +39,7 @@ import NotificationBadge from "../common/NotificationBadge";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import ListViewRow from "../common/ListViewRow";
 import MatchScoreOverlay from "../common/MatchScoreOverlay";
+import MatchScoreSubtitle from "../common/MatchScoreSubtitle";
 import TeamApplicationsModal from "./TeamApplicationsModal";
 import { format } from "date-fns";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
@@ -2133,85 +2134,42 @@ const TeamCard = ({
     const iconSizeSubtitle =
       viewMode === "list" ? 9 : viewMode === "mini" ? 10 : 13;
     scoreSubtitleItem = (
-      <Tooltip content={matchTooltipText}>
-        <span className="flex items-center gap-0.5">
-          <matchTier.Icon size={iconSizeSubtitle} className={matchTier.text} />
-          <span className="text-base-content">{matchTier.pct}%</span>
-        </span>
-      </Tooltip>
+      <MatchScoreSubtitle
+        matchTier={matchTier}
+        tooltipText={matchTooltipText}
+        iconSize={iconSizeSubtitle}
+      />
     );
 
-    if (isRoleVariant) {
-      const isListMatchBadge = viewMode === "list";
-      const isCompactMatchBadge =
-        isListMatchBadge || viewMode === "mini";
-      const matchBadgeIconSize = isListMatchBadge
-        ? 7
-        : isCompactMatchBadge
-          ? 11
-          : 13;
+    const isListMatchBadge = viewMode === "list";
+    const isCompactMatchBadge = isListMatchBadge || viewMode === "mini";
+    const matchBadgeIconSize = isListMatchBadge ? 7 : isCompactMatchBadge ? 11 : 13;
+    const matchBadgePx = isListMatchBadge ? 14 : isCompactMatchBadge ? 22 : 26;
+    const overlayPosition = `absolute ${isListMatchBadge ? "-top-0.5 -left-0.5" : "-top-1 -left-1"} z-10`;
 
+    if (isRoleVariant) {
       matchOverlay = (
-        <Tooltip content={matchTooltipText}>
-          <div
-            aria-label={matchTooltipText}
-            className={`absolute ${isListMatchBadge ? "-top-0.5 -left-0.5" : "-top-1 -left-1"} z-10 rounded-full ring-2 ring-white flex items-center justify-center ${matchTier.bg} text-white`}
-            style={{
-              width: isListMatchBadge
-                ? "14px"
-                : isCompactMatchBadge
-                  ? "22px"
-                  : "26px",
-              height: isListMatchBadge
-                ? "14px"
-                : isCompactMatchBadge
-                  ? "22px"
-                  : "26px",
-            }}
-          >
-            <UserSearch
-              size={matchBadgeIconSize}
-              className="text-white"
-              strokeWidth={2.5}
-            />
-          </div>
-        </Tooltip>
+        <MatchScoreOverlay
+          matchTier={matchTier}
+          icon={UserSearch}
+          tooltipText={matchTooltipText}
+          sizeClassName=""
+          iconSize={matchBadgeIconSize}
+          positionClassName={overlayPosition}
+          style={{ width: `${matchBadgePx}px`, height: `${matchBadgePx}px` }}
+        />
       );
     } else if (isTeamInvitationOrApplicationVariant) {
-      const isListMatchBadge = viewMode === "list";
-      const isCompactMatchBadge =
-        isListMatchBadge || viewMode === "mini";
-      const matchBadgeIconSize = isListMatchBadge
-        ? 7
-        : isCompactMatchBadge
-          ? 11
-          : 13;
-
       matchOverlay = (
-        <Tooltip content={matchTooltipText}>
-          <div
-            aria-label={matchTooltipText}
-            className={`absolute ${isListMatchBadge ? "-top-0.5 -left-0.5" : "-top-1 -left-1"} z-10 rounded-full ring-2 ring-white flex items-center justify-center ${matchTier.bg} text-white`}
-            style={{
-              width: isListMatchBadge
-                ? "14px"
-                : isCompactMatchBadge
-                  ? "22px"
-                  : "26px",
-              height: isListMatchBadge
-                ? "14px"
-                : isCompactMatchBadge
-                  ? "22px"
-                  : "26px",
-            }}
-          >
-            <Users
-              size={matchBadgeIconSize}
-              className="text-white"
-              strokeWidth={2.5}
-            />
-          </div>
-        </Tooltip>
+        <MatchScoreOverlay
+          matchTier={matchTier}
+          icon={Users}
+          tooltipText={matchTooltipText}
+          sizeClassName=""
+          iconSize={matchBadgeIconSize}
+          positionClassName={overlayPosition}
+          style={{ width: `${matchBadgePx}px`, height: `${matchBadgePx}px` }}
+        />
       );
     } else {
       matchOverlay = (

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -42,8 +42,9 @@ import MatchScoreOverlay from "../common/MatchScoreOverlay";
 import TeamApplicationsModal from "./TeamApplicationsModal";
 import { format } from "date-fns";
 import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
-import { getMatchTier } from "../../utils/matchScoreUtils";
+import { getMatchTier, getMatchTooltipText } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
+import { extractNames, summarizeList } from "../../utils/listSummaryUtils";
 import {
   calculateDistanceKm,
   formatListLocation,
@@ -1999,21 +2000,6 @@ const TeamCard = ({
     // Search page: always show View Details button on the card
     if (isSearchResult) {
       return null;
-      // return (
-      //   <div className="mt-auto">
-      //     <Button
-      //       variant="primary"
-      //       size={viewMode === "mini" ? "xs" : "sm"}
-      //       className="w-full"
-      //       onClick={(e) => {
-      //         e.stopPropagation();
-      //         setIsModalOpen(true);
-      //       }}
-      //     >
-      //       View Details
-      //     </Button>
-      //   </div>
-      // );
     }
 
     if (
@@ -2023,8 +2009,6 @@ const TeamCard = ({
     ) {
       return (
         <div className="mt-auto pt-4">
-          {" "}
-          {/* pt-4: spacing from tags row — TODO: revert to pt-0 when LocationDistanceTagsRow mb-4 is restored */}
           <Button
             variant="primary"
             className="w-full"
@@ -2045,8 +2029,6 @@ const TeamCard = ({
     if (effectiveVariant === "application" || effectiveVariant === "role_application" || pendingApplicationForTeam) {
       return (
         <div className="mt-auto pt-4">
-          {" "}
-          {/* pt-4: spacing from tags row — TODO: revert to pt-0 when LocationDistanceTagsRow mb-4 is restored */}
           <Button
             variant="primary"
             className="w-full"
@@ -2066,8 +2048,6 @@ const TeamCard = ({
     // Member variant: View Details + management actions
     return (
       <div className="mt-auto pt-4 flex justify-between items-center">
-        {" "}
-        {/* pt-4: spacing from tags row — TODO: revert to pt-0 when LocationDistanceTagsRow mb-4 is restored */}
         <Button
           variant="primary"
           suppressCardTooltip={true}
@@ -2142,41 +2122,13 @@ const TeamCard = ({
           roleMatchData?.matchDetails ??
           null
         );
-    const hasScoreBreakdown =
-      matchDetails &&
-      ((matchDetails.tagScore ?? matchDetails.tag_score) != null ||
-        (matchDetails.badgeScore ?? matchDetails.badge_score) != null ||
-        (matchDetails.distanceScore ?? matchDetails.distance_score) != null);
-
-    if (hasScoreBreakdown) {
-      const tagPct = Math.round(
-        (matchDetails.tagScore ?? matchDetails.tag_score ?? 0) * 100,
-      );
-      const badgePct = Math.round(
-        (matchDetails.badgeScore ?? matchDetails.badge_score ?? 0) * 100,
-      );
-      const distPct = Math.round(
-        (matchDetails.distanceScore ?? matchDetails.distance_score ?? 0) * 100,
-      );
-      matchTooltipText = `${matchTier.pct}% match — Tags ${tagPct}% · Badges ${badgePct}% · Location ${distPct}%`;
-    } else if (matchDetails) {
-      const sharedTags =
-        matchDetails.sharedTagCount ?? matchDetails.shared_tag_count ?? 0;
-      const sharedBadges =
-        matchDetails.sharedBadgeCount ?? matchDetails.shared_badge_count ?? 0;
-      matchTooltipText =
-        sharedTags > 0 || sharedBadges > 0
-          ? `${matchTier.pct}% profile match — ${sharedTags} shared tags, ${sharedBadges} shared badges`
-          : `${matchTier.pct}% profile match`;
-    } else {
-      const sharedTagCount =
-        normalizedData.team?.sharedTagCount ??
-        normalizedData.team?.shared_tag_count ?? 0;
-      matchTooltipText =
-        sharedTagCount > 0
-          ? `${matchTier.pct}% profile match — ${sharedTagCount} shared focus areas`
-          : `${matchTier.pct}% profile match`;
-    }
+    const sharedTagCount =
+      normalizedData.team?.sharedTagCount ??
+      normalizedData.team?.shared_tag_count ??
+      0;
+    matchTooltipText = getMatchTooltipText(matchTier, matchDetails, {
+      sharedFocusCount: sharedTagCount,
+    });
 
     const iconSizeSubtitle =
       viewMode === "list" ? 9 : viewMode === "mini" ? 10 : 13;
@@ -2311,28 +2263,13 @@ const TeamCard = ({
       distance < 999999 &&
       !(teamData.is_remote || teamData.isRemote);
 
-    const tagNames = (teamData.tags || [])
-      .map((t) => (typeof t === "string" ? t : t.name || t.tag || ""))
-      .filter(Boolean);
-    const maxInlineTags = 3;
-    const visibleTags = tagNames.slice(0, maxInlineTags);
-    const remainingTags = tagNames.length - maxInlineTags;
-    const tagsSummary =
-      visibleTags.length > 0
-        ? visibleTags.join(", ") +
-          (remainingTags > 0 ? ` +${remainingTags}` : "")
-        : "";
+    const tagNames = extractNames(teamData.tags);
+    const { summary: tagsSummary, tooltip: tagsTooltip } =
+      summarizeList(tagNames);
 
-    const badgeNames = getDisplayBadges()
-      .map((badge) => (typeof badge === "string" ? badge : badge.name || ""))
-      .filter(Boolean);
-    const maxInlineBadges = 3;
-    const visibleBadges = badgeNames.slice(0, maxInlineBadges);
-    const remainingBadges = badgeNames.length - maxInlineBadges;
-    const badgesSummary =
-      visibleBadges.length > 0
-        ? visibleBadges.join(", ") + (remainingBadges > 0 ? ` +${remainingBadges}` : "")
-        : "";
+    const badgeNames = extractNames(getDisplayBadges());
+    const { summary: badgesSummary, tooltip: badgesTooltip } =
+      summarizeList(badgeNames);
 
     const memberCount = getMemberCount();
     const maxMembers = getMaxMembers();
@@ -2508,9 +2445,9 @@ const TeamCard = ({
             isRemote={teamData.is_remote || teamData.isRemote}
             distance={showDistance ? Math.round(distance) : null}
             tagsSummary={tagsSummary}
-            tagsTooltip={tagNames.join(", ")}
+            tagsTooltip={tagsTooltip}
             badgesSummary={badgesSummary}
-            badgesTooltip={badgeNames.join(", ")}
+            badgesTooltip={badgesTooltip}
             locationVisibilityClassName={listLocationVisibilityClassName}
             locationWidthClassName={listLocationWidthClassName}
             locationInsetClassName={listLocationInsetClassName}
@@ -2601,6 +2538,7 @@ const TeamCard = ({
               : pendingApplicationForTeam
           }
           onViewApplicationDetails={() => setIsApplicationModalOpen(true)}
+          onSendReminder={onSendReminder}
           showMatchHighlights={shouldShowTeamModalMatchHighlights}
           hideMatchData={shouldHideMatchData}
           matchScore={teamModalRawScore ?? null}
@@ -2684,6 +2622,8 @@ const TeamCard = ({
             role={roleData}
             matchScore={rawScore ?? null}
             matchDetails={roleModalMatchDetails}
+            canManage={canManageInvitations}
+            isTeamMember={Boolean(userRole) || isOwner}
             onViewApplicationDetails={
               isRoleApplicationVariant
                 ? () => {
@@ -3168,6 +3108,7 @@ const TeamCard = ({
             : pendingApplicationForTeam
         }
         onViewApplicationDetails={() => setIsApplicationModalOpen(true)}
+        onSendReminder={onSendReminder}
         showMatchHighlights={shouldShowTeamModalMatchHighlights}
         hideMatchData={shouldHideMatchData}
         roleMatchBadgeNames={roleMatchBadgeNames}
@@ -3254,6 +3195,8 @@ const TeamCard = ({
           role={roleData}
           matchScore={rawScore ?? null}
           matchDetails={roleModalMatchDetails}
+          canManage={canManageInvitations}
+          isTeamMember={Boolean(userRole) || isOwner}
           onViewApplicationDetails={
             isRoleApplicationVariant
               ? () => {

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -127,6 +127,7 @@ const TeamDetailsModal = ({
   hasPendingApplication = false,
   pendingApplication = null,
   onViewApplicationDetails,
+  onSendReminder,
   showMatchHighlights = false,
   roleMatchBadgeNames = null,
   matchScore = null,
@@ -1315,7 +1316,7 @@ const TeamDetailsModal = ({
   const openApplicationDetails = (application = null) => {
     const applicationToOpen = application ?? effectivePendingApplication;
     if (applicationToOpen) {
-      setSelectedPendingApplication(application);
+      setSelectedPendingApplication(applicationToOpen);
       setIsApplicationDetailsOpen(true);
       return;
     }
@@ -1335,13 +1336,35 @@ const TeamDetailsModal = ({
   const handleTeamApplicationSuccess = useCallback(
     (applicationData, submitResponse) => {
       const submittedApplication = submitResponse?.data ?? {};
+      const selectedRoleId =
+        applicationData.roleId ??
+        submittedApplication.roleId ??
+        submittedApplication.role_id ??
+        null;
+      const selectedRole = selectedRoleId
+        ? teamRoles.find((role) => idsMatch(role.id, selectedRoleId))
+        : null;
+      const applicationId =
+        submittedApplication.applicationId ??
+        submittedApplication.application_id ??
+        submittedApplication.id ??
+        null;
+      const createdAt = new Date().toISOString();
+
       setLocalPendingApplication({
-        id: submittedApplication.applicationId,
-        applicationId: submittedApplication.applicationId,
+        id: applicationId,
+        applicationId,
+        application_id: applicationId,
         status: submittedApplication.status ?? "pending",
         message: applicationData.message,
-        created_at: new Date().toISOString(),
+        created_at: createdAt,
+        createdAt,
         team: team ?? { id: effectiveTeamId },
+        teamId: effectiveTeamId,
+        team_id: effectiveTeamId,
+        role: submittedApplication.role ?? selectedRole ?? null,
+        roleId: selectedRoleId,
+        role_id: selectedRoleId,
         isInternalRoleApplication:
           submittedApplication.isInternalRoleApplication ?? false,
         is_internal_role_application:
@@ -1354,7 +1377,7 @@ const TeamDetailsModal = ({
           : "Application sent successfully!",
       });
     },
-    [effectiveTeamId, team],
+    [effectiveTeamId, team, teamRoles],
   );
 
   const renderJoinButton = () => {
@@ -2112,13 +2135,20 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
           </p>
         )}
       </ConfirmModal>
-      <TagAwardsModal {...tagAwardsModalProps} />
-      <SupercategoryAwardsModal {...supercategoryModalProps} />
+      <TagAwardsModal
+        {...tagAwardsModalProps}
+        canViewPrivateAwardees={isTeamMember}
+      />
+      <SupercategoryAwardsModal
+        {...supercategoryModalProps}
+        canViewPrivateAwardees={isTeamMember}
+      />
 
       {/* Badge Category Modal */}
       <BadgeCategoryModal
         {...badgeCategoryModalProps}
         onOpenUser={handleMemberClick}
+        canViewPrivateAwardees={isTeamMember}
       />
 
       {/* Invitation Details Modal */}
@@ -2161,6 +2191,7 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
             setIsApplicationDetailsOpen(false);
             await fetchTeamDetails(true);
           }}
+          onSendReminder={onSendReminder}
         />
       )}
     </>

--- a/src/components/teams/TeamInvitationDetailsModal.jsx
+++ b/src/components/teams/TeamInvitationDetailsModal.jsx
@@ -36,6 +36,7 @@ import { useAuth } from "../../contexts/AuthContext";
 import {
   extractRoleMatchData,
   getMemberUserId,
+  getPrivateAwareUserLabel,
   idsMatch,
   isExistingMemberStatus,
   normalizeBoolean,
@@ -167,12 +168,11 @@ const TeamInvitationDetailsModal = ({
   const [responseExpanded, setResponseExpanded] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [isTeamDetailsOpen, setIsTeamDetailsOpen] = useState(false);
+  const teamHeaderRowRef = useRef(null);
   const teamNameContainerRef = useRef(null);
   const teamNameProbeRef = useRef(null);
   const teamDateRef = useRef(null);
   const [teamDateIsNarrow, setTeamDateIsNarrow] = useState(false);
-  const teamDateIsNarrowRef = useRef(false);
-  teamDateIsNarrowRef.current = teamDateIsNarrow;
 
   // ============ Helpers ============
 
@@ -193,28 +193,31 @@ const TeamInvitationDetailsModal = ({
   const teamName = team.name || "Unknown Team";
 
   useLayoutEffect(() => {
+    const row = teamHeaderRowRef.current;
     const container = teamNameContainerRef.current;
     const probe = teamNameProbeRef.current;
-    if (!container || !probe) return;
+    if (!row || !container || !probe) return;
 
     const update = () => {
-      const dateEl = teamDateRef.current;
-      const reservedWidth =
-        teamDateIsNarrowRef.current && dateEl ? dateEl.offsetWidth + 16 : 0;
-
       probe.textContent = teamName;
+      const rowWidth = row.clientWidth;
+      const shouldCollapseForRowWidth = rowWidth > 0 && rowWidth < 520;
+      const shouldCollapseForTitle =
+        probe.scrollWidth > container.clientWidth;
+
       setTeamDateIsNarrow(
-        probe.scrollWidth > container.clientWidth - reservedWidth,
+        shouldCollapseForRowWidth || shouldCollapseForTitle,
       );
     };
 
     const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(row);
     resizeObserver.observe(container);
     if (teamDateRef.current) resizeObserver.observe(teamDateRef.current);
     update();
 
     return () => resizeObserver.disconnect();
-  }, [teamName]);
+  }, [isOpen, teamName]);
   const roleId =
     invitation?.role?.id ?? invitation?.roleId ?? invitation?.role_id ?? null;
   const teamId = team?.id ?? null;
@@ -688,7 +691,10 @@ const TeamInvitationDetailsModal = ({
         )}
 
         {/* Top row: Team info (left, clickable) + Date (right) */}
-        <div className="relative flex items-start justify-between gap-4 mb-5">
+        <div
+          ref={teamHeaderRowRef}
+          className="relative flex items-start justify-between gap-4 mb-5"
+        >
           {/* Team info (hover + onClick like in TeamInvitesModal) */}
           <div
             className="flex min-w-0 flex-1 items-start space-x-4 cursor-pointer hover:opacity-80 transition-opacity"
@@ -803,7 +809,7 @@ const TeamInvitationDetailsModal = ({
           <div className="mb-5">
             <p className="text-xs text-base-content/60 mb-1 flex items-center">
               <MailOpen size={12} className="text-info mr-1" />
-              {`Invitation message from ${inviter?.first_name || inviter?.firstName || inviter?.username || "them"}:`}
+              {`Invitation message from ${getPrivateAwareUserLabel(inviter, "them")}:`}
             </p>
             <div className="w-fit max-w-full bg-base-200 rounded-lg rounded-bl-none p-3">
               <p className="text-sm text-base-content/90 leading-relaxed">

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -42,6 +42,7 @@ import { vacantRoleService } from "../../services/vacantRoleService";
 import useSocketEvents from "../../hooks/useSocketEvents";
 import {
   isExistingMemberStatus,
+  isPrivateProfileUser,
   normalizeBoolean,
   normalizeNumericId,
   numericIdsMatch,
@@ -213,6 +214,8 @@ const unwrapTeamPayload = (payload) => {
  * @param {string} inviteeAvatar - Avatar URL of the invitee
  * @param {string} inviteeBio - Bio/description of the invitee
  * @param {boolean|string|number} inviteeIsSynthetic - Whether the invitee is demo data
+ * @param {boolean|string|number} inviteeIsPublic - Whether the invitee profile is public
+ * @param {boolean|string|number} inviteeIsPrivate - Whether the invitee profile is private
  * @param {string|number|null} prefillTeamId - Team ID to preselect when available
  * @param {string|number|null} prefillRoleId - Vacant role ID to preselect when available
  * @param {string|null} prefillTeamName - Team name for prefill context
@@ -229,6 +232,8 @@ const TeamInviteModal = ({
   inviteeAvatar,
   inviteeBio,
   inviteeIsSynthetic = false,
+  inviteeIsPublic,
+  inviteeIsPrivate,
   inviteeCity = null,
   inviteeCountry = null,
   inviteeJoinedAt = null,
@@ -599,10 +604,18 @@ const TeamInviteModal = ({
       last_name: inviteeLastName,
       username: inviteeUsername || inviteeName,
       avatar_url: inviteeAvatar || null,
+      avatarUrl: inviteeAvatar || null,
+      is_public: inviteeIsPublic,
+      isPublic: inviteeIsPublic,
+      is_private: inviteeIsPrivate,
+      isPrivate: inviteeIsPrivate,
       is_synthetic: inviteeIsSynthetic,
       isSynthetic: inviteeIsSynthetic,
     };
   };
+  const inviteeUser = getInviteeUserObject();
+  const inviteeIsPrivateProfile = isPrivateProfileUser(inviteeUser);
+  const displayInviteeUser = inviteeUser;
 
   // Get team avatar URL
   const getTeamAvatarUrl = (team) => {
@@ -865,7 +878,9 @@ const TeamInviteModal = ({
       const first = inviteeFirstName || "";
       const last = inviteeLastName || "";
       const full = `${first} ${last}`.trim();
-      const displayName = full || inviteeName || inviteeUsername || "Unknown User";
+      const displayName = inviteeIsPrivateProfile
+        ? "Private Profile"
+        : full || inviteeName || inviteeUsername || "Unknown User";
       const dateEl = dateRef.current;
       const reservedWidth =
         dateIsNarrowRef.current && dateEl ? dateEl.offsetWidth + 16 : 0;
@@ -878,7 +893,7 @@ const TeamInviteModal = ({
     if (dateRef.current) resizeObserver.observe(dateRef.current);
     update();
     return () => resizeObserver.disconnect();
-  }, [inviteeFirstName, inviteeLastName, inviteeName, inviteeUsername]);
+  }, [inviteeFirstName, inviteeLastName, inviteeName, inviteeUsername, inviteeIsPrivateProfile]);
 
   const prefillContextNote = useMemo(() => {
     if (!idsMatch(selectedTeamId, normalizedPrefillTeamId)) return null;
@@ -1254,7 +1269,6 @@ const TeamInviteModal = ({
     !sending &&
     !success &&
     (!selectedTeamRequiresRole || selectedRoleId !== null);
-  const inviteeUser = getInviteeUserObject();
   const showInviteeDemoProfile = isSyntheticUser(inviteeUser);
   const locationText = [inviteeCity, inviteeCountry].filter(Boolean).join(", ");
   const joinedDateText = (() => {
@@ -1487,14 +1501,17 @@ const TeamInviteModal = ({
           {/* Invitee info */}
           <div className="relative flex items-start justify-between gap-4 mb-5">
             <div className="flex min-w-0 flex-1 items-start space-x-4">
-              <Tooltip content="View profile" position="bottom" wrapperClassName="block">
+              <Tooltip content={inviteeIsPrivateProfile ? undefined : "View profile"} position="bottom" wrapperClassName="block">
                 <UserAvatar
-                  user={inviteeUser}
+                  user={displayInviteeUser}
                   sizeClass="w-12 h-12"
                   initialsClassName="text-xl font-medium"
-                  clickable
-                  onClick={() => handleUserClick(inviteeId)}
-                  title="View profile"
+                  clickable={!inviteeIsPrivateProfile}
+                  onClick={() => {
+                    if (!inviteeIsPrivateProfile) handleUserClick(inviteeId);
+                  }}
+                  title={inviteeIsPrivateProfile ? undefined : "View profile"}
+                  privateProfile={false}
                   showDemoOverlay={showInviteeDemoProfile}
                   demoOverlayTextClassName="text-[8px]"
                 />
@@ -1505,9 +1522,13 @@ const TeamInviteModal = ({
                   ref={nameContainerRef}
                   className="font-medium text-base-content leading-[120%] mb-[0.2em] truncate relative"
                 >
-                  <Tooltip content="View profile" position="bottom" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
-                    <span onClick={() => handleUserClick(inviteeId)}>{getInviteeDisplayName()}</span>
-                  </Tooltip>
+                  {inviteeIsPrivateProfile ? (
+                    <span>{getInviteeDisplayName()}</span>
+                  ) : (
+                    <Tooltip content="View profile" position="bottom" wrapperClassName="cursor-pointer hover:text-primary transition-colors">
+                      <span onClick={() => handleUserClick(inviteeId)}>{getInviteeDisplayName()}</span>
+                    </Tooltip>
+                  )}
                   <span
                     ref={nameProbeRef}
                     className="invisible absolute whitespace-nowrap pointer-events-none left-0 top-0 font-medium"
@@ -1518,14 +1539,20 @@ const TeamInviteModal = ({
                 </h4>
 
                 <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0 overflow-hidden text-xs" style={{ maxHeight: "2.1em" }}>
-                  <Tooltip content="View profile" position="bottom" wrapperClassName="inline-flex">
-                    <p
-                      className="text-base-content/70 cursor-pointer hover:text-primary transition-colors"
-                      onClick={() => handleUserClick(inviteeId)}
-                    >
-                      @{getUsername()}
-                    </p>
-                  </Tooltip>
+                  {inviteeUsername && (
+                    inviteeIsPrivateProfile ? (
+                      <p className="text-base-content/70">@{getUsername()}</p>
+                    ) : (
+                      <Tooltip content="View profile" position="bottom" wrapperClassName="inline-flex">
+                        <p
+                          className="text-base-content/70 cursor-pointer hover:text-primary transition-colors"
+                          onClick={() => handleUserClick(inviteeId)}
+                        >
+                          @{getUsername()}
+                        </p>
+                      </Tooltip>
+                    )
+                  )}
                   {dateIsNarrow && joinedDateText && (
                     <div className="flex shrink-0 items-center gap-1 text-base-content/60">
                       <Calendar size={10} className="shrink-0" />
@@ -1565,7 +1592,7 @@ const TeamInviteModal = ({
           </div>
 
           {/* Bio if available */}
-          {inviteeBio && (
+          {!inviteeIsPrivateProfile && inviteeBio && (
             <div className="text-sm text-base-content/80 mb-5">
               <p className="line-clamp-2">{inviteeBio}</p>
             </div>
@@ -1991,6 +2018,8 @@ const TeamInviteModal = ({
           onClose={handleRoleDetailsClose}
           team={selectedTeam}
           role={selectedRoleForDetails}
+          isTeamMember={true}
+          canManage={true}
           hideActions
         />
       )}

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -29,6 +29,7 @@ import {
   getRequestUserLabel,
   getRequestUserId,
   getRequestRoleId,
+  isPrivateProfileUser,
   isRequestForUser,
 } from "../../utils/teamRequestUtils";
 
@@ -269,8 +270,10 @@ const TeamInvitesModal = ({
           "invitee",
           currentUser?.id,
         );
+        const inviteeIsPrivate =
+          isPrivateProfileUser(invitation.invitee) && !isSelfInvitation;
         const inviteeRoleMatch =
-          roleId != null && invitation?.role
+          roleId != null && invitation?.role && !inviteeIsPrivate
             ? extractRoleMatchData(invitation.role)
             : null;
         const selfRoleMatch =
@@ -314,8 +317,8 @@ const TeamInvitesModal = ({
             primaryMatch={inviteeRoleMatch}
             secondaryMatch={selfRoleMatch}
             canManageStatus={false}
-            viewAsUserId={inviteeId}
-            viewAsUser={invitation.invitee}
+            viewAsUserId={inviteeIsPrivate ? null : inviteeId}
+            viewAsUser={inviteeIsPrivate ? null : invitation.invitee}
             hideActions={true}
           />
         ) : null;
@@ -342,6 +345,7 @@ const TeamInvitesModal = ({
           >
             <PersonRequestCard
               user={invitation.invitee}
+              privateProfile={inviteeIsPrivate}
               date={getRequestDateValue(invitation)}
               onNarrowChange={(narrow) =>
                 setNarrowMap((prev) => {

--- a/src/components/teams/TeamMembersSection.jsx
+++ b/src/components/teams/TeamMembersSection.jsx
@@ -77,23 +77,6 @@ const TeamMembersSection = ({
     return statuses;
   }, [members]);
 
-  // Helper function to get member initials (2 letters: "NK" for Nam Khoa)
-  const getMemberInitials = (member) => {
-    const firstName = member.firstName || member.first_name;
-    const lastName = member.lastName || member.last_name;
-
-    if (firstName && lastName) {
-      return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
-    }
-    if (firstName) {
-      return firstName.charAt(0).toUpperCase();
-    }
-    if (member.username) {
-      return member.username.charAt(0).toUpperCase();
-    }
-    return "?";
-  };
-
   // Early return if no members
   if (!team?.members || team.members.length === 0) {
     return null;
@@ -135,6 +118,15 @@ const TeamMembersSection = ({
           const anonymize = shouldAnonymizeMember(member);
           const memberAvatarUrl =
             !anonymize ? member.avatarUrl || member.avatar_url || null : null;
+          const displayMember = {
+            ...member,
+            avatar_url: memberAvatarUrl,
+            avatarUrl: memberAvatarUrl,
+            is_public: anonymize ? false : member.is_public,
+            isPublic: anonymize ? false : member.isPublic,
+            is_private: anonymize ? true : member.is_private,
+            isPrivate: anonymize ? true : member.isPrivate,
+          };
           const memberSyntheticStatus =
             memberId != null ? syntheticMemberStatusMap[String(memberId)] : undefined;
           const showDemoAvatarOverlay =
@@ -174,8 +166,9 @@ const TeamMembersSection = ({
               className="flex items-start bg-green-50 rounded-xl shadow p-4 gap-4 transition-all duration-200 hover:bg-green-100 hover:shadow-md"
             >
               <UserAvatar
-                user={member}
+                user={displayMember}
                 sizeClass="w-14 h-14"
+                privateProfile={anonymize}
                 showDemoOverlay={showDemoAvatarOverlay}
                 demoOverlayTextClassName="text-[8px]"
                 fallbackText={anonymize ? "PP" : undefined}

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -31,6 +31,7 @@ import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import ListViewRow from "../common/ListViewRow";
 import MatchScoreOverlay from "../common/MatchScoreOverlay";
+import MatchScoreSubtitle from "../common/MatchScoreSubtitle";
 import Tooltip from "../common/Tooltip";
 import {
   DEMO_PROFILE_TOOLTIP,
@@ -776,15 +777,11 @@ const VacantRoleCard = ({
     viewMode === "list" ? 9 : viewMode === "mini" ? 10 : 13;
   const formattedPostedDate = getFormattedPostedDate();
   const scoreSubtitleItem = matchTier ? (
-    <Tooltip content={getMatchTooltip()}>
-      <span className="inline-flex items-center gap-0.5 whitespace-nowrap leading-none">
-        <matchTier.Icon
-          size={scoreSubtitleIconSize}
-          className={`${matchTier.text} flex-shrink-0`}
-        />
-        <span className="text-base-content">{matchTier.pct}%</span>
-      </span>
-    </Tooltip>
+    <MatchScoreSubtitle
+      matchTier={matchTier}
+      tooltipText={getMatchTooltip()}
+      iconSize={scoreSubtitleIconSize}
+    />
   ) : null;
   const roleApplicationSubtitleItem = hasCurrentUserRoleApplication ? (
     <Tooltip content="You applied for this role">

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -45,9 +45,11 @@ import UserAvatar from "../users/UserAvatar";
 import { resolveFilledRoleUser } from "../../utils/vacantRoleUtils";
 import {
   getMatchTier,
+  getMatchTooltipText,
   MATCH_TIER_GOOD,
   MATCH_TIER_GREAT,
 } from "../../utils/matchScoreUtils";
+import { summarizeList } from "../../utils/listSummaryUtils";
 import { teamService } from "../../services/teamService";
 import { useAuth } from "../../contexts/AuthContext";
 import { format } from "date-fns";
@@ -650,24 +652,10 @@ const VacantRoleCard = ({
 
   const matchColor = hasMatchScore ? getMatchColor() : null;
 
-  const getMatchTooltip = () => {
-    if (!visibleMatchDetails) return `${pct}% match`;
-    const tagPct = Math.round(
-      (visibleMatchDetails.tagScore ?? visibleMatchDetails.tag_score ?? 0) *
-        100,
-    );
-    const badgePct = Math.round(
-      (visibleMatchDetails.badgeScore ??
-        visibleMatchDetails.badge_score ??
-        0) * 100,
-    );
-    const distPct = Math.round(
-      (visibleMatchDetails.distanceScore ??
-        visibleMatchDetails.distance_score ??
-        0) * 100,
-    );
-    return `${pct}% match — Tags ${tagPct}% · Badges ${badgePct}% · Location ${distPct}%`;
-  };
+  const getMatchTooltip = () =>
+    getMatchTooltipText(matchTier, visibleMatchDetails, {
+      fallbackLabel: "match",
+    });
 
   const getFormattedPostedDate = () => {
     if (!rolePostedAt) return null;
@@ -1004,18 +992,10 @@ const VacantRoleCard = ({
       role,
       { isRemote: is_remote },
     );
-    const visibleTags = tagNames.slice(0, 3);
-    const remainingTagCount = tagNames.length - visibleTags.length;
-    const tagsSummary =
-      visibleTags.length > 0
-        ? visibleTags.join(", ") + (remainingTagCount > 0 ? ` +${remainingTagCount}` : "")
-        : "";
-    const visibleBadges = badgeNames.slice(0, 3);
-    const remainingBadgeCount = badgeNames.length - visibleBadges.length;
-    const badgesSummary =
-      visibleBadges.length > 0
-        ? visibleBadges.join(", ") + (remainingBadgeCount > 0 ? ` +${remainingBadgeCount}` : "")
-        : "";
+    const { summary: tagsSummary, tooltip: tagsTooltip } =
+      summarizeList(tagNames, 3);
+    const { summary: badgesSummary, tooltip: badgesTooltip } =
+      summarizeList(badgeNames, 3);
     const listSubtitle =
       scoreSubtitleItem ||
       postedDateSubtitleItem ||
@@ -1061,9 +1041,9 @@ const VacantRoleCard = ({
             isRemote={is_remote}
             distance={showDistance ? roundedDistanceKm : null}
             tagsSummary={tagsSummary}
-            tagsTooltip={tagNames.join(", ")}
+            tagsTooltip={tagsTooltip}
             badgesSummary={badgesSummary}
-            badgesTooltip={badgeNames.join(", ")}
+            badgesTooltip={badgesTooltip}
           />
         </Card>
         {detailsModal}

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -107,6 +107,81 @@ const roleMemberMatchDataQueryKey = (memberId) => [
 const toPossessive = (value) =>
   !value ? "your" : value.endsWith("s") ? `${value}'` : `${value}'s`;
 
+const firstPresent = (...values) =>
+  values.find((value) => value !== undefined && value !== null);
+
+const idsMatch = (firstId, secondId) => {
+  if (firstId === undefined || firstId === null) return false;
+  if (secondId === undefined || secondId === null) return false;
+  return String(firstId).trim() === String(secondId).trim();
+};
+
+const normalizeBooleanFlag = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes"].includes(normalized)) return true;
+    if (["false", "0", "no"].includes(normalized)) return false;
+  }
+  return null;
+};
+
+const getTeamMemberUserId = (member) =>
+  member?.userId ??
+  member?.user_id ??
+  member?.memberId ??
+  member?.member_id ??
+  member?.user?.id ??
+  member?.id ??
+  null;
+
+const getProfilePublicFlag = (user) =>
+  firstPresent(
+    user?.isPublic,
+    user?.is_public,
+    user?.profileIsPublic,
+    user?.profile_is_public,
+    user?.user?.isPublic,
+    user?.user?.is_public,
+  );
+
+const getProfilePrivateFlag = (user) =>
+  firstPresent(
+    user?.isPrivate,
+    user?.is_private,
+    user?.profileIsPrivate,
+    user?.profile_is_private,
+    user?.user?.isPrivate,
+    user?.user?.is_private,
+  );
+
+const shouldAnonymizePrivateUser = ({
+  targetUser,
+  targetUserId,
+  teamMembers,
+  viewerUserId,
+  viewerIsTeamMember,
+}) => {
+  if (!targetUserId) return false;
+  if (idsMatch(targetUserId, viewerUserId)) return false;
+  if (viewerIsTeamMember) return false;
+
+  const teamMember = Array.isArray(teamMembers)
+    ? teamMembers.find((member) =>
+        idsMatch(getTeamMemberUserId(member), targetUserId),
+      )
+    : null;
+  const privacySource = teamMember || targetUser || {};
+  const isPublic = normalizeBooleanFlag(getProfilePublicFlag(privacySource));
+  const isPrivate = normalizeBooleanFlag(getProfilePrivateFlag(privacySource));
+
+  if (isPublic === true) return false;
+  if (isPrivate === true || isPublic === false) return true;
+
+  return true;
+};
+
 const getRoleRecordId = (record) =>
   record?.role?.id ?? record?.roleId ?? record?.role_id ?? null;
 
@@ -1229,11 +1304,39 @@ const VacantRoleDetailsModal = ({
     displayRole.creator_id ??
     displayRole.creator?.id ??
     null;
+  const creatorIsPublic =
+    displayRole.creator_is_public ??
+    displayRole.creatorIsPublic ??
+    displayRole.creator?.is_public ??
+    displayRole.creator?.isPublic ??
+    null;
+  const creatorUser = {
+    ...(displayRole.creator ?? {}),
+    id: creatorUserId,
+    firstName: creatorFirstName,
+    first_name: creatorFirstName,
+    lastName: creatorLastName,
+    last_name: creatorLastName,
+    username: creatorUsername,
+    is_public: creatorIsPublic,
+    isPublic: creatorIsPublic,
+  };
+  const shouldAnonymizeCreator = shouldAnonymizePrivateUser({
+    targetUser: creatorUser,
+    targetUserId: creatorUserId,
+    teamMembers,
+    viewerUserId: currentUser?.id,
+    viewerIsTeamMember,
+  });
   const creatorName =
-    creatorFirstName && creatorLastName
+    shouldAnonymizeCreator
+      ? "Private Profile"
+      : creatorFirstName && creatorLastName
       ? `${creatorFirstName} ${creatorLastName}`
       : creatorUsername || null;
-  const creatorDisplayName = creatorName
+  const creatorDisplayName = shouldAnonymizeCreator
+    ? "Private Profile"
+    : creatorName
     ? formatDisplayName({
         first_name: creatorFirstName,
         last_name: creatorLastName,
@@ -1273,11 +1376,34 @@ const VacantRoleDetailsModal = ({
   const filledRoleUser = isFilledRole
     ? comparisonUser || resolvedFilledUser
     : null;
-  const filledRoleDisplayName =
-    filledRoleUser && getDisplayName(filledRoleUser) !== "Unknown"
+  const filledRoleUserId =
+    filledRoleUser?.id ?? filledRoleUser?.userId ?? filledRoleUser?.user_id;
+  const shouldAnonymizeFilledRoleUser = shouldAnonymizePrivateUser({
+    targetUser: filledRoleUser,
+    targetUserId: filledRoleUserId,
+    teamMembers,
+    viewerUserId: currentUser?.id,
+    viewerIsTeamMember,
+  });
+  const displayFilledRoleUser = shouldAnonymizeFilledRoleUser
+    ? {
+        ...(filledRoleUser ?? {}),
+        avatar_url: null,
+        avatarUrl: null,
+        is_public: false,
+        isPublic: false,
+        is_private: true,
+        isPrivate: true,
+      }
+    : filledRoleUser;
+  const filledRoleDisplayName = shouldAnonymizeFilledRoleUser
+    ? "Private Profile"
+    : filledRoleUser && getDisplayName(filledRoleUser) !== "Unknown"
       ? getDisplayName(filledRoleUser)
       : null;
-  const filledRoleCompactDisplayName = filledRoleUser
+  const filledRoleCompactDisplayName = shouldAnonymizeFilledRoleUser
+    ? "Private Profile"
+    : filledRoleUser
     ? formatDisplayName(filledRoleUser)
     : filledRoleDisplayName;
   const filledAt =
@@ -1346,8 +1472,12 @@ const VacantRoleDetailsModal = ({
       : `${effectivePct}% match with ${comparisonPossessive} profile`)
     : null;
   const handleFilledUserClick = () => {
-    const filledUserId = filledRoleUser?.id;
-    if (filledUserId && userModal?.openUserModal) {
+    const filledUserId = filledRoleUserId;
+    if (
+      filledUserId &&
+      !shouldAnonymizeFilledRoleUser &&
+      userModal?.openUserModal
+    ) {
       userModal.openUserModal(filledUserId, {
         filledRoleName: roleName ?? null,
         teamName: teamName ?? null,
@@ -1355,7 +1485,7 @@ const VacantRoleDetailsModal = ({
     }
   };
   const handleCreatorUserClick = () => {
-    if (creatorUserId && userModal?.openUserModal) {
+    if (creatorUserId && !shouldAnonymizeCreator && userModal?.openUserModal) {
       userModal.openUserModal(creatorUserId, {
         teamName: teamName ?? null,
       });
@@ -1806,22 +1936,43 @@ const VacantRoleDetailsModal = ({
         <div className="relative flex items-start space-x-4 mb-6">
           <div className="avatar relative">
             {isFilledRole ? (
-              <Tooltip content={filledRoleUser?.id ? `Click to view ${filledRoleDisplayName || "this user"}'s profile` : undefined}>
+              <Tooltip
+                content={
+                  filledRoleUserId && !shouldAnonymizeFilledRoleUser
+                    ? `Click to view ${filledRoleDisplayName || "this user"}'s profile`
+                    : undefined
+                }
+              >
               <div
-                role={filledRoleUser?.id ? "button" : undefined}
-                tabIndex={filledRoleUser?.id ? 0 : undefined}
-                onKeyDown={filledRoleUser?.id ? (e) => { if (e.key === "Enter" || e.key === " ") handleFilledUserClick(); } : undefined}
+                role={
+                  filledRoleUserId && !shouldAnonymizeFilledRoleUser
+                    ? "button"
+                    : undefined
+                }
+                tabIndex={
+                  filledRoleUserId && !shouldAnonymizeFilledRoleUser
+                    ? 0
+                    : undefined
+                }
+                onKeyDown={
+                  filledRoleUserId && !shouldAnonymizeFilledRoleUser
+                    ? (e) => { if (e.key === "Enter" || e.key === " ") handleFilledUserClick(); }
+                    : undefined
+                }
               >
                 <UserAvatar
-                  user={filledRoleUser}
+                  user={displayFilledRoleUser}
                   sizeClass="w-20 h-20"
-                  clickable={!!filledRoleUser?.id}
+                  clickable={Boolean(
+                    filledRoleUserId && !shouldAnonymizeFilledRoleUser,
+                  )}
                   onClick={handleFilledUserClick}
                   initialsClassName="text-2xl font-semibold"
+                  privateProfile={shouldAnonymizeFilledRoleUser}
                   showDemoOverlay={!!demoAvatarOverlay}
                   demoOverlayTextClassName="text-[9px]"
                   demoOverlayTextTranslateClassName="-translate-y-[4px]"
-                  fallbackText={!filledRoleUser ? getRoleInitials() : undefined}
+                  fallbackText={!displayFilledRoleUser ? getRoleInitials() : undefined}
                 />
               </div>
               </Tooltip>
@@ -1884,7 +2035,7 @@ const VacantRoleDetailsModal = ({
               {creatorName && (
                 <span className="flex min-w-0 max-w-[12rem] items-center gap-1 text-base-content/50 sm:max-w-[16rem]">
                   <PenLine size={14} className="flex-shrink-0" />
-                  {creatorUserId ? (
+                  {creatorUserId && !shouldAnonymizeCreator ? (
                     <Tooltip
                       content={`Created by ${creatorName}. Click to view their profile`}
                       wrapperClassName="inline-flex min-w-0 max-w-full items-center"
@@ -1906,7 +2057,7 @@ const VacantRoleDetailsModal = ({
               {isFilledRole && filledRoleDisplayName && (
                 <span className="flex min-w-0 max-w-[12rem] items-center gap-1 text-base-content/50 sm:max-w-[16rem]">
                   <UserCheck size={14} className="flex-shrink-0 text-success" />
-                  {filledRoleUser?.id ? (
+                  {filledRoleUserId && !shouldAnonymizeFilledRoleUser ? (
                     <Tooltip
                       content={`Filled by ${filledRoleDisplayName}. Click to view their profile`}
                       wrapperClassName="inline-flex min-w-0 max-w-full items-center"

--- a/src/components/users/InlineUserLink.jsx
+++ b/src/components/users/InlineUserLink.jsx
@@ -41,6 +41,23 @@ const mergeInlineUserData = (user, profile) => {
   };
 };
 
+const normalizeBooleanFlag = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes"].includes(normalized)) return true;
+    if (["false", "0", "no"].includes(normalized)) return false;
+  }
+  return null;
+};
+
+const isPrivateProfile = (user) =>
+  normalizeBooleanFlag(user?.is_public) === false ||
+  normalizeBooleanFlag(user?.isPublic) === false ||
+  normalizeBooleanFlag(user?.is_private) === true ||
+  normalizeBooleanFlag(user?.isPrivate) === true;
+
 /**
  * InlineUserLink Component
  *
@@ -87,6 +104,7 @@ const InlineUserLink = ({
   // Normalize user ID from various possible field names
   const userId = user?.id || user?.user_id || user?.userId;
   const isFormerUser = isDeletedUser(user);
+  const isPrivateUser = isPrivateProfile(user);
   // Only hydrate when the parent didn't pass enough to render a name —
   // missing avatar / synthetic flag alone aren't worth a network round trip,
   // since UserAvatar falls back to initials and the synthetic indicator is
@@ -99,7 +117,7 @@ const InlineUserLink = ({
       user?.lastName,
   );
   const needsInlineHydration =
-    !isFormerUser && Boolean(userId) && !hasDisplayableName;
+    !isFormerUser && !isPrivateUser && Boolean(userId) && !hasDisplayableName;
   const { data: resolvedInlineProfile = null } = useUserProfile(userId, {
     enabled: needsInlineHydration,
   });
@@ -107,10 +125,21 @@ const InlineUserLink = ({
   if (!user) return null;
 
   // Determine if we can handle clicks
-  const canClick = !isFormerUser && userId && (userModalContext || onOpenUser);
+  const canClick =
+    !isFormerUser &&
+    !isPrivateUser &&
+    userId &&
+    (userModalContext || onOpenUser);
   const inlineUser = mergeInlineUserData(user, resolvedInlineProfile);
-  const name = displayName ?? (getDisplayName(inlineUser) || "Unknown");
-  const showDemoIndicator = !isFormerUser && Boolean(inlineUser?.is_synthetic || inlineUser?.isSynthetic);
+  const name = isFormerUser
+    ? getDisplayName(inlineUser)
+    : isPrivateUser
+      ? "Private Profile"
+      : displayName ?? getDisplayName(inlineUser);
+  const showDemoIndicator =
+    !isFormerUser &&
+    !isPrivateUser &&
+    Boolean(inlineUser?.is_synthetic || inlineUser?.isSynthetic);
 
   const handleClick = (e) => {
     if (!canClick) return;
@@ -142,6 +171,7 @@ const InlineUserLink = ({
           <UserAvatar
             user={inlineUser}
             deleted={isFormerUser}
+            privateProfile={!isFormerUser && isPrivateUser}
             sizeClass={avatarSize}
             clickable={Boolean(canClick)}
             onClick={handleClick}
@@ -151,6 +181,7 @@ const InlineUserLink = ({
                 ? "text-[8px] font-medium"
                 : "text-[10px] font-medium"
             }
+            fallbackText={!isFormerUser && isPrivateUser ? "PP" : undefined}
           />
         </Tooltip>
       )}
@@ -162,7 +193,9 @@ const InlineUserLink = ({
       >
         <span
           className={`font-medium truncate ${
-            isFormerUser ? "text-base-content/50" : "text-base-content/80"
+            isFormerUser || isPrivateUser
+              ? "text-base-content/50"
+              : "text-base-content/80"
           } ${canClick ? "cursor-pointer hover:text-primary transition-colors" : ""}`}
           onClick={canClick ? handleClick : undefined}
         >

--- a/src/components/users/UserAvatar.jsx
+++ b/src/components/users/UserAvatar.jsx
@@ -19,14 +19,21 @@ const UserAvatar = ({
   iconSize = 12,
   initialsClassName = "text-[10px] font-medium",
   fallbackText,
+  privateProfile = false,
   showDemoOverlay = false,
   demoOverlayTextClassName = "text-[7px]",
   demoOverlayTextTranslateClassName = "-translate-y-[2px]",
 }) => {
   const isFormerUser = deleted || isDeletedUser(user);
   const avatarUrl =
-    !isFormerUser && (user?.avatar_url || user?.avatarUrl || null);
-  const displayName = getDisplayName(user, DELETED_USER_DISPLAY_NAME);
+    !isFormerUser &&
+    !privateProfile &&
+    (user?.avatar_url || user?.avatarUrl || null);
+  const displayName = isFormerUser
+    ? DELETED_USER_DISPLAY_NAME
+    : privateProfile
+      ? "Private Profile"
+      : getDisplayName(user, DELETED_USER_DISPLAY_NAME);
   const showSyntheticOverlay =
     showDemoOverlay && !isFormerUser && isSyntheticUser(user);
 
@@ -65,7 +72,7 @@ const UserAvatar = ({
             <User size={iconSize} />
           ) : (
             <span className={initialsClassName}>
-              {fallbackText ?? getUserInitials(user)}
+              {privateProfile ? "PP" : fallbackText ?? getUserInitials(user)}
             </span>
           )}
         </div>

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -25,6 +25,7 @@ import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import ListViewRow from "../common/ListViewRow";
 import MatchScoreOverlay from "../common/MatchScoreOverlay";
+import MatchScoreSubtitle from "../common/MatchScoreSubtitle";
 import { getMatchTier, getMatchTooltipText } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
 import { extractNames, summarizeList } from "../../utils/listSummaryUtils";
@@ -164,12 +165,11 @@ const UserCard = ({
     const iconSizeSubtitle =
       viewMode === "list" ? 9 : viewMode === "mini" ? 10 : 13;
     scoreSubtitleItem = (
-      <Tooltip content={matchTooltipText}>
-        <span className="flex items-center gap-0.5">
-          <matchTier.Icon size={iconSizeSubtitle} className={matchTier.text} />
-          <span className="text-base-content">{matchTier.pct}%</span>
-        </span>
-      </Tooltip>
+      <MatchScoreSubtitle
+        matchTier={matchTier}
+        tooltipText={matchTooltipText}
+        iconSize={iconSizeSubtitle}
+      />
     );
 
     const badgeSize =

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -25,8 +25,9 @@ import LocationDistanceTagsRow from "../common/LocationDistanceTagsRow";
 import SearchResultTypeOverlay from "../common/SearchResultTypeOverlay";
 import ListViewRow from "../common/ListViewRow";
 import MatchScoreOverlay from "../common/MatchScoreOverlay";
-import { getMatchTier } from "../../utils/matchScoreUtils";
+import { getMatchTier, getMatchTooltipText } from "../../utils/matchScoreUtils";
 import { getResultMatchScore } from "../../utils/teamMatchUtils";
+import { extractNames, summarizeList } from "../../utils/listSummaryUtils";
 import {
   formatListLocation,
   formatLocation,
@@ -156,26 +157,9 @@ const UserCard = ({
     const matchType = user.matchType ?? user.match_type;
     const matchDetails = user.matchDetails ?? user.match_details;
 
-    if (matchType === "role_match" && matchDetails) {
-      const tagPct = Math.round(
-        (matchDetails.tagScore ?? matchDetails.tag_score ?? 0) * 100,
-      );
-      const badgePct = Math.round(
-        (matchDetails.badgeScore ?? matchDetails.badge_score ?? 0) * 100,
-      );
-      const distPct = Math.round(
-        (matchDetails.distanceScore ?? matchDetails.distance_score ?? 0) * 100,
-      );
-      matchTooltipText = `${matchTier.pct}% role match — Tags ${tagPct}% · Badges ${badgePct}% · Location ${distPct}%`;
-    } else if (matchDetails) {
-      const sharedTags =
-        matchDetails.sharedTagCount ?? matchDetails.shared_tag_count ?? 0;
-      const sharedBadges =
-        matchDetails.sharedBadgeCount ?? matchDetails.shared_badge_count ?? 0;
-      matchTooltipText = `${matchTier.pct}% profile match — ${sharedTags} shared tags, ${sharedBadges} shared badges`;
-    } else {
-      matchTooltipText = `${matchTier.pct}% profile match`;
-    }
+    matchTooltipText = getMatchTooltipText(matchTier, matchDetails, {
+      breakdownLabel: matchType === "role_match" ? "role match" : "match",
+    });
 
     const iconSizeSubtitle =
       viewMode === "list" ? 9 : viewMode === "mini" ? 10 : 13;
@@ -240,27 +224,13 @@ const UserCard = ({
     const distance = user.distanceKm ?? user.distance_km;
     const showDistance = distance != null && distance < 999999 && !(user.is_remote || user.isRemote);
 
-    const tagNames = (user.tags || [])
-      .map((t) => (typeof t === "string" ? t : t.name || t.tag || ""))
-      .filter(Boolean);
-    const maxInlineTags = 3;
-    const visibleTags = tagNames.slice(0, maxInlineTags);
-    const remainingTags = tagNames.length - maxInlineTags;
-    const tagsSummary =
-      visibleTags.length > 0
-        ? visibleTags.join(", ") + (remainingTags > 0 ? ` +${remainingTags}` : "")
-        : "";
+    const tagNames = extractNames(user.tags);
+    const { summary: tagsSummary, tooltip: tagsTooltip } =
+      summarizeList(tagNames);
 
-    const badgeNames = (user.badges || [])
-      .map((b) => b.name || "")
-      .filter(Boolean);
-    const maxInlineBadges = 3;
-    const visibleBadges = badgeNames.slice(0, maxInlineBadges);
-    const remainingBadges = badgeNames.length - maxInlineBadges;
-    const badgesSummary =
-      visibleBadges.length > 0
-        ? visibleBadges.join(", ") + (remainingBadges > 0 ? ` +${remainingBadges}` : "")
-        : "";
+    const badgeNames = extractNames(user.badges);
+    const { summary: badgesSummary, tooltip: badgesTooltip } =
+      summarizeList(badgeNames);
 
     const listSubtitle = (
       scoreSubtitleItem ||
@@ -311,9 +281,9 @@ const UserCard = ({
           isRemote={user.is_remote || user.isRemote}
           distance={showDistance ? Math.round(distance) : null}
           tagsSummary={tagsSummary}
-          tagsTooltip={tagNames.join(", ")}
+          tagsTooltip={tagsTooltip}
           badgesSummary={badgesSummary}
-          badgesTooltip={badgeNames.join(", ")}
+          badgesTooltip={badgesTooltip}
         />
       </Card>
     );

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -154,7 +154,11 @@ const UserDetailsModal = ({
     badgeCategoryModalProps,
     tagAwardsModalProps,
     supercategoryModalProps,
-  } = useAwardModals({ fetchTagAwards: fetchUserAwards, fetchBadgeAwards: fetchUserAwards });
+  } = useAwardModals({
+    fetchTagAwards: fetchUserAwards,
+    fetchBadgeAwards: fetchUserAwards,
+    subjectUserId: userId,
+  });
 
   // Determine if this modal is showing the current user (more reliable than comparing fetched user)
   const ownProfile =
@@ -933,6 +937,22 @@ const UserDetailsModal = ({
           inviteeAvatar={user.avatar_url || user.avatarUrl}
           inviteeBio={user.bio}
           inviteeIsSynthetic={user.is_synthetic ?? user.isSynthetic}
+          inviteeIsPublic={
+            user.is_public ??
+            user.isPublic ??
+            user.profile_is_public ??
+            user.profileIsPublic ??
+            user.public_profile ??
+            user.publicProfile
+          }
+          inviteeIsPrivate={
+            user.is_private ??
+            user.isPrivate ??
+            user.profile_is_private ??
+            user.profileIsPrivate ??
+            user.private_profile ??
+            user.privateProfile
+          }
           inviteeCity={user.city}
           inviteeCountry={user.country}
           inviteeJoinedAt={user.created_at || user.createdAt}

--- a/src/hooks/useAwardModals.js
+++ b/src/hooks/useAwardModals.js
@@ -10,6 +10,7 @@ import { useState, useCallback } from "react";
  * @param {() => Promise} options.fetchTagAwards   - Fetches awards for tag/supercategory modals
  * @param {() => Promise} options.fetchBadgeAwards - Fetches awards for badge category/pill modals
  * @param {"user"|"team"} [options.entityType="user"]
+ * @param {string|number|null} [options.subjectUserId] - Viewed user when award rows omit awardee id
  * @returns {Object} Modal state, handlers, closers, and props-spreaders
  */
 
@@ -72,7 +73,12 @@ const sameBadge = (a, b) => {
   return Boolean(aName && bName && aName === bName);
 };
 
-const useAwardModals = ({ fetchTagAwards, fetchBadgeAwards, entityType = "user" }) => {
+const useAwardModals = ({
+  fetchTagAwards,
+  fetchBadgeAwards,
+  entityType = "user",
+  subjectUserId = null,
+}) => {
   // ========= Badge Category Modal state =========
   const [badgeCategoryModal, setBadgeCategoryModal] = useState({
     isOpen: false,
@@ -385,6 +391,7 @@ const useAwardModals = ({ fetchTagAwards, fetchBadgeAwards, entityType = "user" 
     totalCredits: badgeCategoryModal.totalCredits,
     loading: badgeModalLoading,
     focusedBadgeName: badgeCategoryModal.focusedBadgeName,
+    subjectUserId,
   };
 
   /** Spread onto <TagAwardsModal ... /> */
@@ -397,6 +404,7 @@ const useAwardModals = ({ fetchTagAwards, fetchBadgeAwards, entityType = "user" 
     awards: tagAwards,
     loading: tagAwardsLoading,
     entityType,
+    subjectUserId,
   };
 
   /** Spread onto <SupercategoryAwardsModal ... /> */
@@ -409,6 +417,7 @@ const useAwardModals = ({ fetchTagAwards, fetchBadgeAwards, entityType = "user" 
     awards: supercategoryAwards,
     loading: supercategoryLoading,
     entityType,
+    subjectUserId,
   };
 
   return {

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -105,7 +105,11 @@ const Profile = () => {
     tagAwardsModalProps,
     supercategoryModalProps,
     removeAwardFromBadgeModal,
-  } = useAwardModals({ fetchTagAwards: fetchUserAwards, fetchBadgeAwards: fetchUserAwards });
+  } = useAwardModals({
+    fetchTagAwards: fetchUserAwards,
+    fetchBadgeAwards: fetchUserAwards,
+    subjectUserId: profileUserId,
+  });
 
   const [avatarDeleteLoading, setAvatarDeleteLoading] = useState(false);
   const [isAvatarDeleteDialogOpen, setIsAvatarDeleteDialogOpen] =

--- a/src/utils/listSummaryUtils.js
+++ b/src/utils/listSummaryUtils.js
@@ -1,0 +1,57 @@
+/**
+ * Extract display names from a mixed array of strings and objects.
+ *
+ * Handles string arrays, object arrays, and mixed values.
+ *
+ * @param {Array} items
+ * @returns {string[]}
+ */
+export const extractNames = (items) =>
+  (items || [])
+    .map((item) => {
+      if (typeof item === "string") return item.trim();
+      if (item && typeof item === "object") {
+        return String(
+          item.name ??
+            item.tag ??
+            item.badgeName ??
+            item.badge_name ??
+            item.label ??
+            "",
+        ).trim();
+      }
+      return "";
+    })
+    .filter(Boolean);
+
+/**
+ * Create a truncated summary from an array of name strings.
+ *
+ * @param {string[]} names - already-extracted name strings
+ * @param {number} maxVisible - how many to show before "+N"
+ * @returns {{ summary: string, tooltip: string, count: number }}
+ */
+export const summarizeList = (names, maxVisible = 3) => {
+  if (!names || names.length === 0) {
+    return { summary: "", tooltip: "", count: 0 };
+  }
+
+  const visible = names.slice(0, maxVisible);
+  const remaining = names.length - maxVisible;
+
+  return {
+    summary: visible.join(", ") + (remaining > 0 ? ` +${remaining}` : ""),
+    tooltip: names.join(", "),
+    count: names.length,
+  };
+};
+
+/**
+ * Convenience: extract names then summarize in one call.
+ *
+ * @param {Array} items - mixed strings/objects
+ * @param {number} maxVisible
+ * @returns {{ summary: string, tooltip: string, count: number }}
+ */
+export const summarizeItems = (items, maxVisible = 3) =>
+  summarizeList(extractNames(items), maxVisible);

--- a/src/utils/matchScoreUtils.js
+++ b/src/utils/matchScoreUtils.js
@@ -45,3 +45,60 @@ export function getMatchTier(score) {
     label: "Low match",
   };
 }
+
+/**
+ * Build a human-readable tooltip string for a match score.
+ *
+ * @param {Object} matchTier - from getMatchTier()
+ * @param {Object|null} matchDetails - optional breakdown object
+ * @param {Object} options
+ * @returns {string}
+ */
+export const getMatchTooltipText = (
+  matchTier,
+  matchDetails = null,
+  {
+    breakdownLabel = "match",
+    fallbackLabel = "profile match",
+    sharedFocusCount = null,
+  } = {},
+) => {
+  if (!matchTier) return "";
+
+  const hasBreakdown =
+    matchDetails &&
+    ((matchDetails.tagScore ?? matchDetails.tag_score) != null ||
+      (matchDetails.badgeScore ?? matchDetails.badge_score) != null ||
+      (matchDetails.distanceScore ?? matchDetails.distance_score) != null);
+
+  if (hasBreakdown) {
+    const tagPct = Math.round(
+      (matchDetails.tagScore ?? matchDetails.tag_score ?? 0) * 100,
+    );
+    const badgePct = Math.round(
+      (matchDetails.badgeScore ?? matchDetails.badge_score ?? 0) * 100,
+    );
+    const distPct = Math.round(
+      (matchDetails.distanceScore ?? matchDetails.distance_score ?? 0) * 100,
+    );
+
+    return `${matchTier.pct}% ${breakdownLabel} — Tags ${tagPct}% · Badges ${badgePct}% · Location ${distPct}%`;
+  }
+
+  if (matchDetails) {
+    const sharedTags =
+      matchDetails.sharedTagCount ?? matchDetails.shared_tag_count ?? 0;
+    const sharedBadges =
+      matchDetails.sharedBadgeCount ?? matchDetails.shared_badge_count ?? 0;
+
+    if (sharedTags > 0 || sharedBadges > 0) {
+      return `${matchTier.pct}% ${fallbackLabel} — ${sharedTags} shared tags, ${sharedBadges} shared badges`;
+    }
+  }
+
+  if (!matchDetails && sharedFocusCount > 0) {
+    return `${matchTier.pct}% ${fallbackLabel} — ${sharedFocusCount} shared focus areas`;
+  }
+
+  return `${matchTier.pct}% ${fallbackLabel}`;
+};

--- a/src/utils/teamRequestUtils.js
+++ b/src/utils/teamRequestUtils.js
@@ -36,6 +36,44 @@ export const normalizeBoolean = (value) => {
   return null;
 };
 
+const firstPresent = (...values) =>
+  values.find((value) => value !== undefined && value !== null);
+
+export const getUserPublicFlag = (user) =>
+  firstPresent(
+    user?.is_public,
+    user?.isPublic,
+    user?.profile_is_public,
+    user?.profileIsPublic,
+    user?.public_profile,
+    user?.publicProfile,
+  );
+
+export const getUserPrivateFlag = (user) =>
+  firstPresent(
+    user?.is_private,
+    user?.isPrivate,
+    user?.profile_is_private,
+    user?.profileIsPrivate,
+    user?.private_profile,
+    user?.privateProfile,
+  );
+
+export const isPrivateProfileUser = (user) => {
+  if (!user) return false;
+
+  return (
+    normalizeBoolean(getUserPublicFlag(user)) === false ||
+    normalizeBoolean(getUserPrivateFlag(user)) === true
+  );
+};
+
+export const getPrivateAwareUserLabel = (user, fallback = "Their") => {
+  if (isPrivateProfileUser(user)) return "Private Profile";
+
+  return user?.first_name ?? user?.firstName ?? user?.username ?? fallback;
+};
+
 export const isExistingMemberStatus = (value) => {
   if (typeof value !== "string") return false;
 
@@ -95,7 +133,7 @@ export const getRequestUser = (request, userKey) =>
 export const getRequestUserLabel = (request, userKey, fallback = "Their") => {
   const user = getRequestUser(request, userKey);
 
-  return user?.first_name ?? user?.firstName ?? user?.username ?? fallback;
+  return getPrivateAwareUserLabel(user, fallback);
 };
 
 export const isRequestForUser = (request, userKey, userId) =>
@@ -162,9 +200,6 @@ export const buildInvitationRoleForCard = (invitation, polledRole = null) => {
     ...(polledRole ?? {}),
   };
 };
-
-const firstPresent = (...values) =>
-  values.find((value) => value !== undefined && value !== null);
 
 export const buildCurrentFilledRoleForCard = (
   invitation,


### PR DESCRIPTION
Summary
Private profiles are now fully anonymized across all team and user views: non-team-member viewers see "Private Profile" as the name and "PP" initials in place of the avatar. Team members, admins, and owners always see real names and avatars.
Extracted MatchScoreSubtitle as a shared component and added an icon override prop to MatchScoreOverlay, eliminating duplicated inline score badge/subtitle JSX across UserCard, TeamCard, and VacantRoleCard.
README updated to accurately reflect the current file tree (previously missing ~30 components, hooks, and utilities).
What changed
Private profile anonymization (feat: implement private profile anonymization across team and user views)

UserAvatar — new privateProfile prop renders "PP" initials, suppresses photo and demo overlay
InlineUserLink, UserCard, PersonRequestCard — privacy-aware display; clicks disabled and username hidden for private users
VacantRoleDetailsModal — shouldAnonymizePrivateUser() logic; creator_is_public threaded through so public creators are never masked
VacantRoleCard, TeamDetailsModal, TeamInvitationDetailsModal — isTeamMember prop correctly forwarded to VacantRoleDetailsModal
TeamCard — isTeamMember and canManage now passed to both VacantRoleDetailsModal instances (role application and invitation variants were missing them)
TeamInviteModal — always shows inviter's real name, avatar, username, date, location, and demo label regardless of invitee privacy setting
TeamApplicationDetailsModal, TeamMembersSection, TeamInvitesModal, TeamApplicationsModal — privacy-aware applicant/invitee display throughout
teamRequestUtils — new helpers: getUserPublicFlag, getUserPrivateFlag, isPrivateProfileUser, getPrivateAwareUserLabel
AwardCard + badge modals — privacy-aware badge awarder display
matchScoreUtils, listSummaryUtils — new shared utility modules extracted from inline logic
useAwardModals, Profile — minor adjustments for consistency
Match score component extraction (refactor: extract MatchScoreSubtitle and add icon override to MatchScoreOverlay)

MatchScoreSubtitle (new) — shared component for the tier icon + % subtitle item, used by all three card types
MatchScoreOverlay — new optional icon prop overrides matchTier.Icon; existing callers unaffected
TeamCard — two verbose inline overlay branches (duplicated Tooltip > div > Icon for UserSearch/Users icons) replaced with the shared component + shared size variables
Test plan
 Search results: public users show real name/avatar; private users show "Private Profile" / "PP" everywhere (search cards, team member lists, invitation/application modals, badge views)
 Team members, admins, and owners always see real names/avatars for all team members regardless of privacy setting
 Role creator on VacantRoleDetailsModal is not anonymized when creator_is_public is true
 Match score badges render correctly in all card variants (UserCard, TeamCard generic/role/invitation, VacantRoleCard) across list, mini, and card view modes
 Match score subtitle (icon + %) shows correctly in all three card types and all view modes
 npm run build passes with no errors