### PR TITLE
open chat panel for new conversations instead of deselecting on click

### DIFF
--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -597,30 +597,15 @@ const UserDetailsModal = ({
     setIsEditing(mode === "edit");
   }, [mode]);
 
-  const handleStartChat = async () => {
+  const handleStartChat = () => {
     if (!isAuthenticated) {
       console.warn("Attempted to start chat while not authenticated");
       return;
     }
     if (!userId) return;
 
-    try {
-      // Create conversation with the user and send an empty message to ensure it appears
-      await messageService.startConversation(userId, "");
-
-      // Give a bit more time for the conversation to be created
-      await new Promise((resolve) => setTimeout(resolve, 600));
-
-      // Open chat in new tab with direct message type
-      const chatUrl = `${window.location.origin}/chat/${userId}?type=direct`;
-      window.open(chatUrl, "_blank", "noopener,noreferrer");
-    } catch (error) {
-      console.error("Error starting conversation:", error);
-
-      // Fallback: still open chat page even if API call fails
-      const chatUrl = `${window.location.origin}/chat/${userId}?type=direct`;
-      window.open(chatUrl, "_blank", "noopener,noreferrer");
-    }
+    const chatUrl = `${window.location.origin}/chat/${userId}?type=direct`;
+    window.open(chatUrl, "_blank", "noopener,noreferrer");
   };
 
   const handleInviteToTeam = () => {

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1527,23 +1527,43 @@ const Chat = () => {
           }
 
           if (type === "direct") {
-            try {
-              await messageService.startConversation(
-                parseInt(conversationId),
-                "",
-              );
-
-              conversationDetails = await messageService.getConversationById(
-                conversationId,
-                type,
-              );
-              setActiveConversation(conversationDetails.data);
-
-              const conversationsResponse =
-                await messageService.getConversations();
-              setConversations(conversationsResponse.data || []);
-            } catch (createError) {
-              console.error("Failed to create conversation:", createError);
+            // No messages exist yet — this is a new/virtual conversation.
+            // Build activeConversation from what we already know so the chat
+            // panel opens and the user can type the first message. The
+            // conversation row is created in the backend when they send it.
+            const knownConv = conversationsRef.current.find(
+              (c) =>
+                String(c.id) === String(conversationId) &&
+                c.type === "direct",
+            );
+            if (knownConv?.partner) {
+              setActiveConversation({
+                id: parseInt(conversationId),
+                type: "direct",
+                partner: knownConv.partner,
+                isVirtual: true,
+              });
+            } else {
+              try {
+                const userResponse = await userService.getUserById(conversationId);
+                const userData = userResponse.data;
+                setActiveConversation({
+                  id: parseInt(conversationId),
+                  type: "direct",
+                  partner: {
+                    id: userData.id,
+                    username: userData.username,
+                    firstName: userData.firstName || userData.first_name,
+                    lastName: userData.lastName || userData.last_name,
+                    avatarUrl: userData.avatarUrl || userData.avatar_url,
+                    isSynthetic: userData.isSynthetic ?? userData.is_synthetic ?? undefined,
+                    is_synthetic: userData.is_synthetic ?? userData.isSynthetic ?? undefined,
+                  },
+                  isVirtual: true,
+                });
+              } catch (userError) {
+                console.error("Failed to load partner for new conversation:", userError);
+              }
             }
           }
         }
@@ -2884,8 +2904,14 @@ const Chat = () => {
   };
 
   const selectConversation = (id) => {
-    // Deselect only when the chat panel is currently visible for this conversation
-    if (showChatView && String(id) === String(conversationId)) {
+    // Deselect only when the chat panel is actually open for this conversation.
+    // If activeConversation is null and not loading, the panel isn't visible yet
+    // (e.g. new virtual conversation) — re-open instead of deselecting.
+    if (
+      showChatView &&
+      String(id) === String(conversationId) &&
+      (activeConversation || loadingMessages)
+    ) {
       setShowChatView(false);
       navigate("/chat");
       return;


### PR DESCRIPTION
Summary
Bug: Opening a new chat (from a user's profile modal or any fresh /chat/{userId} URL) showed the conversation highlighted in the list but left the chat panel collapsed. Clicking the highlighted entry deselected it instead of opening it, making it impossible to send a first message.
Root cause: The backend's getConversationById for direct messages queries for actual message rows — it returns 404 when no messages have been exchanged yet. The old catch-block workaround called startConversation(userId, ""), but the backend skips inserting a row when initial_message is empty, so the retry also returned 404. This left activeConversation = null, hiding the chat panel while showChatView remained true, causing every click on the conversation to trigger deselect.
Fix: When getConversationById returns 404 for a direct message (new conversation), the catch block now builds activeConversation from partner data already in conversationsRef (or fetches it via getUserById as a fallback) so the panel opens immediately. The first message the user sends creates the DB row via the socket as usual.
Changes
src/pages/Chat.jsx — replaced the broken startConversation("") + retry loop in the fetchMessages catch block with a virtual activeConversation built from known partner data; tightened the selectConversation deselect guard to only fire when the panel is actually visible (activeConversation is set or messages are loading)
src/components/users/UserDetailsModal.jsx — removed the no-op startConversation("") + setTimeout(600) call before opening the chat tab; it created no DB row and only added latency and a failure path
Test plan
 Click "Send Message" on a user you've never chatted with → chat tab opens, panel is visible, message input is active
 Type and send a first message → message appears, conversation persists in the list
 Click "Send Message" on a user you've chatted with before → existing conversation opens normally
 Click an already-open conversation to deselect it → still collapses as expected
 Open a brand-new team chat → unaffected (only direct-message path changed)