### PR TITLE
perf(search): stop per-pin vacant-roles fetch on SearchMapView

### DIFF
--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2190,7 +2190,15 @@ const SearchMapView = ({
 
       const teamId = getTeamItemId(item);
       if (teamId == null) return;
-      if (resolveTeamOpenRoleSnapshot(item).source !== "aggregate") return;
+
+      // Only fetch as a true fallback: the search endpoint already embeds both
+      // open_role_count and open_role_names, so when the names are present (or
+      // the team has no open roles) the snapshot is authoritative and no
+      // per-team vacant-roles call is needed. Mirrors the TeamCard list gate
+      // (TeamCard.jsx) — without this the map view fired one call per pin.
+      const snapshot = resolveTeamOpenRoleSnapshot(item);
+      if (snapshot.source !== "aggregate") return;
+      if (snapshot.names.length > 0 || !(snapshot.count > 0)) return;
 
       const key = String(teamId);
       if (seenIds.has(key)) return;


### PR DESCRIPTION
The map view fetched open roles for every team whose snapshot source was
"aggregate", ignoring that the search endpoint already embeds both
open_role_count and open_role_names. Since SearchPage opens in map view by
default, this fired one /vacant-roles?status=open call per team pin on load.

Gate the fetch like the TeamCard list gate: only fall back to a per-team
fetch when there are open roles (count > 0) whose names aren't embedded.