### PR TITLE
fix(chat): hide conversation-card unread badge when count is zero

### DIFF
--- a/src/components/chat/ConversationList.jsx
+++ b/src/components/chat/ConversationList.jsx
@@ -748,7 +748,7 @@ const ConversationList = ({
                       demoOverlayTextTranslateClassName="-translate-y-[2px]"
                     />
                   )}
-                  {(conversation.unreadCount || conversation.unread_count) > 0 && (
+                  {(conversation.unreadCount ?? conversation.unread_count ?? 0) > 0 && (
                     <CountBadge
                       count={conversation.unreadCount ?? conversation.unread_count}
                       className="absolute -top-1 -left-2 z-10"


### PR DESCRIPTION
## Summary

A conversation card in the chat list could show an unread badge displaying
**"0"** after all its messages were read. The badge should only appear when
there is at least one unread message. This makes the visibility guard consistent
with the rendered count so a zero count hides the badge.

## Root cause
The card guarded badge visibility and computed the count with **different**
nullish handling:

```jsx
{(conversation.unreadCount || conversation.unread_count) > 0 && (
  <CountBadge count={conversation.unreadCount ?? conversation.unread_count} ... />
)}
When a conversation is read, unreadCount becomes 0 while the snake_case
unread_count can remain stale (> 0):

Guard uses ||, which treats 0 as falsy → falls through to the stale unread_count → > 0 → badge renders.
Count uses ??, which treats 0 as a valid value → keeps 0 → badge shows "0".
Fix
Resolve the guard with the same ?? … ?? 0 chain used for the count, so a
zero unread count (a read conversation) hides the badge:


{(conversation.unreadCount ?? conversation.unread_count ?? 0) > 0 && (
This matches the correct resolution already used elsewhere in Chat.jsx
(conv.unreadCount ?? conv.unread_count ?? 0).

Scope
One line in src/components/chat/ConversationList.jsx. Pre-existing bug
(present in production), independent of the ongoing Chat.jsx decomposition
work. The same latent pattern in the newly-extracted ConversationHeader.jsx
is fixed on the decomposition branch.

Testing
ESLint clean, production build green.
Manual: open a conversation with unread messages, read them all → the card's unread badge disappears instead of showing "0"; a conversation with real unread messages still shows the correct count.
Risk
Minimal — a single guard-expression change; no data, layout, or API changes.