### PR TITLE
Security/security hardening part3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Contact the project owner for a demo login, or register a new account with a val
 - **Best Match Sorting** — Weighted matching algorithm scores teams and roles against your profile (tags 40%, badges 30%, distance 30%)
 - **Map View** — Leaflet-powered map with custom markers for teams, users, and roles; popups with detail cards; distance-based filtering and proximity sorting
 - **Team Management** — Create teams, manage members and roles, post vacant roles, handle applications and invitations with role-specific targeting; My Teams uses the same responsive sort and result-view controls as search
-- **User Profiles** — Customizable profiles with interest tags, badges, avatar uploads (ImageKit), and geocoded location; profile header shows city and country code; non-public profiles are protected — non-owners and non-teammates see only the username and avatar ("This profile is private")
+- **User Profiles** — Customizable profiles with interest tags, badges, avatar uploads (ImageKit), and geocoded location; profile header shows city and country code; non-public profiles are protected — non-owners and non-teammates see only the username and avatar ("This profile is private"); owners see public/private visibility indicators on profile, card, list, mini-card, and map views
 - **Real-Time Chat** — Direct and team group messaging with typing indicators, read receipts, file/image sharing, @mentions, reply threading, and rich system event messages (Socket.IO)
 - **Badge System** — Browse 30 badges across 5 color-coded categories; award badges to teammates with reasons and team context
 - **Notifications** — In-app notification center for invitations, applications, badge awards, and role updates
 - **Account Deletion** — Multi-step account deletion with impact preview, automatic team ownership transfer, and graceful "Former Lomir User" handling across chat, badges, and notifications
 - **Demo Data Indicators** — Synthetic/seed data is visually labeled with FlaskConical icons and "DEMO" avatar overlays so users can distinguish test content from real data
-- **Contact Page** — Email contact form with optional multipart file attachments (up to 5 files, 25 MB each — images, PDF, Word, Excel, PPT, TXT, ZIP); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; success toast on submit
-- **Authentication UX** — Login and forgot-password flows use shared floating screen alerts for submit-level errors such as rate limits, while field validation remains inline
-- **Security** — Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; real-time email and username availability feedback during registration; unverified accounts are automatically deleted after 24 hours
+- **Contact Page** — Email contact form with optional multipart file attachments (up to 5 files, 25 MB each — images, PDF, Word, Excel, PPT, TXT, ZIP); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; privacy disclosure with `/privacy` link at submission; success toast on submit
+- **Authentication UX** — Login and forgot-password flows use shared floating screen alerts for submit-level errors such as rate limits, while field validation remains inline; registration surfaces backend validation details and availability-check rate limits instead of generic "Invalid input data" errors
+- **Security & Privacy** — Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; new accounts remain private after email verification until users change visibility in settings; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; real-time email and username availability feedback during registration; unverified accounts are automatically deleted after 24 hours
 
 ---
 
@@ -154,7 +154,8 @@ Lomir-frontend/
 │   │   ├── ForgotPassword.jsx
 │   │   ├── ResetPassword.jsx
 │   │   ├── VerifyEmail.jsx
-│   │   ├── Contact.jsx             # Contact form with file attachments + in-app chat routing
+│   │   ├── Contact.jsx             # Contact form with file attachments, privacy notice, and in-app chat routing
+│   │   ├── LegalPlaceholderPage.jsx # Shared /about, /terms, /privacy, /legal-notice placeholder page
 │   │   └── DesignSystem.jsx        # Dev-only component playground
 │   ├── components/
 │   │   ├── BooleanSearchInput.jsx  # Textarea-based Boolean search input with operator helpers
@@ -261,6 +262,7 @@ Lomir-frontend/
 │   │   └── Colors.js               # Shared color constants for badge categories and UI accents
 │   ├── constants/
 │   │   ├── badgeConstants.js       # Badge category metadata (names, colors, icons)
