### PR TITLE
Feature/migrate google accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Contact the project owner for a demo login, or register a new account with a val
 - **Notifications** — In-app notification center for invitations, applications, badge awards, and role updates
 - **Account Deletion** — Multi-step account deletion with impact preview, automatic team ownership transfer, and graceful "Former Lomir User" handling across chat, badges, and notifications
 - **Demo Data Indicators** — Synthetic/seed data is visually labeled with FlaskConical icons and "DEMO" avatar overlays so users can distinguish test content from real data
-- **Contact Page** — Email contact form with optional file attachments (up to 5 files, 25 MB each — images, PDF, Word, Excel, PPT, TXT, ZIP); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; success toast on submit
+- **Contact Page** — Email contact form with optional multipart file attachments (up to 5 files, 25 MB each — images, PDF, Word, Excel, PPT, TXT, ZIP); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; success toast on submit
+- **Authentication UX** — Login and forgot-password flows use shared floating screen alerts for submit-level errors such as rate limits, while field validation remains inline
 - **Security** — Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; real-time email and username availability feedback during registration; unverified accounts are automatically deleted after 24 hours
 
 ---
@@ -200,7 +201,8 @@ Lomir-frontend/
 │   │   └── queryClient.js          # TanStack React Query client configuration
 │   ├── services/
 │   │   ├── api.js                  # Axios instance with default camelCase ↔ snake_case interceptors;
-│   │   │                           #   call sites can opt out via skipRequestCaseTransform /
+│   │   │                           #   preserves FormData requests so multipart boundaries are set by
+│   │   │                           #   the browser; call sites can opt out via skipRequestCaseTransform /
 │   │   │                           #   skipResponseCaseTransform for explicit per-call data contracts
 │   │   ├── userService.js          # Includes deletionPreview + deleteUser
 │   │   ├── teamService.js

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -4,7 +4,7 @@ import { useAuth } from "../../contexts/AuthContext";
 import Card from "../common/Card";
 import Button from "../common/Button";
 import FormGroup from "../common/FormGroup";
-import Alert from "../common/Alert";
+import ScreenAlert from "../common/ScreenAlert";
 import { Eye, EyeOff } from "lucide-react";
 
 const LoginForm = () => {
@@ -64,6 +64,8 @@ const LoginForm = () => {
         navigate("/profile");
       } else if (result.message === "Invalid email") {
         setErrors({ email: result.message });
+      } else if (result.message?.toLowerCase().includes("too many attempts")) {
+        setErrors({ form: result.message });
       } else {
         setErrors({ password: result.message });
       }
@@ -74,99 +76,106 @@ const LoginForm = () => {
     }
   };
 
