### PR TITLE
fix(auth): serve API same-origin via Vercel proxy to fix mobile login

### DIFF
--- a/src/config/imagekit.js
+++ b/src/config/imagekit.js
@@ -1,6 +1,10 @@
 // Centralized ImageKit configuration for Lomir
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5001";
+// Same-origin in production (Vercel rewrites /api/* to the backend); direct to
+// the dev server locally. Keeps the auth call first-party (relative authEndpoint).
+const API_URL = import.meta.env.PROD
+  ? ""
+  : import.meta.env.VITE_API_URL || "http://localhost:5001";
 
 export const IMAGEKIT_CONFIG = {
   publicKey: import.meta.env.VITE_IMAGEKIT_PUBLIC_KEY,

--- a/src/pages/LegalPage.jsx
+++ b/src/pages/LegalPage.jsx
@@ -5,7 +5,7 @@ import Card from "../components/common/Card";
 const CONTACT_EMAIL = "lomirapp@gmail.com";
 const LAST_UPDATED = "June 18, 2026";
 const LEGAL_NOTICE_UPDATED = "June 16, 2026";
-const PRIVACY_UPDATED = "June 18, 2026";
+const PRIVACY_UPDATED = "June 19, 2026";
 
 const mailLink = (
   <a href={`mailto:${CONTACT_EMAIL}`} className="link link-primary">
@@ -170,7 +170,7 @@ const pageContent = {
       {
         title: "13. Third-Party Services",
         items: [
-          "Vercel hosts and delivers the frontend. Vercel may process IP addresses, browser and device data, request metadata, deployment data, and technical logs needed to deliver and secure the frontend.",
+          "Vercel hosts and delivers the frontend and routes the app's API and real-time requests to the backend (so that the frontend and backend share one address). Vercel may therefore process IP addresses, browser and device data, request and API metadata, session authentication data in transit, deployment data, and technical logs needed to deliver, route, and secure the app.",
           "Render hosts the backend API. Render may process IP addresses, browser and device data, API request metadata, server logs, error information, and data transmitted to or from the backend.",
           "Neon, now part of Databricks, provides the PostgreSQL database. App data stored in the database may include account data, profile data, team and role data, messages, notifications, legal acknowledgement records, location data, and related metadata.",
           "ImageKit stores, transforms, optimizes, and delivers uploaded media and files, including profile avatars, team avatars, chat images, chat files, and related delivery logs or metadata.",

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,14 @@
 import axios from "axios";
 import { snakeToCamel, camelToSnake } from "../utils/formatters";
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5001";
+// In production the frontend and backend are served same-origin: REST calls go
+// to /api/* on the Vercel deployment, which rewrites them to the Render backend
+// (see vercel.json). A relative baseURL keeps the session cookie first-party, so
+// mobile browsers with strict tracking protection don't drop it. Locally we hit
+// the backend dev server directly.
+const API_URL = import.meta.env.PROD
+  ? ""
+  : import.meta.env.VITE_API_URL || "http://localhost:5001";
 
 const api = axios.create({
   baseURL: API_URL,

--- a/src/services/socketService.js
+++ b/src/services/socketService.js
@@ -24,8 +24,15 @@ const socketService = {
       socket = null;
     }
 
-    const SOCKET_URL =
-      import.meta.env.VITE_SOCKET_URL || "http://localhost:5001";
+    // In production connect same-origin (undefined → the page origin), so the
+    // Socket.IO traffic is proxied through the Vercel rewrite and the handshake
+    // cookie stays first-party. Note: Vercel (Hobby) does not proxy the
+    // WebSocket upgrade, so Socket.IO runs over HTTP long-polling there; a
+    // future shared-domain setup restores the native WebSocket transport.
+    // Locally, connect to the backend dev server directly.
+    const SOCKET_URL = import.meta.env.PROD
+      ? undefined
+      : import.meta.env.VITE_SOCKET_URL || "http://localhost:5001";
 
     // The backend authenticates the handshake from the httpOnly session
     // cookie; withCredentials makes the browser send it with the connection.

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,14 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
+      "source": "/api/(.*)",
+      "destination": "https://lomir-backend-knae.onrender.com/api/$1"
+    },
+    {
+      "source": "/socket.io/(.*)",
+      "destination": "https://lomir-backend-knae.onrender.com/socket.io/$1"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }
@@ -16,7 +24,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://lomir-backend-knae.onrender.com wss://lomir-backend-knae.onrender.com https://upload.imagekit.io https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://upload.imagekit.io https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; form-action 'self'; upgrade-insecure-requests"
         }
       ]
     }


### PR DESCRIPTION
Mobile browsers with strict tracking protection (e.g. Firefox / Total Cookie Protection) dropped the cross-site session cookie (vercel.app frontend ↔ onrender.com backend), so after login the profile flashed and then bounced back to /login (the cookie-dependent /api/auth/me + authed calls 401'd).

Route API and real-time traffic through Vercel so the app is single-origin and the session cookie stays first-party:
- vercel.json: rewrite /api/* and /socket.io/* to the Render backend (before the SPA catch-all); tighten CSP connect-src to 'self'
- api.js / imagekit.js: relative API base in production
- socketService.js: connect Socket.IO same-origin in production (Vercel Hobby doesn't proxy the WS upgrade -> long-polling there)
- LegalPage.jsx: privacy §13 updated for Vercel's API-routing role; bump PRIVACY_UPDATED

Note: the proxy only takes effect on a Vercel build, not locally.