### PR TITLE
refactor: code-split VacantRoleDetailsModal behind a lazy wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Lomir-frontend/
 │   │   ├── auth/                   # LoginForm, RegisterForm
 │   │   ├── teams/                  # TeamCard, TeamDetailsModal, TeamAvatar, TeamEditForm,
 │   │   │                           #   TeamFocusAreaSection, TeamMembersSection, TeamRoleManager,
-│   │   │                           #   VacantRoleCard, VacantRoleDetailsModal, VacantRolesSection,
+│   │   │                           #   VacantRoleCard, VacantRoleDetailsModal (lazy-loaded via VacantRoleDetailsModalLazy), VacantRolesSection,
 │   │   │                           #   CreateTeamModal, CreateVacantRoleModal, RoleBadgeDropdown,
 │   │   │                           #   TeamApplicationButton, TeamApplicationModal,
 │   │   │                           #   TeamApplicationsModal, TeamApplicationDetailsModal,

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -33,7 +33,7 @@ import {
   CheckCheck,
 } from "lucide-react";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
-import VacantRoleDetailsModal from "../teams/VacantRoleDetailsModal";
+import VacantRoleDetailsModal from "../teams/VacantRoleDetailsModalLazy";
 import UserDetailsModal from "../users/UserDetailsModal";
 import UserAvatar from "../users/UserAvatar";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -31,7 +31,7 @@ import {
   X,
 } from "lucide-react";
 import { format } from "date-fns";
-import VacantRoleDetailsModal from "../teams/VacantRoleDetailsModal";
+import VacantRoleDetailsModal from "../teams/VacantRoleDetailsModalLazy";
 import TeamApplicationDetailsModal from "../teams/TeamApplicationDetailsModal";
 import TeamInvitationDetailsModal from "../teams/TeamInvitationDetailsModal";
 import { useTeamModalSafe } from "../../contexts/TeamModalContext";

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -23,7 +23,7 @@ import {
 import TeamDetailsModal from "./TeamDetailsModal";
 import UserDetailsModal from "../users/UserDetailsModal";
 import TeamApplicationDetailsModal from "./TeamApplicationDetailsModal";
-import VacantRoleDetailsModal from "./VacantRoleDetailsModal";
+import VacantRoleDetailsModal from "./VacantRoleDetailsModalLazy";
 import TeamInvitesModal from "./TeamInvitesModal";
 import TeamInvitationDetailsModal from "./TeamInvitationDetailsModal";
 import { teamService } from "../../services/teamService";

--- a/src/components/teams/TeamInviteModal.jsx
+++ b/src/components/teams/TeamInviteModal.jsx
@@ -28,7 +28,7 @@ import UserDetailsModal from "../users/UserDetailsModal";
 import TeamDetailsModal from "../teams/TeamDetailsModal";
 import TeamInvitesModal from "../teams/TeamInvitesModal";
 import TeamApplicationsModal from "../teams/TeamApplicationsModal";
-import VacantRoleDetailsModal from "./VacantRoleDetailsModal";
+import VacantRoleDetailsModal from "./VacantRoleDetailsModalLazy";
 import {
   DEMO_PROFILE_TOOLTIP,
   DEMO_ROLE_TOOLTIP,

--- a/src/components/teams/VacantRoleCard.jsx
+++ b/src/components/teams/VacantRoleCard.jsx
@@ -22,7 +22,7 @@ import {
   TrendingDown,
   FlaskConical,
 } from "lucide-react";
-import VacantRoleDetailsModal from "./VacantRoleDetailsModal";
+import VacantRoleDetailsModal from "./VacantRoleDetailsModalLazy";
 import Card from "../common/Card";
 import RoleBadgePill from "../common/RoleBadgePill";
 import CardMetaItem from "../common/CardMetaItem";

--- a/src/components/teams/VacantRoleDetailsModalLazy.jsx
+++ b/src/components/teams/VacantRoleDetailsModalLazy.jsx
@@ -1,0 +1,20 @@
+import { lazy, Suspense } from "react";
+
+/**
+ * Lazy boundary for VacantRoleDetailsModal.
+ *
+ * VacantRoleDetailsModal is a large (~3.3k line) modal. Importing it through
+ * this wrapper keeps it out of the main bundle: it is dynamically imported and
+ * code-split into its own chunk, fetched only when a role-details modal is
+ * actually rendered. Call sites import this module instead of the modal
+ * directly and use the exact same props, so no JSX changes are needed.
+ */
+const VacantRoleDetailsModal = lazy(() => import("./VacantRoleDetailsModal"));
+
+const VacantRoleDetailsModalLazy = (props) => (
+  <Suspense fallback={null}>
+    <VacantRoleDetailsModal {...props} />
+  </Suspense>
+);
+
+export default VacantRoleDetailsModalLazy;


### PR DESCRIPTION
Code-splits the large VacantRoleDetailsModal (~3.3k lines) out of the main bundle. No behavior or feature change.

**Problem**
VacantRoleDetailsModal was statically imported by five components and lazily by one (TeamApplicationModal). The mix defeated the lazy import — Vite warned the module "will not move module into another chunk" — so the modal stayed in the main bundle.

**Change**

Add a thin VacantRoleDetailsModalLazy.jsx wrapper that dynamically imports the modal once behind a Suspense fallback={null} boundary.
Point the five static importers (MessageDisplay, SearchMapView, TeamCard, TeamInviteModal, VacantRoleCard) at the wrapper — one import line each, JSX and props unchanged.
TeamApplicationModal already loads it lazily and is left as-is. The modal file is now imported only dynamically, so it splits into its own chunk.

**Result**

New chunk VacantRoleDetailsModal-*.js — 54.7 kB / 13.3 kB gzip.
Main index.js bundle: 1,785 → 1,730 kB raw / 503.8 → 493.0 kB gzip (≈ −10.8 kB gzip on initial load); the modal chunk is fetched only when a role-details modal is opened.
Vite mixed-import warning gone.

**Verification**

ESLint clean (0 errors; only pre-existing exhaustive-deps/fast-refresh warnings in the touched files); production build green.
Local UI smoke across the modal entry points (cards, search map, chat, invite/apply): modal opens and closes normally; DevTools shows the chunk fetched once on first open.

**Docs**

README project structure notes the modal is lazy-loaded via the wrapper.