### PR TITLE
refactor(chat): migrate Chat data fetching to React Query

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -5,9 +5,11 @@ import {
   useContext,
   useCallback,
 } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import api from "../services/api";
 import socketService from "../services/socketService";
 import { userService } from "../services/userService";
+import { conversationsQueryKey } from "../hooks/useChatQueries";
 import { setUserTimezone } from "../utils/dateHelpers";
 
 const AuthContext = createContext(null);
@@ -32,6 +34,7 @@ const normalizeAuthUser = (userData, { defaultIsPublic = false } = {}) => ({
 });
 
 export const AuthProvider = ({ children }) => {
+  const queryClient = useQueryClient();
   const [user, setUser] = useState(null);
   // Auth is carried by an httpOnly session cookie set by the backend and is
   // intentionally not readable by JavaScript. Auth state is derived by calling
@@ -74,6 +77,13 @@ export const AuthProvider = ({ children }) => {
     let activeSocket = null;
     const handleBlocksUpdated = () => {
       refreshBlocks();
+      // A block/unblock changes which direct chats are visible. The conversation
+      // list is filtered server-side by user_blocks, so invalidate its cache
+      // here — app-wide, not just while Chat is mounted — so an unblock made
+      // from Settings restores the DM on the next /chat visit (the cached list
+      // is otherwise served stale by staleTime: Infinity). This event is emitted
+      // after the block row is committed, so the refetch sees the new state.
+      queryClient.invalidateQueries({ queryKey: conversationsQueryKey });
     };
     const unsubscribe = socketService.onSocketReady((socketInstance) => {
       if (!socketInstance) return;
@@ -85,7 +95,7 @@ export const AuthProvider = ({ children }) => {
       unsubscribe?.();
       if (activeSocket) activeSocket.off("blocks:updated", handleBlocksUpdated);
     };
-  }, [userId, refreshBlocks]);
+  }, [userId, refreshBlocks, queryClient]);
 
   // On mount, restore the session from the httpOnly cookie (if present) by
   // asking the backend who we are. skipAuthRedirect keeps a logged-out

--- a/src/hooks/useChatQueries.js
+++ b/src/hooks/useChatQueries.js
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+
+// Cache key for the current user's conversation list. This is both the fetch
+// key and the live cache: the list is seeded from the server, then mutated in
+// place via queryClient.setQueryData as socket events arrive. Invalidate this
+// key to re-fetch the whole list.
+export const conversationsQueryKey = ["chat", "conversations"];
+
+/**
+ * The current user's conversation list. The query function is supplied by the
+ * caller because the dedupe + last-message-preview hydration it needs lives in
+ * Chat.jsx (slated to move into chatHelpers.js with the Tier 2 split). Stays
+ * disabled until the user is authenticated.
+ */
+export const useConversations = (queryFn, enabled) =>
+  useQuery({
+    queryKey: conversationsQueryKey,
+    queryFn,
+    enabled,
+    // The list is kept current by socket handlers (setQueryData) and explicit
+    // refreshes (invalidateQueries) — never by polling. staleTime: Infinity
+    // stops the query from refetching on every Chat mount/remount (the /chat ↔
+    // /chat/:id routes are separate elements, so auto-select remounts Chat) and
+    // on StrictMode's dev double-invoke. Switching chats / navigating back is
+    // then served from cache. gcTime stays at the default so a long absence
+    // (cache garbage-collected) still gets one fresh fetch on return.
+    staleTime: Infinity,
+  });

--- a/src/hooks/useTeamQueries.js
+++ b/src/hooks/useTeamQueries.js
@@ -32,6 +32,28 @@ export const useUserTeams = (
     ...options,
   });
 