+│   │   ├── privacyText.js          # Shared privacy, storage, upload, and visibility notices
 │   │   ├── uiText.js               # Shared UI strings
 │   │   └── pagination.js           # Pagination page-size defaults
 │   ├── config/
@@ -282,6 +284,8 @@ Lomir-frontend/
 |---|---|---|
 | `/` | Landing Page | Public homepage with feature overview |
 | `/login` | Login | Sign in, register redirect, and forgot-password entry point |
+| `/register` | Register | Multi-step registration with legal consent, private-by-default visibility copy, availability checks, and optional Turnstile |
+| `/verify-email` | Verify Email | Confirms new-account email verification links before login |
 | `/forgot-password` | Forgot Password | Request a password reset email |
 | `/reset-password` | Reset Password | Set a new password from a reset email link |
 | `/search` | Search | Find teams, users, and roles; Boolean search input; shared result-view toggle; advanced filtering by tags, badges, distance |
@@ -290,8 +294,12 @@ Lomir-frontend/
 | `/profile/:id` | Public Profile | View any user's profile; shows "private" message for non-public profiles; placeholder for deleted users |
 | `/chat` | Chat | Direct messages and team group chat with file/image sharing, @mentions, and reply threading |
 | `/badges` | Badges | Browse all 30 badges across 5 categories |
-| `/settings` | Settings | Change password and delete account |
-| `/contact` | Contact | Email form with file attachments; authenticated users with a contact user ID configured are routed to in-app chat |
+| `/settings` | Settings | Change profile visibility, password, email, and delete account |
+| `/contact` | Contact | Email form with file attachments and privacy notice; authenticated users with a contact user ID configured are routed to in-app chat |
+| `/about` | About | Legal placeholder content for project/about information |
+| `/terms` | Terms | Terms placeholder content while final documents are prepared |
+| `/privacy` | Privacy | Privacy placeholder content, browser storage notice, and contact link |
+| `/legal-notice` | Legal Notice | Legal notice placeholder content |
 
 ---
 

--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -512,6 +512,73 @@ const RegisterForm = () => {
     return `Account could not be created. Please fix: ${messages.join("; ")}`;
   };
 
