### PR TITLE
Feature/block users

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Contact the project owner for a demo login, or register a new account with a val
 - **Best Match Sorting** — Weighted matching algorithm scores teams and roles against your profile (tags 40%, badges 30%, distance 30%)
 - **Map View** — Leaflet-powered map with custom markers for teams, users, and roles; popups with detail cards; distance-based filtering and proximity sorting
 - **Team Management** — Create teams, manage members and roles, post vacant roles, handle applications and invitations with role-specific targeting; My Teams uses the same responsive sort and result-view controls as search
-- **User Profiles** — Customizable profiles with interest tags, badges, avatar uploads (ImageKit), and geocoded location; profile header shows city and country code; non-public profiles are protected — non-owners and non-teammates see only the username and avatar ("This profile is private"); owners see public/private visibility indicators on profile, card, list, mini-card, and map views
-- **Real-Time Chat** — Direct and team group messaging with typing indicators, read receipts, file/image sharing, @mentions, reply threading, and rich system event messages (Socket.IO)
+- **User Profiles** — Customizable profiles with interest tags, badges, avatar uploads (ImageKit), and geocoded location; profile header shows city and country code; non-public profiles are protected — non-owners and non-teammates see only the username and avatar ("This profile is private"); owners see public/private visibility indicators on profile, card, list, mini-card, and map views; signed-in users can block another profile from the user details modal
+- **Real-Time Chat** — Direct and team group messaging with typing indicators, read receipts, file/image sharing, @mentions, reply threading, and rich system event messages (Socket.IO); blocked users are hidden from direct conversations, team rosters, mention lists, and rendered message streams
 - **Badge System** — Browse 30 badges across 5 color-coded categories; award badges to teammates with reasons and team context
 - **Notifications** — In-app notification center for invitations, applications, badge awards, and role updates
 - **Account Deletion** — Multi-step account deletion with impact preview, automatic team ownership transfer, and graceful "Former Lomir User" handling across chat, badges, and notifications
 - **Demo Data Indicators** — Synthetic/seed data is visually labeled with FlaskConical icons and "DEMO" avatar overlays so users can distinguish test content from real data
 - **Contact Page** — Email contact form with optional multipart file attachments (up to 5 files, 25 MB each — images, PDF, Word, Excel, PPT, TXT, ZIP); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; privacy disclosure with `/privacy` link at submission; success toast on submit
 - **Authentication UX** — Login and forgot-password flows use shared floating screen alerts for submit-level errors such as rate limits, while field validation remains inline; registration surfaces backend validation details and availability-check rate limits instead of generic "Invalid input data" errors
-- **Security & Privacy** — Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; new accounts remain private after email verification until users change visibility in settings; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; real-time email and username availability feedback during registration (results are cached so repeated validation skips redundant API calls); separate age-16 confirmation checkbox at registration; timestamps and document versions stored for accepted Terms of Service, acknowledged Privacy Policy, and age confirmation; unverified accounts are automatically deleted after 24 hours
+- **Security & Privacy** — Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; new accounts remain private after email verification until users change visibility in settings; users can manage a blocklist from Settings, with blocked relationships mutually anonymized across profiles, teams, roles, badge awards, invitations, and inline profile links; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; real-time email and username availability feedback during registration (results are cached so repeated validation skips redundant API calls); separate age-16 confirmation checkbox at registration; timestamps and document versions stored for accepted Terms of Service, acknowledged Privacy Policy, and age confirmation; unverified accounts are automatically deleted after 24 hours
 
 ---
 
@@ -148,9 +148,9 @@ Lomir-frontend/
 │   │   │                           #   limited-access profiles; placeholder for deleted users
 │   │   ├── Register.jsx            # Multi-step registration with CAPTCHA
 │   │   ├── Login.jsx
-│   │   ├── Chat.jsx                # Direct + team messaging with file sharing
+│   │   ├── Chat.jsx                # Direct + team messaging with file sharing; filters blocked users
 │   │   ├── BadgeOverview.jsx       # Badge catalog and details
-│   │   ├── Settings.jsx            # Password change + account deletion modal
+│   │   ├── Settings.jsx            # Visibility, blocklist, password/email changes + account deletion modal
 │   │   ├── ForgotPassword.jsx
 │   │   ├── ResetPassword.jsx
 │   │   ├── VerifyEmail.jsx
@@ -171,7 +171,8 @@ Lomir-frontend/
 │   │   │                           #   TeamInvitationDetailsModal, RequestRoleCard
 │   │   ├── users/                  # UserCard, UserDetailsModal, UserAvatar,
 │   │   │                           #   UserProfileHeaderSection (avatar + name + location header),
-│   │   │                           #   UserBioSection, InlineUserLink, DemoAvatarOverlay,
+│   │   │                           #   UserBioSection, InlineUserLink, BlocklistSection,
+│   │   │                           #   DemoAvatarOverlay,
 │   │   │                           #   DeletedUserProfilePlaceholder
 │   │   ├── badges/                 # Badge display, awarding, category modals, AwardCard
 │   │   ├── tags/                   # Tag input, display, and selection
@@ -193,7 +194,7 @@ Lomir-frontend/
 │   │   │                           #   VisibilityToggle, ScreenAlert, ConfirmModal
 │   │   └── layout/                 # Navbar, Footer, PageContainer, ProtectedRoute, Grid, Section
 │   ├── contexts/
