### PR TITLE
security + legal: CSP/HSTS headers, tighten .env gitignore, rename LegalPage + refresh legal text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ dist/
 
 # Environment variables
 .env
+.env.*
+!.env.example
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Lomir-frontend/
 │   │   ├── VerifyEmailChange.jsx   # Confirms email-change links for logged-in users (verifying/success/error states)
 │   │   ├── Contact.jsx             # Contact form with file attachments, report reference display,
 │   │   │                           #   privacy notice, and in-app chat routing
-│   │   ├── LegalPlaceholderPage.jsx # Shared page for /about, /terms, /privacy, /legal-notice — full legal documents (no longer placeholders)
+│   │   ├── LegalPage.jsx            # Shared page for /about, /terms, /privacy, /legal-notice
 │   │   └── DesignSystem.jsx        # Dev-only component playground
 │   ├── components/
 │   │   ├── BooleanSearchInput.jsx  # Textarea-based Boolean search input with operator helpers

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,7 +32,7 @@ import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import Settings from "./pages/Settings";
 import Contact from "./pages/Contact";
-import LegalPlaceholderPage from "./pages/LegalPlaceholderPage";
+import LegalPage from "./pages/LegalPage";
 
 function AppLayout() {
   const location = useLocation();
@@ -76,12 +76,12 @@ function AppLayout() {
                 />
                 <Route path="/badges" element={<BadgeOverview />} />
                 <Route path="/contact" element={<Contact />} />
-                <Route path="/about" element={<LegalPlaceholderPage type="about" />} />
-                <Route path="/terms" element={<LegalPlaceholderPage type="terms" />} />
-                <Route path="/privacy" element={<LegalPlaceholderPage type="privacy" />} />
+                <Route path="/about" element={<LegalPage type="about" />} />
+                <Route path="/terms" element={<LegalPage type="terms" />} />
+                <Route path="/privacy" element={<LegalPage type="privacy" />} />
                 <Route
                   path="/legal-notice"
-                  element={<LegalPlaceholderPage type="legalNotice" />}
+                  element={<LegalPage type="legalNotice" />}
                 />
                 <Route
                   path="/garden"

--- a/src/constants/privacyText.js
+++ b/src/constants/privacyText.js
@@ -17,7 +17,7 @@ export const CHAT_UPLOAD_NOTICE =
   "Files and images shared in chat are visible to conversation participants. Please do not upload sensitive or confidential information.";
 
 export const BROWSER_STORAGE_NOTICE =
-  "Lomir uses browser storage such as localStorage and sessionStorage for technically necessary functions, including keeping users signed in and managing in-app notifications. We do not currently use advertising cookies, marketing trackers, or third-party analytics tools.";
+  "Lomir uses a technically necessary httpOnly session cookie to keep users signed in. Browser storage such as sessionStorage or short-lived localStorage messages is used only for necessary UI state, for example in-app notification checks or registration success messages. We do not currently use advertising cookies, marketing trackers, or third-party analytics tools.";
 
 export const LEGAL_PLACEHOLDER_NOTICE =
   "Lomir is currently being prepared for public use. Please do not enter sensitive personal information until the final legal documents are available.";

--- a/src/pages/LegalPage.jsx
+++ b/src/pages/LegalPage.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import Card from "../components/common/Card";
 
 const CONTACT_EMAIL = "lomirapp@gmail.com";
-const LAST_UPDATED = "June 15, 2026";
+const LAST_UPDATED = "June 18, 2026";
 const LEGAL_NOTICE_UPDATED = "June 16, 2026";
 const PRIVACY_UPDATED = "June 18, 2026";
 
@@ -96,7 +96,7 @@ const pageContent = {
           "Uploads: profile avatars, team avatars, chat images, chat files, and contact form attachments.",
           "Location data: postal code, city, district, state, country, and coordinates resolved from the location data a user provides. Lomir does not ask for a street address. Postal code and other location details are used as approximate location information for search, distance-based matching, recommendations, and profile/team/role location display. Depending on visibility settings and feature context, postal code, city, district, state, or country may be visible to other users. Public search and map results expose rounded approximate coordinates, not exact stored coordinates.",
           "Contact and report data: name, email address, topic, message, optional contact form attachments, report reference IDs, report status, email-forwarding status, and attachment metadata for abuse or illegal-content reports.",
-          "Security and technical data: IP-related request data handled by hosting providers, browser and device metadata in server logs, rate-limit data, CAPTCHA verification data where enabled, JWT authentication tokens, and browser storage needed for the app to work.",
+          "Security and technical data: IP-related request data handled by hosting providers, browser and device metadata in server logs, rate-limit data, CAPTCHA verification data where enabled, session and authentication data, and browser storage needed for the app to work.",
         ],
       },
       {
@@ -162,7 +162,7 @@ const pageContent = {
       {
         title: "12. Browser Storage, Cookies, and Similar Technologies",
         paragraphs: [
-          "Lomir uses a technically necessary, httpOnly session cookie to keep you signed in after login. This cookie holds your authentication token, is not readable by JavaScript, and is sent only to the Lomir backend to authenticate your requests and real-time chat connection. Lomir also uses technically necessary browser storage such as sessionStorage, for example for in-app notification state.",
+          "Lomir uses a technically necessary, httpOnly session cookie to keep you signed in after login. This cookie contains session authentication data, is not readable by JavaScript, and is sent to the Lomir backend to authenticate your requests and real-time chat connection. Lomir also uses technically necessary browser storage such as sessionStorage, for example for in-app notification state.",
           "This cookie and storage are strictly necessary to provide authentication, API access, real-time chat, and notification features, and therefore do not require consent under Section 25(2) TDDDG. Lomir does not currently use advertising cookies, marketing trackers, or third-party analytics tools.",
           "Where Cloudflare Turnstile is enabled for registration or the contact form, Cloudflare may process technical data to verify that a request is made by a human. This is used for abuse prevention.",
         ],
@@ -174,7 +174,7 @@ const pageContent = {
           "Render hosts the backend API. Render may process IP addresses, browser and device data, API request metadata, server logs, error information, and data transmitted to or from the backend.",
           "Neon, now part of Databricks, provides the PostgreSQL database. App data stored in the database may include account data, profile data, team and role data, messages, notifications, legal acknowledgement records, location data, and related metadata.",
           "ImageKit stores, transforms, optimizes, and delivers uploaded media and files, including profile avatars, team avatars, chat images, chat files, and related delivery logs or metadata.",
-          "Gmail/Google SMTP is used through Nodemailer to send account verification emails, password reset emails, account-change notifications, contact form messages, and abuse or illegal-content report emails. Google may process email addresses, email content, email metadata, contact form attachments, and report-related content as part of email delivery and mailbox operation.",
+          "Gmail/Google SMTP is used to send account verification emails, password reset emails, account-change notifications, contact form messages, and abuse or illegal-content report emails. Google may process email addresses, email content, email metadata, contact form attachments, and report-related content as part of email delivery and mailbox operation.",
           "Cloudflare Turnstile may be used for CAPTCHA checks on registration and contact forms. Cloudflare may process technical data such as IP address, browser and device information, challenge data, and verification tokens to detect abuse and confirm that a request is likely made by a human.",
           "OpenStreetMap/Nominatim is used to resolve user-provided location information such as postal code, city, district, state, or country. OpenStreetMap map tiles may be loaded when the map view is opened. OpenStreetMap-related services may receive location queries, IP addresses, browser and device data, and request metadata.",
         ],
@@ -260,7 +260,7 @@ const pageContent = {
         title: "4. Account Rules",
         items: [
           "Do not create accounts for someone else without permission.",
-          "Do not share your password or authentication token.",
+          "Do not share your password, login links, verification codes, or other account credentials.",
           "Do not use Lomir to harass, deceive, spam, threaten, or unlawfully discriminate against others.",
           "Do not upload malware, illegal content, confidential third-party information, or content that infringes intellectual property rights.",
           "Do not attempt to bypass security, scrape private data, or access accounts, teams, messages, or API endpoints without authorization.",

--- a/src/pages/LegalPage.jsx
+++ b/src/pages/LegalPage.jsx
@@ -5,7 +5,7 @@ import Card from "../components/common/Card";
 const CONTACT_EMAIL = "lomirapp@gmail.com";
 const LAST_UPDATED = "June 15, 2026";
 const LEGAL_NOTICE_UPDATED = "June 16, 2026";
-const PRIVACY_UPDATED = "June 16, 2026";
+const PRIVACY_UPDATED = "June 18, 2026";
 
 const mailLink = (
   <a href={`mailto:${CONTACT_EMAIL}`} className="link link-primary">
@@ -174,7 +174,7 @@ const pageContent = {
           "Render hosts the backend API. Render may process IP addresses, browser and device data, API request metadata, server logs, error information, and data transmitted to or from the backend.",
           "Neon, now part of Databricks, provides the PostgreSQL database. App data stored in the database may include account data, profile data, team and role data, messages, notifications, legal acknowledgement records, location data, and related metadata.",
           "ImageKit stores, transforms, optimizes, and delivers uploaded media and files, including profile avatars, team avatars, chat images, chat files, and related delivery logs or metadata.",
-          "Gmail/Google SMTP is used through Nodemailer to send account verification emails, password reset emails, and contact form messages. Google may process email addresses, email content, email metadata, and contact form attachments as part of email delivery and mailbox operation.",
+          "Gmail/Google SMTP is used through Nodemailer to send account verification emails, password reset emails, account-change notifications, contact form messages, and abuse or illegal-content report emails. Google may process email addresses, email content, email metadata, contact form attachments, and report-related content as part of email delivery and mailbox operation.",
           "Cloudflare Turnstile may be used for CAPTCHA checks on registration and contact forms. Cloudflare may process technical data such as IP address, browser and device information, challenge data, and verification tokens to detect abuse and confirm that a request is likely made by a human.",
           "OpenStreetMap/Nominatim is used to resolve user-provided location information such as postal code, city, district, state, or country. OpenStreetMap map tiles may be loaded when the map view is opened. OpenStreetMap-related services may receive location queries, IP addresses, browser and device data, and request metadata.",
         ],
@@ -427,7 +427,7 @@ const LegalSection = ({ section }) => (
   </section>
 );
 
-const LegalPlaceholderPage = ({ type }) => {
+const LegalPage = ({ type }) => {
   const content = pageContent[type] ?? pageContent.about;
 
   return (
@@ -457,4 +457,4 @@ const LegalPlaceholderPage = ({ type }) => {
   );
 };
 
-export default LegalPlaceholderPage;
+export default LegalPage;

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
         {
           "key": "Strict-Transport-Security",
           "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://lomir-backend-knae.onrender.com wss://lomir-backend-knae.onrender.com https://upload.imagekit.io https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; form-action 'self'; upgrade-insecure-requests"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,16 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## What
Frontend security hardening + public legal-page cleanup (no functional UI change):

**Security headers (`vercel.json`)**
- **HSTS** (`Strict-Transport-Security`; max-age 2y, includeSubDomains, preload).
- **Content-Security-Policy** as defense-in-depth (XSS / unwanted third-party
  loads). Allows Lomir's own assets, Cloudflare Turnstile, the Render API +
  Socket.IO endpoint, ImageKit uploads, and HTTPS images/media for existing
  avatars/badges.

**Repo hygiene**
- `.gitignore`: ignore `.env.*` (keep `!.env.example`) so prod/dev env files
  can't be accidentally tracked.

**Public legal pages**
- Rename `LegalPlaceholderPage.jsx` → `LegalPage.jsx` (+ `App.jsx` / README refs).
- Clarify public legal wording; privacy text updated (Gmail/Google SMTP scope
  incl. account-change & abuse-report mails; login held via **httpOnly session
  cookie**, not localStorage). `PRIVACY_UPDATED = "June 18, 2026"`.

## Why
- HSTS/CSP raise the frontend's baseline security posture (defense-in-depth).
- `.gitignore` previously ignored only `.env`, not `.env.*` — now closed.
- The legal page is the real page (no longer a "placeholder"); text kept accurate
  to the current implementation.

## Verification
- `npm run build` green (known bundle-size warnings only); ESLint: no errors.
- ⚠️ **CSP/HSTS from `vercel.json` do NOT apply locally (Vite)** — verify on a
  Vercel **Preview/Production** deploy:
  - `curl -sI <url> | grep -iE 'strict-transport|content-security-policy'`
  - UI smoke: login/session, chat (API + Socket.IO), Turnstile, ImageKit
    upload/media, map view.

## Scope
Headers config + repo hygiene + public legal text/rename. No app logic or
dependency changes.