### PR TITLE
Release: archived-team farewell UX + chat-search event styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,11 @@ The chat page supports both direct (1-to-1) and team group conversations.
 - Typing indicators and read receipts are shown per conversation
 - Messages can be replied to, edited, and soft-deleted; deleted messages show a placeholder
 
+**Archived (deleted) team chats**
+- When an owner deletes a team that still has other members, the team is archived (scheduled for deletion) and the chat stays open as a "farewell" window — remaining members can still read and post until they leave or the grace period (14 days) elapses
+- The chat shows a red archive banner with the actual time left before deletion (days, then hours on the final day) plus a "leave now" action; the deletion moment is also posted as an in-chat event and sent as a notification
+- Archived team conversations are marked with a red archive icon (and a red active-card state), remain searchable, and their name opens the full Team Details modal with an "Archived" badge/tooltip and no edit/manage actions
+
 **@Mentions**
 - Type `@` in the message input to open a dropdown of conversation participants
 - Select a person or "All members" to insert a mention token

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -612,16 +612,32 @@ const ConversationList = ({
             lastMessageText,
             currentUser,
           );
-          const shouldUseEventPreview = !isSearchActive && eventPreview;
-          const EventPreviewIcon = shouldUseEventPreview
-            ? EVENT_PREVIEW_ICONS[eventPreview.icon]
+          // During search the matched message may be an older system/event
+          // message (not the conversation's last message). Style it through the
+          // same canonical getEventPreview path so it keeps its icon, colour and
+          // weight instead of falling back to raw/plain text.
+          const hasSearchMessageMatch =
+            isSearchActive && Boolean(conversation.searchMatchContent);
+          const searchEventPreview = hasSearchMessageMatch
+            ? getEventPreview(conversation.searchMatchContent, currentUser)
             : null;
-          const previewText =
-            isSearchActive && conversation.searchMatchPreview
+          // When the hit is on the conversation's metadata (e.g. team name) and
+          // no message matched, the preview shows the last message — style it the
+          // same way the non-search list does instead of leaving it raw.
+          const activeEventPreview = isSearchActive
+            ? hasSearchMessageMatch
+              ? searchEventPreview
+              : eventPreview
+            : eventPreview;
+          const shouldUseEventPreview = Boolean(activeEventPreview);
+          const EventPreviewIcon = shouldUseEventPreview
+            ? EVENT_PREVIEW_ICONS[activeEventPreview.icon]
+            : null;
+          const previewText = shouldUseEventPreview
+            ? activeEventPreview.text
+            : isSearchActive && conversation.searchMatchPreview
               ? conversation.searchMatchPreview
-              : shouldUseEventPreview
-                ? eventPreview.text
-                : attachmentPreview?.text || lastMessageText || "No messages yet";
+              : attachmentPreview?.text || lastMessageText || "No messages yet";
           const formattedAttachmentPreview =
             !isSearchActive && !attachmentPreview
               ? getFormattedAttachmentPreview(previewText)
@@ -764,10 +780,10 @@ const ConversationList = ({
                       <p
                         className="text-sm font-medium truncate"
                         style={{
-                          color: eventPreview.color,
-                          ...(eventPreview.backgroundColor
+                          color: activeEventPreview.color,
+                          ...(activeEventPreview.backgroundColor
                             ? {
-                                backgroundColor: eventPreview.backgroundColor,
+                                backgroundColor: activeEventPreview.backgroundColor,
                                 borderRadius: "0.375rem",
                                 maxWidth: "100%",
                                 paddingLeft: "3px",
@@ -782,7 +798,9 @@ const ConversationList = ({
                             size={14}
                             className="flex-shrink-0"
                           />
-                          <span className="truncate">{previewText}</span>
+                          <span className="truncate">
+                            {renderHighlightedText(previewText, searchQuery)}
+                          </span>
                         </span>
                       </p>
                     ) : visibleAttachmentPreview ? (

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import {
   AlertTriangle,
+  Archive,
   ChevronRight,
   CircleX,
   File,
@@ -43,6 +44,7 @@ import { getEventPreview } from "../../utils/eventPreview";
 
 const EVENT_PREVIEW_ICONS = {
   AlertTriangle,
+  Archive,
   CircleX,
   Crown,
   FileText,
@@ -661,11 +663,23 @@ const ConversationList = ({
           const isActive =
             chatVisible && String(activeConversationId) === String(conversation.id);
 
+          // Archived (deleted, scheduled-for-deletion) team conversation —
+          // backend getConversations exposes archived_at/status on the team.
+          const isArchived =
+            isTeam &&
+            Boolean(
+              conversationData?.archived_at ||
+                conversationData?.archivedAt ||
+                conversationData?.status === "inactive",
+            );
+
           const conversationCard = (
             <div className={isActive ? "lomir-active-conversation-wrap" : undefined}>
               {isActive && (
                 <span
-                  className="lomir-active-conversation-arrow"
+                  className={`lomir-active-conversation-arrow${
+                    isArchived ? " lomir-active-conversation-arrow--archived" : ""
+                  }`}
                   aria-hidden="true"
                 />
               )}
@@ -675,7 +689,9 @@ const ConversationList = ({
                   p-4 mr-4 cursor-pointer rounded-lg border shadow-soft transition-all duration-300 hover:shadow-md group
                   ${
                     isActive
-                      ? "lomir-active-conversation-card bg-green-100 border-transparent"
+                      ? `lomir-active-conversation-card border-transparent ${
+                          isArchived ? "bg-red-500/10" : "bg-green-100"
+                        }`
                       : "bg-white/80 border-base-200"
                   }
                 `}
@@ -838,6 +854,12 @@ const ConversationList = ({
                     >
                       {isTeam ? (
                         <>
+                          {isArchived && (
+                            <Archive
+                              size={12}
+                              className="flex-shrink-0 text-red-600"
+                            />
+                          )}
                           <Users size={12} className="flex-shrink-0" />
                           <span className={`lomir-conversation-kind-label whitespace-nowrap ${isSearchActive && chatVisible ? "hidden sm:inline md:hidden" : "inline"}`}>
                             {renderHighlightedText("Team Chat", searchQuery)}

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -83,7 +83,10 @@ const renderHighlightedText = (value, query) => {
     return (
       <mark
         key={`${part}-${index}`}
-        className="rounded-full bg-yellow-100 px-1.5 py-0.5 text-[var(--color-primary-focus)]"
+        className="rounded-full bg-yellow-100 px-1.5 py-0.5"
+        // Highlight only adds the yellow background — keep the surrounding text's
+        // colour and weight (override the browser's default <mark> styling).
+        style={{ color: "inherit", fontWeight: "inherit" }}
       >
         {part}
       </mark>

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -1216,6 +1216,7 @@ const MessageDisplay = ({
     renderOwnershipTeamMessage,
     renderOwnershipTransferredMessage,
     renderMemberRemovedMessage,
+    renderTeamDeletedMessage,
   } = createEventRenderers({
     Mention,
     MentionById,
@@ -1784,8 +1785,11 @@ const MessageDisplay = ({
                       renderOwnershipTeamMessage(message, parsedMessage),
                     );
                   } else if (parsedMessage.type === "team_deleted") {
-                    // not rendered here (fixed banner elsewhere)
-                    return null;
+                    // Timeline event marking the deletion moment (who + when),
+                    // complementing the persistent archived-chat banner.
+                    return renderSystemMessage(
+                      renderTeamDeletedMessage(message, parsedMessage),
+                    );
                   }
                 }
               }

--- a/src/components/chat/MessageDisplay.jsx
+++ b/src/components/chat/MessageDisplay.jsx
@@ -307,12 +307,27 @@ const MessageDisplay = ({
     }
 
     (teamMembers || []).forEach((member) => {
-      const memberId = member?.user_id ?? member?.userId ?? null;
+      const memberUser = member?.user || member;
+      const memberId =
+        member?.user_id ??
+        member?.userId ??
+        memberUser?.user_id ??
+        memberUser?.userId ??
+        memberUser?.id ??
+        null;
       if (memberId == null) return;
 
       if (
-        !(member?.avatar_url || member?.avatarUrl) ||
-        (member?.is_synthetic == null && member?.isSynthetic == null)
+        !(
+          member?.avatar_url ||
+          member?.avatarUrl ||
+          memberUser?.avatar_url ||
+          memberUser?.avatarUrl
+        ) ||
+        (member?.is_synthetic == null &&
+          member?.isSynthetic == null &&
+          memberUser?.is_synthetic == null &&
+          memberUser?.isSynthetic == null)
       ) {
         userIdsToFetch.push(memberId);
       }
@@ -451,6 +466,38 @@ const MessageDisplay = ({
       userData,
       userId != null ? resolvedChatUsers[String(userId)] : null,
     );
+
+  const getTeamMemberUserId = (member) => {
+    const memberUser = member?.user || member;
+    return (
+      member?.user_id ??
+      member?.userId ??
+      memberUser?.user_id ??
+      memberUser?.userId ??
+      memberUser?.id ??
+      null
+    );
+  };
+
+  const knownTeamMembers = useMemo(
+    () => [
+      ...(teamMembers || []),
+      ...(resolvedTeamData?.members || []),
+      ...(teamData?.members || []),
+    ],
+    [teamMembers, resolvedTeamData?.members, teamData?.members],
+  );
+
+  const findKnownTeamMember = (userId) => {
+    if (userId == null) return null;
+
+    return (
+      knownTeamMembers.find((member) => {
+        const memberId = getTeamMemberUserId(member);
+        return memberId != null && String(memberId) === String(userId);
+      }) || null
+    );
+  };
 
   const getTeamMemberFullName = (m) => {
     const first = m.first_name ?? m.firstName;
@@ -861,33 +908,49 @@ const MessageDisplay = ({
 
   // Get sender info from team members or message data
   const getSenderInfo = (senderId, message = null) => {
-    if (conversationType === "team" && teamMembers.length > 0) {
-      const member = teamMembers.find(
-        (m) =>
-          m.user_id === senderId ||
-          m.userId === senderId ||
-          String(m.user_id) === String(senderId) ||
-          String(m.userId) === String(senderId),
-      );
+    const member =
+      conversationType === "team" ? findKnownTeamMember(senderId) : null;
 
-      if (member) {
-        return getResolvedUserData(
-          {
-          id: member.user_id || member.userId || senderId,
-          username: member.username,
-          firstName: member.first_name || member.firstName,
-          lastName: member.last_name || member.lastName,
-          avatarUrl: member.avatar_url || member.avatarUrl,
+    if (member) {
+      const memberUser = member.user || member;
+      const memberId = getTeamMemberUserId(member) ?? senderId;
+
+      return getResolvedUserData(
+        {
+          id: memberId,
+          username: member.username ?? memberUser.username,
+          firstName:
+            member.first_name ??
+            member.firstName ??
+            memberUser.first_name ??
+            memberUser.firstName,
+          lastName:
+            member.last_name ??
+            member.lastName ??
+            memberUser.last_name ??
+            memberUser.lastName,
+          avatarUrl:
+            member.avatar_url ??
+            member.avatarUrl ??
+            memberUser.avatar_url ??
+            memberUser.avatarUrl,
           isSynthetic:
-            member.isSynthetic ?? member.is_synthetic ?? undefined,
+            member.isSynthetic ??
+            member.is_synthetic ??
+            memberUser.isSynthetic ??
+            memberUser.is_synthetic ??
+            undefined,
           is_synthetic:
-            member.is_synthetic ?? member.isSynthetic ?? undefined,
+            member.is_synthetic ??
+            member.isSynthetic ??
+            memberUser.is_synthetic ??
+            memberUser.isSynthetic ??
+            undefined,
           isCurrentMember: true,
           isDeletedUser: false,
-          },
-          member.user_id || member.userId || senderId,
-        );
-      }
+        },
+        memberId,
+      );
     }
 
     if (resolvedConversationPartner && senderId === resolvedConversationPartner.id) {
@@ -908,7 +971,10 @@ const MessageDisplay = ({
           message.senderFirstName ?? message.sender_first_name ?? null,
         lastName: message.senderLastName ?? message.sender_last_name ?? null,
         avatarUrl: message.senderAvatarUrl ?? message.sender_avatar_url ?? null,
-        isCurrentMember: message.isCurrentMember === true,
+        isCurrentMember:
+          knownTeamMembers.length > 0
+            ? Boolean(findKnownTeamMember(senderId))
+            : undefined,
       };
       const hasMessageSenderInfo =
         embeddedSender.username ||

--- a/src/components/chat/messageEventRenderers.jsx
+++ b/src/components/chat/messageEventRenderers.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  AlertTriangle,
   CircleX,
   Crown,
   FileText,
@@ -1784,7 +1785,44 @@ export const createEventRenderers = (ctx) => {
     );
   };
 
+  // =============================================================================
+  // renderTeamDeletedMessage - Red danger theme (matches the archived-chat footer)
+  // Posted at deletion time so the moment + who deleted stay visible in history.
+  // =============================================================================
+  const renderTeamDeletedMessage = (message, parsedMessage) => {
+    const messageText = parsedMessage.ownerName ? (
+      <>
+        This team has just been deleted by{" "}
+        {userMentionOrYou(parsedMessage.ownerId, parsedMessage.ownerName)}.
+      </>
+    ) : (
+      <>This team has just been deleted.</>
+    );
+
+    return (
+      <div className="flex flex-col items-center w-full my-4">
+        <div
+          className="event-banner mb-3"
+          style={{
+            backgroundColor: "rgba(239, 68, 68, 0.1)",
+            color: "#dc2626",
+          }}
+        >
+          <span className="text-sm font-medium event-message-text">
+            <AlertTriangle size={16} className="event-inline-icon mr-1" />
+            {highlightEventContent(messageText)}
+          </span>
+        </div>
+
+        <div className="text-xs text-base-content/50">
+          {formatLocalTime(message.createdAt)}
+        </div>
+      </div>
+    );
+  };
+
   return {
+    renderTeamDeletedMessage,
     renderApplicationApprovedDmMessage,
     renderApplicationApprovedMessage,
     renderRoleApplicationApprovedMessage,

--- a/src/components/chat/messageEventRenderers.jsx
+++ b/src/components/chat/messageEventRenderers.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  AlertTriangle,
+  Archive,
   CircleX,
   Crown,
   FileText,
@@ -1792,11 +1792,11 @@ export const createEventRenderers = (ctx) => {
   const renderTeamDeletedMessage = (message, parsedMessage) => {
     const messageText = parsedMessage.ownerName ? (
       <>
-        This team has just been deleted by{" "}
+        This team has just been archived (scheduled for deletion) by{" "}
         {userMentionOrYou(parsedMessage.ownerId, parsedMessage.ownerName)}.
       </>
     ) : (
-      <>This team has just been deleted.</>
+      <>This team has just been archived (scheduled for deletion).</>
     );
 
     return (
@@ -1809,7 +1809,7 @@ export const createEventRenderers = (ctx) => {
           }}
         >
           <span className="text-sm font-medium event-message-text">
-            <AlertTriangle size={16} className="event-inline-icon mr-1" />
+            <Archive size={16} className="event-inline-icon mr-1" />
             {highlightEventContent(messageText)}
           </span>
         </div>

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -2889,7 +2889,10 @@ const TeamCard = ({
         confirmIcon={<Trash2 size={16} />}
       >
         <p className="text-sm text-base-content/80">
-          Delete this team? This action cannot be undone.
+          Delete this team? If you are the only member, the team and chat are
+          deleted immediately. If other members remain, the team is archived
+          first and permanently deleted after they leave or after the archive
+          grace period, currently 30 days by default.
         </p>
       </ConfirmModal>
 

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -2892,7 +2892,7 @@ const TeamCard = ({
           Delete this team? If you are the only member, the team and chat are
           deleted immediately. If other members remain, the team is archived
           first and permanently deleted after they leave or after the archive
-          grace period, currently 30 days by default.
+          grace period, currently 14 days by default.
         </p>
       </ConfirmModal>
 

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -1795,10 +1795,16 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
 
                       {/* Archived status - ALWAYS show for archived teams */}
                       {(team?.archived_at || team?.status === "inactive") && (
-                        <div className="flex items-center gap-1 text-base-content/70">
-                          <Archive size={14} className="flex-shrink-0" />
-                          <span>Archived</span>
-                        </div>
+                        <Tooltip
+                          content="Archived (scheduled for deletion and inactive — no invitations or changes to the team possible)."
+                          position="bottom"
+                          wrapperClassName="inline-flex"
+                        >
+                          <div className="flex items-center gap-1 text-base-content/70 cursor-help">
+                            <Archive size={14} className="flex-shrink-0" />
+                            <span>Archived</span>
+                          </div>
+                        </Tooltip>
                       )}
 
                       {/* Public/Private status - only for members of NON-archived teams */}
@@ -2047,7 +2053,7 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
           Delete this team? If you are the only member, the team and chat are
           deleted immediately. If other members remain, the team is archived
           first and permanently deleted after they leave or after the archive
-          grace period, currently 30 days by default.
+          grace period, currently 14 days by default.
         </p>
       </ConfirmModal>
 

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -2044,7 +2044,10 @@ on ${format(new Date((effectivePendingInvitation.createdAt ?? effectivePendingIn
         confirmIcon={<Trash2 size={16} />}
       >
         <p className="text-sm text-base-content/80">
-          Delete this team? This action cannot be undone.
+          Delete this team? If you are the only member, the team and chat are
+          deleted immediately. If other members remain, the team is archived
+          first and permanently deleted after they leave or after the archive
+          grace period, currently 30 days by default.
         </p>
       </ConfirmModal>
 

--- a/src/constants/privacyText.js
+++ b/src/constants/privacyText.js
@@ -23,4 +23,4 @@ export const LEGAL_PLACEHOLDER_NOTICE =
   "Lomir is currently being prepared for public use. Please do not enter sensitive personal information until the final legal documents are available.";
 
 export const ACCOUNT_DELETION_NOTICE =
-  "Account deletion is permanent. Some content may be deleted, while certain references may be anonymized as 'Former Lomir User' to preserve team and conversation context.";
+  "Account deletion is permanent. Your profile and direct messages are deleted immediately after confirmation. Some team and badge references may be anonymized as 'Former Lomir User' to preserve team and conversation context.";

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,13 @@
     mask-size: 100% 100%;
     filter: drop-shadow(0 2px 6px rgba(4, 80, 20, 0.12));
   }
+
+  /* Archived (deleted) team conversation: opaque light-red arrow (the red
+     counterpart of the green #dcfce7 arrow) to match the card's red fill. */
+  .lomir-active-conversation-arrow--archived {
+    background-color: #fee2e2;
+    filter: drop-shadow(0 2px 6px rgba(80, 4, 4, 0.12));
+  }
 }
 
 @layer components {

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   LogOut,
+  AlertTriangle,
   ChevronRight,
   ChevronLeft,
   Users,
@@ -226,11 +227,21 @@ const mergeTeamDetailsIntoConversationData = (conversationData, teamPayload) => 
   if (!conversationData || !teamPayload) return conversationData;
 
   const currentTeam = conversationData.team || {};
+  const archivedAt =
+    currentTeam.archivedAt ??
+    currentTeam.archived_at ??
+    teamPayload.archivedAt ??
+    teamPayload.archived_at ??
+    undefined;
+  const status = currentTeam.status ?? teamPayload.status ?? undefined;
 
   return {
     ...conversationData,
     team: {
       ...currentTeam,
+      archived_at: currentTeam.archived_at ?? teamPayload.archived_at ?? archivedAt,
+      archivedAt,
+      status,
       avatarUrl:
         currentTeam.avatarUrl ||
         currentTeam.teamavatarUrl ||
@@ -256,6 +267,9 @@ const mergeTeamDetailsIntoConversationData = (conversationData, teamPayload) => 
     },
   };
 };
+
+const isArchivedTeamData = (team) =>
+  Boolean(team?.archived_at || team?.archivedAt || team?.status === "inactive");
 
 const getConversationUpdatedAt = (conversation) => {
   const timestamp =
@@ -454,7 +468,7 @@ const buildSystemMessageSearchSnippet = (parsedMessage) => {
     case "ownership_transferred":
       return `${parsedMessage.prevOwnerName} transferred ownership of ${parsedMessage.teamName} to you. You transferred team ownership of ${parsedMessage.teamName} to ${parsedMessage.newOwnerName}. Congratulations`;
     case "team_deleted":
-      return `${parsedMessage.ownerName} has initiated the deletion of the team ${parsedMessage.teamName}. You initiated the deletion of the team ${parsedMessage.teamName}. The team is archived and inactive now.`;
+      return `${parsedMessage.ownerName} deleted the team ${parsedMessage.teamName}. You deleted the team ${parsedMessage.teamName}.`;
     default:
       return "";
   }
@@ -908,6 +922,7 @@ const Chat = () => {
 
   const teamData =
     conversationType === "team" ? activeConversation?.team || null : null;
+  const isActiveTeamArchived = isTeamArchived || isArchivedTeamData(teamData);
 
   const teamMembers = useMemo(() => {
     const members =
@@ -985,10 +1000,36 @@ const Chat = () => {
     async (teamId) => {
       if (!teamId || !user?.id) return true;
 
-      const teamPayload = await fetchTeamDetails(teamId, { force: true });
+      let teamPayload = null;
+
+      try {
+        const conversationResponse = await messageService.getConversationById(
+          teamId,
+          "team",
+        );
+        teamPayload = conversationResponse?.data?.team || null;
+      } catch (conversationError) {
+        if (
+          conversationError.response?.status === 404 ||
+          conversationError.response?.status === 403
+        ) {
+          revokeTeamChatAccess(teamId);
+          return false;
+        }
+
+        throw conversationError;
+      }
 
       if (!Array.isArray(teamPayload?.members)) {
-        return true;
+        try {
+          teamPayload = await fetchTeamDetails(teamId, { force: true });
+        } catch (teamError) {
+          if (teamError.response?.status === 404 && isArchivedTeamData(teamPayload)) {
+            return true;
+          }
+
+          throw teamError;
+        }
       }
 
       if (!isUserTeamMember(teamPayload.members, user.id)) {
@@ -1007,10 +1048,7 @@ const Chat = () => {
 
         return {
           ...prev,
-          team: {
-            ...prev.team,
-            members: teamPayload.members,
-          },
+          team: mergeTeamDetailsIntoConversationData(prev, teamPayload).team,
         };
       });
 
@@ -1023,12 +1061,24 @@ const Chat = () => {
     async (conversationDetails, teamId) => {
       if (!conversationDetails?.data || !teamId) return false;
 
+      if (isArchivedTeamData(conversationDetails.data.team)) {
+        setIsTeamArchived(true);
+
+        if (Array.isArray(conversationDetails.data.team?.members)) {
+          if (!isUserTeamMember(conversationDetails.data.team.members, user?.id)) {
+            revokeTeamChatAccess(teamId);
+            setLoadingMessages(false);
+            return true;
+          }
+        }
+
+        return false;
+      }
+
       try {
         const teamPayload = await fetchTeamDetails(teamId);
 
-        setIsTeamArchived(
-          Boolean(teamPayload?.archived_at || teamPayload?.status === "inactive"),
-        );
+        setIsTeamArchived(isArchivedTeamData(teamPayload));
 
         if (Array.isArray(teamPayload?.members)) {
           if (!isUserTeamMember(teamPayload.members, user?.id)) {
@@ -1541,6 +1591,8 @@ const Chat = () => {
           );
 
           if (type === "team" && conversationDetails?.data) {
+            setIsTeamArchived(isArchivedTeamData(conversationDetails.data.team));
+
             const accessRevoked = await hydrateTeamConversationDetails(
               conversationDetails,
               conversationId,
@@ -1575,6 +1627,11 @@ const Chat = () => {
                       conversationDetails.data.team.is_synthetic ??
                       conversationDetails.data.team.isSynthetic ??
                       undefined,
+                    archived_at: conversationDetails.data.team.archived_at,
+                    archivedAt:
+                      conversationDetails.data.team.archivedAt ??
+                      conversationDetails.data.team.archived_at,
+                    status: conversationDetails.data.team.status,
                   },
                   lastMessage: "Start your team conversation...",
                   updatedAt: new Date().toISOString(),
@@ -2300,35 +2357,7 @@ const Chat = () => {
         return;
       }
 
-      fetchTeamDetails(data.teamId, { force: true })
-        .then((teamPayload) => {
-          if (!Array.isArray(teamPayload?.members)) {
-            return;
-          }
-
-          if (!isUserTeamMember(teamPayload.members, user?.id)) {
-            revokeTeamChatAccess(data.teamId);
-            return;
-          }
-
-          setActiveConversation((prev) => {
-            if (
-              !prev ||
-              prev.type !== "team" ||
-              String(prev.team?.id ?? prev.id) !== String(data.teamId)
-            ) {
-              return prev;
-            }
-
-            return {
-              ...prev,
-              team: {
-                ...prev.team,
-                members: teamPayload.members,
-              },
-            };
-          });
-        })
+      refreshActiveTeamMembership(data.teamId)
         .catch((err) =>
           console.error("Error refreshing active team members:", err),
         );
@@ -3402,7 +3431,9 @@ const Chat = () => {
               {/* Deleted team banner + message input */}
               <div className="border-t border-base-200">
                 {/* Show banner for archived teams */}
-                {isTeamArchived && conversationType === "team" && (
+                {isActiveTeamArchived &&
+                  conversationType === "team" &&
+                  isCurrentUserActiveTeamMember && (
                   <div
                     className="flex flex-col items-center gap-3 px-5 py-4 mx-4 mt-4 rounded-2xl text-center"
                     style={{
@@ -3410,36 +3441,23 @@ const Chat = () => {
                       color: "#dc2626",
                     }}
                   >
-                    <span className="text-sm font-medium">
-                      {activeConversation?.team?.members?.some(
-                        (m) => m.userId === user?.id && m.role === "owner",
-                      )
-                        ? `You initiated the deletion of this team. The team is archived and inactive now. Remaining members are able to text in this chat until the last member leaves.`
-                        : `${(() => {
-                            const owner =
-                              activeConversation?.team?.members?.find(
-                                (m) => m.role === "owner",
-                              );
-                            return owner
-                              ? `${owner.firstName} ${owner.lastName}`
-                              : "The owner";
-                          })()} has initiated the deletion of this team. The team is archived and inactive now. Remaining members are able to text in this chat until the last member leaves.`}
-                    </span>
+                    <AlertTriangle size={18} className="shrink-0" />
+                    <div className="inline-flex max-w-full rounded-md bg-red-500/10 px-3 py-2 text-sm font-medium text-red-600">
+                      <span>
+                        This team was deleted. The chat stays available for up
+                        to 30 days so remaining teammates can say goodbye. Leave
+                        anytime; after leaving or deletion, messages and files
+                        are no longer accessible.
+                      </span>
+                    </div>
 
-                    {/* Leave Team Button */}
                     <button
                       onClick={() => handleLeaveTeam()}
-                      className="flex items-center gap-1 text-xs underline hover:no-underline opacity-80 hover:opacity-100 transition-opacity cursor-pointer"
+                      className="flex items-center gap-1 text-xs text-red-600 underline opacity-80 transition-opacity hover:opacity-100 hover:no-underline cursor-pointer"
                     >
                       <LogOut size={14} />
-                      Leave team and remove from chat list
+                      Leave team chat now
                     </button>
-                  </div>
-                )}
-
-                {conversationType === "team" && !isCurrentUserActiveTeamMember && (
-                  <div className="mx-4 mt-4 rounded-lg bg-base-200 px-4 py-3 text-sm text-base-content/70">
-                    You are no longer a member of this team, so this chat is read-only.
                   </div>
                 )}
 

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   LogOut,
-  AlertTriangle,
+  Archive,
   ChevronRight,
   ChevronLeft,
   Users,
@@ -42,6 +42,8 @@ import { formatDisplayName } from "../utils/nameFormatters";
 import {
   formatRelativeChatTimestamp,
   normalizeTimestampToDate,
+  formatArchiveTimeRemaining,
+  msUntilNextArchiveChange,
 } from "../utils/dateHelpers";
 import { getMessageConversationTarget } from "../utils/messageNotificationUtils";
 
@@ -923,6 +925,32 @@ const Chat = () => {
   const teamData =
     conversationType === "team" ? activeConversation?.team || null : null;
   const isActiveTeamArchived = isTeamArchived || isArchivedTeamData(teamData);
+
+  // Time left before an archived team + its chat are permanently deleted
+  // (whole days, then remaining hours on the final day). Refreshed on a
+  // self-scheduling timer — once per day, then hourly on the final day —
+  // instead of recomputing on every render.
+  const activeTeamArchivedAt = teamData?.archivedAt ?? teamData?.archived_at;
+  const [activeTeamArchiveTimeRemaining, setActiveTeamArchiveTimeRemaining] =
+    useState(null);
+  useEffect(() => {
+    if (!isActiveTeamArchived || !activeTeamArchivedAt) {
+      setActiveTeamArchiveTimeRemaining(null);
+      return undefined;
+    }
+    let timeoutId;
+    const update = () => {
+      setActiveTeamArchiveTimeRemaining(
+        formatArchiveTimeRemaining(activeTeamArchivedAt),
+      );
+      const delay = msUntilNextArchiveChange(activeTeamArchivedAt);
+      if (delay != null) {
+        timeoutId = setTimeout(update, delay);
+      }
+    };
+    update();
+    return () => clearTimeout(timeoutId);
+  }, [isActiveTeamArchived, activeTeamArchivedAt]);
 
   const teamMembers = useMemo(() => {
     const members =
@@ -3441,12 +3469,14 @@ const Chat = () => {
                       color: "#dc2626",
                     }}
                   >
-                    <AlertTriangle size={18} className="shrink-0" />
+                    <Archive size={18} className="shrink-0" />
                     <div className="inline-flex max-w-full rounded-md bg-red-500/10 px-3 py-2 text-sm font-medium text-red-600">
                       <span>
-                        This team was deleted. The chat stays available for up
-                        to 30 days so remaining teammates can say goodbye. Leave
-                        anytime; after leaving or deletion, messages and files
+                        This team has been archived and is scheduled for
+                        deletion. The chat stays available for{" "}
+                        {activeTeamArchiveTimeRemaining || "up to 14 days"} so
+                        remaining teammates can say goodbye. Leave anytime; once
+                        you leave or the chat is deleted, its messages and files
                         are no longer accessible.
                       </span>
                     </div>

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -698,6 +698,10 @@ const buildMessageSearchSnippets = (messages) =>
     .map(({ message }) => ({
       id: getMessageSearchId(message),
       text: buildMessageSearchSnippet(message),
+      // Raw content is kept alongside the humanised search text so the
+      // conversation list can render a matched system/event message with its
+      // canonical icon + colour styling (via getEventPreview), not just plain text.
+      content: message?.content ?? "",
       timestamp: getMessageSearchTimestampValue(message),
     }))
     .filter((snippet) => snippet.text);
@@ -1305,6 +1309,7 @@ const Chat = () => {
                 matchedMessageSnippet.text,
                 normalizedChatSearchQuery,
               ),
+              searchMatchContent: matchedMessageSnippet.content,
               searchMatchMessageId: matchedMessageSnippet.id,
               searchMatchCreatedAt: matchedMessageSnippet.timestamp,
             }

--- a/src/pages/LegalPage.jsx
+++ b/src/pages/LegalPage.jsx
@@ -192,7 +192,7 @@ const pageContent = {
         title: "15. Storage Periods",
         items: [
           "Account and profile data are stored while the account exists. When a user deletes their account, the user profile row and direct messages involving that user are deleted immediately after confirmation, while limited team and badge references may remain only in anonymized form.",
-          "When a solo team is deleted, the team, its chat, members, invitations, applications, badges, notifications, and team avatar are deleted immediately. When a team with other remaining members is deleted, it is archived first so remaining members can see the deletion notice and read the team history; it is permanently deleted when the last member leaves or after the configured archive grace period, currently 30 days by default.",
+          "When a solo team is deleted, the team, its chat, members, invitations, applications, badges, notifications, and team avatar are deleted immediately. When a team with other remaining members is deleted, it is archived first so remaining members can see the deletion notice and read the team history; it is permanently deleted when the last member leaves or after the configured archive grace period, currently 14 days by default.",
           "Legal acknowledgement records are stored while the account exists and may be retained where necessary to document compliance or defend legal claims.",
           "Unverified accounts are scheduled for deletion after the verification link expires, with a one-hour buffer. Cleanup runs periodically and once on server startup.",
           "Password reset tokens expire after one hour and are cleared by scheduled cleanup.",

--- a/src/pages/LegalPage.jsx
+++ b/src/pages/LegalPage.jsx
@@ -5,7 +5,7 @@ import Card from "../components/common/Card";
 const CONTACT_EMAIL = "lomirapp@gmail.com";
 const LAST_UPDATED = "June 18, 2026";
 const LEGAL_NOTICE_UPDATED = "June 16, 2026";
-const PRIVACY_UPDATED = "June 25, 2026";
+const PRIVACY_UPDATED = "June 30, 2026";
 
 const mailLink = (
   <a href={`mailto:${CONTACT_EMAIL}`} className="link link-primary">
@@ -191,9 +191,10 @@ const pageContent = {
       {
         title: "15. Storage Periods",
         items: [
-          "Account and profile data are stored while the account exists and are deleted or anonymized according to the account deletion workflow.",
+          "Account and profile data are stored while the account exists. When a user deletes their account, the user profile row and direct messages involving that user are deleted immediately after confirmation, while limited team and badge references may remain only in anonymized form.",
+          "When a solo team is deleted, the team, its chat, members, invitations, applications, badges, notifications, and team avatar are deleted immediately. When a team with other remaining members is deleted, it is archived first so remaining members can see the deletion notice and read the team history; it is permanently deleted when the last member leaves or after the configured archive grace period, currently 30 days by default.",
           "Legal acknowledgement records are stored while the account exists and may be retained where necessary to document compliance or defend legal claims.",
-          "Unverified accounts are scheduled for deletion after the verification link expires, with cleanup running periodically.",
+          "Unverified accounts are scheduled for deletion after the verification link expires, with a one-hour buffer. Cleanup runs periodically and once on server startup.",
           "Password reset tokens expire after one hour and are cleared by scheduled cleanup.",
           "Chat file and image uploads expire after 60 days and are removed by scheduled cleanup where possible. Message records may remain with deleted file references removed.",
           "Avatars and team avatars are stored until replaced, removed, or deleted with the relevant account or team where technically possible.",
@@ -204,7 +205,7 @@ const pageContent = {
       {
         title: "16. Account Deletion",
         paragraphs: [
-          "Users can delete their account from the app. Deletion is designed to remove the user row and direct messages involving the user. Some team context may be preserved in anonymized form, for example as 'Former Lomir User', so that remaining teams, badge histories, ownership transfers, and role status remain understandable.",
+          "Users can delete their account from the app. After confirmation, deletion removes the user row and direct messages involving the user immediately. Some team context may be preserved in anonymized form, for example as 'Former Lomir User', so that remaining teams, badge histories, ownership transfers, and role status remain understandable.",
           "Uploaded avatars are deleted from ImageKit on a best-effort basis after successful account deletion.",
         ],
       },
@@ -301,7 +302,7 @@ const pageContent = {
       {
         title: "9. Account Deletion",
         paragraphs: [
-          "You may delete your account in the app. Account deletion is intended to be permanent. Some team and badge context may remain in anonymized or system-message form so that other users' team history and collaboration context stay understandable.",
+          "You may delete your account in the app. Account deletion is intended to be permanent; your profile and direct messages involving you are deleted immediately after confirmation. Some team and badge context may remain in anonymized or system-message form so that other users' team history and collaboration context stay understandable.",
         ],
       },
       {

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1293,7 +1293,8 @@ const Settings = () => {
                             {getTransferTeamName(team)}
                           </p>
                           <p className="text-sm text-warning">
-                            This team will be permanently deleted
+                            This solo team will be permanently deleted
+                            immediately
                           </p>
                         </div>
                       </div>

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -178,6 +178,59 @@ export const formatRelativeChatTimestamp = (value) => {
   return formatDistanceToNow(date, { addSuffix: true }).replace("about ", "");
 };
 
+// Default archive grace period in days — mirrors the backend
+// ARCHIVED_TEAM_GRACE_DAYS default. Kept in sync manually.
+export const ARCHIVE_GRACE_DAYS = 14;
+
+// Human-readable time left before an archived team (and its chat) is permanently
+// deleted: whole days while more than a day remains, then remaining hours on the
+// final day. Returns null when the archive date is missing/invalid.
+export const formatArchiveTimeRemaining = (
+  archivedAt,
+  graceDays = ARCHIVE_GRACE_DAYS,
+) => {
+  const archivedDate = normalizeTimestampToDate(archivedAt);
+  if (!archivedDate) return null;
+
+  const deletionMs =
+    archivedDate.getTime() + graceDays * 24 * 60 * 60 * 1000;
+  const remainingMs = deletionMs - Date.now();
+  if (remainingMs <= 0) return "less than an hour";
+
+  const remainingHours = remainingMs / (60 * 60 * 1000);
+  if (remainingHours < 24) {
+    const hours = Math.max(1, Math.ceil(remainingHours));
+    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+  }
+
+  const days = Math.floor(remainingHours / 24);
+  return `${days} ${days === 1 ? "day" : "days"}`;
+};
+
+// Milliseconds until formatArchiveTimeRemaining would next change its output:
+// the next whole-day boundary while more than a day remains, otherwise the next
+// hour boundary. Lets a caller refresh the countdown once per day (then hourly
+// on the final day) instead of on every render. Returns null once the grace
+// period has elapsed (nothing left to update).
+export const msUntilNextArchiveChange = (
+  archivedAt,
+  graceDays = ARCHIVE_GRACE_DAYS,
+) => {
+  const archivedDate = normalizeTimestampToDate(archivedAt);
+  if (!archivedDate) return null;
+
+  const HOUR = 60 * 60 * 1000;
+  const DAY = 24 * HOUR;
+  const remainingMs =
+    archivedDate.getTime() + graceDays * DAY - Date.now();
+  if (remainingMs <= 0) return null;
+
+  const unit = remainingMs < DAY ? HOUR : DAY;
+  const untilNext = remainingMs % unit;
+  // +1s buffer so the recompute lands just past the boundary.
+  return (untilNext === 0 ? unit : untilNext) + 1000;
+};
+
 export const formatShortRelativeChatTimestamp = (value) => {
   return formatRelativeChatTimestamp(value).replace(
     "less than a minute ago",

--- a/src/utils/eventPreview.js
+++ b/src/utils/eventPreview.js
@@ -501,8 +501,8 @@ export const getEventPreview = (lastMessage, currentUser = null) => {
       return {
         text:
           ownerName === "You"
-            ? "You archived this team"
-            : `${ownerName || "Owner"} archived this team`,
+            ? "You deleted this team"
+            : `${ownerName || "Owner"} deleted this team`,
         icon: "AlertTriangle",
         bannerClass: null,
         color: "#dc2626",

--- a/src/utils/eventPreview.js
+++ b/src/utils/eventPreview.js
@@ -501,9 +501,9 @@ export const getEventPreview = (lastMessage, currentUser = null) => {
       return {
         text:
           ownerName === "You"
-            ? "You deleted this team"
-            : `${ownerName || "Owner"} deleted this team`,
-        icon: "AlertTriangle",
+            ? "You archived this team (scheduled for deletion)"
+            : `${ownerName || "Owner"} archived this team (scheduled for deletion)`,
+        icon: "Archive",
         bannerClass: null,
         color: "#dc2626",
         backgroundColor: "rgba(239, 68, 68, 0.1)",


### PR DESCRIPTION
Ships the frontend chat work to production (PRs #537, #538). Pairs with the backend dev → main release — deploy backend first / together, since the archived-team UX consumes the backend's new archived_at/status/members fields and member-gated archived endpoints.

**Archived-team "farewell" UX (#538)**
When an owner deletes a team that still has other members, it is archived (scheduled for deletion) and its chat becomes a "farewell" window: 

- Archived chats resolve via getConversationById (no more /api/teams/:id 404 spam on open/send); archived state + membership are detected from the payload.
- The TEAM_DELETED moment is rendered as an in-chat event (red banner, Archive icon, deletion timestamp) and its notification links to it.
- Wording reframed "deleted" → "archived (scheduled for deletion)" with the Archive icon (banner, in-chat event, list preview).
- Active archived conversation card: red fill + opaque red active-arrow + red archive icon in its subline.
- Full Team Details modal for archived teams (info, focus areas, badges, roles, members) with an "Archived" tooltip; edit/manage actions hidden.
- The banner shows the real time left before deletion — whole days, then hours on the final day — via formatArchiveTimeRemaining/msUntilNextArchiveChange (ARCHIVE_GRACE_DAYS = 14), refreshed by a self-scheduling timer (daily, hourly on the last day).
- Team delete confirmations + public privacy/legal retention wording describe the solo-immediate vs. archive + 14-day-grace behavior.

**Chat-search event-message styling (#537)**

- Conversation search results now render system/event messages through the canonical getEventPreview (correct icon, colour, weight) instead of raw/plain text; metadata-only hits fall back to the last message's event preview, plain-text matches keep the windowed snippet.
- Search highlight <mark> adds only the yellow background now — it inherits the surrounding text's colour and weight (no green/bold on matched terms).

**Verification**

- ESLint 0 errors, Vite build green.
- UI smoke-verified across both features (search result styling + highlight; archived modal/tooltip, banner icon/wording + live time-left, in-chat event + notification jump, red active card/arrow + subline icon).

**Deploy notes**

- Deploy with / after the backend release (depends on the archived-team endpoints/fields).
- Remember to git push myfork main after merging origin (Vercel deploys main from the fork).
