### PR TITLE
Use httpOnly session cookie for auth instead of localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Contact the project owner for a demo login, or register a new account with a val
 - **Demo Data Indicators** — Synthetic/seed data is visually labeled with FlaskConical icons and "DEMO" avatar overlays so users can distinguish test content from real data
 - **Contact Page** — Email contact form with optional multipart file attachments (up to 3 files, 5 MB each, 10 MB total — JPG, PNG, WebP, PDF, TXT, CSV); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; privacy disclosure with `/privacy` link at submission; abuse/content reports show a persistent reference ID after submit
 - **Authentication UX** — Login and forgot-password flows use shared floating screen alerts for submit-level errors such as rate limits, while field validation remains inline; registration surfaces backend validation details and username availability-check rate limits instead of generic "Invalid input data" errors
-- **Security & Privacy** — Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; new accounts remain private after email verification until users change visibility in settings; users can manage a blocklist from Settings, with blocked relationships mutually anonymized across profiles, teams, roles, badge awards, invitations, and inline profile links; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; username availability feedback during registration is rate-limited while email availability is not exposed; separate age-16 confirmation checkbox at registration; timestamps and document versions stored for accepted Terms of Service, acknowledged Privacy Policy, and age confirmation; unverified accounts are automatically deleted after 24 hours
+- **Security & Privacy** — the session is held in a backend-set `httpOnly` cookie rather than `localStorage`, so the auth token is never readable by JavaScript (XSS-resistant); requests and the realtime socket send it automatically via credentialed requests, and auth state is restored on load from `GET /api/auth/me`; Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; new accounts remain private after email verification until users change visibility in settings; users can manage a blocklist from Settings, with blocked relationships mutually anonymized across profiles, teams, roles, badge awards, invitations, and inline profile links; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; username availability feedback during registration is rate-limited while email availability is not exposed; separate age-16 confirmation checkbox at registration; timestamps and document versions stored for accepted Terms of Service, acknowledged Privacy Policy, and age confirmation; unverified accounts are automatically deleted after 24 hours
 
 ---
 
@@ -195,7 +195,7 @@ Lomir-frontend/
 │   │   │                           #   VisibilityToggle, ScreenAlert, ConfirmModal
 │   │   └── layout/                 # Navbar, Footer, PageContainer, ProtectedRoute, Grid, Section
 │   ├── contexts/
-│   │   ├── AuthContext.jsx         # Authentication state, JWT management, and block relationship state
+│   │   ├── AuthContext.jsx         # Authentication state (httpOnly cookie session, restored via /api/auth/me) and block relationship state
 │   │   ├── UserModalContext.jsx    # Global user detail modal stack
 │   │   ├── TeamModalContext.jsx    # Global team detail modal state
 │   │   ├── ToastContext.jsx        # Toast notification state + dispatch
@@ -372,7 +372,7 @@ The chat page supports both direct (1-to-1) and team group conversations.
 
 - **CORS errors** — Make sure the backend is running on port 5001 and the frontend on 5173; check that `VITE_API_URL` matches
 - **Socket.IO won't connect** — Verify `VITE_SOCKET_URL` in `.env` if you set it; otherwise the client falls back to `VITE_API_URL`
-- **"Access denied. No token provided."** — Your JWT has expired; log out and log back in
+- **"Access denied. No token provided."** — Your session cookie is missing or expired; log out and log back in (and ensure the API is reached over a credentialed/CORS-allowed origin so the cookie is sent)
 - **CAPTCHA not showing locally** — Expected behavior; if `VITE_TURNSTILE_SITE_KEY` is unset, registration skips CAPTCHA
 - **Images not uploading** — Check that `VITE_IMAGEKIT_PUBLIC_KEY` and `VITE_IMAGEKIT_URL_ENDPOINT` are set in `.env`
 - **Map not rendering** — Leaflet CSS must be imported; check that `leaflet` and `react-leaflet` are installed