-│   │   ├── AuthContext.jsx         # Authentication state + JWT management
+│   │   ├── AuthContext.jsx         # Authentication state, JWT management, and block relationship state
 │   │   ├── UserModalContext.jsx    # Global user detail modal stack
 │   │   ├── TeamModalContext.jsx    # Global team detail modal state
 │   │   ├── ToastContext.jsx        # Toast notification state + dispatch
@@ -205,7 +206,7 @@ Lomir-frontend/
 │   │   │                           #   preserves FormData requests so multipart boundaries are set by
 │   │   │                           #   the browser; call sites can opt out via skipRequestCaseTransform /
 │   │   │                           #   skipResponseCaseTransform for explicit per-call data contracts
-│   │   ├── userService.js          # Includes deletionPreview + deleteUser
+│   │   ├── userService.js          # Profile, avatar, blocklist, and account deletion endpoints
 │   │   ├── teamService.js
 │   │   ├── searchService.js
 │   │   ├── matchingService.js
@@ -294,7 +295,7 @@ Lomir-frontend/
 | `/profile/:id` | Public Profile | View any user's profile; shows "private" message for non-public profiles; placeholder for deleted users |
 | `/chat` | Chat | Direct messages and team group chat with file/image sharing, @mentions, and reply threading |
 | `/badges` | Badges | Browse all 30 badges across 5 categories |
-| `/settings` | Settings | Change profile visibility, password, email, and delete account |
+| `/settings` | Settings | Change profile visibility, manage blocked users, update password/email, and delete account |
 | `/contact` | Contact | Email form with file attachments and privacy notice; authenticated users with a contact user ID configured are routed to in-app chat |
 | `/about` | About | Project description, status, and contact information |
 | `/terms` | Terms | Full Terms of Service (14 sections, German law) |
@@ -336,6 +337,11 @@ All components handle deleted user references gracefully: chat messages show "Fo
 ## Chat
 
 The chat page supports both direct (1-to-1) and team group conversations.
+
+**Blocking**
+- Blocking a user removes unavailable direct conversations from the chat list and closes the active direct conversation if the relationship changes while it is open
+- Team chats stay available, but blocked members are filtered out of rosters, mention suggestions, and the visible message stream
+- Socket.IO `blocks:updated` events refresh block relationships without requiring a page reload
 
 **Messaging**
 - Messages are delivered in real time via Socket.IO