+  const clearFormError = () => {
+    setErrors((prev) => ({ ...prev, form: undefined }));
+  };
+
   return (
-    <div className="max-w-md mx-auto w-full">
-      <Card>
-        <h2 className="card-title text-2xl font-bold text-center justify-center mt-6 mb-4 text-success">
-          Login
-        </h2>
-        <p className="text-center text-base-content/70 mb-6">
-          Welcome back to Lomir
-        </p>
+    <>
+      <ScreenAlert
+        type="error"
+        message={errors.form || ""}
+        onClose={clearFormError}
+      />
+      <div className="max-w-md mx-auto w-full">
+        <Card>
+          <h2 className="card-title text-2xl font-bold text-center justify-center mt-6 mb-4 text-success">
+            Login
+          </h2>
+          <p className="text-center text-base-content/70 mb-6">
+            Welcome back to Lomir
+          </p>
 
-        {errors.form && (
-          <Alert type="error" message={errors.form} className="mb-6 w-full shadow-sm" />
-        )}
-
-        <form onSubmit={handleSubmit} noValidate>
-          <FormGroup
-            label="Email"
-            htmlFor="email"
-            error={errors.email}
-            required
-          >
-            <input
-              id="email"
-              type="email"
-              name="email"
-              placeholder="email@example.com"
-              className={`input input-bordered w-full ${errors.email ? "input-error" : ""}`}
-              value={formData.email}
-              onChange={handleChange}
-            />
-          </FormGroup>
-
-          <FormGroup
-            label="Password"
-            htmlFor="password"
-            error={errors.password}
-            required
-          >
-            <div className="relative">
+          <form onSubmit={handleSubmit} noValidate>
+            <FormGroup
+              label="Email"
+              htmlFor="email"
+              error={errors.email}
+              required
+            >
               <input
-                id="password"
-                type={showPassword ? "text" : "password"}
-                name="password"
-                placeholder="••••••••"
-                className={`input input-bordered w-full pr-12 ${errors.password ? "input-error" : ""}`}
-                value={formData.password}
+                id="email"
+                type="email"
+                name="email"
+                placeholder="email@example.com"
+                className={`input input-bordered w-full ${errors.email ? "input-error" : ""}`}
+                value={formData.email}
                 onChange={handleChange}
               />
-              <button
-                type="button"
-                className="absolute inset-y-0 right-0 flex items-center px-3 text-base-content/60 transition-colors hover:text-base-content"
-                onClick={() => setShowPassword((prev) => !prev)}
-                onMouseDown={(e) => e.preventDefault()}
-                aria-label={showPassword ? "Hide password" : "Show password"}
-                aria-pressed={showPassword}
-              >
-                {showPassword ? (
-                  <EyeOff className="h-4 w-4" />
-                ) : (
-                  <Eye className="h-4 w-4" />
-                )}
-              </button>
-            </div>
-          </FormGroup>
+            </FormGroup>
 
-          <div className="text-right mt-1">
-            <Link to="/forgot-password" className="link link-primary text-sm">
-              Forgot password?
+            <FormGroup
+              label="Password"
+              htmlFor="password"
+              error={errors.password}
+              required
+            >
+              <div className="relative">
+                <input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  name="password"
+                  placeholder="••••••••"
+                  className={`input input-bordered w-full pr-12 ${errors.password ? "input-error" : ""}`}
+                  value={formData.password}
+                  onChange={handleChange}
+                />
+                <button
+                  type="button"
+                  className="absolute inset-y-0 right-0 flex items-center px-3 text-base-content/60 transition-colors hover:text-base-content"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                  onMouseDown={(e) => e.preventDefault()}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                  aria-pressed={showPassword}
+                >
+                  {showPassword ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
+            </FormGroup>
+
+            <div className="text-right mt-1">
+              <Link to="/forgot-password" className="link link-primary text-sm">
+                Forgot password?
+              </Link>
+            </div>
+
+            <div className="mt-6">
+              <Button
+                type="submit"
+                variant="primary"
+                fullWidth
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? "Logging in..." : "Login"}
+              </Button>
+            </div>
+          </form>
+
+          <div className="divider my-6">OR</div>
+
+          <div className="text-center">
+            <p className="mb-2">Don't have an account?</p>
+            <Link to="/register" className="link link-primary">
+              Register
             </Link>
           </div>
-
-          <div className="mt-6">
-            <Button
-              type="submit"
-              variant="primary"
-              fullWidth
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? "Logging in..." : "Login"}
-            </Button>
-          </div>
-        </form>
-
-        <div className="divider my-6">OR</div>
-
-        <div className="text-center">
-          <p className="mb-2">Don't have an account?</p>
-          <Link to="/register" className="link link-primary">
-            Register
-          </Link>
-        </div>
-      </Card>
-    </div>
+        </Card>
+      </div>
+    </>
   );
 };
 

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -4,7 +4,7 @@ import api from "../services/api";
 import Card from "../components/common/Card";
 import Button from "../components/common/Button";
 import FormGroup from "../components/common/FormGroup";
-import Alert from "../components/common/Alert";
+import ScreenAlert from "../components/common/ScreenAlert";
 import { Mail, ArrowLeft, CheckCircle } from "lucide-react";
 
 const ForgotPassword = () => {
@@ -52,6 +52,11 @@ const ForgotPassword = () => {
           "Something went wrong. Please try again.",
       );
     }
+  };
+
+  const clearErrorMessage = () => {
+    setStatus("idle");
+    setMessage("");
   };
 
   // Success state
@@ -103,7 +108,12 @@ const ForgotPassword = () => {
   // Form state
   return (
     <div className="content-container">
-    <div className="max-w-md mx-auto w-full">
+      <ScreenAlert
+        type="error"
+        message={status === "error" ? message : ""}
+        onClose={clearErrorMessage}
+      />
+      <div className="max-w-md mx-auto w-full">
       <Card>
         <div className="card-body">
           <div className="text-center mb-6">
@@ -115,10 +125,6 @@ const ForgotPassword = () => {
               No worries! Enter your email and we'll send you a reset link.
             </p>
           </div>
-
-          {status === "error" && (
-            <Alert type="error" message={message} className="mb-6 w-full shadow-sm" />
-          )}
 
           <form onSubmit={handleSubmit}>
             <FormGroup

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -19,11 +19,12 @@ api.interceptors.request.use(
       config.headers["Authorization"] = `Bearer ${token}`;
     }
 
-    if (
+    if (config.data instanceof FormData) {
+      delete config.headers["Content-Type"];
+    } else if (
       config.skipRequestCaseTransform !== true &&
       config.data &&
-      typeof config.data === "object" &&
-      !(config.data instanceof FormData)
+      typeof config.data === "object"
     ) {
       config.data = camelToSnake(config.data);
     }


### PR DESCRIPTION
## Summary

This PR updates the frontend auth error handling and multipart request behavior, then documents the changes in the README.

## What Changed

- Replaced inline submit-level auth errors on login and forgot-password with the shared `ScreenAlert` component.
- Kept field-level validation inline while showing broader form errors, including login rate-limit messages, as dismissible screen alerts.
- Updated the shared Axios request interceptor so `FormData` requests preserve browser-managed multipart headers and boundaries.
- Updated the README to document multipart contact attachments, auth screen alerts, and the `FormData` handling in `api.js`.

## Testing

- Not run in this pass.