### PR TITLE
Verified email-change flow for logged-in users

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Contact the project owner for a demo login, or register a new account with a val
 - **Demo Data Indicators** — Synthetic/seed data is visually labeled with FlaskConical icons and "DEMO" avatar overlays so users can distinguish test content from real data
 - **Contact Page** — Email contact form with optional multipart file attachments (up to 3 files, 5 MB each, 10 MB total — JPG, PNG, WebP, PDF, TXT, CSV); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; privacy disclosure with `/privacy` link at submission; abuse/content reports show a persistent reference ID after submit
 - **Authentication UX** — Login and forgot-password flows use shared floating screen alerts for submit-level errors such as rate limits, while field validation remains inline; registration surfaces backend validation details and username availability-check rate limits instead of generic "Invalid input data" errors
-- **Security & Privacy** — the session is held in a backend-set `httpOnly` cookie rather than `localStorage`, so the auth token is never readable by JavaScript (XSS-resistant); requests and the realtime socket send it automatically via credentialed requests, and auth state is restored on load from `GET /api/auth/me`; Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; new accounts remain private after email verification until users change visibility in settings; users can manage a blocklist from Settings, with blocked relationships mutually anonymized across profiles, teams, roles, badge awards, invitations, and inline profile links; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; username availability feedback during registration is rate-limited while email availability is not exposed; separate age-16 confirmation checkbox at registration; timestamps and document versions stored for accepted Terms of Service, acknowledged Privacy Policy, and age confirmation; unverified accounts are automatically deleted after 24 hours
+- **Security & Privacy** — the session is held in a backend-set `httpOnly` cookie rather than `localStorage`, so the auth token is never readable by JavaScript (XSS-resistant); requests and the realtime socket send it automatically via credentialed requests, and auth state is restored on load from `GET /api/auth/me`; Cloudflare Turnstile CAPTCHA on registration and contact form (feature-flagged), enforced password policy (min 8 chars, letter + number), self-service password reset from the login form; changing your account email requires confirming the new address via a verification link before it takes effect — the current email stays active until then; new accounts remain private after email verification until users change visibility in settings; users can manage a blocklist from Settings, with blocked relationships mutually anonymized across profiles, teams, roles, badge awards, invitations, and inline profile links; search results use approximate coordinates (~11km precision) so exact user locations are never exposed to the frontend; username availability feedback during registration is rate-limited while email availability is not exposed; separate age-16 confirmation checkbox at registration; timestamps and document versions stored for accepted Terms of Service, acknowledged Privacy Policy, and age confirmation; unverified accounts are automatically deleted after 24 hours
 
 ---
 
@@ -150,10 +150,11 @@ Lomir-frontend/
 │   │   ├── Login.jsx
 │   │   ├── Chat.jsx                # Direct + team messaging with file sharing; filters blocked users
 │   │   ├── BadgeOverview.jsx       # Badge catalog and details
-│   │   ├── Settings.jsx            # Visibility, blocklist, password/email changes + account deletion modal
+│   │   ├── Settings.jsx            # Visibility, blocklist, password/email changes (email change sends a verification link) + account deletion modal
 │   │   ├── ForgotPassword.jsx
 │   │   ├── ResetPassword.jsx
 │   │   ├── VerifyEmail.jsx
+│   │   ├── VerifyEmailChange.jsx   # Confirms email-change links for logged-in users (verifying/success/error states)
 │   │   ├── Contact.jsx             # Contact form with file attachments, report reference display,
 │   │   │                           #   privacy notice, and in-app chat routing
 │   │   ├── LegalPlaceholderPage.jsx # Shared page for /about, /terms, /privacy, /legal-notice — full legal documents (no longer placeholders)
@@ -207,7 +208,7 @@ Lomir-frontend/
 │   │   │                           #   preserves FormData requests so multipart boundaries are set by
 │   │   │                           #   the browser; call sites can opt out via skipRequestCaseTransform /
 │   │   │                           #   skipResponseCaseTransform for explicit per-call data contracts
-│   │   ├── userService.js          # Profile, avatar, blocklist, and account deletion endpoints
+│   │   ├── userService.js          # Profile, avatar, blocklist, account deletion, and email-change verification endpoints
 │   │   ├── teamService.js
 │   │   ├── searchService.js
 │   │   ├── matchingService.js
@@ -288,6 +289,7 @@ Lomir-frontend/
 | `/login` | Login | Sign in, register redirect, and forgot-password entry point |
 | `/register` | Register | Multi-step registration with legal consent, private-by-default visibility copy, username availability helper, and optional Turnstile |
 | `/verify-email` | Verify Email | Confirms new-account email verification links before login |
