### PR TITLE
chore: allow the 00-Repos dir in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,9 @@
       "/Users/juliabaur/Library/CloudStorage/OneDrive-Persönlich/Dokumente/00 Beruf & Bewerbung/01 Lernen/Programmieren/WBS Coding School/02 Projects/01-final-project/00-Repos/Lomir-backend/src/routes",
       "/Users/juliabaur/Library/CloudStorage/OneDrive-Persönlich/Dokumente/00 Beruf & Bewerbung/01 Lernen/Programmieren/WBS Coding School/02 Projects/01-final-project/00-Repos/Lomir-backend/src/database/migrations",
       "/Users/juliabaur/Library/CloudStorage/OneDrive-Persönlich/Dokumente/00 Beruf & Bewerbung/01 Lernen/Programmieren/WBS Coding School/02 Projects/01-final-project/00-Repos/Lomir-backend/src/middlewares",
-      "/Users/juliabaur/Library/CloudStorage/OneDrive-Persönlich/Dokumente/00 Beruf & Bewerbung/01 Lernen/Programmieren/WBS Coding School/02 Projects/01-final-project/00-Repos/Lomir-backend/src"
+      "/Users/juliabaur/Library/CloudStorage/OneDrive-Persönlich/Dokumente/00 Beruf & Bewerbung/01 Lernen/Programmieren/WBS Coding School/02 Projects/01-final-project/00-Repos/Lomir-backend/src",
+      "/Users/juliabaur/Library/CloudStorage/OneDrive-Persönlich/Dokumente/00 Beruf & Bewerbung/01 Lernen/Programmieren/WBS Coding School/02 Projects/01-final-project/00-Repos",
+      "/Users/juliabaur/Library/CloudStorage/OneDrive-Persönlich/Dokumente/00 Beruf & Bewerbung/01 Lernen/Programmieren/WBS Coding School/02 Projects"
     ]
   }
 }


### PR DESCRIPTION
Add the 00-Repos folder to additionalDirectories in .claude/settings.json so the internal docs/handovers (now consolidated under 00-Repos/lomir-docs-internal/) can be read and edited from the frontend workspace.