### PR TITLE
Refactor/chat jsx decomposition stage 3 subcomponents

### DIFF
--- a/src/components/chat/ArchivedTeamBanner.jsx
+++ b/src/components/chat/ArchivedTeamBanner.jsx
@@ -1,0 +1,38 @@
+import { Archive, LogOut } from "lucide-react";
+
+// Farewell banner shown inside an archived team's chat during the deletion
+// grace window, for remaining members. Presentational — the parent gates
+// visibility and passes the remaining-time label and the leave handler.
+const ArchivedTeamBanner = ({ timeRemaining, onLeave }) => {
+  return (
+                  <div
+                    className="flex flex-col items-center gap-3 px-5 py-4 mx-4 mt-4 rounded-2xl text-center"
+                    style={{
+                      backgroundColor: "rgba(239, 68, 68, 0.1)",
+                      color: "#dc2626",
+                    }}
+                  >
+                    <Archive size={18} className="shrink-0" />
+                    <div className="inline-flex max-w-full rounded-md bg-red-500/10 px-3 py-2 text-sm font-medium text-red-600">
+                      <span>
+                        This team has been archived and is scheduled for
+                        deletion. The chat stays available for{" "}
+                        {timeRemaining || "up to 14 days"} so
+                        remaining teammates can say goodbye. Leave anytime; once
+                        you leave or the chat is deleted, its messages and files
+                        are no longer accessible.
+                      </span>
+                    </div>
+
+                    <button
+                      onClick={onLeave}
+                      className="flex items-center gap-1 text-xs text-red-600 underline opacity-80 transition-opacity hover:opacity-100 hover:no-underline cursor-pointer"
+                    >
+                      <LogOut size={14} />
+                      Leave team chat now
+                    </button>
+                  </div>
+  );
+};
+
+export default ArchivedTeamBanner;