+  const getApiErrorMessages = (errorSource) => {
+    const responseData = errorSource?.response?.data ?? errorSource ?? {};
+    const rawErrors = responseData.errors;
+
+    if (Array.isArray(rawErrors)) {
+      return rawErrors
+        .map((error) => {
+          if (typeof error === "string") return error;
+          if (!error || typeof error !== "object") return null;
+
+          const field = error.path || error.param || error.field;
+          const message = error.msg || error.message;
+
+          if (field && message) return `${field}: ${message}`;
+          return message || field || null;
+        })
+        .filter(Boolean);
+    }
+
+    if (rawErrors && typeof rawErrors === "object") {
+      return getAccountCreationErrorMessages(rawErrors);
+    }
+
+    return [];
+  };
+
+  const getApiErrorMessage = (errorSource, fallback = "Registration failed.") =>
+    errorSource?.response?.data?.message || errorSource?.message || fallback;
+
+  const buildRegistrationErrorState = (errorSource) => {
+    const apiMessages = getApiErrorMessages(errorSource);
+    const message = getApiErrorMessage(errorSource);
+
+    if (apiMessages.length > 0) {
+      return {
+        form: getAccountCreationErrorMessage({ api: apiMessages }),
+        formMessages: apiMessages,
+      };
+    }
+
+    if (isEmailConflictMessage(message)) {
+      const formMessages = ["This email address is already registered."];
+
+      return {
+        email: "This email address is already registered.",
+        form: getAccountCreationErrorMessage({
+          email: "This email address is already registered.",
+        }),
+        formMessages,
+      };
+    }
+
+    if (isUsernameConflictMessage(message)) {
+      const formMessages = ["This username is already taken."];
+
+      return {
+        username: ["This username is already taken."],
+        form: getAccountCreationErrorMessage({
+          username: "This username is already taken.",
+        }),
+        formMessages,
+      };
+    }
+
+    return { form: message };
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
 
@@ -562,6 +629,9 @@ const RegisterForm = () => {
         await Promise.all(availabilityChecks);
       } catch (availabilityError) {
         console.warn("Availability check failed:", availabilityError);
+        availabilityErrors.form =
+          availabilityError.response?.data?.message ||
+          "We could not check username or email availability. Please try again in a few minutes.";
       }
 
       const blockingErrors = {
@@ -631,70 +701,18 @@ const RegisterForm = () => {
         }
       } else {
         resetTurnstile();
-        const msg = result.message || "";
-
-        if (isEmailConflictMessage(msg)) {
-          const formMessages = ["This email address is already registered."];
-
-          setErrors((prev) => ({
-            ...prev,
-            email: "This email address is already registered.",
-            form: getAccountCreationErrorMessage({
-              email: "This email address is already registered.",
-            }),
-            formMessages,
-          }));
-        } else if (isUsernameConflictMessage(msg)) {
-          const formMessages = ["This username is already taken."];
-
-          setErrors((prev) => ({
-            ...prev,
-            username: ["This username is already taken."],
-            form: getAccountCreationErrorMessage({
-              username: "This username is already taken.",
-            }),
-            formMessages,
-          }));
-        } else {
-          setErrors((prev) => ({
-            ...prev,
-            form: msg,
-          }));
-        }
+        setErrors((prev) => ({
+          ...prev,
+          ...buildRegistrationErrorState(result),
+        }));
       }
     } catch (error) {
       resetTurnstile();
       console.error("Full Registration error:", error);
-      const msg = error.response?.data?.message || "Registration failed.";
-
-      if (isEmailConflictMessage(msg)) {
-        const formMessages = ["This email address is already registered."];
-
-        setErrors((prev) => ({
-          ...prev,
-          email: "This email address is already registered.",
-          form: getAccountCreationErrorMessage({
-            email: "This email address is already registered.",
-          }),
-          formMessages,
-        }));
-      } else if (isUsernameConflictMessage(msg)) {
-        const formMessages = ["This username is already taken."];
-
-        setErrors((prev) => ({
-          ...prev,
-          username: ["This username is already taken."],
-          form: getAccountCreationErrorMessage({
-            username: "This username is already taken.",
-          }),
-          formMessages,
-        }));
-      } else {
-        setErrors((prev) => ({
-          ...prev,
-          form: msg,
-        }));
-      }
+      setErrors((prev) => ({
+        ...prev,
+        ...buildRegistrationErrorState(error),
+      }));
     } finally {
       setIsSubmitting(false);
     }
