### PR TITLE
Make the registration form fully responsive on mobile

### DIFF
--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -1207,7 +1207,7 @@ const RegisterForm = () => {
               />
 
               <div className="form-control w-full">
-                <label className="label">
+                <label className="label whitespace-normal">
                   <span className="label-text">
                     Select focus areas matching your interests and skills
                   </span>
@@ -1227,7 +1227,7 @@ const RegisterForm = () => {
               {renderFormAlert(formAlertClassName)}
 
               <div className="form-control">
-                <label className="label cursor-pointer items-start justify-start gap-3 rounded-lg border border-base-300 bg-base-100/70 p-4">
+                <label className="label flex w-full cursor-pointer items-start justify-start gap-3 whitespace-normal rounded-lg border border-base-300 bg-base-100/70 p-4">
                   <input
                     type="checkbox"
                     name="acceptedLegal"
@@ -1258,7 +1258,7 @@ const RegisterForm = () => {
               </div>
 
               <div className="form-control">
-                <label className="label cursor-pointer items-start justify-start gap-3 rounded-lg border border-base-300 bg-base-100/70 p-4">
+                <label className="label flex w-full cursor-pointer items-start justify-start gap-3 whitespace-normal rounded-lg border border-base-300 bg-base-100/70 p-4">
                   <input
                     type="checkbox"
                     name="confirmedAge16"
@@ -1306,7 +1306,7 @@ const RegisterForm = () => {
 
                 {hasTurnstile && (
                   <div className="form-control w-full sm:w-auto sm:items-end">
-                    <div className="flex w-full justify-end">
+                    <div className="flex w-full justify-center sm:justify-end">
                       <TurnstileWidget
                         ref={turnstileRef}
                         onVerify={(token) => {
@@ -1326,7 +1326,7 @@ const RegisterForm = () => {
                       />
                     </div>
                     {errors.turnstile && (
-                      <label className="label flex w-full justify-end px-0">
+                      <label className="label flex w-full justify-center px-0 sm:justify-end">
                         <span className="label-text-alt text-error">
                           {errors.turnstile}
                         </span>

--- a/src/components/common/VisibilityToggle.jsx
+++ b/src/components/common/VisibilityToggle.jsx
@@ -75,8 +75,8 @@ const VisibilityToggle = ({
 } ${disabled ? "opacity-60 cursor-not-allowed" : ""} flex flex-col items-start gap-0`}
 >
   {/* Row 1: icon + state text + toggle */}
-  <div className="flex items-center justify-between w-full">
-    <div className="flex items-center">
+  <div className="flex items-center justify-between w-full gap-3">
+    <div className="flex items-center min-w-0">
       {isChecked ? (
         <Eye size={24} className="text-primary mr-3 flex-shrink-0" />
       ) : (
@@ -86,14 +86,14 @@ const VisibilityToggle = ({
         />
       )}
 
-      <span className="text-base-content font-normal">
+      <span className="text-base-content font-normal min-w-0 break-words">
         {isChecked ? visibleLabel : hiddenLabel}
       </span>
     </div>
 
     <label
       htmlFor={inputId}
-      className={`relative inline-flex items-center ${
+      className={`relative inline-flex flex-shrink-0 items-center ${
         disabled ? "cursor-not-allowed" : "cursor-pointer"
       }`}
     >


### PR DESCRIPTION
Summary
Fixes horizontal overflow and layout issues on the registration form at narrow viewports. The root cause for most of it was daisyUI v5's .label shipping white-space: nowrap + display: inline-flex, so any long label text refused to wrap and pushed the layout wider than the screen.

Changes
RegisterForm.jsx

Focus Areas – added whitespace-normal so the long section label ("Select focus areas matching your interests and skills") wraps instead of overflowing.
Legal / age consent checkboxes – added flex w-full whitespace-normal to both consent boxes so the Terms/Privacy and age-16 text wrap, and the bordered boxes fill the row instead of shrinking to (overflowing) content width.
Cloudflare Turnstile box – switched from justify-end to justify-center sm:justify-end (widget + error label) so it centers on narrow screens and only right-aligns from the sm breakpoint up.
VisibilityToggle.jsx (shared component – also benefits the team/profile forms)

Hardened the state row: gap-3 to keep the label and toggle apart, min-w-0 + break-words so a long state label wraps, and flex-shrink-0 on the toggle so it never gets squashed.
Notes
Cosmetic/CSS-only; no behavior or validation changes.
eslint passes on both files.
One caveat: the Turnstile iframe is a fixed ~300px (Cloudflare doesn't allow resizing), so it can still touch the edges below ~300px wide — centering is in place, but a future overflow-x guard could be added if needed.