--- a/src/components/badges/AwardCard.jsx
+++ b/src/components/badges/AwardCard.jsx
@@ -129,7 +129,9 @@ const AwardCard = ({
     ? `0 0 12px ${isBadgeHidden ? "#9CA3AF66" : `${catColor}66`}`
     : undefined;
   const childTeamModalZIndex = useChildModalZIndex();
-  const { user: currentUser } = useAuth();
+  const { user: currentUser, blockedRelationshipIds } = useAuth();
+  const isBlockedUser = (id) =>
+    id != null && blockedRelationshipIds?.has?.(String(id));
 
   // --- Normalize fields (camelCase + snake_case) ---
   const awardId = award?.awardId || award?.award_id || award?.id || null;
@@ -388,11 +390,16 @@ const AwardCard = ({
   const recipientUserId = firstPresent(awardedToUserId, subjectUserId);
   const viewerIsRecipient = idsMatch(currentUser?.id, recipientUserId);
   const viewerCanSeeAwardee = viewerIsRecipient || canViewPrivateAwardees;
+  // A block in either direction always anonymizes the other person, even on my
+  // own badge where I'd otherwise see them.
+  const awarderIsBlocked = isBlockedUser(awardedByUserId);
+  const awardeeIsBlocked = isBlockedUser(awardedToUserId);
   const shouldFetchAwarderPrivacy = Boolean(
     awardedByUserId &&
       !viewerIsRecipient &&
       !awardedByHasExplicitPrivacy &&
-      !awarderIsFormerUser,
+      !awarderIsFormerUser &&
+      !awarderIsBlocked,
   );
   const {
     data: resolvedAwarderProfile = null,
@@ -404,7 +411,8 @@ const AwardCard = ({
   const shouldFetchAwardeePrivacy = Boolean(
     awardedToUserId &&
       !viewerCanSeeAwardee &&
-      !awardedToHasExplicitPrivacy,
+      !awardedToHasExplicitPrivacy &&
+      !awardeeIsBlocked,
   );
   const {
     data: resolvedAwardeeProfile = null,
@@ -432,7 +440,8 @@ const AwardCard = ({
       !awardedByHasExplicitPrivacy &&
       (awarderPrivacyLoading ||
           normalizeBooleanFlag(resolvedAwarderIsPublic) !== true)));
-  const shouldAnonymizeAwarder = awarderProfileIsPrivate && !viewerIsRecipient;
+  const shouldAnonymizeAwarder =
+    awarderIsBlocked || (awarderProfileIsPrivate && !viewerIsRecipient);
   const explicitAwardeeProfileIsPrivate =
     normalizeBooleanFlag(awardedToIsPublic) === false ||
     normalizeBooleanFlag(awardedToIsPrivate) === true ||
@@ -444,7 +453,7 @@ const AwardCard = ({
       (awardeePrivacyLoading ||
         normalizeBooleanFlag(resolvedAwardeeIsPublic) !== true));
   const shouldAnonymizeAwardee =
-    awardeeProfileIsPrivate && !viewerCanSeeAwardee;
+    awardeeIsBlocked || (awardeeProfileIsPrivate && !viewerCanSeeAwardee);
   const awardedByDisplayIsPublic = shouldAnonymizeAwarder
     ? false
     : awarderProfileIsPrivate

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -141,7 +141,7 @@ const TeamDetailsModal = ({
 }) => {
   const navigate = useNavigate();
   const { id: urlTeamId } = useParams();
-  const { user, isAuthenticated } = useAuth();
+  const { user, isAuthenticated, blockedRelationshipIds } = useAuth();
 
   const effectiveTeamId = useMemo(
     () => propTeamId || urlTeamId,
@@ -698,6 +698,15 @@ const TeamDetailsModal = ({
       String(memberId) === String(viewerId)
     ) {
       return false;
+    }
+
+    // Blocked users are mutually anonymized everywhere, even if their profile is
+    // public — so a blocked member shows as "Private Profile" in shared teams.
+    if (
+      memberId != null &&
+      blockedRelationshipIds?.has?.(String(memberId))
+    ) {
+      return true;
     }
 
     // Determine profile visibility flags (support snake_case + camelCase)

--- a/src/components/teams/TeamInvitesModal.jsx
+++ b/src/components/teams/TeamInvitesModal.jsx
@@ -73,7 +73,9 @@ const TeamInvitesModal = ({
   const highlightedRef = useRef(null);
 
   // ============ Context ============
-  const { user: currentUser } = useAuth();
+  const { user: currentUser, blockedRelationshipIds } = useAuth();
+  const isBlockedUser = (id) =>
+    id != null && blockedRelationshipIds?.has?.(String(id));
   const { openUserModal } = useUserModal();
   const { openTeamModal } = useTeamModal();
   const hydratedRoleMap = usePolledRequestRoles(invitations, {
@@ -271,7 +273,9 @@ const TeamInvitesModal = ({
           currentUser?.id,
         );
         const inviteeIsPrivate =
-          isPrivateProfileUser(invitation.invitee) && !isSelfInvitation;
+          (isPrivateProfileUser(invitation.invitee) ||
+            isBlockedUser(inviteeId)) &&
+          !isSelfInvitation;
         const inviteeRoleMatch =
           roleId != null && invitation?.role && !inviteeIsPrivate
             ? extractRoleMatchData(invitation.role)

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -222,7 +222,7 @@ const VacantRoleCard = ({
     useState(null);
   const [isCurrentUserTeamMember, setIsCurrentUserTeamMember] =
     useState(false);
-  const { user, isAuthenticated } = useAuth();
+  const { user, isAuthenticated, blockedRelationshipIds } = useAuth();
   const usesSharedSearchCard = hideActions && Boolean(teamContext);
   const roleId = role?.id ?? role?.roleId ?? role?.role_id ?? null;
   const roleNameForMatch = role?.roleName ?? role?.role_name ?? "";
@@ -709,13 +709,21 @@ const VacantRoleCard = ({
   const filledUser = isFilled
     ? resolveFilledRoleUser(role, { viewAsUserId, viewAsUser })
     : null;
-  const filledUserAvatarUrl =
-    filledUser?.avatar_url ?? filledUser?.avatarUrl ?? null;
+  // A block in either direction anonymizes the member filling this role.
+  const filledUserIsBlocked = Boolean(
+    filledUser?.id != null &&
+      blockedRelationshipIds?.has?.(String(filledUser.id)),
+  );
+  const filledUserAvatarUrl = filledUserIsBlocked
+    ? null
+    : filledUser?.avatar_url ?? filledUser?.avatarUrl ?? null;
   const filledUserDisplayName =
     filledUser && getDisplayName(filledUser) !== "Unknown"
       ? getDisplayName(filledUser)
       : null;
-  const filledByText = filledUser
+  const filledByText = filledUserIsBlocked
+    ? "Private Profile"
+    : filledUser
     ? formatDisplayName(filledUser)
     : filledUserDisplayName
     ? filledUserDisplayName
@@ -874,15 +882,47 @@ const VacantRoleCard = ({
       </span>
     </Tooltip>
   ) : null;
-  const hasDemoRoleMeta = isSyntheticRole(role) || isSyntheticUser(filledUser);
+  // The role itself and the member filling it are independent "demo" dimensions,
+  // so they get separate markers/labels: a synthetic role shows the DEMO_ROLE
+  // tooltip, a synthetic filled member shows the DEMO_PROFILE tooltip (and both
+  // can appear together on a filled card). A blocked member is never flagged.
+  const roleIsDemo = isSyntheticRole(role);
+  const filledMemberIsDemo =
+    isFilled && !filledUserIsBlocked && isSyntheticUser(filledUser);
+  const hasDemoRoleMeta = roleIsDemo || filledMemberIsDemo;
   const demoRoleMetaItem = hasDemoRoleMeta ? (
-    <Tooltip
-      content={isSyntheticRole(role) ? DEMO_ROLE_TOOLTIP : DEMO_PROFILE_TOOLTIP}
-      wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
-    >
-      <FlaskConical size={9} className="flex-shrink-0" />
-    </Tooltip>
+    <>
+      {roleIsDemo && (
+        <Tooltip
+          content={DEMO_ROLE_TOOLTIP}
+          wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
+        >
+          <FlaskConical size={9} className="flex-shrink-0" />
+        </Tooltip>
+      )}
+      {filledMemberIsDemo && (
+        <Tooltip
+          content={DEMO_PROFILE_TOOLTIP}
+          wrapperClassName="flex items-center gap-1 whitespace-nowrap text-base-content/50"
+        >
+          <FlaskConical size={9} className="flex-shrink-0" />
+        </Tooltip>
+      )}
+    </>
   ) : null;
+
+  // The filled-member avatar should carry the "DEMO" badge whenever the card is
+  // demo data (synthetic role or synthetic member), matching the vacant demo
+  // cards. UserAvatar only paints that overlay when the user object is flagged
+  // synthetic, but role payloads don't include the member's synthetic flag, so
+  // flag the avatar's copy when the card is demo data. A demo *role* still shows
+  // the badge even when the filling member is blocked (the role's demo status is
+  // independent of the member); `hasDemoRoleMeta` already drops a blocked
+  // member's own synthetic status, so this never reveals a blocked profile.
+  const showFilledDemoOverlay = hasDemoRoleMeta;
+  const filledAvatarUser = showFilledDemoOverlay
+    ? { ...(filledUser || {}), is_synthetic: true }
+    : filledUser;
 
   const renderMatchOverlay = ({ size, iconSize }) => {
     if (!matchTier) return null;
@@ -1063,9 +1103,20 @@ const VacantRoleCard = ({
         {roleInvitationSubtitleItem}
         {roleApplicationSubtitleItem}
         {miniLocationSubtitleItem}
-        {isSyntheticRole(role) && (
+        {roleIsDemo && (
           <Tooltip
             content={DEMO_ROLE_TOOLTIP}
+            wrapperClassName="flex items-center gap-1 text-base-content/50"
+          >
+            <FlaskConical
+              size={viewMode === "mini" ? 10 : 13}
+              className="flex-shrink-0"
+            />
+          </Tooltip>
+        )}
+        {filledMemberIsDemo && (
+          <Tooltip
+            content={DEMO_PROFILE_TOOLTIP}
             wrapperClassName="flex items-center gap-1 text-base-content/50"
           >
             <FlaskConical
@@ -1085,7 +1136,11 @@ const VacantRoleCard = ({
           hoverable
           image={isFilled ? filledUserAvatarUrl : null}
           imageFallback={
-            isFilled && filledUser ? getUserInitials(filledUser) : getRoleInitials()
+            filledUserIsBlocked
+              ? "PP"
+              : isFilled && filledUser
+              ? getUserInitials(filledUser)
+              : getRoleInitials()
           }
           imageAlt={role_name || "Vacant Role"}
           imageSize="medium"
@@ -1183,9 +1238,12 @@ const VacantRoleCard = ({
         {isFilled && filledUser ? (
             <div className="relative">
               <UserAvatar
-                user={filledUser}
+                user={filledAvatarUser}
                 sizeClass={avatarSizeClass}
-                showDemoOverlay={isSyntheticUser(filledUser)}
+                initialsClassName={avatarTextClass}
+                privateProfile={filledUserIsBlocked}
+                fallbackText={filledUserIsBlocked ? "PP" : undefined}
+                showDemoOverlay={showFilledDemoOverlay}
                 demoOverlayTextClassName={isMiniView ? "text-[6px]" : "text-[7px]"}
                 demoOverlayTextTranslateClassName="-translate-y-[3px]"
               />

--- a/src/components/users/BlocklistSection.jsx
+++ b/src/components/users/BlocklistSection.jsx
@@ -1,0 +1,229 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Ban, MapPin, Users, CalendarX, FlaskConical, UserX } from "lucide-react";
+import { userService } from "../../services/userService";
+import { formatDisplayName } from "../../utils/nameFormatters";
+import { formatListLocation } from "../../utils/locationUtils";
+import { normalizeTimestampToDate } from "../../utils/dateHelpers";
+import { DEMO_PROFILE_TOOLTIP, isSyntheticUser } from "../../utils/userHelpers";
+
+const formatShortDate = (value) => {
+  const date = normalizeTimestampToDate(value);
+  if (!date) return "";
+  return new Intl.DateTimeFormat("en-US", {
+    year: "2-digit",
+    month: "numeric",
+    day: "numeric",
+  }).format(date);
+};
+import UserAvatar from "./UserAvatar";
+import CardMetaRow from "../common/CardMetaRow";
+import CardMetaItem from "../common/CardMetaItem";
+import Tooltip from "../common/Tooltip";
+import ConfirmModal from "../common/ConfirmModal";
+import ScreenAlert from "../common/ScreenAlert";
+
+/**
+ * BlocklistSection
+ * Renders the users the current user has blocked as cards (mirrors the team
+ * members section). Selecting a card opens a confirmation to unblock.
+ */
+const BlocklistSection = ({ userId, onChange }) => {
+  const [blocked, setBlocked] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState(null);
+  const [unblocking, setUnblocking] = useState(false);
+  const [notification, setNotification] = useState({
+    type: null,
+    message: null,
+  });
+
+  const loadBlocked = useCallback(async () => {
+    if (!userId) return;
+    try {
+      setLoading(true);
+      const response = await userService.getBlockedUsers(userId);
+      setBlocked(Array.isArray(response?.data) ? response.data : []);
+    } catch {
+      setNotification({
+        type: "error",
+        message: "Failed to load your blocklist. Please try again.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    loadBlocked();
+  }, [loadBlocked]);
+
+  const handleConfirmUnblock = async () => {
+    if (!selected) return;
+    try {
+      setUnblocking(true);
+      await userService.unblockUser(userId, selected.id);
+      setBlocked((prev) => prev.filter((u) => u.id !== selected.id));
+      setNotification({
+        type: "success",
+        message: `${formatDisplayName(selected)} has been removed from your blocklist.`,
+      });
+      setSelected(null);
+      onChange?.();
+    } catch (error) {
+      setNotification({
+        type: "error",
+        message:
+          error.response?.data?.message || "Failed to unblock this user.",
+      });
+    } finally {
+      setUnblocking(false);
+    }
+  };
+
+  return (
+    <div>
+      <ScreenAlert
+        type={notification.type}
+        message={notification.message}
+        onClose={() => setNotification({ type: null, message: null })}
+      />
+
+      {/* Section Header */}
+      <div className="flex items-center mb-4">
+        <Ban size={18} className="mr-2 text-primary flex-shrink-0" />
+        <h3 className="label-text">
+          Blocked Users
+          {!loading && <span className="label-text ml-1">({blocked.length})</span>}
+        </h3>
+      </div>
+
+      {loading ? (
+        <p className="form-helper-text px-1">Loading your blocklist…</p>
+      ) : blocked.length === 0 ? (
+        <p className="form-helper-text px-1">
+          You haven’t blocked anyone. Blocked users can’t message you or see your
+          profile, and you won’t see theirs.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {blocked.map((blockedUser) => {
+            const locationText = formatListLocation(blockedUser, {
+              isRemote: blockedUser.isRemote || blockedUser.is_remote,
+            }).short;
+            const sharedTeams = Array.isArray(blockedUser.sharedTeams)
+              ? blockedUser.sharedTeams
+              : Array.isArray(blockedUser.shared_teams)
+                ? blockedUser.shared_teams
+                : [];
+            const isDemo = isSyntheticUser(blockedUser);
+            const blockedDate = formatShortDate(
+              blockedUser.createdAt ?? blockedUser.created_at,
+            );
+            const hasMetaRow =
+              locationText || blockedDate || isDemo || sharedTeams.length > 0;
+
+            return (
+              <button
+                key={blockedUser.id}
+                type="button"
+                onClick={() => setSelected(blockedUser)}
+                className="flex items-start text-left bg-white rounded-xl shadow p-4 gap-4 transition-all duration-200 hover:bg-gray-50 hover:shadow-md"
+              >
+                <UserAvatar
+                  user={blockedUser}
+                  sizeClass="w-14 h-14"
+                  initialsClassName="text-xl"
+                  showDemoOverlay={isDemo}
+                  demoOverlayTextClassName="text-[8px]"
+                />
+
+                <div className="flex-1 min-w-0 pt-[1px]">
+                  <h3 className="font-medium text-base truncate leading-[120%]">
+                    {formatDisplayName(blockedUser)}
+                  </h3>
+                  {hasMetaRow && (
+                    <CardMetaRow maxRows={3}>
+                      {blockedDate && (
+                        <Tooltip
+                          content="Blocked on this date"
+                          wrapperClassName="flex shrink-0 items-center gap-1 text-base-content/60"
+                        >
+                          <CalendarX size={10} className="shrink-0" />
+                          <span className="whitespace-nowrap leading-[1.05]">
+                            {blockedDate}
+                          </span>
+                        </Tooltip>
+                      )}
+                      {locationText && (
+                        <CardMetaItem icon={MapPin}>{locationText}</CardMetaItem>
+                      )}
+                      {isDemo && (
+                        <Tooltip
+                          content={DEMO_PROFILE_TOOLTIP}
+                          wrapperClassName="flex items-center gap-1 min-w-0 text-base-content/50"
+                        >
+                          <FlaskConical size={10} className="shrink-0" />
+                        </Tooltip>
+                      )}
+                      {sharedTeams.length > 0 && (
+                        <Tooltip
+                          wrapperClassName="flex min-w-0 max-w-full flex-[1_1_100%] items-start gap-1 overflow-hidden text-base-content/60"
+                          content={
+                            <div className="text-left">
+                              <div className="font-medium mb-0.5">
+                                {sharedTeams.length === 1
+                                  ? "1 team in common"
+                                  : `${sharedTeams.length} teams in common`}
+                              </div>
+                              <ul className="list-disc list-inside space-y-0.5">
+                                {sharedTeams.map((name) => (
+                                  <li key={name}>{name}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          }
+                        >
+                          <Users size={10} className="shrink-0 mt-[2px]" />
+                          <span className="min-w-0 line-clamp-2 leading-[1.05]">
+                            {sharedTeams.join(", ")}
+                          </span>
+                        </Tooltip>
+                      )}
+                    </CardMetaRow>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {!loading && blocked.length > 0 && (
+        <p className="form-helper-text px-1 mt-3">
+          Blocked users can’t message you or see your profile, and you won’t see
+          theirs.
+        </p>
+      )}
+
+      <ConfirmModal
+        isOpen={Boolean(selected)}
+        onClose={() => !unblocking && setSelected(null)}
+        onConfirm={handleConfirmUnblock}
+        title="Remove from blocklist?"
+        confirmLabel="Unblock"
+        loadingLabel="Unblocking…"
+        confirmIcon={<UserX size={16} />}
+        loading={unblocking}
+      >
+        {selected && (
+          <p className="text-base-content/80">
+            {formatDisplayName(selected)} will be able to message you and see
+            your profile again, and you’ll see theirs.
+          </p>
+        )}
+      </ConfirmModal>
+    </div>
+  );
+};
+
+export default BlocklistSection;

--- a/src/components/users/InlineUserLink.jsx
+++ b/src/components/users/InlineUserLink.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FlaskConical } from "lucide-react";
 import { useUserModalSafe } from "../../contexts/UserModalContext";
+import { useAuth } from "../../contexts/AuthContext";
 import { useUserProfile } from "../../hooks/useUserQueries";
 import Tooltip from "../common/Tooltip";
 import { DEMO_PROFILE_TOOLTIP } from "../../utils/userHelpers";
@@ -100,11 +101,16 @@ const InlineUserLink = ({
 }) => {
   // Try to get global modal context (returns null if not available)
   const userModalContext = useUserModalSafe();
+  const { blockedRelationshipIds } = useAuth();
 
   // Normalize user ID from various possible field names
   const userId = user?.id || user?.user_id || user?.userId;
   const isFormerUser = isDeletedUser(user);
-  const isPrivateUser = isPrivateProfile(user);
+  // A block in either direction anonymizes the referenced user everywhere this
+  // inline link appears (e.g. "Invited by", "Awarded by", "Applied by").
+  const isBlockedUser =
+    userId != null && blockedRelationshipIds?.has?.(String(userId));
+  const isPrivateUser = isPrivateProfile(user) || isBlockedUser;
   // Only hydrate when the parent didn't pass enough to render a name —
   // missing avatar / synthetic flag alone aren't worth a network round trip,
   // since UserAvatar falls back to initials and the synthetic indicator is

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -24,7 +24,8 @@ import Button from "../common/Button";
 import Alert from "../common/Alert";
 import Tooltip from "../common/Tooltip";
 import { useAuth } from "../../contexts/AuthContext";
-import { Edit, MessageCircle, UserPlus, Award, Check, CheckCheck, X, Ruler, User } from "lucide-react";
+import { Edit, MessageCircle, UserPlus, Award, Check, CheckCheck, X, Ruler, User, Ban } from "lucide-react";
+import ConfirmModal from "../common/ConfirmModal";
 import TeamInviteModal from "../teams/TeamInviteModal";
 import BadgeAwardModal from "../badges/BadgeAwardModal";
 import SupercategoryAwardsModal from "../badges/SupercategoryAwardsModal";
@@ -215,7 +216,7 @@ const UserDetailsModal = ({
   initialUserData = null,
   sharedTeamId = null,
 }) => {
-  const { user: currentUser, isAuthenticated } = useAuth();
+  const { user: currentUser, isAuthenticated, refreshBlocks } = useAuth();
   const queryClient = useQueryClient();
   const normalizedRoleMatchTagIds = useMemo(
     () => normalizeNumericSet(roleMatchTagIds),
@@ -255,6 +256,11 @@ const UserDetailsModal = ({
 
   // ========= Badge Award Modal state =========
   const [isBadgeAwardModalOpen, setIsBadgeAwardModalOpen] = useState(false);
+
+  // ========= Block user state =========
+  const [isBlockModalOpen, setIsBlockModalOpen] = useState(false);
+  const [blocking, setBlocking] = useState(false);
+  const [blockError, setBlockError] = useState(null);
 
   // =====================================================
 
@@ -612,6 +618,25 @@ const UserDetailsModal = ({
     setIsInviteModalOpen(true);
   };
 
+  const handleConfirmBlock = async () => {
+    if (!currentUser?.id || !userId) return;
+    try {
+      setBlocking(true);
+      await userService.blockUser(currentUser.id, userId);
+      await refreshBlocks?.();
+      // Drop any cached view of this now-hidden profile.
+      queryClient.invalidateQueries({ queryKey: userProfileQueryKey(userId) });
+      setIsBlockModalOpen(false);
+      onClose?.();
+    } catch (error) {
+      setBlockError(
+        error.response?.data?.message || "Failed to block this user.",
+      );
+    } finally {
+      setBlocking(false);
+    }
+  };
+
   const handleInviteModalClose = () => {
     setIsInviteModalOpen(false);
   };
@@ -888,6 +913,24 @@ const UserDetailsModal = ({
             >
               <Award size={16} />
               <span className="hidden sm:inline">Award</span>
+            </Button>
+          </Tooltip>
+          <Tooltip
+            content="Block this person. They won't be able to message you or see your profile."
+            position="bottom"
+          >
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setBlockError(null);
+                setIsBlockModalOpen(true);
+              }}
+              className="flex items-center gap-1 hover:bg-red-100 hover:text-red-700"
+              aria-label="Block user"
+            >
+              <Ban size={16} />
+              <span className="hidden sm:inline">Block</span>
             </Button>
           </Tooltip>
         </>
@@ -1202,6 +1245,28 @@ const UserDetailsModal = ({
           }}
         />
       )}
+
+      {/* Block User Confirmation */}
+      <ConfirmModal
+        isOpen={isBlockModalOpen}
+        onClose={() => !blocking && setIsBlockModalOpen(false)}
+        onConfirm={handleConfirmBlock}
+        title="Block this user?"
+        confirmLabel="Block"
+        loadingLabel="Blocking…"
+        confirmVariant="error"
+        confirmIcon={<Ban size={16} />}
+        loading={blocking}
+      >
+        <div className="space-y-2">
+          <p className="text-base-content/80">
+            {getUserDisplayName()} won’t be able to message you or see your
+            profile anywhere on Lomir, and you won’t see theirs. You can undo this
+            from Settings → Privacy.
+          </p>
+          {blockError && <Alert type="error" message={blockError} />}
+        </div>
+      </ConfirmModal>
     </>
   );
 };

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,6 +1,13 @@
-import { createContext, useState, useEffect, useContext } from "react";
+import {
+  createContext,
+  useState,
+  useEffect,
+  useContext,
+  useCallback,
+} from "react";
 import api from "../services/api";
 import socketService from "../services/socketService";
+import { userService } from "../services/userService";
 import { setUserTimezone } from "../utils/dateHelpers";
 
 const AuthContext = createContext(null);
@@ -31,6 +38,54 @@ export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(localStorage.getItem("token"));
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  // Ids of users in a block relationship with the current user (either
+  // direction), used to mutually anonymize blocked users across the app.
+  const [blockedRelationshipIds, setBlockedRelationshipIds] = useState(
+    () => new Set(),
+  );
+
+  const userId = user?.id ?? null;
+
+  // Refresh the block-relationship set from the backend. Exposed so screens
+  // that change the blocklist (Settings, profile Block action) can keep the
+  // app-wide set in sync.
+  const refreshBlocks = useCallback(async () => {
+    if (!userId) {
+      setBlockedRelationshipIds(new Set());
+      return;
+    }
+    try {
+      const response = await userService.getBlockRelationships(userId);
+      const ids = Array.isArray(response?.data?.ids) ? response.data.ids : [];
+      setBlockedRelationshipIds(new Set(ids.map((id) => String(id))));
+    } catch (err) {
+      console.error("Failed to load block relationships:", err);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    refreshBlocks();
+  }, [refreshBlocks]);
+
+  // Refresh the block set in realtime when the server signals a block/unblock
+  // (from either party), so hiding/restoring takes effect without a reload.
+  useEffect(() => {
+    if (!userId) return undefined;
+    let activeSocket = null;
+    const handleBlocksUpdated = () => {
+      refreshBlocks();
+    };
+    const unsubscribe = socketService.onSocketReady((socketInstance) => {
+      if (!socketInstance) return;
+      activeSocket = socketInstance;
+      socketInstance.off("blocks:updated", handleBlocksUpdated);
+      socketInstance.on("blocks:updated", handleBlocksUpdated);
+    });
+    return () => {
+      unsubscribe?.();
+      if (activeSocket) activeSocket.off("blocks:updated", handleBlocksUpdated);
+    };
+  }, [userId, refreshBlocks]);
 
   // Load user data if token exists
   useEffect(() => {
@@ -199,6 +254,7 @@ export const AuthProvider = ({ children }) => {
     setToken(null);
     setUser(null);
     setUserTimezone(null);
+    setBlockedRelationshipIds(new Set());
     setError(null); // Clear error when logging out
     // Disconnect socket
     socketService.disconnect();
@@ -223,6 +279,8 @@ export const AuthProvider = ({ children }) => {
         login,
         logout,
         updateUser,
+        blockedRelationshipIds,
+        refreshBlocks,
       }}
     >
       {children}

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -694,7 +694,12 @@ const Chat = () => {
   const { conversationId } = useParams();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { user, isAuthenticated } = useAuth();
+  const { user, isAuthenticated, blockedRelationshipIds } = useAuth();
+  const isBlockedId = useCallback(
+    (id) =>
+      id != null && blockedRelationshipIds?.has?.(String(id)),
+    [blockedRelationshipIds],
+  );
   const [conversations, setConversations] = useState([]);
   const [activeConversation, setActiveConversation] = useState(null);
   const [messages, setMessages] = useState([]);
@@ -810,8 +815,26 @@ const Chat = () => {
   const teamData =
     conversationType === "team" ? activeConversation?.team || null : null;
 
-  const teamMembers =
-    conversationType === "team" ? activeConversation?.team?.members || [] : [];
+  const teamMembers = useMemo(() => {
+    const members =
+      conversationType === "team" ? activeConversation?.team?.members || [] : [];
+    // Hide blocked users from the roster/mention list (both directions).
+    return members.filter((member) => {
+      const memberId =
+        member?.userId ?? member?.user_id ?? member?.id ?? member?.user?.id;
+      return !isBlockedId(memberId);
+    });
+  }, [conversationType, activeConversation?.team?.members, isBlockedId]);
+  // Hide messages from blocked users from the rendered stream (both directions).
+  // The backend already filters fetches and realtime delivery; this keeps an
+  // open session consistent the instant a block is added/removed.
+  const visibleMessages = useMemo(
+    () =>
+      messages.filter(
+        (message) => !isBlockedId(message?.senderId ?? message?.sender_id),
+      ),
+    [messages, isBlockedId],
+  );
   const isCurrentUserActiveTeamMember =
     conversationType !== "team" || isUserTeamMember(teamMembers, user?.id);
   const canSendInActiveConversation =
@@ -1341,6 +1364,47 @@ const Chat = () => {
       console.error("Error refreshing conversations:", err);
     }
   }, [hydrateMissingConversationPreviews]);
+
+  // Apply live block/unblock changes to the chat view: drop blocked DMs (and
+  // restore unblocked ones) from the list, and close the active DM if its
+  // partner is now blocked. Team chats stay open — the blocker is hidden via
+  // the visibleMessages / teamMembers filters. The first run is skipped because
+  // the initial conversation fetch below already loads the correct state.
+  const blocksSyncInitializedRef = useRef(false);
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    if (!blocksSyncInitializedRef.current) {
+      blocksSyncInitializedRef.current = true;
+      return;
+    }
+
+    refreshConversationList();
+
+    const currentUrlType =
+      new URLSearchParams(window.location.search).get("type") ||
+      activeConversationRef.current?.type ||
+      "direct";
+    if (currentUrlType !== "direct") return;
+
+    const activePartnerId = getConversationPartnerId(
+      activeConversationRef.current,
+    );
+    if (isBlockedId(activePartnerId)) {
+      setError("This conversation is no longer available.");
+      setActiveConversation(null);
+      setMessages([]);
+      setTypingUsers({});
+      setHighlightMessageIds([]);
+      setHasMoreMessages(false);
+      navigate("/chat", { replace: true });
+    }
+  }, [
+    blockedRelationshipIds,
+    isAuthenticated,
+    isBlockedId,
+    refreshConversationList,
+    navigate,
+  ]);
 
   // Fetch conversations
   useEffect(() => {
@@ -3286,7 +3350,7 @@ const Chat = () => {
 
               <div ref={messagesContainerRef} className="flex-grow overflow-y-auto p-4">
                 <MessageDisplay
-                  messages={messages}
+                  messages={visibleMessages}
                   currentUserId={user?.id}
                   conversationPartner={conversationPartner}
                   teamData={teamData}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -7,6 +7,7 @@ import Alert from "../components/common/Alert";
 import ScreenAlert from "../components/common/ScreenAlert";
 import FormSectionDivider from "../components/common/FormSectionDivider";
 import VisibilityToggle from "../components/common/VisibilityToggle";
+import BlocklistSection from "../components/users/BlocklistSection";
 import Modal from "../components/common/Modal";
 import { userService } from "../services/userService";
 import { teamService } from "../services/teamService";
@@ -207,7 +208,7 @@ const normalizeTransferOptions = (members, currentUserId) =>
     .filter(Boolean);
 
 const Settings = () => {
-  const { user, updateUser, logout } = useAuth();
+  const { user, updateUser, logout, refreshBlocks } = useAuth();
   const navigate = useNavigate();
 
   const [success, setSuccess] = useState(null);
@@ -682,6 +683,10 @@ const Settings = () => {
             <p className="form-helper-text px-1">
               {PROFILE_VISIBILITY_SETTINGS_NOTICE}
             </p>
+
+            {user?.id && (
+              <BlocklistSection userId={user.id} onChange={refreshBlocks} />
+            )}
           </section>
 
           {/* ── Account ── */}

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -158,6 +158,52 @@ export const userService = {
       api.delete(`/api/users/${userId}/avatar`),
     ),
 
+  // --- User Blocks ---
+
+  /**
+   * Fetches the users the current user has blocked (card data for the blocklist).
+   * @param {string|number} userId
+   * @returns {Promise<object>}
+   */
+  getBlockedUsers: (userId) =>
+    call(`fetching blocked users for ${userId}`, () =>
+      api.get(`/api/users/${userId}/blocks`),
+    ),
+
+  /**
+   * Blocks another user. The request interceptor converts `blockedId` to
+   * `blocked_id` for the backend.
+   * @param {string|number} userId - The current (blocking) user's id.
+   * @param {string|number} blockedId - The user to block.
+   * @returns {Promise<object>}
+   */
+  blockUser: (userId, blockedId) =>
+    call(`blocking user ${blockedId}`, () =>
+      api.post(`/api/users/${userId}/blocks`, { blockedId }),
+    ),
+
+  /**
+   * Removes a user from the current user's blocklist.
+   * @param {string|number} userId
+   * @param {string|number} blockedId
+   * @returns {Promise<object>}
+   */
+  unblockUser: (userId, blockedId) =>
+    call(`unblocking user ${blockedId}`, () =>
+      api.delete(`/api/users/${userId}/blocks/${blockedId}`),
+    ),
+
+  /**
+   * Fetches every user id in a block relationship with the current user
+   * (either direction), used to mutually anonymize blocked users in teams.
+   * @param {string|number} userId
+   * @returns {Promise<object>}
+   */
+  getBlockRelationships: (userId) =>
+    call(`fetching block relationships for ${userId}`, () =>
+      api.get(`/api/users/${userId}/block-relationships`),
+    ),
+
   changePassword: (currentPassword, newPassword) =>
     call("changing password", () =>
       api.put("/api/auth/change-password", { currentPassword, newPassword }),


### PR DESCRIPTION
## Summary

Adds frontend support for user blocking and blocked-user privacy handling across Lomir.

## What Changed

- Added a **Block** action in the user details modal with confirmation and error handling.
- Added a **Blocked Users** section in Settings where users can view and unblock blocked profiles.
- Added frontend blocklist API methods for fetching, blocking, unblocking, and loading mutual block relationships.
- Stores blocked relationship IDs in `AuthContext` and refreshes them via `blocks:updated` Socket.IO events.
- Hides or anonymizes blocked users across:
  - direct and team chat
  - team member displays
  - team invitations
  - vacant role cards
  - badge awards
  - inline user links
- Filters blocked users out of team rosters, mention suggestions, and visible message streams.
- Closes unavailable direct conversations when a block relationship changes.
- Updates the frontend README with the new blocking behavior and project structure notes.

## Notes

This frontend expects the backend block endpoints and `blocks:updated` socket event to be available.

## Testing

- `npm run build` passes

Build completed with existing Vite warnings about chunk size and mixed static/dynamic imports for `VacantRoleDetailsModal.jsx`.