+export const teamByIdQueryKey = (teamId) => ["teams", "byId", String(teamId)];
+
+// The getTeamById endpoint may return either the bare team object or an axios
+// envelope ({ data: team }); normalize to the team payload either way.
+const extractTeamDetailsPayload = (response) =>
+  response?.data && typeof response.data === "object" ? response.data : response;
+
+/**
+ * Imperatively fetch (and cache) a team's full detail payload through React
+ * Query — replaces a hand-rolled Map cache plus in-flight-request dedup. A
+ * cached hit is reused while fresh (mirrors the old never-expiring Map);
+ * `force` drops staleness so the call always refetches and refreshes the cache.
+ * Resolves to the unwrapped team payload, not the axios envelope.
+ */
+export const fetchTeamById = (queryClient, teamId, { force = false } = {}) =>
+  queryClient.fetchQuery({
+    queryKey: teamByIdQueryKey(teamId),
+    queryFn: () =>
+      teamService.getTeamById(teamId).then(extractTeamDetailsPayload),
+    staleTime: force ? 0 : Infinity,
+  });
+
 export const teamMemberBadgesQueryKey = (teamIds) => [
   "teams",
   "memberBadges",

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -13,6 +13,7 @@ import {
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { fetchTeamById } from "../hooks/useTeamQueries";
+import { useConversations, conversationsQueryKey } from "../hooks/useChatQueries";
 import PageContainer from "../components/layout/PageContainer";
 import ConversationList from "../components/chat/ConversationList";
 import MessageDisplay, { parseSystemMessage } from "../components/chat/MessageDisplay";
@@ -275,6 +276,10 @@ const getConversationUpdatedAt = (conversation) => {
 const isDirectConversationForPartner = (conversation, partnerId) =>
   conversation?.type === "direct" &&
   String(getConversationPartnerId(conversation)) === String(partnerId);
+
+// Stable empty fallback so the conversations query's default never changes
+// identity between renders (avoids needless re-renders / effect re-runs).
+const EMPTY_CONVERSATIONS = [];
 
 const CHAT_SEARCH_PAGE_SIZE = 100;
 const CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION = 500;
@@ -594,6 +599,71 @@ const hasConversationPreview = (conversation) => {
   );
 };
 
+// Fill in last-message previews for conversations the list endpoint returned
+// without one, by fetching the latest message per conversation. Pure: returns a
+// new list with previews merged in (or the input unchanged when nothing needs
+// hydrating), so it can run inside the conversations queryFn.
+const hydrateConversationPreviews = async (conversationList) => {
+  const conversationsToHydrate = (conversationList || []).filter(
+    (conversation) =>
+      !conversation.isVirtual && !hasConversationPreview(conversation),
+  );
+
+  if (conversationsToHydrate.length === 0) return conversationList || [];
+
+  const hydratedPreviews = await Promise.allSettled(
+    conversationsToHydrate.map(async (conversation) => {
+      const type = conversation.type || "direct";
+      const response = await messageService.getMessages(conversation.id, type, {
+        limit: 1,
+      });
+      const latestMessage = response?.data?.[response.data.length - 1];
+      const preview = buildConversationLastMessagePreview(latestMessage);
+
+      if (!latestMessage || !preview) return null;
+
+      return {
+        id: conversation.id,
+        type,
+        preview,
+        updatedAt:
+          latestMessage.createdAt ||
+          latestMessage.created_at ||
+          conversation.updatedAt,
+      };
+    }),
+  );
+
+  const previewByKey = new Map();
+
+  hydratedPreviews.forEach((result) => {
+    if (result.status !== "fulfilled" || !result.value) return;
+    previewByKey.set(
+      `${result.value.type}:${String(result.value.id)}`,
+      result.value,
+    );
+  });
+
+  if (previewByKey.size === 0) return conversationList || [];
+
+  return (conversationList || []).map((conversation) => {
+    const type = conversation.type || "direct";
+    const hydratedPreview = previewByKey.get(
+      `${type}:${String(conversation.id)}`,
+    );
+
+    if (!hydratedPreview || hasConversationPreview(conversation)) {
+      return conversation;
+    }
+
+    return {
+      ...conversation,
+      lastMessage: hydratedPreview.preview,
+      updatedAt: hydratedPreview.updatedAt || conversation.updatedAt,
+    };
+  });
+};
+
 const getMessageSearchTimestamp = (message) => {
   const timestamp =
     message?.createdAt ||
@@ -701,11 +771,31 @@ const Chat = () => {
       id != null && blockedRelationshipIds?.has?.(String(id)),
     [blockedRelationshipIds],
   );
-  const [conversations, setConversations] = useState([]);
+  // Conversation list is backed by the React Query cache. The query fetches +
+  // dedupes + hydrates previews once (keyed on a constant, so switching chats
+  // no longer refetches the list); socket/local updates mutate that cache via
+  // the setConversations wrapper below, keeping their (prev) => next shape.
+  const fetchConversations = useCallback(async () => {
+    const response = await messageService.getConversations();
+    return hydrateConversationPreviews(dedupeConversations(response.data || []));
+  }, []);
+  const {
+    data: conversations = EMPTY_CONVERSATIONS,
+    isLoading: loading,
+    isError: conversationsLoadError,
+  } = useConversations(fetchConversations, isAuthenticated);
+  const setConversations = useCallback(
+    (next) =>
+      queryClient.setQueryData(
+        conversationsQueryKey,
+        (prev = EMPTY_CONVERSATIONS) =>
+          typeof next === "function" ? next(prev) : next,
+      ),
+    [queryClient],
+  );
   const [activeConversation, setActiveConversation] = useState(null);
   const [messages, setMessages] = useState([]);
   const [replyingTo, setReplyingTo] = useState(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [onlineUsers, setOnlineUsers] = useState([]);
   const [typingUsers, setTypingUsers] = useState({});
@@ -883,7 +973,7 @@ const Chat = () => {
         navigate("/chat", { replace: true });
       }
     },
-    [conversationId, navigate, searchParams],
+    [conversationId, navigate, searchParams, setConversations],
   );
 
   const refreshActiveTeamMembership = useCallback(
@@ -1271,91 +1361,31 @@ const Chat = () => {
     );
   }, []);
 
-  const hydrateMissingConversationPreviews = useCallback(async (conversationList) => {
-    const conversationsToHydrate = (conversationList || []).filter(
-      (conversation) => !conversation.isVirtual && !hasConversationPreview(conversation),
-    );
-
-    if (conversationsToHydrate.length === 0) return;
-
-    const hydratedPreviews = await Promise.allSettled(
-      conversationsToHydrate.map(async (conversation) => {
-        const type = conversation.type || "direct";
-        const response = await messageService.getMessages(conversation.id, type, {
-          limit: 1,
-        });
-        const latestMessage = response?.data?.[response.data.length - 1];
-        const preview = buildConversationLastMessagePreview(latestMessage);
-
-        if (!latestMessage || !preview) return null;
-
-        return {
-          id: conversation.id,
-          type,
-          preview,
-          updatedAt:
-            latestMessage.createdAt ||
-            latestMessage.created_at ||
-            conversation.updatedAt,
-        };
-      }),
-    );
-
-    const previewByKey = new Map();
-
-    hydratedPreviews.forEach((result) => {
-      if (result.status !== "fulfilled" || !result.value) return;
-      previewByKey.set(
-        `${result.value.type}:${String(result.value.id)}`,
-        result.value,
-      );
-    });
-
-    if (previewByKey.size === 0) return;
-
-    setConversations((prev) =>
-      prev.map((conversation) => {
-        const type = conversation.type || "direct";
-        const hydratedPreview = previewByKey.get(
-          `${type}:${String(conversation.id)}`,
-        );
-
-        if (!hydratedPreview || hasConversationPreview(conversation)) {
-          return conversation;
-        }
-
-        return {
-          ...conversation,
-          lastMessage: hydratedPreview.preview,
-          updatedAt: hydratedPreview.updatedAt || conversation.updatedAt,
-        };
-      }),
-    );
-  }, []);
-
-  const refreshConversationList = useCallback(async () => {
-    try {
-      const response = await messageService.getConversations();
-      const deduplicatedList = dedupeConversations(response.data || []);
-      setConversations(deduplicatedList);
-      hydrateMissingConversationPreviews(deduplicatedList);
-    } catch (err) {
-      console.error("Error refreshing conversations:", err);
-    }
-  }, [hydrateMissingConversationPreviews]);
+  // Re-fetch the conversation list by invalidating its query (the queryFn
+  // re-runs the dedupe + preview hydration). React Query dedupes concurrent
+  // invalidations, so the burst of socket handlers that used to each trigger a
+  // fresh getConversations now collapse into a single refetch.
+  const refreshConversationList = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: conversationsQueryKey }),
+    [queryClient],
+  );
 
   // Apply live block/unblock changes to the chat view: drop blocked DMs (and
   // restore unblocked ones) from the list, and close the active DM if its
   // partner is now blocked. Team chats stay open — the blocker is hidden via
   // the visibleMessages / teamMembers filters. The first run is skipped because
   // the initial conversation fetch below already loads the correct state.
