### PR TITLE
 fix: silence expected 404s for missing teams/roles/conversations/users

### DIFF
--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -20,6 +20,7 @@ import { messageService } from "../services/messageService";
 import socketService from "../services/socketService";
 import useSocketEvents from "../hooks/useSocketEvents";
 import { userService } from "../services/userService";
+import { isQuietError } from "../services/api";
 import { teamService } from "../services/teamService";
 import ScreenAlert from "../components/common/ScreenAlert";
 import Button from "../components/common/Button";
@@ -1427,9 +1428,13 @@ const Chat = () => {
 
             if (type === "direct") {
               try {
-                // Get the user details for the virtual conversation
-                const userResponse =
-                  await userService.getUserById(conversationId);
+                // Get the user details for the virtual conversation. A 404
+                // (no such user — e.g. a stale link or deleted account) is an
+                // expected, gracefully-handled case, not console noise.
+                const userResponse = await userService.getUserById(
+                  conversationId,
+                  { quietErrorStatuses: [404] },
+                );
 
                 const userData = userResponse.data;
 
@@ -1457,7 +1462,9 @@ const Chat = () => {
                 // Add to the beginning of the conversations list
                 conversationsList = [virtualConversation, ...conversationsList];
               } catch (error) {
-                console.error("Error creating virtual conversation:", error);
+                if (!isQuietError(error)) {
+                  console.error("Error creating virtual conversation:", error);
+                }
               }
             }
           }
@@ -1609,7 +1616,12 @@ const Chat = () => {
               });
             } else {
               try {
-                const userResponse = await userService.getUserById(conversationId);
+                // A 404 (no such user — stale link or deleted account) is an
+                // expected, gracefully-handled case, not console noise.
+                const userResponse = await userService.getUserById(
+                  conversationId,
+                  { quietErrorStatuses: [404] },
+                );
                 const userData = userResponse.data;
                 setActiveConversation({
                   id: parseInt(conversationId),
@@ -1626,7 +1638,12 @@ const Chat = () => {
                   isVirtual: true,
                 });
               } catch (userError) {
-                console.error("Failed to load partner for new conversation:", userError);
+                if (!isQuietError(userError)) {
+                  console.error(
+                    "Failed to load partner for new conversation:",
+                    userError,
+                  );
+                }
               }
             }
           }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -38,6 +38,20 @@ api.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+/**
+ * Whether an error response should be kept out of the console. True when the
+ * caller opted out entirely (`skipErrorLog`) or the status is an expected,
+ * already-handled one declared via `quietErrorStatuses` (e.g. a 404 for a
+ * resource that may have been deleted — graceful UX, not red console noise).
+ * The error still propagates; this only governs logging.
+ */
+export const isQuietError = (error) => {
+  if (error?.config?.skipErrorLog === true) return true;
+  const quiet = error?.config?.quietErrorStatuses;
+  const status = error?.response?.status;
+  return Array.isArray(quiet) && status != null && quiet.includes(status);
+};
+
 // Add response interceptor to convert response data to camelCase
 api.interceptors.response.use(
   (response) => {
@@ -49,9 +63,8 @@ api.interceptors.response.use(
   (error) => {
     if (error.response) {
       const skipAuthRedirect = error.config?.skipAuthRedirect === true;
-      const skipErrorLog = error.config?.skipErrorLog === true;
 
-      if (!skipErrorLog) {
+      if (!isQuietError(error)) {
         console.error("API Error:", error.response.data);
       }
 
@@ -87,7 +100,9 @@ export const call = async (label, requestFn) => {
     const response = await requestFn();
     return response.data;
   } catch (error) {
-    console.error(`Error ${label}:`, error);
+    if (!isQuietError(error)) {
+      console.error(`Error ${label}:`, error);
+    }
     throw error;
   }
 };

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -313,6 +313,9 @@ export const messageService = {
     call(`fetching conversation ${conversationId}`, () =>
       api.get(`/api/messages/conversations/${conversationId}?type=${type}`, {
         skipResponseCaseTransform: true,
+        // A 404 ("not found or access denied") is expected for a deleted or
+        // inaccessible conversation — handled by the caller, not console noise.
+        quietErrorStatuses: [404],
       }),
     ).then(normalizeConversationPayload),
 

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -1,4 +1,4 @@
-import api, { call } from "./api";
+import api, { call, isQuietError } from "./api";
 
 export const teamService = {
   // Create a new team — keeps explicit try/catch for the extra response-data
@@ -134,7 +134,12 @@ export const teamService = {
     };
 
     try {
-      const response = await api.get(`/api/teams/${teamId}`);
+      // A 404 here is expected when the team was deleted or is private/hidden
+      // (the backend returns 404, not 403, to avoid leaking existence) —
+      // callers handle it gracefully, so keep it out of the console.
+      const response = await api.get(`/api/teams/${teamId}`, {
+        quietErrorStatuses: [404],
+      });
 
       const teamData = response.data?.data || response.data;
       if (!Array.isArray(teamData.members)) teamData.members = [];
@@ -151,7 +156,9 @@ export const teamService = {
 
       return response.data;
     } catch (error) {
-      console.error(`Error fetching team ${teamId}:`, error);
+      if (!isQuietError(error)) {
+        console.error(`Error fetching team ${teamId}:`, error);
+      }
       throw error;
     }
   },

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -28,12 +28,17 @@ export const userService = {
   /**
    * Fetches user details by their ID.
    * @param {string|number} userId - The ID of the user to fetch.
+   * @param {object} [options]
+   * @param {number[]} [options.quietErrorStatuses] - Status codes to keep out
+   *   of the console (e.g. `[404]` when a missing user is an expected,
+   *   gracefully-handled case rather than an error worth logging).
    * @returns {Promise<object>} A promise resolving to the user data.
    */
-  getUserById: (userId) =>
+  getUserById: (userId, { quietErrorStatuses } = {}) =>
     call(`fetching user details for ID ${userId}`, () =>
       api.get(`/api/users/${userId}`, {
         skipResponseCaseTransform: true,
+        quietErrorStatuses,
       }),
     ).then(normalizeUserPayload),
 

--- a/src/services/vacantRoleService.js
+++ b/src/services/vacantRoleService.js
@@ -25,8 +25,11 @@ export const vacantRoleService = {
    * @param {number} roleId
    */
   async getVacantRoleById(teamId, roleId) {
+    // A 404 here is expected when the role was filled/closed/deleted — callers
+    // handle it gracefully, so keep it out of the console.
     const response = await api.get(
       `/api/teams/${teamId}/vacant-roles/${roleId}`,
+      { quietErrorStatuses: [404] },
     );
     return response.data;
   },


### PR DESCRIPTION
## What & why

Fetching a team, vacant role, conversation, or user that has been deleted or
is inaccessible returns a 404. These are expected, gracefully-handled cases —
callers already degrade fine — but they spilled red errors into the console
(`API Error:`, `Error fetching team …`, `Failed to load partner …`), which was
just noise.

## Changes

- **`api.js`**: new `isQuietError(error)` helper + a `quietErrorStatuses` request
  flag (alongside the existing `skipErrorLog` / `skipAuthRedirect`). The response
  interceptor and the `call()` helper skip logging when the status is declared
  quiet. Control flow is unchanged — the error still propagates.
- Opted the expected-404 fetches into `quietErrorStatuses: [404]`:
  - `vacantRoleService.getVacantRoleById`
  - `teamService.getTeamById`
  - `messageService.getConversationById`
  - `userService.getUserById` (opt-in param, default unchanged — used by the
    Chat virtual-conversation path)
- **`Chat.jsx`**: both virtual-direct-conversation partner lookups pass `[404]`
  and guard their catch logs via `isQuietError`.

Non-404 errors (e.g. 500) are still logged. No behavior/UX change beyond the
removed console noise.

## Testing

- ESLint clean, Vite build green.
- Verified live: opening `/chat/<nonexistent-id>` previously logged several red
  errors; the console is now quiet, UI behavior unchanged.