### PR TITLE
Upload registration avatar server-side via multipart

### DIFF
--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -17,7 +17,6 @@ import {
   EyeOff,
 } from "lucide-react";
 import ImageUploader from "../common/ImageUploader";
-import { uploadToImageKit } from "../../config/imagekit";
 import api from "../../services/api";
 import LocationInput from "../common/LocationInput";
 import { useLocationAutoFill } from "../../hooks/useLocationAutoFill";
@@ -495,43 +494,42 @@ const RegisterForm = () => {
         return;
       }
 
-      const userData = {
-        username: trimmedUsername,
-        email: trimmedEmail,
-        password: formData.password,
-        first_name: formData.first_name,
-        last_name: formData.last_name,
-        bio: formData.bio,
-        postal_code: formData.postal_code,
-        city: formData.city,
-        country: formData.country,
-        acceptedTerms: true,
-        acceptedPrivacy: true,
-        confirmed_age_16: true,
-        tags:
-          formData.selectedTags.length > 0
-            ? formData.selectedTags
-                .map((id) => Number(id))
-                .filter((n) => Number.isFinite(n))
-                .map((id) => ({ tag_id: id }))
-            : [],
-        ...(hasTurnstile ? { turnstile_token: turnstileToken } : {}),
-      };
+      const selectedTagObjects =
+        formData.selectedTags.length > 0
+          ? formData.selectedTags
+              .map((id) => Number(id))
+              .filter((n) => Number.isFinite(n))
+              .map((id) => ({ tag_id: id }))
+          : [];
 
-      if (formData.profile_image) {
-        const uploadResult = await uploadToImageKit(
-          formData.profile_image,
-          "avatars",
-        );
+      // Send registration as multipart/form-data so the avatar is uploaded
+      // to ImageKit server-side, only after the account is actually created.
+      // This avoids exposing the image (and an ImageKit auth token) from the
+      // browser before a valid registration exists.
+      const registrationData = new FormData();
+      registrationData.append("username", trimmedUsername);
+      registrationData.append("email", trimmedEmail);
+      registrationData.append("password", formData.password);
+      registrationData.append("first_name", formData.first_name);
+      registrationData.append("last_name", formData.last_name);
+      registrationData.append("bio", formData.bio);
+      registrationData.append("postal_code", formData.postal_code);
+      registrationData.append("city", formData.city);
+      registrationData.append("country", formData.country);
+      registrationData.append("accepted_terms", "true");
+      registrationData.append("accepted_privacy", "true");
+      registrationData.append("confirmed_age_16", "true");
+      registrationData.append("tags", JSON.stringify(selectedTagObjects));
 
-        if (uploadResult.success) {
-          userData.avatar_url = uploadResult.url;
-        } else {
-          console.error("Avatar upload failed:", uploadResult.error);
-        }
+      if (hasTurnstile) {
+        registrationData.append("turnstile_token", turnstileToken);
       }
 
-      const result = await register(userData);
+      if (formData.profile_image) {
+        registrationData.append("avatar", formData.profile_image);
+      }
+
+      const result = await register(registrationData);
 
       if (result.success) {
         if (result.requiresVerification) {


### PR DESCRIPTION
Summary
Migrates the registration avatar upload from a client-side ImageKit call to a server-side upload via multipart/form-data. The avatar image now leaves the browser only after the backend has validated the registration and is actually creating the account — instead of being uploaded anonymously from the browser before a valid account exists.

Background
Previously, [RegisterForm.jsx](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/components/auth/RegisterForm.jsx) called uploadToImageKit() directly from the browser before submitting the registration. In the unauthenticated registration flow this is problematic:

The image is sent to a third party (ImageKit) before the account is created — even if registration then fails validation, CAPTCHA, or hits a duplicate email/username.
It relied on the client obtaining an ImageKit auth token via /api/imagekit/auth during an unauthenticated flow.
The backend register endpoint already supports multipart avatar handling (upload.single("avatar") + server-side ImageKit upload), so only the frontend needed to be switched over.

Changes
Build the registration request as FormData and send the avatar as an avatar file field; the backend uploads it to ImageKit after validating the payload.
Remove the client-side uploadToImageKit() call from the registration flow.
Remove the now-unused uploadToImageKit import.
Privacy impact (GDPR / data minimisation)
The avatar is only transmitted to ImageKit once a valid account is being created.
Removes the ImageKit auth-token dependency from the unauthenticated registration flow.
Scope / not touched
[config/imagekit.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/config/imagekit.js) and client-side uploadToImageKit are intentionally kept — they remain in use in authenticated contexts (Profile, Chat, team modals), where a valid JWT exists and a client-side upload is fine. No backend changes were required.
How it works
The shared API client strips the Content-Type header for FormData so the browser sets the multipart boundary ([api.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/services/api.js)).
The backend parses tags as a JSON string and accepts the consent booleans as "true" strings, so the multipart payload validates identically to the previous JSON payload.
Testing
 Register with an avatar → image appears on the newly created profile.
 Register without an avatar → registration completes, initials shown as fallback.
 Invalid registration (e.g. duplicate email) → no orphaned image is uploaded.