--- a/src/config/imagekit.js
+++ b/src/config/imagekit.js
@@ -46,10 +46,11 @@ export const uploadToImageKit = async (file, type) => {
   }
 
   try {
-    // 1. Get auth params from backend (requires JWT)
-    const token = localStorage.getItem("token");
+    // 1. Get auth params from backend (requires an authenticated session).
+    // The session lives in an httpOnly cookie, so send credentials instead of
+    // an Authorization header.
     const authRes = await fetch(IMAGEKIT_CONFIG.authEndpoint, {
-      headers: { Authorization: `Bearer ${token}` },
+      credentials: "include",
     });
 
     if (!authRes.ok) {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -33,9 +33,9 @@ const normalizeAuthUser = (userData, { defaultIsPublic = false } = {}) => ({
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
-  // Browser storage note: Lomir currently keeps the JWT in localStorage.token
-  // for signed-in sessions. TODO: evaluate moving auth to httpOnly cookies.
-  const [token, setToken] = useState(localStorage.getItem("token"));
+  // Auth is carried by an httpOnly session cookie set by the backend and is
+  // intentionally not readable by JavaScript. Auth state is derived by calling
+  // /api/auth/me; the cookie is sent automatically (api uses withCredentials).
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   // Ids of users in a block relationship with the current user (either
@@ -87,60 +87,52 @@ export const AuthProvider = ({ children }) => {
     };
   }, [userId, refreshBlocks]);
 
-  // Load user data if token exists
+  // On mount, restore the session from the httpOnly cookie (if present) by
+  // asking the backend who we are. skipAuthRedirect keeps a logged-out
+  // visitor's 401 from bouncing them to /login.
   useEffect(() => {
     let cancelled = false;
 
-    const loadUser = async () => {
-      if (token) {
+    const bootstrapSession = async () => {
+      try {
+        const response = await api.get("/api/auth/me", {
+          skipAuthRedirect: true,
+          skipErrorLog: true,
+        });
+
+        if (cancelled) return;
+
+        const userData = response.data.data.user;
+        const enhancedUserData = normalizeAuthUser(userData);
+        setUser(enhancedUserData);
+        setUserTimezone(enhancedUserData);
+        setError(null);
+
+        // Connect socket AFTER user is loaded
         try {
-          const response = await api.get("/api/auth/me", {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          });
-
-          if (cancelled) return;
-
-          const userData = response.data.data.user;
-          const enhancedUserData = normalizeAuthUser(userData);
-          setUser(enhancedUserData);
-          setUserTimezone(enhancedUserData);
-          setError(null);
-
-          // Connect socket AFTER user is loaded
-          try {
-            socketService.connect(token);
-          } catch (socketError) {
-            console.error("Failed to connect socket on load:", socketError);
-          }
-        } catch (err) {
-          if (cancelled) return;
-          console.error("Failed to load user:", err);
-          // If token is invalid, clear it
-          if (
-            err.response &&
-            (err.response.status === 401 || err.response.status === 403)
-          ) {
-            localStorage.removeItem("token");
-            setToken(null);
-            setUser(null);
-          }
-          setError("Authentication failed. Please login again.");
-        } finally {
-          if (!cancelled) setLoading(false);
+          socketService.connect();
+        } catch (socketError) {
+          console.error("Failed to connect socket on load:", socketError);
         }
-      } else {
+      } catch (err) {
+        if (cancelled) return;
+        // A 401/403 simply means "not logged in" — not an error to surface.
+        const status = err.response?.status;
+        if (status !== 401 && status !== 403) {
+          console.error("Failed to restore session:", err);
+        }
+        setUser(null);
+      } finally {
         if (!cancelled) setLoading(false);
       }
     };
 
-    loadUser();
+    bootstrapSession();
 
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, []);
 
   // Register a new user
   const register = async (userData) => {
@@ -158,19 +150,18 @@ export const AuthProvider = ({ children }) => {
         };
       }
 
-      // If no verification required (shouldn't happen with new flow, but just in case)
-      const { token, user } = response.data.data;
+      // If no verification required (shouldn't happen with new flow, but just
+      // in case). The session cookie is set by the backend on this response.
+      const { user } = response.data.data;
 
       const enhancedUser = normalizeAuthUser(user);
 
-      localStorage.setItem("token", token);
-      setToken(token);
       setUser(enhancedUser);
       setUserTimezone(enhancedUser);
       setError(null);
 
       try {
-        socketService.connect(token);
+        socketService.connect();
       } catch (socketError) {
         console.error(
           "Failed to connect socket after registration:",
@@ -201,19 +192,18 @@ export const AuthProvider = ({ children }) => {
       const response = await api.post("/api/auth/login", credentials, {
         skipAuthRedirect: true,
       });
-      const { token, user } = response.data.data;
+      // The session cookie is set by the backend on this response.
+      const { user } = response.data.data;
 
       const enhancedUser = normalizeAuthUser(user);
 
-      localStorage.setItem("token", token);
-      setToken(token);
       setUser(enhancedUser);
       setUserTimezone(enhancedUser);
       setError(null);
 
       // Initialize socket connection AFTER user is set
       try {
-        socketService.connect(token);
+        socketService.connect();
       } catch (socketError) {
         console.error("Failed to connect socket after login:", socketError);
         // Don't fail login if socket fails
@@ -249,15 +239,22 @@ export const AuthProvider = ({ children }) => {
   };
 
   // Logout user
-  const logout = () => {
-    localStorage.removeItem("token");
-    setToken(null);
+  const logout = async () => {
+    // Clear client state immediately so the UI reflects logout without delay.
     setUser(null);
     setUserTimezone(null);
     setBlockedRelationshipIds(new Set());
     setError(null); // Clear error when logging out
     // Disconnect socket
     socketService.disconnect();
+
+    // Ask the backend to clear the httpOnly session cookie. Send an empty
+    // object (not null) so the JSON body parser receives a valid payload.
+    try {
+      await api.post("/api/auth/logout", {}, { skipAuthRedirect: true });
+    } catch (err) {
+      console.error("Logout request failed:", err);
+    }
   };
 
   // Add cleanup on unmount

--- a/src/pages/LegalPlaceholderPage.jsx
+++ b/src/pages/LegalPlaceholderPage.jsx
@@ -5,6 +5,7 @@ import Card from "../components/common/Card";
 const CONTACT_EMAIL = "lomirapp@gmail.com";
 const LAST_UPDATED = "June 15, 2026";
 const LEGAL_NOTICE_UPDATED = "June 16, 2026";
+const PRIVACY_UPDATED = "June 16, 2026";
 
 const mailLink = (
   <a href={`mailto:${CONTACT_EMAIL}`} className="link link-primary">
@@ -48,7 +49,7 @@ const pageContent = {
   },
   privacy: {
     title: "Privacy Policy",
-    updated: LAST_UPDATED,
+    updated: PRIVACY_UPDATED,
     intro:
       "This Privacy Policy explains how Lomir processes personal data. It is written for an app operated from Germany and aligned with the GDPR, the German Federal Data Protection Act, and German rules on technically necessary browser storage under the TDDDG.",
     sections: [
@@ -161,8 +162,8 @@ const pageContent = {
       {
         title: "12. Browser Storage, Cookies, and Similar Technologies",
         paragraphs: [
-          "Lomir currently uses technically necessary browser storage such as localStorage and sessionStorage. For example, the app stores the login token in localStorage and uses sessionStorage for in-app notification state.",
-          "This storage is necessary to provide authentication, API access, real-time chat, and notification features. Lomir does not currently use advertising cookies, marketing trackers, or third-party analytics tools.",
+          "Lomir uses a technically necessary, httpOnly session cookie to keep you signed in after login. This cookie holds your authentication token, is not readable by JavaScript, and is sent only to the Lomir backend to authenticate your requests and real-time chat connection. Lomir also uses technically necessary browser storage such as sessionStorage, for example for in-app notification state.",
+          "This cookie and storage are strictly necessary to provide authentication, API access, real-time chat, and notification features, and therefore do not require consent under Section 25(2) TDDDG. Lomir does not currently use advertising cookies, marketing trackers, or third-party analytics tools.",
           "Where Cloudflare Turnstile is enabled for registration or the contact form, Cloudflare may process technical data to verify that a request is made by a human. This is used for abuse prevention.",
         ],
       },

--- a/src/pages/VerifyEmail.jsx
+++ b/src/pages/VerifyEmail.jsx
@@ -31,9 +31,6 @@ const VerifyEmail = () => {
       if (response.data.success) {
         setStatus("success");
         setMessage("Your email has been verified successfully!");
-
-        const authToken = response.data?.data?.token;
-        if (authToken) localStorage.setItem("token", authToken);
       }
     } catch (error) {
       console.error("Verification error:", error);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -14,11 +14,8 @@ const api = axios.create({
 // Add request interceptor to convert request data to snake_case
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem("token");
-    if (token) {
-      config.headers["Authorization"] = `Bearer ${token}`;
-    }
-
+    // Auth travels in an httpOnly session cookie sent automatically via
+    // withCredentials; there is no JS-readable token to attach here.
     if (config.data instanceof FormData) {
       delete config.headers["Content-Type"];
     } else if (
@@ -51,9 +48,9 @@ api.interceptors.response.use(
         console.error("API Error:", error.response.data);
       }
 
-      // 401 = invalid/expired token → log out. 403 = forbidden resource → stay logged in.
+      // 401 = invalid/expired session → send to login. 403 = forbidden
+      // resource → stay logged in. The cookie is cleared server-side on logout.
       if (!skipAuthRedirect && error.response.status === 401) {
-        localStorage.removeItem("token");
         window.location.href = "/login";
       }
     } else if (error.request) {

--- a/src/services/socketService.js
+++ b/src/services/socketService.js
@@ -12,7 +12,7 @@ const notifySocketReady = (socketInstance) => {
 
 const socketService = {
   // Connect to the socket server
-  connect: (token) => {
+  connect: () => {
     if (socket && socket.connected) {
       notifySocketReady(socket);
       return socket;
@@ -27,8 +27,10 @@ const socketService = {
     const SOCKET_URL =
       import.meta.env.VITE_SOCKET_URL || "http://localhost:5001";
 
+    // The backend authenticates the handshake from the httpOnly session
+    // cookie; withCredentials makes the browser send it with the connection.
     const newSocket = io(SOCKET_URL, {
-      auth: { token },
+      withCredentials: true,
       transports: ["polling", "websocket"],
       reconnection: true,
       reconnectionAttempts: 5,


### PR DESCRIPTION
Summary
Stops storing the JWT in localStorage. The session now lives in a backend-set httpOnly cookie that JavaScript cannot read, closing the XSS token-theft vector. Auth state is derived from the backend instead of a JS-held token.

Changes
[AuthContext](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/contexts/AuthContext.jsx) — removes the localStorage token; restores the session on load via GET /api/auth/me (cookie sent automatically with withCredentials); login/register set user state directly; logout calls POST /api/auth/logout to clear the cookie.
[api.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/services/api.js) — drops the Authorization header injection from localStorage; relies on withCredentials (already enabled).
[socketService.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/services/socketService.js) — connects with withCredentials: true (no token passed); the handshake cookie authenticates the socket.
[imagekit.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/config/imagekit.js) — fetches upload auth params with credentials: "include" instead of a localStorage token.
[VerifyEmail.jsx](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/pages/VerifyEmail.jsx) — removes a dead localStorage token write.
[Privacy notice](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/pages/LegalPlaceholderPage.jsx) — updated to describe the technically necessary httpOnly session cookie under TDDDG §25(2) (strictly necessary → no consent banner required); its own "last updated" date bumped. README updated.
Notes
No cookie banner is required: the session cookie is strictly necessary (TDDDG §25(2)). Client-side ImageKit uploads in authenticated areas (Profile, Chat, team modals) are intentionally kept and now rely on the cookie session.

Testing
Verified locally: login, session persistence across reload/navigation, realtime chat (socket cookie auth), avatar upload, and logout (cookie cleared, redirect to /login).