+| `/verify-email-change` | Verify Email Change | Confirms an email-change link for a logged-in user and updates the account email |
 | `/forgot-password` | Forgot Password | Request a password reset email |
 | `/reset-password` | Reset Password | Set a new password from a reset email link |
 | `/search` | Search | Find teams, users, and roles; Boolean search input; shared result-view toggle; advanced filtering by tags, badges, distance |
@@ -296,7 +298,7 @@ Lomir-frontend/
 | `/profile/:id` | Public Profile | View any user's profile; shows "private" message for non-public profiles; placeholder for deleted users |
 | `/chat` | Chat | Direct messages and team group chat with file/image sharing, @mentions, and reply threading |
 | `/badges` | Badges | Browse all 30 badges across 5 categories |
-| `/settings` | Settings | Change profile visibility, manage blocked users, update password/email, and delete account |
+| `/settings` | Settings | Change profile visibility, manage blocked users, update password, request a verified email change, and delete account |
 | `/contact` | Contact | Email form with file attachments and privacy notice; abuse/content reports show a reference ID; authenticated users with a contact user ID configured are routed to in-app chat |
 | `/about` | About | Project description, status, and contact information |
 | `/terms` | Terms | Full Terms of Service (14 sections, German law) |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import Register from "./pages/Register";
 import Profile from "./pages/Profile";
 import PublicProfile from "./pages/PublicProfile";
 import VerifyEmail from "./pages/VerifyEmail";
+import VerifyEmailChange from "./pages/VerifyEmailChange";
 import BadgeOverview from "./pages/BadgeOverview";
 import MyTeams from "./pages/MyTeams";
 import SearchPage from "./pages/SearchPage";
