### PR TITLE
SearchPage performance (React Query + N+1 cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Lomir-frontend/
 │   │   ├── useTagQueries.js        # React Query hooks for structured tags
 │   │   ├── useBadgeQueries.js      # React Query hooks for badge catalog and shared-teams lookups
 │   │   ├── useTeamQueries.js       # React Query hooks for the paginated user-teams list and bulk member badges (MyTeams)
+│   │   ├── useSearchQueries.js     # React Query hook for the global search (SearchPage): whole criteria object as query key, keepPreviousData
 │   │   ├── useViewerMatchProfile.js # Viewer's tags/badges/location for client-side scoring
 │   │   ├── useViewerPendingRequests.js # Shared cache of viewer's pending invitations + applications, consumed by MyTeams and modals
 │   │   ├── useViewerTeamMemberships.js # Viewer's team memberships for "already in team" gates

--- a/src/components/search/SearchMapView.jsx
+++ b/src/components/search/SearchMapView.jsx
@@ -2190,7 +2190,15 @@ const SearchMapView = ({
 
       const teamId = getTeamItemId(item);
       if (teamId == null) return;
-      if (resolveTeamOpenRoleSnapshot(item).source !== "aggregate") return;
+
+      // Only fetch as a true fallback: the search endpoint already embeds both
+      // open_role_count and open_role_names, so when the names are present (or
+      // the team has no open roles) the snapshot is authoritative and no
+      // per-team vacant-roles call is needed. Mirrors the TeamCard list gate
+      // (TeamCard.jsx) — without this the map view fired one call per pin.
+      const snapshot = resolveTeamOpenRoleSnapshot(item);
+      if (snapshot.source !== "aggregate") return;
+      if (snapshot.names.length > 0 || !(snapshot.count > 0)) return;
 
       const key = String(teamId);
       if (seenIds.has(key)) return;

--- a/src/hooks/useSearchQueries.js
+++ b/src/hooks/useSearchQueries.js
@@ -1,0 +1,34 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { searchService } from "../services/searchService";
+
+// One key per fully-resolved search request. The whole criteria object (plus the
+// auth flag, which changes what the backend returns) is part of the key, so RQ
+// caches every page/filter/sort combination independently and dedupes identical
+// requests across navigations.
+export const globalSearchQueryKey = (criteria, isAuthenticated) => [
+  "search",
+  "global",
+  { ...criteria, isAuthenticated: Boolean(isAuthenticated) },
+];
+
+/**
+ * Run the global search (or the unfiltered "all" listing) for the given request
+ * criteria. The criteria object's `mode` selects the endpoint, mirroring the old
+ * imperative `fetchData`. Returns the raw service payload (`{ data, pagination,
+ * userLocation, matchRole, … }`).
+ *
+ * `keepPreviousData` keeps the last successful results on screen while the next
+ * page/filter loads (no full-page spinner flash); the caller blanks the list on
+ * an actual error via the query's `isError` flag.
+ */
+export const useGlobalSearch = (criteria, isAuthenticated, options = {}) =>
+  useQuery({
+    queryKey: globalSearchQueryKey(criteria, isAuthenticated),
+    queryFn: () =>
+      criteria.mode === "search"
+        ? searchService.globalSearch({ ...criteria, isAuthenticated })
+        : searchService.getAllUsersAndTeams({ ...criteria, isAuthenticated }),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+    ...options,
+  });

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -40,7 +40,12 @@ import {
   Globe,
   Target,
 } from "lucide-react";
-import { searchService, getApiErrorMessage } from "../services/searchService";
+import { useQueryClient } from "@tanstack/react-query";
+import { getApiErrorMessage } from "../services/searchService";
+import {
+  globalSearchQueryKey,
+  useGlobalSearch,
+} from "../hooks/useSearchQueries";
 import { tagService } from "../services/tagService";
 import { badgeService } from "../services/badgeService";
 import {
@@ -234,17 +239,28 @@ const compareProximityItems = (a, b, sortDir) => {
 const sortByProximity = (items, sortDir) =>
   [...items].sort((a, b) => compareProximityItems(a, b, sortDir));
 
+// Stable fallbacks so the derived search state keeps a constant identity between
+// renders (avoids churning the downstream `effectiveSearchResults` memo).
+const EMPTY_SEARCH_RESULTS = { teams: [], users: [], roles: [] };
+const DEFAULT_PAGINATION = {
+  page: 1,
+  limit: DEFAULT_RESULTS_PER_PAGE,
+  totalTeams: 0,
+  totalUsers: 0,
+  totalRoles: 0,
+  totalItems: 0,
+  totalPages: 1,
+  hasNextPage: false,
+  hasPrevPage: false,
+};
+
 const SearchPage = () => {
   const location = useLocation();
   const { user, isAuthenticated, loading: authLoading } = useAuth();
   const { data: structuredTags = EMPTY_QUERY_ARRAY } = useStructuredTags();
+  const queryClient = useQueryClient();
 
   const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState({
-    teams: [],
-    users: [],
-    roles: [],
-  });
 
   const [searchType, setSearchType] = useState(() => {
     const urlParams = new URLSearchParams(location.search);
@@ -258,7 +274,6 @@ const SearchPage = () => {
         : "all";
   });
 
-  const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [hasSearched, setHasSearched] = useState(false);
   const [searchInputResetSignal, setSearchInputResetSignal] = useState(0);
@@ -411,17 +426,123 @@ const SearchPage = () => {
   const [resultsPerPage, setResultsPerPage] = useState(
     DEFAULT_RESULTS_PER_PAGE,
   );
-  const [pagination, setPagination] = useState({
-    page: 1,
-    limit: DEFAULT_RESULTS_PER_PAGE,
-    totalTeams: 0,
-    totalUsers: 0,
-    totalRoles: 0,
-    totalItems: 0,
-    totalPages: 1,
-    hasNextPage: false,
-    hasPrevPage: false,
+
+  // Effective filter values (a couple of filters are forced depending on the
+  // active search type / auth) — feed both the request criteria and the UI.
+  const effectiveOpenRolesOnly =
+    searchType === "users" ? false : openRolesOnly;
+  const effectiveIncludeOwnTeams =
+    !isAuthenticated || searchType === "users" ? true : includeOwnTeams;
+
+  // ===== SEARCH QUERY (React Query) =====
+  // The fully-resolved request criteria double as the query key, so each
+  // page/filter/sort combination is cached independently and identical requests
+  // are deduped across navigations (saves Render CPU + Neon compute).
+  const requestCriteria = useMemo(
+    () =>
+      buildSearchRequestCriteria({
+        hasSearched,
+        searchQuery,
+        searchType,
+        currentPage,
+        resultsPerPage,
+        sortBy,
+        sortDir,
+        maxDistance,
+        effectiveOpenRolesOnly,
+        effectiveIncludeOwnTeams,
+        includeDemoData,
+        capacityMode,
+        filterTagIds,
+        filterBadgeIds,
+        matchRoleId,
+        excludeTeamId,
+      }),
+    [
+      hasSearched,
+      searchQuery,
+      searchType,
+      currentPage,
+      resultsPerPage,
+      sortBy,
+      sortDir,
+      maxDistance,
+      effectiveOpenRolesOnly,
+      effectiveIncludeOwnTeams,
+      includeDemoData,
+      capacityMode,
+      filterTagIds,
+      filterBadgeIds,
+      matchRoleId,
+      excludeTeamId,
+    ],
+  );
+
+  const {
+    data: searchData,
+    isFetching: isSearchFetching,
+    isError: isSearchError,
+    error: searchQueryError,
+  } = useGlobalSearch(requestCriteria, isAuthenticated, {
+    // Wait until auth resolves so we don't fetch with a stale auth flag baked
+    // into the request (the result set differs for authenticated viewers).
+    enabled: !authLoading,
   });
+
+  // On an actual error, blank the list (keepPreviousData would otherwise keep
+  // the last results on screen); on success / while refetching, show the data.
+  const activeSearchData = isSearchError ? undefined : searchData;
+
+  const searchResults = useMemo(
+    () =>
+      activeSearchData?.data
+        ? {
+            teams: activeSearchData.data.teams ?? [],
+            users: activeSearchData.data.users ?? [],
+            roles: activeSearchData.data.roles ?? [],
+          }
+        : EMPTY_SEARCH_RESULTS,
+    [activeSearchData],
+  );
+
+  const pagination = useMemo(
+    () => activeSearchData?.pagination ?? DEFAULT_PAGINATION,
+    [activeSearchData],
+  );
+
+  // `loading` keeps its old "a request is in flight" meaning (button-disabled
+  // states, the no-results gate). The full-page spinner instead uses
+  // `showInitialLoader` so background refetches keep the previous list visible.
+  const loading = isSearchFetching;
+  const showInitialLoader = isSearchFetching && !activeSearchData;
+
+  // Write back the response-derived values that live in editable / URL-bound
+  // state. Gated on the (truthy) data object per the RQ default-vs-effect
+  // footgun; skipped on error (activeSearchData is undefined), matching the old
+  // success-only behaviour.
+  useEffect(() => {
+    if (!activeSearchData) return;
+    setUserHasCoordinates(!!activeSearchData.userLocation?.hasCoordinates);
+    if (activeSearchData.matchRole?.roleName) {
+      setMatchRoleName(activeSearchData.matchRole.roleName);
+    }
+    const nextRoleMaxDistanceKm = Number(
+      activeSearchData.matchRole?.maxDistanceKm ??
+        activeSearchData.matchRole?.max_distance_km ??
+        activeSearchData.matchRole?.distanceLimitKm ??
+        activeSearchData.matchRole?.distance_limit_km,
+    );
+    if (Number.isFinite(nextRoleMaxDistanceKm) && nextRoleMaxDistanceKm > 0) {
+      setMatchRoleMaxDistanceKm(nextRoleMaxDistanceKm);
+    }
+  }, [activeSearchData]);
+
+  // Mirror the query error into the dismissable `error` alert state. Only
+  // re-runs when the query error itself flips, so a manual dismiss (or the
+  // explicit setError(null) clears elsewhere) sticks until the next fetch.
+  useEffect(() => {
+    setError(searchQueryError ? getApiErrorMessage(searchQueryError) : null);
+  }, [searchQueryError]);
 
   const withResolvedDistance = useCallback((item, viewerEntity) => {
     if (!item) return item;
@@ -985,9 +1106,6 @@ const SearchPage = () => {
     filteredResults.users.length > 0 ||
     filteredResults.roles.length > 0;
 
-  const effectiveOpenRolesOnly = searchType === "users" ? false : openRolesOnly;
-  const effectiveIncludeOwnTeams =
-    !isAuthenticated || searchType === "users" ? true : includeOwnTeams;
   const isCapacitySpotsSort =
     searchType === "teams" && sortBy === "capacity" && capacityMode === "spots";
   const isCapacityRolesSort =
@@ -1014,23 +1132,6 @@ const SearchPage = () => {
   );
   const visibleFilterOptions = visibleSortOptions.filter(
     (option) => !SORTING_OPTION_VALUES.has(option.value),
-  );
-
-  const fetchData = useCallback(
-    async (criteria) => {
-      if (criteria.mode === "search") {
-        return await searchService.globalSearch({
-          ...criteria,
-          isAuthenticated,
-        });
-      }
-
-      return await searchService.getAllUsersAndTeams({
-        ...criteria,
-        isAuthenticated,
-      });
-    },
-    [isAuthenticated],
   );
 
   // Fetch all badges once on mount for client-side suggestion filtering
@@ -1092,102 +1193,6 @@ const SearchPage = () => {
     excludeTeamName,
   });
   const showIncludeOwnTeamsFilter = isAuthenticated && searchType !== "users";
-
-  useEffect(() => {
-    // Wait until auth resolves so we don't double-fetch with stale
-    // isAuthenticated baked into fetchData.
-    if (authLoading) return;
-
-    const run = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-
-        const requestCriteria = buildSearchRequestCriteria({
-          hasSearched,
-          searchQuery,
-          searchType,
-          currentPage,
-          resultsPerPage,
-          sortBy,
-          sortDir,
-          maxDistance,
-          effectiveOpenRolesOnly,
-          effectiveIncludeOwnTeams,
-          includeDemoData,
-          capacityMode,
-          filterTagIds,
-          filterBadgeIds,
-          matchRoleId,
-          excludeTeamId,
-        });
-
-        const results = await fetchData(requestCriteria);
-
-        setSearchResults({
-          teams: results.data?.teams ?? [],
-          users: results.data?.users ?? [],
-          roles: results.data?.roles ?? [],
-        });
-        setUserHasCoordinates(!!results.userLocation?.hasCoordinates);
-
-        if (results.matchRole?.roleName) {
-          setMatchRoleName(results.matchRole.roleName);
-        }
-        const nextRoleMaxDistanceKm = Number(
-          results.matchRole?.maxDistanceKm ??
-            results.matchRole?.max_distance_km ??
-            results.matchRole?.distanceLimitKm ??
-            results.matchRole?.distance_limit_km,
-        );
-        if (Number.isFinite(nextRoleMaxDistanceKm) && nextRoleMaxDistanceKm > 0) {
-          setMatchRoleMaxDistanceKm(nextRoleMaxDistanceKm);
-        }
-
-        if (results.pagination) {
-          setPagination(results.pagination);
-        }
-      } catch (err) {
-        console.error("Error fetching data:", err);
-        setSearchResults({ teams: [], users: [], roles: [] });
-        setPagination((p) => ({
-          ...p,
-          totalTeams: 0,
-          totalUsers: 0,
-          totalRoles: 0,
-          totalItems: 0,
-          totalPages: 1,
-          hasNextPage: false,
-          hasPrevPage: false,
-        }));
-        setError(getApiErrorMessage(err));
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    run();
-  }, [
-    authLoading,
-    fetchData,
-    currentPage,
-    resultsPerPage,
-    searchType,
-    sortBy,
-    sortDir,
-    maxDistance,
-    openRolesOnly,
-    effectiveOpenRolesOnly,
-    effectiveIncludeOwnTeams,
-    includeDemoData,
-    capacityMode,
-    hasSearched,
-    searchQuery,
-    filterTagIds,
-    filterBadgeIds,
-    matchRoleId,
-    excludeTeamId,
-  ]);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(location.search);
@@ -1802,22 +1807,47 @@ const SearchPage = () => {
     }
   };
 
+  // Optimistically patch the cached search response so the affected card
+  // reflects the change immediately; the next genuine refetch reconciles it.
   const handleUserUpdate = (updatedUser) => {
-    setSearchResults((prev) => ({
-      ...prev,
-      users: prev.users.map((u) => (u.id === updatedUser.id ? updatedUser : u)),
-    }));
+    queryClient.setQueryData(
+      globalSearchQueryKey(requestCriteria, isAuthenticated),
+      (prev) =>
+        prev?.data
+          ? {
+              ...prev,
+              data: {
+                ...prev.data,
+                users: (prev.data.users ?? []).map((u) =>
+                  u.id === updatedUser.id ? updatedUser : u,
+                ),
+              },
+            }
+          : prev,
+    );
   };
 
   const handleTeamUpdate = (updatedTeam) => {
-    setSearchResults((prev) => ({
-      ...prev,
-      teams: prev.teams.map((t) =>
-        t.id === updatedTeam.id
-          ? { ...updatedTeam, is_public: updatedTeam.is_public === true }
-          : t,
-      ),
-    }));
+    queryClient.setQueryData(
+      globalSearchQueryKey(requestCriteria, isAuthenticated),
+      (prev) =>
+        prev?.data
+          ? {
+              ...prev,
+              data: {
+                ...prev.data,
+                teams: (prev.data.teams ?? []).map((t) =>
+                  t.id === updatedTeam.id
+                    ? {
+                        ...updatedTeam,
+                        is_public: updatedTeam.is_public === true,
+                      }
+                    : t,
+                ),
+              },
+            }
+          : prev,
+    );
   };
 
   const getTotalItemsForFilter = () => {
@@ -2433,7 +2463,7 @@ const SearchPage = () => {
         ]}
       />
 
-      {loading ? (
+      {showInitialLoader ? (
         <div className="flex justify-center items-center h-64">
           <div className="loading loading-spinner loading-lg text-primary"></div>
         </div>

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -47,7 +47,7 @@ import {
   useGlobalSearch,
 } from "../hooks/useSearchQueries";
 import { tagService } from "../services/tagService";
-import { badgeService } from "../services/badgeService";
+import { useBadges } from "../hooks/useBadgeQueries";
 import {
   enrichTeamMatchData,
   enrichUserMatchData,
@@ -413,7 +413,11 @@ const SearchPage = () => {
     return [];
   });
   const [filterBadgeMap, setFilterBadgeMap] = useState({});
-  const [allBadges, setAllBadges] = useState([]);
+  // All badges, fetched once and cached across navigation via React Query
+  // (staleTime 5min). Used for client-side suggestion filtering + resolving
+  // badge names from URL params. Replaces a manual mount-effect fetch that
+  // refetched on every SearchPage mount (and double-fired under StrictMode).
+  const { data: allBadges = EMPTY_QUERY_ARRAY } = useBadges();
   const {
     viewerMatchProfile: viewerTeamMatchProfile,
     viewerDistanceSource,
@@ -1133,14 +1137,6 @@ const SearchPage = () => {
   const visibleFilterOptions = visibleSortOptions.filter(
     (option) => !SORTING_OPTION_VALUES.has(option.value),
   );
-
-  // Fetch all badges once on mount for client-side suggestion filtering
-  useEffect(() => {
-    badgeService
-      .getAllBadges()
-      .then((res) => setAllBadges(res.data || []))
-      .catch(() => {});
-  }, []);
 
   // Resolve badge names from URL params once allBadges has loaded
   useEffect(() => {


### PR DESCRIPTION
Frontend-only release. Backend dev is level with main, so nothing ships there. All changes are scoped to the search experience and have been smoke/HAR-verified on dev. No API contract changes, no new dependencies.

**What's included**
perf(search): adopt React Query on SearchPage (#526)
SearchPage moves from a manual useEffect + setState fetch to a dedicated useGlobalSearch hook (src/hooks/useSearchQueries.js). The whole resolved criteria object is the query key, so every page/filter/sort combination is cached independently and identical requests are deduped across navigations (staleTime 30s + keepPreviousData). Dropped the searchResults/pagination/loading/error state and the ~95-line fetch effect. UX: previous results stay visible during a refetch; full-page spinner only on first load.

perf(search): stop per-pin vacant-roles fetch on SearchMapView (#527)
The map view fired one GET /api/teams/:id/vacant-roles?status=open per team pin, even though the search endpoint already embeds open_role_count + open_role_names. Since the search page opens in map view by default, this meant one request per pin on every load. The fetch is now gated like the TeamCard list gate (only a true fallback when a team has open roles whose names aren't embedded). HAR-verified: 0 vacant-roles calls on map-default load (was one per pin).

perf(search): cache all-badges fetch via React Query (#528)
SearchPage fetched the full badge list in a raw mount effect that refetched on every mount. Switched to the existing useBadges() hook (staleTime 5min) so the list is cached across navigation and deduped.

docs(readme): list useSearchQueries hook (#529)
Adds the new useSearchQueries.js hook to the README project structure.

**Verification**
ESLint clean + Vite build green on each PR.
Live smoke (DevTools/HAR): SearchPage spinner only on first load; keepPreviousData on filter change; back-navigation within the stale window = cache hit (0 /api/search/all); map-default load = 0 vacant-roles calls; badge list cached across navigation; sort/filter/optimistic apply unchanged.
Net effect: fewer requests per search-page load and on navigation → less Render/Neon load on the free tier; no behavioural changes for users.

**Scope / risk**
Frontend-only; 4 files (SearchPage.jsx, useSearchQueries.js, SearchMapView.jsx, README.md).
No backend, API, schema, or dependency changes.

**Deploy notes**
After merge, also git push myfork main (Vercel deploys main from myfork).
Post-deploy: confirm a fresh Vercel build (HSTS/CSP via curl -sI, age:/x-vercel-id), then a quick UI smoke (search map-default → 0 vacant-roles, badges load), allowing for the Render cold start.