### PR TITLE
Fix event-message styling and search highlight in chat search results

### DIFF
--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -612,16 +612,32 @@ const ConversationList = ({
             lastMessageText,
             currentUser,
           );
-          const shouldUseEventPreview = !isSearchActive && eventPreview;
-          const EventPreviewIcon = shouldUseEventPreview
-            ? EVENT_PREVIEW_ICONS[eventPreview.icon]
+          // During search the matched message may be an older system/event
+          // message (not the conversation's last message). Style it through the
+          // same canonical getEventPreview path so it keeps its icon, colour and
+          // weight instead of falling back to raw/plain text.
+          const hasSearchMessageMatch =
+            isSearchActive && Boolean(conversation.searchMatchContent);
+          const searchEventPreview = hasSearchMessageMatch
+            ? getEventPreview(conversation.searchMatchContent, currentUser)
             : null;
-          const previewText =
-            isSearchActive && conversation.searchMatchPreview
+          // When the hit is on the conversation's metadata (e.g. team name) and
+          // no message matched, the preview shows the last message — style it the
+          // same way the non-search list does instead of leaving it raw.
+          const activeEventPreview = isSearchActive
+            ? hasSearchMessageMatch
+              ? searchEventPreview
+              : eventPreview
+            : eventPreview;
+          const shouldUseEventPreview = Boolean(activeEventPreview);
+          const EventPreviewIcon = shouldUseEventPreview
+            ? EVENT_PREVIEW_ICONS[activeEventPreview.icon]
+            : null;
+          const previewText = shouldUseEventPreview
+            ? activeEventPreview.text
+            : isSearchActive && conversation.searchMatchPreview
               ? conversation.searchMatchPreview
-              : shouldUseEventPreview
-                ? eventPreview.text
-                : attachmentPreview?.text || lastMessageText || "No messages yet";
+              : attachmentPreview?.text || lastMessageText || "No messages yet";
           const formattedAttachmentPreview =
             !isSearchActive && !attachmentPreview
               ? getFormattedAttachmentPreview(previewText)
@@ -764,10 +780,10 @@ const ConversationList = ({
                       <p
                         className="text-sm font-medium truncate"
                         style={{
-                          color: eventPreview.color,
-                          ...(eventPreview.backgroundColor
+                          color: activeEventPreview.color,
+                          ...(activeEventPreview.backgroundColor
                             ? {
-                                backgroundColor: eventPreview.backgroundColor,
+                                backgroundColor: activeEventPreview.backgroundColor,
                                 borderRadius: "0.375rem",
                                 maxWidth: "100%",
                                 paddingLeft: "3px",
@@ -782,7 +798,9 @@ const ConversationList = ({
                             size={14}
                             className="flex-shrink-0"
                           />
-                          <span className="truncate">{previewText}</span>
+                          <span className="truncate">
+                            {renderHighlightedText(previewText, searchQuery)}
+                          </span>
                         </span>
                       </p>
                     ) : visibleAttachmentPreview ? (

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -83,7 +83,10 @@ const renderHighlightedText = (value, query) => {
     return (
       <mark
         key={`${part}-${index}`}
-        className="rounded-full bg-yellow-100 px-1.5 py-0.5 text-[var(--color-primary-focus)]"
+        className="rounded-full bg-yellow-100 px-1.5 py-0.5"
+        // Highlight only adds the yellow background — keep the surrounding text's
+        // colour and weight (override the browser's default <mark> styling).
+        style={{ color: "inherit", fontWeight: "inherit" }}
       >
         {part}
       </mark>

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -698,6 +698,10 @@ const buildMessageSearchSnippets = (messages) =>
     .map(({ message }) => ({
       id: getMessageSearchId(message),
       text: buildMessageSearchSnippet(message),
+      // Raw content is kept alongside the humanised search text so the
+      // conversation list can render a matched system/event message with its
+      // canonical icon + colour styling (via getEventPreview), not just plain text.
+      content: message?.content ?? "",
       timestamp: getMessageSearchTimestampValue(message),
     }))
     .filter((snippet) => snippet.text);
@@ -1305,6 +1309,7 @@ const Chat = () => {
                 matchedMessageSnippet.text,
                 normalizedChatSearchQuery,
               ),
+              searchMatchContent: matchedMessageSnippet.content,
               searchMatchMessageId: matchedMessageSnippet.id,
               searchMatchCreatedAt: matchedMessageSnippet.timestamp,
             }


### PR DESCRIPTION
Improves how conversations rendered as chat search results display their preview text. Two related fixes; frontend only.

1. Style system/event messages in search results
Previously, when a search was active, the conversation list disabled the event preview and showed the matched message as raw/plain text — so system/event messages (role created, ownership transferred, application approved/declined, role changed, "left Lomir", etc.) lost their icon, colour and weight and sometimes appeared as raw tokens (e.g. 🆕 ROLE_CREATED: 155:Test Team 9 | …).

Now the matched message is rendered through the same canonical getEventPreview path the normal conversation list uses, so it keeps its lucide icon, event colour and weight, while the search term stays highlighted.

The matched message's raw content is carried alongside the humanised search text (searchMatchContent) so the list can style the actual matched message (which may be an older message, not the conversation's last one).
When the hit is on conversation metadata (e.g. the team name) and no message matched, the preview falls back to the last message's event preview — matching the non-search list instead of showing raw text.
Plain-text message matches keep the existing windowed snippet (…match…) behaviour.
2. Limit search highlight to the yellow background only
The highlight <mark> no longer changes the matched term's font colour (was primary-focus green) or weight — it now inherits both from the surrounding text and adds only the yellow background, so highlighted text is visually identical to its context apart from the background.

Files
src/pages/Chat.jsx — carry raw content in search snippets → searchMatchContent
src/components/chat/ConversationList.jsx — event-preview styling for search results + metadata-match fallback + highlight tweak
Verification
ESLint: 0 errors · Vite build: green
Manually verified in the chat search: event types render with correct icon/colour/weight + highlighted term; metadata-only hits style the last message like the normal list; plain-text matches keep windowed snippets; highlight shows yellow background only.