@@ -42,6 +43,7 @@ function AppLayout() {
     "/forgot-password",
     "/reset-password",
     "/verify-email",
+    "/verify-email-change",
   ].includes(location.pathname);
 
   return (
@@ -68,6 +70,10 @@ function AppLayout() {
                 <Route path="/login" element={<Login />} />
                 <Route path="/register" element={<Register />} />
                 <Route path="/verify-email" element={<VerifyEmail />} />
+                <Route
+                  path="/verify-email-change"
+                  element={<VerifyEmailChange />}
+                />
                 <Route path="/badges" element={<BadgeOverview />} />
                 <Route path="/contact" element={<Contact />} />
                 <Route path="/about" element={<LegalPlaceholderPage type="about" />} />

--- a/src/components/users/BlocklistSection.jsx
+++ b/src/components/users/BlocklistSection.jsx
@@ -81,7 +81,7 @@ const BlocklistSection = ({ userId, onChange }) => {
   };
 
   return (
-    <div>
+    <div className="!mt-[25px]">
       <ScreenAlert
         type={notification.type}
         message={notification.message}
@@ -91,10 +91,14 @@ const BlocklistSection = ({ userId, onChange }) => {
       {/* Section Header */}
       <div className="flex items-center mb-4">
         <Ban size={18} className="mr-2 text-primary flex-shrink-0" />
-        <h3 className="label-text">
-          Blocked Users
-          {!loading && <span className="label-text ml-1">({blocked.length})</span>}
-        </h3>
+        <label className="label">
+          <span className="label-text">
+            Blocked Users
+            {!loading && (
+              <span className="label-text ml-1">({blocked.length})</span>
+            )}
+          </span>
+        </label>
       </div>
 
       {loading ? (

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -763,13 +763,6 @@ const Profile = () => {
       errors.username = "Use 3–20 chars: letters, numbers, underscore";
     }
 
-    // Email validation
-    if (!formData.email.trim()) {
-      errors.email = "Email is required";
-    } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
-      errors.email = "Email is invalid";
-    }
-
     // First name validation (optional)
     if (!formData.firstName.trim()) {
       errors.firstName = "First name is required";
@@ -798,7 +791,6 @@ const Profile = () => {
         firstName: formData.firstName,
         lastName: formData.lastName,
         username: formData.username.trim(),
-        email: formData.email,
         bio: formData.bio,
         postalCode: formData.postalCode,
         city: formData.city,
@@ -861,7 +853,6 @@ const Profile = () => {
           firstName: formData.firstName,
           lastName: formData.lastName,
           username: formData.username.trim(),
-          email: formData.email, // Include email in the updated user object
           bio: formData.bio,
           city: formData.city,
           country: formData.country,

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -382,11 +382,7 @@ const Settings = () => {
     `input input-bordered w-full ${hasError ? "input-error" : ""}`;
 
   const FieldError = ({ msg }) =>
-    msg ? (
-      <label className="label">
-        <span className="label-text-alt text-error">{msg}</span>
-      </label>
-    ) : null;
+    msg ? <p className="text-xs text-error mt-2 px-1">{msg}</p> : null;
 
   const resetDeleteState = () => {
     setDeletionStep(DELETE_STEP_PASSWORD);

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -210,6 +210,7 @@ const normalizeTransferOptions = (members, currentUserId) =>
 const Settings = () => {
   const { user, updateUser, logout, refreshBlocks } = useAuth();
   const navigate = useNavigate();
+  const pendingEmail = user?.pendingEmail || user?.pending_email || null;
 
   const [success, setSuccess] = useState(null);
   const [error, setError] = useState(null);
@@ -265,16 +266,30 @@ const Settings = () => {
     setEmailLoading(true);
 
     try {
-      await userService.changeEmail(
+      const response = await userService.changeEmail(
         emailData.newEmail,
         emailData.currentPasswordForEmail,
       );
-      updateUser({ email: emailData.newEmail });
-      setSuccess("Email address updated successfully");
+      const nextPendingEmail =
+        response?.data?.pendingEmail || emailData.newEmail;
+
+      updateUser({ pendingEmail: nextPendingEmail });
+      setSuccess(
+        `Verification email sent to ${nextPendingEmail}. Your current email stays active until you confirm the new address.`,
+      );
       setEmailData({ newEmail: "", currentPasswordForEmail: "" });
       setShowEmailForm(false);
     } catch (err) {
-      setError(err.response?.data?.message || "Failed to update email");
+      if (err.response?.status === 401) {
+        setEmailErrors((prev) => ({
+          ...prev,
+          currentPasswordForEmail:
+            err.response?.data?.message || "Current password is incorrect",
+        }));
+        return;
+      }
+
+      setError(err.response?.data?.message || "Failed to send verification email");
     } finally {
       setEmailLoading(false);
     }
@@ -334,6 +349,15 @@ const Settings = () => {
       });
       setShowPasswordForm(false);
     } catch (err) {
+      if (err.response?.status === 401) {
+        setPasswordErrors((prev) => ({
+          ...prev,
+          currentPassword:
+            err.response?.data?.message || "Current password is incorrect",
+        }));
+        return;
+      }
+
       setError(err.response?.data?.message || "Failed to change password");
     } finally {
       setPasswordLoading(false);
@@ -714,6 +738,12 @@ const Settings = () => {
                   {showEmailForm ? "Cancel" : "Change"}
                 </button>
               </div>
+              {pendingEmail && (
+                <p className="mt-2 text-sm text-info">
+                  Pending change to {pendingEmail}. Check that inbox to confirm
+                  the new address.
+                </p>
+              )}
             </div>
 
             {/* Change email form */}
@@ -781,7 +811,7 @@ const Settings = () => {
                     {emailLoading ? (
                       <span className="loading loading-spinner loading-xs" />
                     ) : (
-                      "Update Email"
+                      "Send Verification Email"
                     )}
                   </Button>
                 </div>

--- a/src/pages/VerifyEmailChange.jsx
+++ b/src/pages/VerifyEmailChange.jsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { BadgeCheck, Info, Loader2, MailCheck, XCircle } from "lucide-react";
+import Card from "../components/common/Card";
+import Button from "../components/common/Button";
+import { useAuth } from "../contexts/AuthContext";
+import userService from "../services/userService";
+
+const VerifyEmailChange = () => {
+  const [searchParams] = useSearchParams();
+  const { user, updateUser } = useAuth();
+  const [status, setStatus] = useState("verifying");
+  const [message, setMessage] = useState("");
+  const verifiedOnce = useRef(false);
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (verifiedOnce.current) return;
+
+    if (!token) {
+      setStatus("error");
+      setMessage("No verification token found. Please check your email link.");
+      return;
+    }
+
+    verifiedOnce.current = true;
+
+    const verifyEmailChange = async () => {
+      try {
+        const response = await userService.verifyEmailChange(token);
+        const verifiedUser = response?.data?.user;
+
+        if (user && verifiedUser?.email) {
+          updateUser({
+            email: verifiedUser.email,
+            pendingEmail: null,
+          });
+        }
+
+        setStatus("success");
+        setMessage("Your email address has been changed successfully.");
+      } catch (error) {
+        console.error("Email change verification error:", error);
+
+        if (error.response?.status === 409) {
+          setStatus("info");
+          setMessage(
+            error.response?.data?.message ||
+              "This email address is already in use.",
+          );
+          return;
+        }
+
+        setStatus("error");
+        setMessage(
+          error.response?.data?.message ||
+            "Verification failed. The link may be invalid or expired.",
+        );
+      }
+    };
+
+    verifyEmailChange();
+  }, [searchParams, updateUser, user]);
+
+  const renderIcon = () => {
+    const base = "mx-auto mb-4";
+    const size = 56;
+
+    if (status === "verifying")
+      return (
+        <Loader2 size={size} className={`${base} text-primary animate-spin`} />
+      );
+    if (status === "success")
+      return <BadgeCheck size={size} className={`${base} text-success`} />;
+    if (status === "info")
+      return <Info size={size} className={`${base} text-info`} />;
+    return <XCircle size={size} className={`${base} text-error`} />;
+  };
+
+  const renderTitle = () => {
+    if (status === "verifying") return "Verifying your new email…";
+    if (status === "success") return "Email changed";
+    if (status === "info") return "Email not changed";
+    return "Verification failed";
+  };
+
+  const renderBodyText = () => {
+    if (status === "verifying") return "Please wait a moment.";
+    if (status === "success")
+      return "Your Lomir account now uses the confirmed email address.";
+    return message;
+  };
+
+  const primaryLink = user ? "/settings" : "/login";
+  const primaryLabel = user ? "Back to Settings" : "Log in";
+
+  return (
+    <div className="max-w-md mx-auto mt-12">
+      <Card className="w-full">
+        <div className="card-body text-center py-10 px-8">
+          {renderIcon()}
+
+          <h2 className="card-title text-2xl font-bold justify-center mb-3">
+            {renderTitle()}
+          </h2>
+
+          <p className="text-base-content/70 mb-8">{renderBodyText()}</p>
+
+          {status !== "verifying" && (
+            <Link to={primaryLink} className="w-full">
+              <Button variant="primary" fullWidth>
+                {primaryLabel}
+              </Button>
+            </Link>
+          )}
+
+          {status === "verifying" && (
+            <div className="mt-2 text-sm text-base-content/60 flex items-center justify-center gap-2">
+              <MailCheck size={16} className="text-primary" />
+              <span>Checking your verification link…</span>
+            </div>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default VerifyEmailChange;

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -206,12 +206,28 @@ export const userService = {
 
   changePassword: (currentPassword, newPassword) =>
     call("changing password", () =>
-      api.put("/api/auth/change-password", { currentPassword, newPassword }),
+      api.put(
+        "/api/auth/change-password",
+        { currentPassword, newPassword },
+        { skipAuthRedirect: true },
+      ),
     ),
 
   changeEmail: (newEmail, currentPassword) =>
     call("changing email", () =>
-      api.put("/api/auth/change-email", { newEmail, currentPassword }),
+      api.put(
+        "/api/auth/change-email",
+        { newEmail, currentPassword },
+        { skipAuthRedirect: true },
+      ),
+    ),
+
+  verifyEmailChange: (token) =>
+    call("verifying email change", () =>
+      api.get("/api/auth/verify-email-change", {
+        params: { token },
+        skipAuthRedirect: true,
+      }),
     ),
 };
 


### PR DESCRIPTION
Summary
Changing your account email now requires confirming ownership of the new address via a verification link before it takes effect. The current email stays active until the new one is confirmed, preventing account lockout from typos and unauthorized email takeover. Also includes a few related Settings UI fixes.

What changed
New verified email-change flow

Added [VerifyEmailChange.jsx](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/pages/VerifyEmailChange.jsx) — a landing page that reads the token from the URL and confirms the change, with distinct verifying / success / info (email already in use, 409) / error states.
Registered the public /verify-email-change route in [App.jsx](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/App.jsx) (added to the no-navbar/public route list).
[Settings.jsx](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/pages/Settings.jsx): the email form now sends a verification email instead of updating the address immediately. Shows a confirmation message, a persistent "pending change to …" banner, and relabels the button to "Send Verification Email."
[userService.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/services/userService.js): added verifyEmailChange(); both changeEmail and changePassword now pass skipAuthRedirect: true so a wrong-password 401 surfaces inline instead of forcing a logout/redirect.
Related cleanups

[Profile.jsx](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/pages/Profile.jsx): removed inline email editing/validation — email is now changed only through the verified Settings flow.
[Settings.jsx](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/pages/Settings.jsx): 401 errors on email/password changes now render as inline field errors ("Current password is incorrect") rather than a top-level alert; field-error text aligned to the registration form's smaller text-xs size.
Settings UI polish

[BlocklistSection.jsx](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/components/users/BlocklistSection.jsx): "Blocked Users" header now matches the "Profile Visibility" label styling (wrapped in .label for the muted grey), and added top spacing above the section.
Testing
Request an email change → verify the confirmation email is sent and the pending banner appears.
Open the verification link → confirm the account email updates and the banner clears.
Reuse an already-taken email link → confirm the "email already in use" info state.
Enter a wrong current password on email/password change → confirm the inline field error appears and no logout occurs.