### PR TITLE
Release the frontend chat conversation-list performance fixes from `dev` to `main`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Lomir-frontend/
 │   │   ├── teamRequestUtils.js     # Invitation + application helper functions (build card data, labels)
 │   │   ├── eventPreview.js         # Parse + format chat system event messages for previews and toasts
 │   │   ├── roleEventMessages.js    # Build role event message strings (filled, closed, updated, deleted, reopened)
-│   │   ├── chatEntityResolvers.js  # Resolve user/team entity objects from chat conversation payloads
+│   │   ├── chatEntityResolvers.js  # Merge/resolve user/team entities for chat; conversation list trusts the embedded getConversations payload (name/avatar/synthetic) — per-entity fetch only as a fallback when the synthetic flag is missing
 │   │   ├── messageSystemParser.js  # parseSystemMessage: parse chat system/event message payloads (MessageDisplay)
 │   │   ├── messageDisplayHelpers.js # Pure MessageDisplay helpers: getEventReactionPreview, formatReplyTooltipText, getFileIcon
 │   │   ├── messageDisplayRenderers.jsx # JSX render helpers for MessageDisplay: renderReplyContent, renderHighlightedSearchText
@@ -387,6 +387,7 @@ The chat page supports both direct (1-to-1) and team group conversations.
 - Team actions (joins, role changes, invitations accepted/declined, ownership transfers) post styled event banners into the team chat automatically
 - Role lifecycle events post dedicated banners: role filled (via application or invitation acceptance), role closed, role updated, role deleted, and role reopened — each with a distinct icon and colour
 - Conversation list cards show a colour-coded icon and short preview for event messages instead of raw system text; notification toasts resolve the same icons and preview text
+- Conversation list cards render each team's/partner's name, avatar, and demo overlay directly from the embedded conversation payload — no per-conversation profile fetch on chat load (only the active conversation resolves its own details)
 
 **Render resilience**
 - Chat routes are wrapped in a small `ErrorBoundary` so unexpected render errors show a visible fallback instead of a blank white screen

--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -36,7 +36,6 @@ import {
 import {
   getCachedChatTeamProfile,
   getCachedChatUserProfile,
-  getTeamAvatarUrl,
   mergeResolvedTeamData,
   mergeResolvedUserData,
 } from "../../utils/chatEntityResolvers";
@@ -397,6 +396,12 @@ const ConversationList = ({
     const userIdsToFetch = [];
     const teamIdsToFetch = [];
 
+    // getConversations already embeds everything this list renders — name,
+    // avatar and (as of the N+1 fix) the synthetic flag. Avatar and synthetic
+    // status come from the same DB columns getTeamById/getUserById would read,
+    // so a null avatar is a valid final state, not a reason to re-fetch. Only
+    // resolve when the synthetic flag is genuinely absent, which keeps a
+    // graceful fallback if an older backend omits it from the payload.
     conversations.forEach((conversation) => {
       if (conversation.type === "team") {
         const team = conversation.team;
@@ -404,8 +409,8 @@ const ConversationList = ({
 
         if (
           teamId != null &&
-          (!getTeamAvatarUrl(team) ||
-            (team?.is_synthetic == null && team?.isSynthetic == null))
+          team?.is_synthetic == null &&
+          team?.isSynthetic == null
         ) {
           teamIdsToFetch.push(teamId);
         }
@@ -418,8 +423,8 @@ const ConversationList = ({
 
       if (
         userId != null &&
-        (!(partner?.avatar_url || partner?.avatarUrl) ||
-          (partner?.is_synthetic == null && partner?.isSynthetic == null))
+        partner?.is_synthetic == null &&
+        partner?.isSynthetic == null
       ) {
         userIdsToFetch.push(userId);
       }

--- a/src/utils/chatEntityResolvers.js
+++ b/src/utils/chatEntityResolvers.js
@@ -13,6 +13,14 @@ export const extractEntityPayload = (response) => {
   return payload?.data?.data ?? payload?.data ?? payload;
 };
 
+// A 404 from an entity endpoint is a stable "gone or not visible to you"
+// result for the session (e.g. a chat system/event message that references a
+// deleted team). Keep the rejected request cached so repeat renders/intervals
+// short-circuit through the cache instead of re-hitting /api/teams/:id or
+// /api/users/:id every time. Transient failures (network, 5xx) stay evicted so
+// they can be retried on the next call.
+const isCacheableAbsence = (error) => error?.response?.status === 404;
+
 const getCachedEntity = async (cache, cacheKey, loader) => {
   if (cache.has(cacheKey)) {
     return cache.get(cacheKey);
@@ -26,7 +34,12 @@ const getCachedEntity = async (cache, cacheKey, loader) => {
     cache.set(cacheKey, Promise.resolve(result));
     return result;
   } catch (error) {
-    cache.delete(cacheKey);
+    // Leave the (rejected) request in the cache for a known-absent entity so
+    // future lookups reuse it; evict only transient failures. Callers already
+    // handle the rejection, so the caching is transparent to them.
+    if (!isCacheableAbsence(error)) {
+      cache.delete(cacheKey);
+    }
     throw error;
   }
 };


### PR DESCRIPTION
## Summary

Release the frontend chat conversation-list performance fixes from `dev` to `main`.

This removes unnecessary per-conversation entity refetching in the chat list and caches stable 404 misses in the chat entity resolver.

## Changes

- Update `ConversationList` to trust the embedded conversation payload for avatars/display data.
- Gate extra team/user resolution only on a missing synthetic flag, instead of treating a missing avatar as a reason to refetch.
- Remove the unused `getTeamAvatarUrl` import.
- Cache 404 responses in `chatEntityResolvers` so hard-deleted/missing entities are not retried on every render.
- Continue evicting transient failures such as network errors or 5xx responses so they can retry later.
- Update the README to document the embedded-payload chat list behavior.

## Why

The previous resolver gate caused one `getTeamById` / `getUserById` call per conversation in common chat-list loads. A `null` avatar is valid final display data, not proof that the entity needs to be fetched again.

This release keeps the list render on the existing conversation payload and avoids repeated 404 lookups for entities that are permanently gone or no longer visible.

## Verification

- `npx eslint`
- `npm run build`
- Local smoke verified:
  - chat list renders cleanly
  - avatars/demo overlays/event previews still display from the payload
  - no spurious per-conversation `/api/teams/:id` or `/api/users/:id` calls during normal chat-list load

## Deploy Notes

Deploy together with, or after, the backend `dev → main` release. After production deploy, verify with a HAR/network smoke that chat loading produces `0` per-conversation `/api/teams|users` API calls. Avatar image asset requests from ImageKit or placeholder services are expected and should not be counted as API refetches.