-  const blocksSyncInitializedRef = useRef(false);
+  const prevBlockedIdsRef = useRef(blockedRelationshipIds);
   useEffect(() => {
     if (!isAuthenticated) return;
-    if (!blocksSyncInitializedRef.current) {
-      blocksSyncInitializedRef.current = true;
-      return;
-    }
+    // Only react to an ACTUAL block/unblock change — compare the value, not a
+    // first-run boolean. A "skip first run" boolean ref is defeated by React
+    // StrictMode's mount double-invoke: the ref persists, so the 2nd invoke
+    // passes the guard and refetches the list on every Chat mount. Comparing
+    // the blockedRelationshipIds Set by reference (it only changes when
+    // AuthContext updates it) is StrictMode-safe and mount-safe.
+    if (prevBlockedIdsRef.current === blockedRelationshipIds) return;
+    prevBlockedIdsRef.current = blockedRelationshipIds;
 
     refreshConversationList();
 
@@ -1377,101 +1407,96 @@ const Chat = () => {
       setHasMoreMessages(false);
       navigate("/chat", { replace: true });
     }
-  }, [
-    blockedRelationshipIds,
-    isAuthenticated,
-    isBlockedId,
-    refreshConversationList,
-    navigate,
-  ]);
+    // `navigate` is intentionally NOT a dependency: useNavigate() returns a new
+    // function identity on every navigation, so including it made this effect
+    // re-run — and refetch the whole conversation list — on every chat switch.
+    // This effect must only react to block/unblock state changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [blockedRelationshipIds, isAuthenticated, isBlockedId, refreshConversationList]);
 