@@ -754,9 +772,9 @@ const RegisterForm = () => {
       <div className="flex w-full justify-center">
         <Alert
           type="error"
-        message={errors.form}
-        onClose={clearFormError}
-        autoCloseMs={10000}
+          message={errors.form}
+          onClose={clearFormError}
+          autoCloseMs={10000}
           className={className}
         >
           {formErrorMessages.length > 0 ? (

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -127,6 +127,10 @@ const Card = ({
     return "[&>p:first-of-type]:line-clamp-3 [&>p:first-of-type]:-mt-4";
   };
 
+  const contentPaddingClass = title
+    ? "p-4 sm:p-7 pt-0.5 sm:pt-1"
+    : "p-4 sm:p-7";
+
   const handleRowMouseOver = clickTooltip
     ? (e) => {
         const shouldShow = !e.target.closest("[data-tooltip-trigger]");
@@ -357,7 +361,7 @@ const Card = ({
 
         {/* Only the first direct <p> inside this wrapper will be clamped */}
         <div
-          className={`p-4 sm:p-7 pt-0.5 sm:pt-1 flex-1 flex flex-col ${getTruncateClasses()} ${contentClassName}`}
+          className={`${contentPaddingClass} flex-1 flex flex-col ${getTruncateClasses()} ${contentClassName}`}
         >
           {children}
         </div>

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -1199,6 +1199,11 @@ const normalizeMapPoint = (
           rawId != null ? fetchedOpenRoleSnapshots[String(rawId)] : null,
         )
       : null;
+  const isOwnProfile =
+    type === "user" &&
+    rawId != null &&
+    viewerUser?.id != null &&
+    String(rawId) === String(viewerUser.id);
 
   return {
     id: `${type}-${rawId ?? getDisplayName(item, type)}`,
@@ -1240,12 +1245,18 @@ const normalizeMapPoint = (
     initials: avatarData.initials,
     isDemo: isDemoPoint(item, type),
     username: type === "user" ? (item.username ?? null) : null,
+    isOwnProfile,
     isPublicProfile: type === "user"
-      ? normalizeBooleanFlag(firstPresent(item?.is_public, item?.isPublic))
+      ? normalizeBooleanFlag(
+          firstPresent(
+            isOwnProfile
+              ? firstPresent(viewerUser?.is_public, viewerUser?.isPublic)
+              : undefined,
+            item?.is_public,
+            item?.isPublic,
+          ),
+        )
       : null,
-    isOwnProfile: type === "user" && rawId != null && viewerUser?.id != null
-      ? String(rawId) === String(viewerUser.id)
-      : false,
     postedAt: type === "role" ? getRolePostedAt(item) : null,
     hasApplied: type === "role" ? (
       getRoleHasApplied(item) ||

--- a/src/components/users/UserCard.jsx
+++ b/src/components/users/UserCard.jsx
@@ -107,11 +107,18 @@ const UserCard = ({
     }
 
     // Only show if this card represents the current user's profile
-    return currentUser.id === user.id;
+    return String(currentUser.id) === String(user.id);
   };
 
   // Helper function to check if user profile is public
   const isUserProfilePublic = () => {
+    if (shouldShowVisibilityIcon()) {
+      if (currentUser.is_public === true) return true;
+      if (currentUser.isPublic === true) return true;
+      if (currentUser.is_public === false) return false;
+      if (currentUser.isPublic === false) return false;
+    }
+
     // Check both possible property names for is_public
     if (user.is_public === true) return true;
     if (user.isPublic === true) return true;

--- a/src/components/users/UserProfileHeaderSection.jsx
+++ b/src/components/users/UserProfileHeaderSection.jsx
@@ -57,12 +57,19 @@ const UserProfileHeaderSection = ({
       return false;
     }
     // Only show for the user's own profile
-    return currentUser.id === user.id;
+    return String(currentUser.id) === String(user.id);
   };
 
   // Helper to check if profile is public
   const isUserProfilePublic = () => {
     if (!user) return false;
+
+    if (shouldShowVisibilityIndicator()) {
+      if (currentUser.is_public === true) return true;
+      if (currentUser.isPublic === true) return true;
+      if (currentUser.is_public === false) return false;
+      if (currentUser.isPublic === false) return false;
+    }
 
     // Check both property name formats
     if (user.is_public === true) return true;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -48,9 +48,7 @@ export const AuthProvider = ({ children }) => {
           if (cancelled) return;
 
           const userData = response.data.data.user;
-          const enhancedUserData = normalizeAuthUser(userData, {
-            defaultIsPublic: true,
-          });
+          const enhancedUserData = normalizeAuthUser(userData);
           setUser(enhancedUserData);
           setUserTimezone(enhancedUserData);
           setError(null);
@@ -134,6 +132,7 @@ export const AuthProvider = ({ children }) => {
       return {
         success: false,
         message: err.response?.data?.message || "Registration failed",
+        errors: err.response?.data?.errors,
       };
     } finally {
       setLoading(false);

--- a/src/index.css
+++ b/src/index.css
@@ -994,6 +994,7 @@ body {
   font-size: 0.775rem !important;
   line-height: 1.15 !important;
   box-shadow: 0 2px 8px rgba(4, 80, 20, 0.15) !important;
+  white-space: pre-line !important;
   pointer-events: none;
 
   /* stacking */

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -433,36 +433,7 @@ const Contact = () => {
               </div>
             )}
 
-            <p className="form-helper-text rounded-lg border border-base-300 bg-base-100/70 p-3">
-              By submitting this form, you agree that we process your name,
-              email address, message, and any attachments you provide in order
-              to respond to your inquiry. For details, please see our{" "}
-              <Link to="/privacy" className="link link-primary">
-                Privacy Policy
-              </Link>
-              .
-            </p>
-
-            <div className="pt-3 flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
-              <div className="sm:pt-0">
-                <Button
-                  type="submit"
-                  variant="primary"
-                  icon={!isSubmitting ? <Send size={16} /> : null}
-                  className="w-full sm:w-auto"
-                  disabled={isSubmitting}
-                >
-                  {isSubmitting ? (
-                    <>
-                      <span className="loading loading-spinner loading-sm"></span>
-                      Sending...
-                    </>
-                  ) : (
-                    "Send Message"
-                  )}
-                </Button>
-              </div>
-
+            <div className="pt-3 flex flex-col gap-5">
               {hasTurnstile && (
                 <div className="form-control w-full sm:w-auto sm:items-end">
                   <div className="flex justify-center sm:justify-end">
@@ -482,6 +453,34 @@ const Contact = () => {
                   )}
                 </div>
               )}
+
+              <p className="text-xs text-base-content/50 leading-relaxed">
+                By submitting this form, your name and email address will be processed
+                to respond to your inquiry. See our{" "}
+                <Link to="/privacy" className="link link-primary">
+                  Privacy Policy
+                </Link>{" "}
+                for details on how we handle your data.
+              </p>
+
+              <div className="flex justify-end">
+                <Button
+                  type="submit"
+                  variant="primary"
+                  icon={!isSubmitting ? <Send size={16} /> : null}
+                  className="w-full sm:w-auto"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? (
+                    <>
+                      <span className="loading loading-spinner loading-sm"></span>
+                      Sending...
+                    </>
+                  ) : (
+                    "Send Message"
+                  )}
+                </Button>
+              </div>
             </div>
         </form>
 

--- a/src/pages/LegalPlaceholderPage.jsx
+++ b/src/pages/LegalPlaceholderPage.jsx
@@ -31,7 +31,7 @@ const LegalPlaceholderPage = ({ type }) => {
   const content = pageContent[type] ?? pageContent.about;
 
   return (
-    <div className="mx-auto max-w-3xl">
+    <div className="max-w-5xl mx-auto space-y-6">
       <Card hoverable={false} truncateContent={false}>
         <div className="space-y-5">
           <div>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1317,8 +1317,8 @@ const Profile = () => {
                     className="flex items-center text-base-content/70 tooltip tooltip-bottom tooltip-lomir cursor-help"
                     data-tip={
                       isProfilePublic()
-                        ? "Public Profile - visible for everyone"
-                        : "Private Profile - only visible for you"
+                        ? "Public Profile - visible for everyone\nChange in profile settings"
+                        : "Private Profile - only visible for you\nChange in profile settings"
                     }
                   >
                     {isProfilePublic() ? (


### PR DESCRIPTION
## Summary

- Add a DSGVO privacy disclosure to the unauthenticated contact form, including a link to `/privacy`
- Improve legal placeholder page layout by matching the wider contact-page container and restoring comfortable card padding
- Improve registration UX by surfacing backend validation details and rate-limit messages instead of generic “Invalid input data”
- Keep frontend auth state private-by-default when visibility is omitted from API responses
- Show owner-only public/private visibility indicators consistently across profile, user cards, list/mini views, and map user sublines
- Add a second-line tooltip hint on the profile visibility indicator: “Change in profile settings”
- Update the frontend README to document the privacy, registration, contact, and legal-page changes

## Testing

- `npm run build` passes
- Existing Vite warnings remain about large chunks and `VacantRoleDetailsModal.jsx` being both dynamically and statically imported