### PR TITLE
Fix frontend lint errors

### DIFF
--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -65,7 +65,7 @@ const LoginForm = () => {
       } else {
         setErrors({ form: result.message });
       }
-    } catch (error) {
+    } catch {
       setErrors({ form: "An unexpected error occurred. Please try again." });
     } finally {
       setIsSubmitting(false);

--- a/src/components/badges/BadgesDisplaySection.jsx
+++ b/src/components/badges/BadgesDisplaySection.jsx
@@ -38,7 +38,6 @@ const BadgesDisplaySection = ({
   showCredits = true,
   onCategoryClick = null,
   onBadgeClick = null,
-  onOpenUser = null,
   highlightBadgeName = null,
   matchingBadgeNames = null,
   headerRight = null,

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -1,7 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from "react";
-import { format, isToday, isYesterday } from "date-fns";
 import {
-  normalizeTimestampToDate,
   formatLocalTime,
   formatDateHeading as formatMessageDateHeading,
   getDateGroupKey,
@@ -1062,10 +1060,8 @@ const MessageDisplay = ({
   loadingMore = false,
   teamMembersRefreshSignal = null,
   onLoadEarlierMessages,
-  onDeleteConversation,
   onDeleteMessage,
   onEditMessage,
-  onLeaveTeam,
   onReply,
   onConversationHeaderVisibilityChange,
   searchQuery = "",
@@ -2303,10 +2299,6 @@ const MessageDisplay = ({
     parsedMessage,
     isCurrentUser,
   ) => {
-    const approver = parsedMessage.approverName;
-    const applicant = parsedMessage.applicantName;
-    const teamName = parsedMessage.teamName;
-
     const messageText = isCurrentUser ? (
       parsedMessage.hasPersonalMessage ? (
         <>
@@ -2389,9 +2381,6 @@ const MessageDisplay = ({
   const renderApplicationApprovedMessage = (
     message,
     parsedMessage,
-    senderInfo,
-    isCurrentUser,
-    senderId,
   ) => {
     const isApplicantCurrentUser = isCurrentViewer(parsedMessage.applicantId);
     const isApproverCurrentUser = isCurrentViewer(parsedMessage.approverId);
@@ -3166,7 +3155,7 @@ const MessageDisplay = ({
   // =============================================================================
   // renderUserLeftLomirMessage - Neutral grey theme
   // =============================================================================
-  const renderUserLeftLomirMessage = (message, parsedMessage) => {
+  const renderUserLeftLomirMessage = (message) => {
     const leaveText = <>Former Lomir Member has left Lomir.</>;
 
     return (
@@ -3218,70 +3207,6 @@ const MessageDisplay = ({
           <span className="text-sm font-medium event-message-text">
             <UserMinus size={16} className="event-inline-icon mr-1" />
             {highlightEventContent(text)}
-          </span>
-        </div>
-
-        <div className="text-xs text-base-content/50">
-          {formatLocalTime(message.createdAt)}
-        </div>
-      </div>
-    );
-  };
-
-  // =============================================================================
-  // renderInvitationAcceptedMessage - Green success theme
-  // =============================================================================
-  const renderInvitationAcceptedMessage = (
-    message,
-    parsedMessage,
-    isCurrentUser,
-  ) => {
-    const isInviteeCurrentUser = isCurrentViewer(parsedMessage.inviteeId);
-    const isInviterCurrentUser = isCurrentViewer(parsedMessage.inviterId);
-    const messageText = isInviteeCurrentUser ? (
-      <>
-        You accepted <Mention name={parsedMessage.inviterName} />
-        {"'s"} invitation for{" "}
-        <TeamMentionById
-          teamId={parsedMessage.teamId}
-          name={parsedMessage.teamName}
-        />
-        . Welcome to the team!
-      </>
-    ) : isInviterCurrentUser ? (
-      <>
-        {userMentionOrYou(parsedMessage.inviteeId, parsedMessage.inviteeName, {
-          capitalized: true,
-        })}{" "}
-        accepted your invitation for{" "}
-        <TeamMentionById
-          teamId={parsedMessage.teamId}
-          name={parsedMessage.teamName}
-        />
-        . Welcome to the team!
-      </>
-    ) : (
-      <>
-        {userMentionOrYou(parsedMessage.inviteeId, parsedMessage.inviteeName, {
-          capitalized: true,
-        })}{" "}
-        accepted{" "}
-        {userMentionOrYou(parsedMessage.inviterId, parsedMessage.inviterName)}
-        {"'s"} invitation for{" "}
-        <TeamMentionById
-          teamId={parsedMessage.teamId}
-          name={parsedMessage.teamName}
-        />
-        . Welcome to the team!
-      </>
-    );
-
-    return (
-      <div className="flex flex-col items-center w-full my-4">
-        <div className="event-banner event-banner--success mb-3">
-          <span className="text-sm font-medium event-message-text">
-            {highlightEventContent(messageText)}
-            <PartyPopper size={16} className="event-inline-icon ml-1" />
           </span>
         </div>
 
@@ -3462,8 +3387,6 @@ const MessageDisplay = ({
     parsedMessage,
     isCurrentUser,
   ) => {
-    const team = parsedMessage.teamName;
-
     const messageText = isCurrentUser ? (
       parsedMessage.hasPersonalMessage ? (
         <>
@@ -3621,8 +3544,6 @@ const MessageDisplay = ({
     parsedMessage,
     isCurrentUser,
   ) => {
-    const team = parsedMessage.teamName;
-
     const messageText = isCurrentUser ? (
       parsedMessage.hasPersonalMessage ? (
         <>
@@ -3813,7 +3734,7 @@ const MessageDisplay = ({
   // =============================================================================
   // renderRoleChangedMessage - Dynamic theme based on new role
   // =============================================================================
-  const renderRoleChangedMessage = (message, parsedMessage, isCurrentUser) => {
+  const renderRoleChangedMessage = (message, parsedMessage) => {
     const isPromotion = parsedMessage.newRole === "admin";
     const newRole = parsedMessage.newRole;
 
@@ -4077,50 +3998,6 @@ const MessageDisplay = ({
             <UserMinus size={16} className="event-inline-icon mr-1" />
             {highlightEventContent(messageText)}
           </span>
-        </div>
-
-        <div className="text-xs text-base-content/50">
-          {formatLocalTime(message.createdAt)}
-        </div>
-      </div>
-    );
-  };
-
-  /**
-   * Render a team deleted message with special formatting (red/error theme)
-   * Shows in team chat with option to leave team
-   */
-  const renderTeamDeletedMessage = (message, parsedMessage, isCurrentUser) => {
-    let messageText;
-
-    if (isCurrentUser) {
-      messageText = `You initiated the deletion of the team "${parsedMessage.teamName}". The team is archived and inactive now. Remaining members are able to text in this chat until the last member leaves.`;
-    } else {
-      messageText = `${parsedMessage.ownerName} has initiated the deletion of the team "${parsedMessage.teamName}". The team is archived and inactive now. Remaining members are able to text in this chat until the last member leaves.`;
-    }
-
-    return (
-      <div className="flex flex-col items-center w-full my-4">
-        <div
-          className="flex flex-col items-center gap-3 px-5 py-4 rounded-2xl mb-3 max-w-md text-center"
-          style={{
-            backgroundColor: "rgba(239, 68, 68, 0.1)",
-            color: "#dc2626",
-          }}
-        >
-          <span className="text-sm font-medium event-message-text">
-            {highlightEventContent(messageText)}
-          </span>
-
-          {onLeaveTeam && (
-            <button
-              onClick={() => onLeaveTeam()}
-              className="flex items-center gap-1 text-xs underline hover:no-underline opacity-80 hover:opacity-100 transition-opacity cursor-pointer"
-            >
-              <LogOut size={14} />
-              Leave team and remove from chat list
-            </button>
-          )}
         </div>
 
         <div className="text-xs text-base-content/50">

--- a/src/components/common/LocationDistanceTagsRow.jsx
+++ b/src/components/common/LocationDistanceTagsRow.jsx
@@ -24,7 +24,7 @@ const MAX_LINES = 2;
  * then final state is committed once — no multi-render loop,
  * no CSS ellipsis, no visible flash.
  */
-const TruncatedList = ({ items, icon: Icon, compact = false }) => {
+const TruncatedList = ({ items, icon: LeadingIcon, compact = false }) => {
   const spanRef = useRef(null);
   const [displayText, setDisplayText] = useState(() => items.join(", "));
 
@@ -69,7 +69,10 @@ const TruncatedList = ({ items, icon: Icon, compact = false }) => {
     <div
       className={`flex items-start leading-[110%] text-base-content/70 ${compact ? "text-xs" : "text-sm"}`}
     >
-      <Icon size={compact ? 10 : 13} className="mr-1 flex-shrink-0 mt-0.5" />
+      {React.createElement(LeadingIcon, {
+        size: compact ? 10 : 13,
+        className: "mr-1 flex-shrink-0 mt-0.5",
+      })}
       <span ref={spanRef}>{displayText}</span>
     </div>
   );

--- a/src/components/common/SendMessageButton.jsx
+++ b/src/components/common/SendMessageButton.jsx
@@ -5,14 +5,12 @@ import { messageService } from "../../services/messageService";
 
 const SendMessageButton = ({
   recipientId,
-  recipientName,
   variant = "primary",
   size = "sm",
   className = "",
   children,
   type = "direct", // "direct" or "team"
   teamId = null,
-  teamName = null,
 }) => {
   const handleSendMessage = async () => {
     if (type === "team" && teamId) {

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -98,9 +98,13 @@ const buildNotificationTooltip = (count, types, teamCounts) => {
 
   return (
     <div className="flex flex-col gap-1">
-      {lines.map(({ Icon, label }, i) => (
+      {lines.map(({ Icon: NotificationIcon, label }, i) => (
         <div key={i} className="flex items-center gap-1.5">
-          <Icon size={11} strokeWidth={2.5} className="flex-shrink-0 opacity-70" />
+          {React.createElement(NotificationIcon, {
+            size: 11,
+            strokeWidth: 2.5,
+            className: "flex-shrink-0 opacity-70",
+          })}
           <span>{label}</span>
         </div>
       ))}

--- a/src/components/teams/CreateVacantRoleModal.jsx
+++ b/src/components/teams/CreateVacantRoleModal.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, useEffect } from "react";
-import { useAuth } from "../../contexts/AuthContext";
 import Modal from "../common/Modal";
 import Button from "../common/Button";
 import Alert from "../common/Alert";
@@ -22,7 +21,6 @@ import {
   Save,
   X,
 } from "lucide-react";
-import api from "../../services/api";
 
 /**
  * CreateVacantRoleModal Component
@@ -34,7 +32,6 @@ import api from "../../services/api";
  * @param {boolean} isOpen
  * @param {Function} onClose
  * @param {number} teamId
- * @param {Object|null} team - Team object (used for chat event message on creation)
  * @param {Object|null} existingRole - If provided, modal is in edit mode
  * @param {Function} onSuccess - Called after successful create/update
  */
@@ -42,12 +39,10 @@ const CreateVacantRoleModal = ({
   isOpen,
   onClose,
   teamId,
-  team = null,
   existingRole = null,
   onSuccess,
   onDelete,
 }) => {
-  const { user: currentUser } = useAuth();
   const SUCCESS_CLOSE_DELAY_MS = 3000;
   const isEditMode = !!existingRole;
 

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -7,7 +7,6 @@ import {
   UserSearch,
   EyeClosed,
   EyeIcon,
-  Tag,
   Award,
   User,
   Crown,
@@ -343,9 +342,6 @@ const TeamCard = ({
   activeFilters = {},
   showSearchResultTypeOverlay = false,
 
-  // Loading state
-  loading = false,
-
   autoOpenApplications = false,
   highlightApplicantId = null,
   highlightApplicationId = null,
@@ -630,7 +626,6 @@ const TeamCard = ({
   const [isApplicationsModalOpen, setIsApplicationsModalOpen] = useState(false);
   const [isInvitesModalOpen, setIsInvitesModalOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
-  const [responses, setResponses] = useState({});
   const [isInvitationDetailsModalOpen, setIsInvitationDetailsModalOpen] =
     useState(false);
   const [pendingInvitationForTeam, setPendingInvitationForTeam] =
@@ -1475,7 +1470,7 @@ const TeamCard = ({
     if (!date) return null;
     try {
       return format(new Date(date), "MM/dd/yy");
-    } catch (e) {
+    } catch {
       return null;
     }
   };
@@ -1490,7 +1485,7 @@ const TeamCard = ({
         new Date(normalizedData.date),
         "MMM d, yyyy",
       )}`;
-    } catch (e) {
+    } catch {
       return "You are invited to fill a role in this team";
     }
   };
@@ -1552,7 +1547,7 @@ const TeamCard = ({
           .map((tagStr) => {
             try {
               return JSON.parse(tagStr.trim());
-            } catch (e) {
+            } catch {
               return null;
             }
           })
@@ -1573,14 +1568,14 @@ const TeamCard = ({
         } else if (typeof teamData.tags === "string") {
           try {
             displayTags = JSON.parse(teamData.tags);
-          } catch (e) {
+          } catch {
             displayTags = teamData.tags
               .split(",")
               .map((name) => ({ name: name.trim() }));
           }
         }
       }
-    } catch (e) {
+    } catch {
       displayTags = [];
     }
     return displayTags.filter(
@@ -1653,12 +1648,6 @@ const TeamCard = ({
 
   // ============ Event Handlers ============
 
-  const handleUserClick = (userId) => {
-    if (userId) {
-      setSelectedUserId(userId);
-    }
-  };
-
   const openRoleDetails = (event) => {
     if (event) {
       event.stopPropagation();
@@ -1674,13 +1663,6 @@ const TeamCard = ({
     } else {
       setIsModalOpen(true);
     }
-  };
-
-  const handleResponseChange = (id, response) => {
-    setResponses((prev) => ({
-      ...prev,
-      [id]: response,
-    }));
   };
 
   const handleModalClose = async () => {
@@ -1828,12 +1810,6 @@ const TeamCard = ({
     }
   };
 
-  // Member variant handlers
-  const handleDeleteClick = async (e) => {
-    e.stopPropagation();
-    setIsDeleteDialogOpen(true);
-  };
-
   const closeDeleteTeamDialog = () => {
     if (isDeleting) return;
     setIsDeleteDialogOpen(false);
@@ -1858,12 +1834,6 @@ const TeamCard = ({
     if (onLeave) onLeave(teamId);
   };
 
-  // Application variant handlers
-  const handleCancelApplication = (e) => {
-    e?.stopPropagation();
-    setIsCancelApplicationDialogOpen(true);
-  };
-
   const closeCancelApplicationDialog = () => {
     if (actionLoading === "cancel") return;
     setIsCancelApplicationDialogOpen(false);
@@ -1885,115 +1855,7 @@ const TeamCard = ({
     }
   };
 
-  const handleSendReminder = async (e) => {
-    e.stopPropagation();
-    setActionLoading("reminder");
-    setReminderNotice(null);
-    try {
-      if (onSendReminder) {
-        await onSendReminder(normalizedData.id);
-      } else {
-        setReminderNotice("Reminder feature coming soon!");
-      }
-    } catch (err) {
-      console.error("Error sending reminder:", err);
-      setError("Failed to send reminder. Please try again.");
-    } finally {
-      setActionLoading(null);
-    }
-  };
-
-  // Invitation variant handlers
-  const handleAccept = async () => {
-    if (!onAccept) return;
-    try {
-      setActionLoading("accept");
-      const invitationId = invitation?.id;
-      const responseMessage = responses[invitationId] || "";
-      await onAccept(invitationId, responseMessage, false);
-      // Clear the response after successful action
-      setResponses((prev) => {
-        const newResponses = { ...prev };
-        delete newResponses[invitationId];
-        return newResponses;
-      });
-    } catch (error) {
-      console.error("Error accepting invitation:", error);
-    } finally {
-      setActionLoading(null);
-    }
-  };
-
-  const handleDecline = async () => {
-    if (!onDecline) return;
-    try {
-      setActionLoading("decline");
-      const invitationId = invitation?.id;
-      const responseMessage = responses[invitationId] || "";
-      await onDecline(invitationId, responseMessage);
-      // Clear the response after successful action
-      setResponses((prev) => {
-        const newResponses = { ...prev };
-        delete newResponses[invitationId];
-        return newResponses;
-      });
-    } catch (error) {
-      console.error("Error declining invitation:", error);
-    } finally {
-      setActionLoading(null);
-    }
-  };
-
   // ============ Render Helpers ============
-
-  const renderBadges = () => {
-    const formattedDate = getFormattedDate();
-    const displayTags = getDisplayTags();
-    const isPublic = teamData.is_public === true || teamData.isPublic === true;
-
-    return (
-      <div className="flex flex-wrap items-center gap-2 mb-4">
-        {/* Tags display (member / invitation / application) */}
-        {(
-          effectiveVariant === "member" ||
-          effectiveVariant === "invitation" ||
-          effectiveVariant === "application" ||
-          effectiveVariant === "role_application" ||
-          effectiveVariant === "role_invitation"
-        ) &&
-          displayTags.length > 0 && (
-            <div className="flex items-start text-sm text-base-content/70">
-              <Tag size={16} className="mr-1 flex-shrink-0 mt-0.5" />
-              <span>
-                {(() => {
-                  const maxVisible = 5;
-                  const visibleTags = displayTags.slice(0, maxVisible);
-                  const remainingCount = displayTags.length - maxVisible;
-
-                  return (
-                    <>
-                      {visibleTags.map((tag, index) => {
-                        const tagName =
-                          typeof tag === "string"
-                            ? tag
-                            : tag.name || tag.tag || "";
-                        return (
-                          <span key={index}>
-                            {index > 0 ? ", " : ""}
-                            {tagName}
-                          </span>
-                        );
-                      })}
-                      {remainingCount > 0 && ` +${remainingCount}`}
-                    </>
-                  );
-                })()}
-              </span>
-            </div>
-          )}
-      </div>
-    );
-  };
 
   const renderActionButtons = () => {
     // If user has a pending invitation (search or invitation variant)

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -12,7 +12,6 @@ import TeamRoleManager from "./TeamRoleManager";
 import TeamEditForm from "./TeamEditForm";
 import { useAuth } from "../../contexts/AuthContext";
 import { teamService } from "../../services/teamService";
-import { userService } from "../../services/userService";
 import Button from "../common/Button";
 import SendMessageButton from "../common/SendMessageButton";
 import ScreenAlert from "../common/ScreenAlert";
@@ -60,7 +59,6 @@ import TeamInvitationDetailsModal from "./TeamInvitationDetailsModal";
 import TeamMembersSection from "./TeamMembersSection";
 import TeamFocusAreaSection from "./TeamFocusAreaSection";
 import VacantRolesSection from "./VacantRolesSection";
-import axios from "axios";
 import Modal from "../common/Modal";
 import ConfirmModal from "../common/ConfirmModal";
 import LocationSection from "../common/LocationSection";
@@ -189,7 +187,6 @@ const TeamDetailsModal = ({
   const [distanceViewerUser, setDistanceViewerUser] = useState(null);
 
   const [teamBadges, setTeamBadges] = useState(null);
-  const [teamBadgesTotalCredits, setTeamBadgesTotalCredits] = useState(0);
   const [currentUserBadgeNames, setCurrentUserBadgeNames] = useState(null); // Set<string>
 
   const fetchTeamTagAwards = useCallback(
@@ -299,7 +296,7 @@ const TeamDetailsModal = ({
   const handledMembersRefreshKeyRef = useRef(0);
 
   const fetchTeamDetails = useCallback(
-    async (forceRefresh = false) => {
+    async () => {
       if (!effectiveTeamId) return null;
 
       // If we already have data and don't need a refresh, skip the loading state
@@ -603,14 +600,6 @@ const TeamDetailsModal = ({
   // Use internal role state, fall back to prop
   const effectiveUserRole = internalUserRole || userRole;
 
-  // Use independent isOwner state for more reliability
-  const isTeamOwner = useMemo(() => isOwner, [isOwner]);
-
-  const isTeamAdmin = useMemo(
-    () => effectiveUserRole === "admin",
-    [effectiveUserRole],
-  );
-
   const canEditTeam = useMemo(() => {
     if (!isAuthenticated || !user || !team) {
       return false;
@@ -752,54 +741,6 @@ const TeamDetailsModal = ({
     }, 300);
   }, [onClose, navigate, urlTeamId]);
 
-  const handleChange = (e) => {
-    const { name, value, type, checked } = e.target;
-
-    // Special handling for isPublic to ensure it's always a boolean
-    if (name === "isPublic") {
-      setFormData((prev) => ({
-        ...prev,
-        isPublic: checked, // Explicitly use the checked property
-      }));
-      return;
-    }
-
-    // Handle other form fields normally
-    const newValue = type === "checkbox" ? checked : value;
-
-    // Clear error for this field when user starts typing
-    if (formErrors[name]) {
-      setFormErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[name];
-        return newErrors;
-      });
-    }
-
-    setFormData((prev) => ({
-      ...prev,
-      [name]:
-        name === "maxMembers"
-          ? newValue === null
-            ? null
-            : parseInt(newValue, 10)
-          : newValue,
-    }));
-  };
-
-  const handleTagSelection = useCallback((selected) => {
-    userHasEditedTagsRef.current = true; // mark as intentional user edit
-    const ids = (selected ?? [])
-      .map((t) => (typeof t === "object" ? (t.id ?? t.value ?? t) : t))
-      .map((x) => Number(x))
-      .filter((x) => Number.isFinite(x));
-
-    setFormData((prev) => ({
-      ...prev,
-      selectedTags: Array.from(new Set(ids)),
-    }));
-  }, []);
-
   useEffect(() => {
     if (!isEditing) return;
     const ids = normalizeTeamTagIds(team);
@@ -822,13 +763,6 @@ const TeamDetailsModal = ({
     if (teamMemberBadges !== undefined) {
       if (Array.isArray(teamMemberBadges)) {
         setTeamBadges(teamMemberBadges);
-        setTeamBadgesTotalCredits(
-          teamMemberBadges.reduce(
-            (sum, badge) =>
-              sum + Number(badge?.totalCredits ?? badge?.total_credits ?? 0),
-            0,
-          ),
-        );
       }
       return;
     }
@@ -838,7 +772,6 @@ const TeamDetailsModal = ({
         const response = await teamService.getTeamMemberBadges(effectiveTeamId);
         const badges = response?.data || [];
         setTeamBadges(badges);
-        setTeamBadgesTotalCredits(response?.meta?.totalCredits || 0);
       } catch (error) {
         console.warn("Could not fetch team member badges:", error);
         setTeamBadges([]);
@@ -913,30 +846,6 @@ const TeamDetailsModal = ({
       console.error("Error fetching tags:", structuredTagsError);
     }
   }, [structuredTagsError]);
-
-  // Handle team tags update
-  const handleTeamTagsUpdate = async (newTagIds) => {
-    try {
-      // Normalize tag IDs to numbers and format for the API
-      const tagsPayload = newTagIds
-        .map((tagId) => Number(tagId))
-        .filter((id) => !Number.isNaN(id))
-        .map((tag_id) => ({ tag_id }));
-
-      await teamService.updateTeam(effectiveTeamId, { tags: tagsPayload });
-
-      // Refresh team details to show updated tags
-      await fetchTeamDetails();
-
-      setNotification({
-        type: "success",
-        message: "Focus areas updated successfully!",
-      });
-    } catch (error) {
-      console.error("Error updating team tags:", error);
-      throw new Error("Failed to update team focus areas");
-    }
-  };
 
   const handleLeaveTeam = async () => {
     if (!user?.id || !team?.id) return;
@@ -1172,10 +1081,7 @@ const TeamDetailsModal = ({
         .filter((id) => Number.isFinite(id) && id > 0)
         .map((tag_id) => ({ tag_id }));
 
-      const response = await teamService.updateTeam(
-        effectiveTeamId,
-        submissionData,
-      );
+      await teamService.updateTeam(effectiveTeamId, submissionData);
 
       // Update our local state with the new visibility value
       setIsPublic(isPublicBoolean);

--- a/src/components/teams/TeamEditForm.jsx
+++ b/src/components/teams/TeamEditForm.jsx
@@ -47,10 +47,9 @@ const TeamEditForm = ({
   onCancel,
   onDelete,
   loading = false,
-  isOwner = false,
   onAvatarDeleted,
 }) => {
-  const [uploadingImage, setUploadingImage] = useState(false);
+  const [uploadingImage] = useState(false);
   const [avatarDeleteLoading, setAvatarDeleteLoading] = useState(false);
   const [isAvatarDeleteDialogOpen, setIsAvatarDeleteDialogOpen] =
     useState(false);
@@ -566,7 +565,7 @@ const TeamEditForm = ({
           </label>
           <TagInput
             // Pass objects so TagInput can render names for preselected tags
-            selectedTags={formData.selectedTags ?? []}
+            selectedTags={selectedFocusAreaTags}
             onTagsChange={handleTagSelection}
             placeholder={UI_TEXT.focusAreas.searchPlaceholder}
             showPopularTags={true}

--- a/src/components/teams/TeamRoleManager.jsx
+++ b/src/components/teams/TeamRoleManager.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useAuth } from "../../contexts/AuthContext";
 import { teamService } from "../../services/teamService";
 import Button from "../common/Button";

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -442,8 +442,6 @@ const VacantRoleCard = ({
   // Handle both camelCase (from API response interceptor) and snake_case
   const role_name = role.roleName ?? role.role_name;
   const role_bio = role.bio ?? role.roleBio ?? role.role_bio ?? "";
-  const city = role.city;
-  const country = role.country;
   const max_distance_km = role.maxDistanceKm ?? role.max_distance_km;
   const is_remote = role.isRemote ?? role.is_remote;
   const status = role.status;

--- a/src/components/teams/VacantRoleDetailsModal.jsx
+++ b/src/components/teams/VacantRoleDetailsModal.jsx
@@ -306,7 +306,6 @@ const VacantRoleDetailsModal = ({
   onViewApplicationDetails = null,
   hideActions = false,
   onEdit = null,
-  onDelete = null,
   onStatusChange = null,
 }) => {
   const { user: currentUser, isAuthenticated } = useAuth();
@@ -387,16 +386,6 @@ const VacantRoleDetailsModal = ({
     return map;
   }, [roleTeamMembers]);
   const canViewTeamMemberMatches = canManage || viewerIsTeamMember;
-  const teamMemberIdsKey = JSON.stringify(
-    [
-      ...new Set(
-        teamMembers
-          .map((member) => member?.userId ?? member?.user_id ?? null)
-          .filter((id) => id != null)
-          .map(String),
-      ),
-    ],
-  );
   useEffect(() => {
     const fetchFullRole = async () => {
       if (!isOpen || !roleId || !teamId) return;
@@ -1186,15 +1175,11 @@ const VacantRoleDetailsModal = ({
   const roleName =
     displayRole.roleName ?? displayRole.role_name ?? "Vacant Role";
   const bio = displayRole.bio ?? "";
-  const city = displayRole.city;
-  const country = displayRole.country;
-  const state = displayRole.state;
   const _postalCode = displayRole.postalCode ?? displayRole.postal_code;
   const maxDistanceKm =
     displayRole.maxDistanceKm ?? displayRole.max_distance_km;
   const isRemote = displayRole.isRemote ?? displayRole.is_remote;
   const createdAt = displayRole.createdAt ?? displayRole.created_at;
-  const updatedAt = displayRole.updatedAt ?? displayRole.updated_at;
   const tags =
     displayRole.tags?.length > 0
       ? displayRole.tags
@@ -1406,11 +1391,6 @@ const VacantRoleDetailsModal = ({
     : filledRoleUser
     ? formatDisplayName(filledRoleUser)
     : filledRoleDisplayName;
-  const filledAt =
-    displayRole.filledAt ??
-    displayRole.filled_at ??
-    updatedAt ??
-    createdAt;
   const serverRoleMatchScore =
     shouldShowRoleMatchScore
       ? matchScore ??

--- a/src/components/users/UserDetailsModal.jsx
+++ b/src/components/users/UserDetailsModal.jsx
@@ -9,7 +9,6 @@ import BadgesDisplaySection from "../badges/BadgesDisplaySection";
 import BadgeCategoryModal from "../badges/BadgeCategoryModal";
 import TagAwardsModal from "../badges/TagAwardsModal";
 import UserProfileHeaderSection from "./UserProfileHeaderSection";
-import { messageService } from "../../services/messageService";
 import { geocodingService } from "../../services/geocodingService";
 import { userService } from "../../services/userService";
 import { teamService } from "../../services/teamService";

--- a/src/pages/BadgeOverview.jsx
+++ b/src/pages/BadgeOverview.jsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import PageContainer from '../components/layout/PageContainer';
 import BadgeCategorySection from '../components/badges/BadgeCategorySection';
 import Alert from '../components/common/Alert';
-import api from '../services/api';
 
 const BadgeOverview = () => {
   const [badgeCategories, setBadgeCategories] = useState({});

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1791,7 +1791,7 @@ const Chat = () => {
               }, 3000);
             }
           }
-        } catch (messagesError) {
+        } catch {
           setHasMoreMessages(false);
           setMessages([]);
         }
@@ -2675,7 +2675,7 @@ const Chat = () => {
     }
   };
 
-  const handleSendImage = async (file, previewUrl) => {
+  const handleSendImage = async (file) => {
     if (!canSendInActiveConversation || !file) {
       if (!isCurrentUserActiveTeamMember) {
         setError("You no longer have access to this team chat.");
@@ -3017,7 +3017,7 @@ const Chat = () => {
   // Get active typing users for current conversation
   const activeTypingUsers = Object.entries(typingUsers)
     .filter(([userId, username]) => userId !== user?.id && username)
-    .map(([_, username]) => username);
+    .map(([, username]) => username);
 
   const pendingChatActionType = pendingChatAction?.type;
   const pendingChatActionConfig = {

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -97,9 +97,16 @@ const getFileExtension = (fileName = "") => {
   return match ? match[0] : "";
 };
 
+const isUnsafeFileNameCharacter = (char) => {
+  const code = char.charCodeAt(0);
+  return code <= 31 || code === 127 || char === "/" || char === "\\";
+};
+
 const getAttachmentDisplayName = (fileName = "") => {
   const sanitizedName = fileName
-    .replace(/[\u0000-\u001f\u007f/\\]/g, "")
+    .split("")
+    .filter((char) => !isUnsafeFileNameCharacter(char))
+    .join("")
     .trim();
 
   if (!sanitizedName) {
@@ -118,7 +125,7 @@ const hasUnsafeFileName = (fileName = "") => {
     !trimmedFileName ||
     fileName.length > 120 ||
     trimmedFileName.startsWith(".") ||
-    /[\u0000-\u001f\u007f/\\]/.test(fileName)
+    [...fileName].some(isUnsafeFileNameCharacter)
   );
 };
 

--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -361,7 +361,7 @@ const MyTeams = () => {
   };
 
   // Handler for when user LEAVES a team (not deletes it)
-  const handleTeamLeave = (teamId) => {
+  const handleTeamLeave = () => {
     // Refetch to update pagination correctly
     fetchUserTeams(currentPage, resultsPerPage);
   };
@@ -376,7 +376,7 @@ const MyTeams = () => {
     }
   };
 
-  const handleSendReminder = async (applicationId) => {
+  const handleSendReminder = async () => {
     showToast("Reminder feature coming soon!", "violet");
   };
 
@@ -423,7 +423,7 @@ const MyTeams = () => {
   };
 
   // Handler for when a new team is created
-  const handleTeamCreated = (newTeam) => {
+  const handleTeamCreated = () => {
     // Refresh the teams list
     fetchUserTeams(1, resultsPerPage);
     setCurrentPage(1);

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import FormSectionDivider from "../components/common/FormSectionDivider";
 import { useAuth } from "../contexts/AuthContext";
 import PageContainer from "../components/layout/PageContainer";
@@ -44,7 +44,6 @@ import BadgeCategoryModal from "../components/badges/BadgeCategoryModal";
 import TagsDisplaySection from "../components/tags/TagsDisplaySection";
 import TagAwardsModal from "../components/badges/TagAwardsModal";
 import LocationDisplay from "../components/common/LocationDisplay";
-import { geocodingService } from "../services/geocodingService";
 import { useLocationAutoFill } from "../hooks/useLocationAutoFill";
 import ImageUploader from "../components/common/ImageUploader";
 import {
@@ -66,7 +65,7 @@ import { format } from "date-fns";
 const EMPTY_QUERY_ARRAY = [];
 
 const Profile = () => {
-  const { user, updateUser, logout } = useAuth();
+  const { user, updateUser } = useAuth();
   const queryClient = useQueryClient();
   const [localUser, setLocalUser] = useState(null);
   const [registrationMessage, setRegistrationMessage] = useState("");
@@ -80,7 +79,6 @@ const Profile = () => {
   const [success, setSuccess] = useState(null);
   const [imagePreview, setImagePreview] = useState(null);
   const [imageError, setImageError] = useState(false);
-  const navigate = useNavigate();
   const { openUserModal } = useUserModal();
   const { data: structuredTags, error: structuredTagsError } =
     useStructuredTags();
@@ -122,8 +120,6 @@ const Profile = () => {
     useState(false);
   const [badgeActionLoadingKey, setBadgeActionLoadingKey] = useState(null);
   const [pendingBadgeAction, setPendingBadgeAction] = useState(null);
-  const [selectedUserId, setSelectedUserId] = useState(null);
-
   // Add form errors state
   const [formErrors, setFormErrors] = useState({});
   const [formData, setFormData] = useState({
@@ -756,31 +752,6 @@ const Profile = () => {
     }
   };
 
-  const handleTagsUpdate = async (newTags) => {
-    if (!user) return;
-
-    try {
-      setLoading(true);
-      setError(null);
-
-      // Use the newTags parameter instead of selectedTags
-      await userService.updateUserTags(user.id, newTags);
-
-      // Update Profile's state with the new tags
-      setSelectedTags(newTags);
-      queryClient.invalidateQueries({
-        queryKey: userTagsQueryKey(user.id),
-      });
-
-      setSuccess("Tags updated successfully");
-    } catch (error) {
-      console.error("Error updating user tags:", error);
-      setError("Failed to update tags. Please try again.");
-    } finally {
-      setLoading(false);
-    }
-  };
-
   // Add form validation function
   const validateForm = () => {
     const errors = {};
@@ -939,25 +910,6 @@ const Profile = () => {
     } finally {
       setLoading(false);
     }
-  };
-
-  // For debugging purposes
-  const displayUserData = () => {
-    if (!user) return "No user data available";
-
-    return (
-      <pre className="text-xs overflow-auto p-2 bg-gray-100 rounded">
-        {JSON.stringify(user, null, 2)}
-      </pre>
-    );
-  };
-
-  const displayFormData = () => {
-    return (
-      <pre className="text-xs overflow-auto p-2 bg-gray-100 rounded">
-        {JSON.stringify(formData, null, 2)}
-      </pre>
-    );
   };
 
   if (!displayUser) {

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useRef } from "react";
-import { useSearchParams, Link, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useSearchParams, Link } from "react-router-dom";
 import api from "../services/api";
 import Card from "../components/common/Card";
 import Button from "../components/common/Button";
@@ -15,7 +15,6 @@ import {
 
 const ResetPassword = () => {
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
   const [status, setStatus] = useState("idle"); // idle, submitting, success, error
   const [message, setMessage] = useState("");
   const [formData, setFormData] = useState({

--- a/src/utils/locationUtils.js
+++ b/src/utils/locationUtils.js
@@ -68,7 +68,6 @@ export const COUNTRY_NAMES = {
   AR: "Argentina",
   CL: "Chile",
   PE: "Peru",
-  CO: "Colombia",
   VE: "Venezuela",
   UA: "Ukraine",
   TR: "Turkey",


### PR DESCRIPTION
## Summary

- Fixes all blocking frontend ESLint errors so `npm run lint` exits successfully again.
- Removes unused imports, props, state, handlers, and stale render helpers across profile, team, chat, role, and form components.
- Replaces the contact attachment control-character regex with an explicit filename character check.
- Uses normalized focus-area tag objects in the team edit form so preselected tags render with names.
- Removes a duplicate `CO` country-code mapping.

## Verification

- `npm run lint` passes with 0 errors.
  - Existing warnings remain, mostly React Hook dependency and Fast Refresh structure warnings.
- `npm run build` passes.
  - Vite still reports existing chunk-size/dynamic-import warnings.
- Manual smoke tests passed:
  - login
  - profile editing
  - contact form
  - My Teams and team details/edit modals
  - team requests
  - vacant roles
  - chat
  - user details modal
  - search
  - badge overview