### PR TITLE
perf(teamcard): render open roles from embedded payload, drop per-card fetch

### DIFF
--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -710,7 +710,17 @@ const TeamCard = ({
     }
 
     const localSnapshot = resolveTeamOpenRoleSnapshot(teamData);
-    if (localSnapshot.source !== "aggregate") {
+    // Render straight from the embedded payload: the team-list endpoints
+    // (getUserTeams + search) embed both the open-role count and the names. Only
+    // fall back to a per-card fetch when there *are* open roles (count > 0) whose
+    // names aren't embedded. A zero count needs no fetch (nothing to list), and
+    // embedded names are authoritative — this is what removes the vacant-roles
+    // fan-out across list views.
+    if (
+      localSnapshot.source !== "aggregate" ||
+      localSnapshot.names.length > 0 ||
+      !(localSnapshot.count > 0)
+    ) {
       setFreshOpenRoleSnapshot(null);
       return;
     }


### PR DESCRIPTION
TeamCard fetched each team's open roles individually to obtain the role names, fanning out one vacant-roles?status=open call per card across the MyTeams and search lists. Now that the list endpoints embed both the open-role count and names, the card renders straight from the payload and only falls back to a per-card fetch when a team actually has open roles (count > 0) whose names aren't embedded — teams with zero open roles no longer fetch either.