--- a/src/components/chat/ConversationHeader.jsx
+++ b/src/components/chat/ConversationHeader.jsx
@@ -1,0 +1,174 @@
+import Tooltip from "../common/Tooltip";
+import { CountBadge } from "../common/NotificationBadge";
+import UserAvatar from "../users/UserAvatar";
+import TeamAvatar from "../teams/TeamAvatar";
+import { ChevronLeft, Users, User, FlaskConical } from "lucide-react";
+import {
+  isSyntheticTeam,
+  isSyntheticUser,
+  DEMO_PROFILE_TOOLTIP,
+  DEMO_TEAM_TOOLTIP,
+} from "../../utils/userHelpers";
+import { formatRelativeChatTimestamp } from "../../utils/dateHelpers";
+
+// Compact conversation header for the chat page: avatar, name, and meta line
+// (team member count / DM label, demo overlay, relative timestamp), plus a
+// mobile back button. Presentational — all data and click handlers are passed
+// in by Chat.jsx. Extracted verbatim from Chat.jsx (Stage 3 decomposition).
+const ConversationHeader = ({
+  showCompactConversationHeader,
+  onBack,
+  conversationType,
+  teamData,
+  conversationPartner,
+  activeConversation,
+  conversationUpdatedAt,
+  onTeamClick,
+  onUserClick,
+}) => {
+  return (
+              <div
+                className={`flex items-center justify-between border-b border-base-200 p-3 md:p-4 bg-base-100 ${
+                  showCompactConversationHeader ? "md:flex" : "md:hidden"
+                }`}
+              >
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  {/* Back/List toggle button - visible on small screens */}
+                  <Tooltip
+                    content="Back to conversation list"
+                    position="bottom"
+                    wrapperClassName="md:hidden inline-flex items-center flex-shrink-0"
+                  >
+                    <button
+                      onClick={onBack}
+                      className="flex items-center justify-center p-2 hover:bg-base-200 rounded-lg transition-colors"
+                      aria-label="Back to conversation list"
+                    >
+                      <ChevronLeft size={20} />
+                    </button>
+                  </Tooltip>
+                  
+                  {/* Conversation Header - Avatar and name */}
+                  <div className="flex items-center gap-3 min-w-0 flex-1">
+                    {conversationType === "team" && teamData ? (
+                      <Tooltip
+                        content={`View ${teamData.name} details`}
+                        position="bottom"
+                        wrapperClassName="inline-flex items-center flex-shrink-0"
+                      >
+                        <div className="relative">
+                          <TeamAvatar
+                            team={teamData}
+                            sizeClass="w-10 h-10"
+                            clickable={true}
+                            onClick={onTeamClick}
+                            initialsClassName="text-sm font-medium"
+                            showDemoOverlay={isSyntheticTeam(teamData)}
+                            demoOverlayTextClassName="text-[7px]"
+                          />
+                          {(activeConversation?.unreadCount || activeConversation?.unread_count) > 0 && (
+                            <CountBadge
+                              count={activeConversation.unreadCount ?? activeConversation.unread_count}
+                              className="absolute -top-1 -left-2 z-10"
+                            />
+                          )}
+                        </div>
+                      </Tooltip>
+                    ) : conversationPartner ? (
+                      <Tooltip
+                        content={`View ${[conversationPartner.firstName, conversationPartner.lastName].filter(Boolean).join(" ")} details`}
+                        position="bottom"
+                        wrapperClassName="inline-flex items-center flex-shrink-0"
+                      >
+                        <div
+                          className="cursor-pointer hover:opacity-80 transition-opacity relative"
+                          onClick={onUserClick}
+                        >
+                          <UserAvatar
+                            user={conversationPartner}
+                            sizeClass="w-10 h-10"
+                            iconSize={20}
+                            initialsClassName="text-sm font-medium"
+                            showDemoOverlay
+                            demoOverlayTextClassName="text-[7px]"
+                            demoOverlayTextTranslateClassName="-translate-y-[2px]"
+                          />
+                          {(activeConversation?.unreadCount || activeConversation?.unread_count) > 0 && (
+                            <CountBadge
+                              count={activeConversation.unreadCount ?? activeConversation.unread_count}
+                              className="absolute -top-1 -left-2 z-10"
+                            />
+                          )}
+                        </div>
+                      </Tooltip>
+                    ) : null}
+                    <div className="min-w-0 flex-1">
+                      <Tooltip
+                        content={
+                          conversationType === "team"
+                            ? `View ${teamData?.name} details`
+                            : `View ${[conversationPartner?.firstName, conversationPartner?.lastName].filter(Boolean).join(" ")} details`
+                        }
+                        position="bottom"
+                        wrapperClassName="block min-w-0"
+                      >
+                        <h3
+                          className="font-medium truncate text-sm cursor-pointer hover:text-primary transition-colors"
+                          onClick={conversationType === "team" ? onTeamClick : onUserClick}
+                        >
+                          {conversationType === "team" ? teamData?.name : [conversationPartner?.firstName, conversationPartner?.lastName].filter(Boolean).join(" ")}
+                        </h3>
+                      </Tooltip>
+                      {conversationType === "team" ? (
+                        <div className="text-xs text-base-content/60 flex items-center justify-between gap-1.5 flex-nowrap">
+                          <div className="flex items-center gap-1.5 min-w-0">
+                            <Users size={12} className="flex-shrink-0" />
+                            <span className="truncate">
+                              {teamData?.members
+                                ? `Team Chat with ${teamData.members.length} ${teamData.members.length === 1 ? "Member" : "Members"}`
+                                : "Team Chat"}
+                            </span>
+                            {isSyntheticTeam(teamData) && (
+                              <Tooltip
+                                content={DEMO_TEAM_TOOLTIP}
+                                wrapperClassName="flex items-center gap-0.5 text-base-content/50 flex-shrink-0"
+                              >
+                                <FlaskConical size={10} className="flex-shrink-0" />
+                              </Tooltip>
+                            )}
+                          </div>
+                          {conversationUpdatedAt && (
+                            <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
+                              {formatRelativeChatTimestamp(conversationUpdatedAt)}
+                            </span>
+                          )}
+                        </div>
+                      ) : conversationType === "direct" ? (
+                        <div className="text-xs text-base-content/60 flex items-center justify-between gap-1.5 flex-nowrap">
+                          <div className="flex items-center gap-1.5 min-w-0">
+                            <User size={12} className="flex-shrink-0" />
+                            <span className="truncate">DM Chat</span>
+                            {isSyntheticUser(conversationPartner) && (
+                              <Tooltip
+                                content={DEMO_PROFILE_TOOLTIP}
+                                wrapperClassName="flex items-center gap-0.5 text-base-content/50 flex-shrink-0"
+                              >
+                                <FlaskConical size={10} className="flex-shrink-0" />
+                              </Tooltip>
+                            )}
+                          </div>
+                          {conversationUpdatedAt && (
+                            <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
+                              {formatRelativeChatTimestamp(conversationUpdatedAt)}
+                            </span>
+                          )}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </div>
+  );
+};
+
+export default ConversationHeader;

--- a/src/components/chat/ConversationHeader.jsx
+++ b/src/components/chat/ConversationHeader.jsx
@@ -66,7 +66,7 @@ const ConversationHeader = ({
                             showDemoOverlay={isSyntheticTeam(teamData)}
                             demoOverlayTextClassName="text-[7px]"
                           />
-                          {(activeConversation?.unreadCount || activeConversation?.unread_count) > 0 && (
+                          {(activeConversation?.unreadCount ?? activeConversation?.unread_count ?? 0) > 0 && (
                             <CountBadge
                               count={activeConversation.unreadCount ?? activeConversation.unread_count}
                               className="absolute -top-1 -left-2 z-10"
@@ -93,7 +93,7 @@ const ConversationHeader = ({
                             demoOverlayTextClassName="text-[7px]"
                             demoOverlayTextTranslateClassName="-translate-y-[2px]"
                           />
-                          {(activeConversation?.unreadCount || activeConversation?.unread_count) > 0 && (
+                          {(activeConversation?.unreadCount ?? activeConversation?.unread_count ?? 0) > 0 && (
                             <CountBadge
                               count={activeConversation.unreadCount ?? activeConversation.unread_count}
                               className="absolute -top-1 -left-2 z-10"

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1,15 +1,12 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   LogOut,
-  Archive,
   ChevronRight,
   ChevronLeft,
-  Users,
   User,
   Trash2,
   Search,
   X,
-  FlaskConical,
 } from "lucide-react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
@@ -18,6 +15,7 @@ import { useConversations, conversationsQueryKey } from "../hooks/useChatQueries
 import PageContainer from "../components/layout/PageContainer";
 import ConversationList from "../components/chat/ConversationList";
 import ConversationHeader from "../components/chat/ConversationHeader";
+import ArchivedTeamBanner from "../components/chat/ArchivedTeamBanner";
 import MessageDisplay from "../components/chat/MessageDisplay";
 import { parseSystemMessage } from "../utils/messageSystemParser";
 import MessageInput from "../components/chat/MessageInput";
@@ -2631,33 +2629,10 @@ const Chat = () => {
                 {isActiveTeamArchived &&
                   conversationType === "team" &&
                   isCurrentUserActiveTeamMember && (
-                  <div
-                    className="flex flex-col items-center gap-3 px-5 py-4 mx-4 mt-4 rounded-2xl text-center"
-                    style={{
-                      backgroundColor: "rgba(239, 68, 68, 0.1)",
-                      color: "#dc2626",
-                    }}
-                  >
-                    <Archive size={18} className="shrink-0" />
-                    <div className="inline-flex max-w-full rounded-md bg-red-500/10 px-3 py-2 text-sm font-medium text-red-600">
-                      <span>
-                        This team has been archived and is scheduled for
-                        deletion. The chat stays available for{" "}
-                        {activeTeamArchiveTimeRemaining || "up to 14 days"} so
-                        remaining teammates can say goodbye. Leave anytime; once
-                        you leave or the chat is deleted, its messages and files
-                        are no longer accessible.
-                      </span>
-                    </div>
-
-                    <button
-                      onClick={() => handleLeaveTeam()}
-                      className="flex items-center gap-1 text-xs text-red-600 underline opacity-80 transition-opacity hover:opacity-100 hover:no-underline cursor-pointer"
-                    >
-                      <LogOut size={14} />
-                      Leave team chat now
-                    </button>
-                  </div>
+                  <ArchivedTeamBanner
+                    timeRemaining={activeTeamArchiveTimeRemaining}
+                    onLeave={() => handleLeaveTeam()}
+                  />
                 )}
 
                 <div className="p-4">

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -17,6 +17,7 @@ import { fetchTeamById } from "../hooks/useTeamQueries";
 import { useConversations, conversationsQueryKey } from "../hooks/useChatQueries";
 import PageContainer from "../components/layout/PageContainer";
 import ConversationList from "../components/chat/ConversationList";
+import ConversationHeader from "../components/chat/ConversationHeader";
 import MessageDisplay from "../components/chat/MessageDisplay";
 import { parseSystemMessage } from "../utils/messageSystemParser";
 import MessageInput from "../components/chat/MessageInput";
@@ -37,10 +38,9 @@ import UserAvatar from "../components/users/UserAvatar";
 import TeamAvatar from "../components/teams/TeamAvatar";
 import TeamDetailsModal from "../components/teams/TeamDetailsModal";
 import UserDetailsModal from "../components/users/UserDetailsModal";
-import { isSyntheticTeam, isSyntheticUser, DEMO_PROFILE_TOOLTIP, DEMO_TEAM_TOOLTIP } from "../utils/userHelpers";
+import { DEMO_PROFILE_TOOLTIP, DEMO_TEAM_TOOLTIP } from "../utils/userHelpers";
 import { formatDisplayName } from "../utils/nameFormatters";
 import {
-  formatRelativeChatTimestamp,
   normalizeTimestampToDate,
   formatArchiveTimeRemaining,
   msUntilNextArchiveChange,
@@ -2589,148 +2589,17 @@ const Chat = () => {
         }`}>
           {conversationId ? (
             <>
-              {/* Compact header, also shown on desktop when both regular headers are out of view */}
-              <div
-                className={`flex items-center justify-between border-b border-base-200 p-3 md:p-4 bg-base-100 ${
-                  showCompactConversationHeader ? "md:flex" : "md:hidden"
-                }`}
-              >
-                <div className="flex items-center gap-2 min-w-0 flex-1">
-                  {/* Back/List toggle button - visible on small screens */}
-                  <Tooltip
-                    content="Back to conversation list"
-                    position="bottom"
-                    wrapperClassName="md:hidden inline-flex items-center flex-shrink-0"
-                  >
-                    <button
-                      onClick={() => setShowChatView(false)}
-                      className="flex items-center justify-center p-2 hover:bg-base-200 rounded-lg transition-colors"
-                      aria-label="Back to conversation list"
-                    >
-                      <ChevronLeft size={20} />
-                    </button>
-                  </Tooltip>
-                  
-                  {/* Conversation Header - Avatar and name */}
-                  <div className="flex items-center gap-3 min-w-0 flex-1">
-                    {conversationType === "team" && teamData ? (
-                      <Tooltip
-                        content={`View ${teamData.name} details`}
-                        position="bottom"
-                        wrapperClassName="inline-flex items-center flex-shrink-0"
-                      >
-                        <div className="relative">
-                          <TeamAvatar
-                            team={teamData}
-                            sizeClass="w-10 h-10"
-                            clickable={true}
-                            onClick={handleHeaderTeamClick}
-                            initialsClassName="text-sm font-medium"
-                            showDemoOverlay={isSyntheticTeam(teamData)}
-                            demoOverlayTextClassName="text-[7px]"
-                          />
-                          {(activeConversation?.unreadCount || activeConversation?.unread_count) > 0 && (
-                            <CountBadge
-                              count={activeConversation.unreadCount ?? activeConversation.unread_count}
-                              className="absolute -top-1 -left-2 z-10"
-                            />
-                          )}
-                        </div>
-                      </Tooltip>
-                    ) : conversationPartner ? (
-                      <Tooltip
-                        content={`View ${[conversationPartner.firstName, conversationPartner.lastName].filter(Boolean).join(" ")} details`}
-                        position="bottom"
-                        wrapperClassName="inline-flex items-center flex-shrink-0"
-                      >
-                        <div
-                          className="cursor-pointer hover:opacity-80 transition-opacity relative"
-                          onClick={handleHeaderUserClick}
-                        >
-                          <UserAvatar
-                            user={conversationPartner}
-                            sizeClass="w-10 h-10"
-                            iconSize={20}
-                            initialsClassName="text-sm font-medium"
-                            showDemoOverlay
-                            demoOverlayTextClassName="text-[7px]"
-                            demoOverlayTextTranslateClassName="-translate-y-[2px]"
-                          />
-                          {(activeConversation?.unreadCount || activeConversation?.unread_count) > 0 && (
-                            <CountBadge
-                              count={activeConversation.unreadCount ?? activeConversation.unread_count}
-                              className="absolute -top-1 -left-2 z-10"
-                            />
-                          )}
-                        </div>
-                      </Tooltip>
-                    ) : null}
-                    <div className="min-w-0 flex-1">
-                      <Tooltip
-                        content={
-                          conversationType === "team"
-                            ? `View ${teamData?.name} details`
-                            : `View ${[conversationPartner?.firstName, conversationPartner?.lastName].filter(Boolean).join(" ")} details`
-                        }
-                        position="bottom"
-                        wrapperClassName="block min-w-0"
-                      >
-                        <h3
-                          className="font-medium truncate text-sm cursor-pointer hover:text-primary transition-colors"
-                          onClick={conversationType === "team" ? handleHeaderTeamClick : handleHeaderUserClick}
-                        >
-                          {conversationType === "team" ? teamData?.name : [conversationPartner?.firstName, conversationPartner?.lastName].filter(Boolean).join(" ")}
-                        </h3>
-                      </Tooltip>
-                      {conversationType === "team" ? (
-                        <div className="text-xs text-base-content/60 flex items-center justify-between gap-1.5 flex-nowrap">
-                          <div className="flex items-center gap-1.5 min-w-0">
-                            <Users size={12} className="flex-shrink-0" />
-                            <span className="truncate">
-                              {teamData?.members
-                                ? `Team Chat with ${teamData.members.length} ${teamData.members.length === 1 ? "Member" : "Members"}`
-                                : "Team Chat"}
-                            </span>
-                            {isSyntheticTeam(teamData) && (
-                              <Tooltip
-                                content={DEMO_TEAM_TOOLTIP}
-                                wrapperClassName="flex items-center gap-0.5 text-base-content/50 flex-shrink-0"
-                              >
-                                <FlaskConical size={10} className="flex-shrink-0" />
-                              </Tooltip>
-                            )}
-                          </div>
-                          {conversationUpdatedAt && (
-                            <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
-                              {formatRelativeChatTimestamp(conversationUpdatedAt)}
-                            </span>
-                          )}
-                        </div>
-                      ) : conversationType === "direct" ? (
-                        <div className="text-xs text-base-content/60 flex items-center justify-between gap-1.5 flex-nowrap">
-                          <div className="flex items-center gap-1.5 min-w-0">
-                            <User size={12} className="flex-shrink-0" />
-                            <span className="truncate">DM Chat</span>
-                            {isSyntheticUser(conversationPartner) && (
-                              <Tooltip
-                                content={DEMO_PROFILE_TOOLTIP}
-                                wrapperClassName="flex items-center gap-0.5 text-base-content/50 flex-shrink-0"
-                              >
-                                <FlaskConical size={10} className="flex-shrink-0" />
-                              </Tooltip>
-                            )}
-                          </div>
-                          {conversationUpdatedAt && (
-                            <span className="text-xs text-base-content/50 whitespace-nowrap ml-2">
-                              {formatRelativeChatTimestamp(conversationUpdatedAt)}
-                            </span>
-                          )}
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <ConversationHeader
+                showCompactConversationHeader={showCompactConversationHeader}
+                onBack={() => setShowChatView(false)}
+                conversationType={conversationType}
+                teamData={teamData}
+                conversationPartner={conversationPartner}
+                activeConversation={activeConversation}
+                conversationUpdatedAt={conversationUpdatedAt}
+                onTeamClick={handleHeaderTeamClick}
+                onUserClick={handleHeaderUserClick}
+              />
 
               <div ref={messagesContainerRef} className="flex-grow overflow-y-auto p-4">
                 <MessageDisplay


### PR DESCRIPTION
## Summary

Stage 3 of the Chat.jsx decomposition (presentational sub-components).
Chat.jsx 2843 → 2689 lines.

- **`components/chat/ConversationHeader.jsx`** (new) — the compact conversation
  header (avatar, name, team/DM meta line, mobile back button). Presentational;
  data + click handlers come in as props.
- **`components/chat/ArchivedTeamBanner.jsx`** (new) — the archived-team
  farewell banner; parent keeps the visibility guard.
- **Bugfix** — the extracted header guarded its unread badge with `||` but
  rendered the count with `??`, so a read conversation showed "0"; resolved
  both with the same `?? … ?? 0` chain (matches the card fix in #544).

Verbatim moves otherwise — no behaviour change. Six imports orphaned by the
extraction were reconciled by hand (uppercase component imports aren't flagged
by `no-unused-vars`).

## Testing

ESLint 0 errors, build green. Smoke: team + DM headers (avatar/name/meta,
click → details modal, back button, unread badge hidden at 0) and the
archived-team farewell banner.

## Notes

Conflict-free with `dev` (touches only Chat.jsx + the two new files). The
separate conversation-list / navbar unread-count discrepancy is a pre-existing
issue unrelated to this branch.