### PR TITLE
perf(chat): stop per-conversation `getTeamById`/`getUserById` refetch in the conversation list

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Lomir-frontend/
 │   │   ├── teamRequestUtils.js     # Invitation + application helper functions (build card data, labels)
 │   │   ├── eventPreview.js         # Parse + format chat system event messages for previews and toasts
 │   │   ├── roleEventMessages.js    # Build role event message strings (filled, closed, updated, deleted, reopened)
-│   │   ├── chatEntityResolvers.js  # Resolve user/team entity objects from chat conversation payloads
+│   │   ├── chatEntityResolvers.js  # Merge/resolve user/team entities for chat; conversation list trusts the embedded getConversations payload (name/avatar/synthetic) — per-entity fetch only as a fallback when the synthetic flag is missing
 │   │   ├── messageSystemParser.js  # parseSystemMessage: parse chat system/event message payloads (MessageDisplay)
 │   │   ├── messageDisplayHelpers.js # Pure MessageDisplay helpers: getEventReactionPreview, formatReplyTooltipText, getFileIcon
 │   │   ├── messageDisplayRenderers.jsx # JSX render helpers for MessageDisplay: renderReplyContent, renderHighlightedSearchText
@@ -387,6 +387,7 @@ The chat page supports both direct (1-to-1) and team group conversations.
 - Team actions (joins, role changes, invitations accepted/declined, ownership transfers) post styled event banners into the team chat automatically
 - Role lifecycle events post dedicated banners: role filled (via application or invitation acceptance), role closed, role updated, role deleted, and role reopened — each with a distinct icon and colour
 - Conversation list cards show a colour-coded icon and short preview for event messages instead of raw system text; notification toasts resolve the same icons and preview text
+- Conversation list cards render each team's/partner's name, avatar, and demo overlay directly from the embedded conversation payload — no per-conversation profile fetch on chat load (only the active conversation resolves its own details)
 
 **Render resilience**
 - Chat routes are wrapped in a small `ErrorBoundary` so unexpected render errors show a visible fallback instead of a blank white screen

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -36,7 +36,6 @@ import {
 import {
   getCachedChatTeamProfile,
   getCachedChatUserProfile,
-  getTeamAvatarUrl,
   mergeResolvedTeamData,
   mergeResolvedUserData,
 } from "../../utils/chatEntityResolvers";
@@ -397,6 +396,12 @@ const ConversationList = ({
     const userIdsToFetch = [];
     const teamIdsToFetch = [];
 
+    // getConversations already embeds everything this list renders — name,
+    // avatar and (as of the N+1 fix) the synthetic flag. Avatar and synthetic
+    // status come from the same DB columns getTeamById/getUserById would read,
+    // so a null avatar is a valid final state, not a reason to re-fetch. Only
+    // resolve when the synthetic flag is genuinely absent, which keeps a
+    // graceful fallback if an older backend omits it from the payload.
     conversations.forEach((conversation) => {
       if (conversation.type === "team") {
         const team = conversation.team;
@@ -404,8 +409,8 @@ const ConversationList = ({
 
         if (
           teamId != null &&
-          (!getTeamAvatarUrl(team) ||
-            (team?.is_synthetic == null && team?.isSynthetic == null))
+          team?.is_synthetic == null &&
+          team?.isSynthetic == null
         ) {
           teamIdsToFetch.push(teamId);
         }
@@ -418,8 +423,8 @@ const ConversationList = ({
 
       if (
         userId != null &&
-        (!(partner?.avatar_url || partner?.avatarUrl) ||
-          (partner?.is_synthetic == null && partner?.isSynthetic == null))
+        partner?.is_synthetic == null &&
+        partner?.isSynthetic == null
       ) {
         userIdsToFetch.push(userId);
       }


### PR DESCRIPTION
### Problem
`ConversationList` resolved every conversation by firing a per-entity `getTeamById` / `getUserById` request whenever the avatar **or** the synthetic flag looked absent. This produced ~17 redundant `GET /api/teams/:id` + `GET /api/users/:id` requests on every chat load (prod-confirmed, pre-existing).

Two triggers were at fault:
1. **Teams** always re-fetched, because `getConversations` never included `is_synthetic`, so the `is_synthetic == null` gate was always true.
2. **A `null` avatar** was treated as "needs fetching" — but avatar and synthetic status come from the *same* DB columns `getTeamById` / `getUserById` would read, so a missing avatar is a valid final state, not a reason to round-trip.

### Change
- Gate resolution on the **synthetic flag only** (drop the avatar-absence trigger) for both team and direct conversations.
- Remove the now-unused `getTeamAvatarUrl` import.
- README: document that conversation list cards render name/avatar/demo overlay directly from the embedded conversation payload, and refine the `chatEntityResolvers` file-tree note to reflect the per-entity fetch is now a fallback.

With the paired backend change embedding `is_synthetic` (incl. teams) in `getConversations`, both gates now stay silent → **0 extra calls**. If an older backend omits the flag, the team gate still fires as a graceful fallback.

The conversation list now renders team/user avatars directly from the embedded payload (image assets only, no `/api` round-trips). On-demand resolver caches (`getCachedChatTeamProfile` etc.) remain in use by `MessageDisplay` and `AwardCard` and are unaffected.

### Testing
- ESLint: **0 problems** ✅
- Production build: **green** ✅
- Local smoke (both repos on the branch, Firefox Network): chat load issues **no** per-conversation `/api/teams/:id` or `/api/users/:id` — only a single `GET /api/teams/143` for the *active* conversation (expected membership check). The `conversations/:id ×2` are the known StrictMode dev double-invoke, not a prod issue. Avatars and demo overlays render correctly from the payload.

### Depends on
Backend PR embedding `is_synthetic` in `getConversations`. Safe to merge independently thanks to the fallback, but the extra calls only disappear once the backend ships.
