### PR TITLE
security: default new profiles to private until email verification

### DIFF
--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -44,7 +44,7 @@ const RegisterForm = () => {
     postal_code: "",
     city: "",
     country: "",
-    isPublic: true,
+    isPublic: false,
     acceptedLegal: false,
     profile_image: null,
     selectedTags: [],
@@ -592,7 +592,6 @@ const RegisterForm = () => {
         postal_code: formData.postal_code,
         city: formData.city,
         country: formData.country,
-        isPublic: formData.isPublic,
         acceptedTerms: true,
         acceptedPrivacy: true,
         tags:
@@ -613,7 +612,6 @@ const RegisterForm = () => {
 
         if (uploadResult.success) {
           userData.avatar_url = uploadResult.url;
-          userData.avatar_file_id = uploadResult.fileId;
         } else {
           console.error("Avatar upload failed:", uploadResult.error);
         }
@@ -1079,11 +1077,11 @@ const RegisterForm = () => {
                   entityType="profile"
                   visibleLabel="Public Profile"
                   hiddenLabel="Private Profile"
-                  visibleDescription="Default: your profile can be discovered by other Lomir users."
-                  hiddenDescription="Your profile is hidden from search results, but may still appear where you interact."
+                  hiddenDescription="Your profile will be private until you verify your email."
+                  disabled={true}
                 />
                 <p className="form-helper-text mt-2 px-1">
-                  {PROFILE_VISIBILITY_NOTICE}
+                  Profile visibility is locked to private during registration. Once you verify your email and log in, you can make your profile public in your settings.
                 </p>
               </div>
             </section>

--- a/src/components/common/VisibilityToggle.jsx
+++ b/src/components/common/VisibilityToggle.jsx
@@ -72,7 +72,7 @@ const VisibilityToggle = ({
 <div
   className={`input input-bordered w-full h-auto px-4 py-3 ${
   error ? "input-error" : ""
-} flex flex-col items-start gap-0`}
+} ${disabled ? "opacity-60 cursor-not-allowed" : ""} flex flex-col items-start gap-0`}
 >
   {/* Row 1: icon + state text + toggle */}
   <div className="flex items-center justify-between w-full">
@@ -94,7 +94,7 @@ const VisibilityToggle = ({
     <label
       htmlFor={inputId}
       className={`relative inline-flex items-center ${
-        disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"
+        disabled ? "cursor-not-allowed" : "cursor-pointer"
       }`}
     >
       <input


### PR DESCRIPTION
Summary
New user profiles are now private by default from registration until email verification. Previously, is_public was hardcoded to TRUE on insert, making every new account immediately discoverable — even before the user had confirmed their identity.
On email verification, is_public is automatically flipped to TRUE, so verified users are visible to others without any extra step.
The registration form reflects this: the profile visibility toggle is shown as disabled with a clear explanation, and the verification email now tells users their profile will go public on verification and links directly to Settings to change it.
Two fields that were silently breaking registration (isPublic and avatar_file_id) are removed from the register API payload — both were being converted to unknown snake_case keys by the camelToSnake request interceptor, causing Joi validation failures.
Changes
Backend

userModel.createUser: is_public INSERT value changed from TRUE → FALSE
authController.verifyEmail: UPDATE now also sets is_public = TRUE alongside email_verified = TRUE
emailService.sendVerificationEmail: Added a paragraph informing users that verification makes their profile public, with a direct link to /settings
Frontend

RegisterForm.jsx: isPublic initial state true → false; isPublic and avatar_file_id removed from the register API payload; profile visibility toggle rendered as disabled with lock-to-private messaging
VisibilityToggle.jsx: When disabled, the entire field body container is greyed out (opacity-60 cursor-not-allowed), not just the toggle knob
Test plan
 Register a new account — confirm the backend creates the user with is_public = FALSE
 Registration form shows the profile visibility toggle as greyed out and non-interactive
 Receive the verification email — confirm the new paragraph about public visibility is present with a working settings link
 Click the verification link — confirm is_public is set to TRUE in the database
 Log in as the newly verified user — confirm they appear in search results for other users
 Log in as a verified user and set profile to private in Settings — confirm the toggle works as before
 Confirm existing verified users are unaffected (no change to their is_public value)