-  // Fetch conversations
+  // Surface a load failure from the conversations query (matches the old
+  // fetch-effect error message).
   useEffect(() => {
-    const fetchConversations = async () => {
-      try {
-        setLoading(true);
-        const response = await messageService.getConversations();
-        let conversationsList = response.data || [];
-
-        // If we have a conversationId from URL but it's not in the conversations list,
-        // create a virtual conversation entry
-        if (conversationId && conversationsList.length >= 0) {
-          const conversationExists = conversationsList.some(
-            (conv) => String(conv.id) === String(conversationId),
-          );
-
-          if (!conversationExists) {
-            const urlParams = new URLSearchParams(window.location.search);
-            const type = urlParams.get("type") || "direct";
-
-            if (type === "direct") {
-              try {
-                // Get the user details for the virtual conversation. A 404
-                // (no such user — e.g. a stale link or deleted account) is an
-                // expected, gracefully-handled case, not console noise.
-                const userResponse = await userService.getUserById(
-                  conversationId,
-                  { quietErrorStatuses: [404] },
-                );
-
-                const userData = userResponse.data;
-
-                // Create a virtual conversation entry
-                const virtualConversation = {
-                  id: parseInt(conversationId),
-                  type: "direct",
-                  partner: {
-                    id: userData.id,
-                    username: userData.username,
-                    firstName: userData.firstName || userData.first_name,
-                    lastName: userData.lastName || userData.last_name,
-                    avatarUrl: userData.avatarUrl || userData.avatar_url,
-                    isSynthetic:
-                      userData.isSynthetic ?? userData.is_synthetic ?? undefined,
-                    is_synthetic:
-                      userData.is_synthetic ?? userData.isSynthetic ?? undefined,
-                  },
-                  lastMessage: "Start your conversation...",
-                  updatedAt: new Date().toISOString(),
-                  isVirtual: true,
-                  unreadCount: 0,
-                };
-
-                // Add to the beginning of the conversations list
-                conversationsList = [virtualConversation, ...conversationsList];
-              } catch (error) {
-                if (!isQuietError(error)) {
-                  console.error("Error creating virtual conversation:", error);
-                }
-              }
-            }
-          }
-        }
-
-        const deduplicatedList = dedupeConversations(conversationsList);
-        setConversations(deduplicatedList);
-        hydrateMissingConversationPreviews(deduplicatedList);
-
-        // If there are conversations but none is selected, select the first one
-        if (deduplicatedList.length > 0 && !conversationId) {
-          const firstConversationType = deduplicatedList[0].type || "direct";
-          navigate(
-            `/chat/${deduplicatedList[0].id}?type=${firstConversationType}`,
-          );
-        }
-
-        setLoading(false);
-      } catch (err) {
-        console.error("Error fetching conversations:", err);
-        setError("Failed to load conversations. Please try again.");
-        setLoading(false);
-      }
-    };
-
-    if (isAuthenticated) {
-      fetchConversations();
+    if (conversationsLoadError) {
+      setError("Failed to load conversations. Please try again.");
     }
-  }, [hydrateMissingConversationPreviews, isAuthenticated, conversationId, navigate]);
+  }, [conversationsLoadError]);
+
+  // Once the conversation list has loaded, either auto-select the first chat
+  // (landed on /chat with none chosen) or seed a virtual DM entry when the URL
+  // points at a partner not yet in the list (new/never-messaged conversation).
+  // Team virtuals are created in the messages effect, so this only handles
+  // direct chats. Guarded so each missing id is attempted at most once.
+  const seededVirtualConvRef = useRef(null);
+  useEffect(() => {
+    if (!isAuthenticated || loading) return;
+
+    if (!conversationId) {
+      if (conversations.length > 0) {
+        const firstConversationType = conversations[0].type || "direct";
+        navigate(`/chat/${conversations[0].id}?type=${firstConversationType}`);
+      }
+      return;
+    }
+
+    const conversationExists = conversations.some(
+      (conv) => String(conv.id) === String(conversationId),
+    );
+    if (conversationExists) return;
+    if (seededVirtualConvRef.current === String(conversationId)) return;
+
+    const type =
+      new URLSearchParams(window.location.search).get("type") || "direct";
+    if (type !== "direct") return;
+
+    seededVirtualConvRef.current = String(conversationId);
+
+    (async () => {
+      try {
+        // A 404 (no such user — stale link or deleted account) is expected and
+        // handled gracefully, not console noise.
+        const userResponse = await userService.getUserById(conversationId, {
+          quietErrorStatuses: [404],
+        });
+        const userData = userResponse.data;
+
+        const virtualConversation = {
+          id: parseInt(conversationId),
+          type: "direct",
+          partner: {
+            id: userData.id,
+            username: userData.username,
+            firstName: userData.firstName || userData.first_name,
+            lastName: userData.lastName || userData.last_name,
+            avatarUrl: userData.avatarUrl || userData.avatar_url,
+            isSynthetic:
+              userData.isSynthetic ?? userData.is_synthetic ?? undefined,
+            is_synthetic:
+              userData.is_synthetic ?? userData.isSynthetic ?? undefined,
+          },
+          lastMessage: "Start your conversation...",
+          updatedAt: new Date().toISOString(),
+          isVirtual: true,
+          unreadCount: 0,
+        };
+
+        setConversations((prev) =>
+          dedupeConversations([virtualConversation, ...prev]),
+        );
+      } catch (error) {
+        if (!isQuietError(error)) {
+          console.error("Error creating virtual conversation:", error);
+        }
+      }
+    })();
+  }, [
+    isAuthenticated,
+    loading,
+    conversationId,
+    conversations,
+    navigate,
+    setConversations,
+  ]);
 
   // Fetch messages when conversation changes
   useEffect(() => {
@@ -1838,6 +1863,7 @@ const Chat = () => {
     setSearchParams,
     navigate,
     user?.id,
+    setConversations,
   ]);
 
   useEffect(() => {
@@ -1872,7 +1898,7 @@ const Chat = () => {
         prev.filter((c) => !(c.type === "team" && c.id === data.teamId)),
       );
     },
-    [conversationId, conversationType, revokeTeamChatAccess],
+    [conversationId, conversationType, revokeTeamChatAccess, setConversations],
   );
 
   // Set up WebSocket event listeners

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -11,6 +11,8 @@ import {
   FlaskConical,
 } from "lucide-react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { fetchTeamById } from "../hooks/useTeamQueries";
 import PageContainer from "../components/layout/PageContainer";
 import ConversationList from "../components/chat/ConversationList";
 import MessageDisplay, { parseSystemMessage } from "../components/chat/MessageDisplay";
@@ -217,9 +219,6 @@ const isCurrentUserRemovalPayload = (payload, userId) => {
   const text = getPayloadText(payload);
   return /\byou\b/.test(text) && /removed from/.test(text);
 };
-
-const extractTeamDetailsPayload = (response) =>
-  response?.data && typeof response.data === "object" ? response.data : response;
 
 const mergeTeamDetailsIntoConversationData = (conversationData, teamPayload) => {
   if (!conversationData || !teamPayload) return conversationData;
@@ -694,6 +693,7 @@ const buildConversationSearchText = (conversation) => {
 const Chat = () => {
   const { conversationId } = useParams();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const { user, isAuthenticated, blockedRelationshipIds } = useAuth();
   const isBlockedId = useCallback(
@@ -742,8 +742,6 @@ const Chat = () => {
   const messagesRef = useRef([]);
   const chatSearchLoadingKeysRef = useRef(new Set());
   const pendingChatSearchTargetRef = useRef(null);
-  const teamDetailsCacheRef = useRef(new Map());
-  const teamDetailsRequestsRef = useRef(new Map());
   const [loadingMessages, setLoadingMessages] = useState(false);
 
   // ---- Message de-duplication (focus: ownership/system duplicates) ----
@@ -841,35 +839,15 @@ const Chat = () => {
   const canSendInActiveConversation =
     Boolean(activeConversation) && isCurrentUserActiveTeamMember;
 
-  const fetchTeamDetails = useCallback(async (teamId, { force = false } = {}) => {
-    if (!teamId) return null;
-
-    const cacheKey = String(teamId);
-
-    if (!force && teamDetailsCacheRef.current.has(cacheKey)) {
-      return teamDetailsCacheRef.current.get(cacheKey);
-    }
-
-    if (!force && teamDetailsRequestsRef.current.has(cacheKey)) {
-      return teamDetailsRequestsRef.current.get(cacheKey);
-    }
-
-    const request = teamService
-      .getTeamById(teamId)
-      .then((response) => {
-        const teamPayload = extractTeamDetailsPayload(response);
-        teamDetailsCacheRef.current.set(cacheKey, teamPayload);
-        teamDetailsRequestsRef.current.delete(cacheKey);
-        return teamPayload;
-      })
-      .catch((error) => {
-        teamDetailsRequestsRef.current.delete(cacheKey);
-        throw error;
-      });
-
-    teamDetailsRequestsRef.current.set(cacheKey, request);
-    return request;
-  }, []);
+  const fetchTeamDetails = useCallback(
+    (teamId, { force = false } = {}) => {
+      if (!teamId) return Promise.resolve(null);
+      // React Query handles caching and in-flight request dedup that this
+      // component used to track by hand (see fetchTeamById).
+      return fetchTeamById(queryClient, teamId, { force });
+    },
+    [queryClient],
+  );
 
   const revokeTeamChatAccess = useCallback(
     (teamId, message = "You no longer have access to this team chat.") => {


### PR DESCRIPTION
Move Chat's server data off manual useState/useEffect onto the shared
React Query cache, matching the MyTeams and SearchPage migrations.

**Team details:**
- Replace the hand-rolled teamDetailsCacheRef/teamDetailsRequestsRef
  Map + in-flight-dedup with fetchTeamById(queryClient, teamId, {force})
  and teamByIdQueryKey in useTeamQueries. Non-forced reads reuse the
  cache (staleTime: Infinity mirrors the old never-expiring Map); force
  always refetches. Team details now share the app-wide RQ cache.

**Conversation list:**
- New useChatQueries (conversationsQueryKey + useConversations). The
  queryFn fetches + dedupes + hydrates previews once. The list is kept
  live by socket handlers and explicit invalidations, not polling, so it
  uses staleTime: Infinity — no refetch on Chat mount/remount (the /chat
  and /chat/:id routes are separate elements, so auto-select remounts
  Chat) or on StrictMode's dev double-invoke.
- The ~15 socket/local updaters keep their (prev) => next shape via a
  setConversations wrapper over setQueryData; refreshConversationList
  becomes invalidateQueries; the old mount fetch-effect is replaced by a
  slim seeding / auto-navigate effect.

**Latent bugs fixed (surfaced by the migration; all pre-existing):**
- The block/unblock sync effect listed `navigate` as a dependency.
  useNavigate() returns a new identity on every navigation, so the effect
  re-ran and refetched the whole conversation list on every chat switch.
  navigate is now excluded (documented).
- The same effect used a "skip first run" boolean ref guard that React
  StrictMode's mount double-invoke defeats (the ref persists, so the 2nd
  invoke passes the guard and refetches on every mount). Replaced with a
  StrictMode-safe value comparison of the blockedRelationshipIds set.
- Unblocking from Settings (Chat unmounted) never refreshed the cached
  list, so with staleTime: Infinity the restored DM stayed hidden until a
  new message. AuthContext now invalidates the conversations query on the
  app-wide blocks:updated event (emitted post-commit), so DMs restore/hide
  whether or not Chat is mounted.

Smoke-verified (dev, HAR): 1x initial list fetch (2x in dev via
StrictMode); 0 refetches on sidebar switching and navigate-away-and-back;
send/receive update the UI with no list request; block and unblock
restore/hide DMs on both the /chat and Settings paths.