### PR TITLE
Refactor/chat jsx decomposition stage 4 hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Lomir-frontend/
 │   │   ├── useMyTeamsSort.js       # Sort state for MyTeams page
 │   │   ├── useClientPagination.js  # Client-side pagination state for lists
 │   │   ├── useSocketEvents.js      # Subscribe to a set of Socket.IO events with React-safe cleanup
+│   │   ├── useChatTyping.js        # Chat typing indicator state, timeout cleanup, and user-name resolution
 │   │   ├── useAwardModals.js       # Badge award modal state management (user profile context)
 │   │   ├── useTeamAwardModals.js   # Badge award modal state management (team context)
 │   │   └── useTheme.js             # Theme toggle state
@@ -365,6 +366,7 @@ The chat page supports both direct (1-to-1) and team group conversations.
 - Messages are delivered in real time via Socket.IO
 - Typing indicators and read receipts are shown per conversation
 - Messages can be replied to, edited, and soft-deleted; deleted messages show a placeholder
+- Typing indicator state is isolated in `useChatTyping`; `Chat.jsx` still owns the broader socket-event wiring, conversation cache updates, and message loading orchestration
 
 **Archived (deleted) team chats**
 - When an owner deletes a team that still has other members, the team is archived (scheduled for deletion) and the chat stays open as a "farewell" window — remaining members can still read and post until they leave or the grace period (14 days) elapses
@@ -411,6 +413,7 @@ The chat page supports both direct (1-to-1) and team group conversations.
 
 - **Backend repo:** [Lomir-backend](https://github.com/KasparSinitsin/Lomir-backend)
 - **Account deletion spec:** Backend repo → `docs/USER_DELETION_SPEC.md`
+- **Chat refactor tracker:** `docs/CHAT_REFACTOR_TODO.md`
 
 ---
 

--- a/docs/CHAT_REFACTOR_TODO.md
+++ b/docs/CHAT_REFACTOR_TODO.md
@@ -1,0 +1,44 @@
+# Chat Refactor To-do
+
+Status as of 2026-07-02. This tracks the focused `Chat.jsx` decomposition work on the frontend.
+
+## Completed
+
+- Stage 1: Extracted pure entity and payload helpers to `src/utils/chatHelpers.js`.
+- Stage 2: Extracted chat search, snippets, preview hydration, and conversation search helpers to `src/utils/chatSearch.js`.
+- Stage 3: Extracted `ConversationHeader.jsx` and `ArchivedTeamBanner.jsx`.
+- Stage 4a: Extracted typing indicator state, typing timeout cleanup, typing user resolution, and active typing names to `src/hooks/useChatTyping.js`.
+
+## Current Branch
+
+- `refactor/chat-jsx-decomposition-stage-4-hooks`
+- Latest completed commit: `refactor(chat): extract typing state into custom hook`
+
+## Verification
+
+- `npm run lint` passes with existing warnings.
+- `npm run build` passes with the existing Vite chunk-size warning.
+- Manual smoke passed:
+  - DM typing indicator appears and clears.
+  - DM send keeps the optimistic message without duplicate rendering.
+  - Team chat typing indicator shows the expected display name.
+  - Switching conversations does not leak old typing indicators.
+
+## Next Recommended Work
+
+- Stage 4b: Extract `useChatSocketEvents`.
+  - Move the large Socket.IO subscription block out of `Chat.jsx`.
+  - Keep the hook API explicit: pass state setters, refs, cache refresh, team-access helpers, and navigation callbacks instead of importing page state indirectly.
+  - Preserve current handling for `message:received`, `message:status`, `conversation:updated`, `team:member_left`, `conversation:deleted`, `team:member_kicked`, `message:deleted`, `message:edited`, and `notification:new`.
+- Stage 4c: Consider `useChatSearchState`.
+  - Move chat query state, message search indexing, no-result toast handling, and filtered conversation derivation.
+  - Keep `pendingChatSearchTargetRef` integration with message loading explicit.
+- Stage 4d: Consider `useActiveChatConversation`.
+  - Move conversation fetch/load, socket join/leave, read marking, highlighted message loading, and earlier-message pagination.
+
+## Guardrails
+
+- Keep one focused branch and one focused commit per extraction stage.
+- Prefer verbatim moves where possible; behavior changes should be separate commits.
+- After each stage, run `npm run lint`, `npm run build`, and a chat smoke test.
+- Watch JSX imports manually: ESLint does not reliably catch all missing or stale uppercase component/icon imports in this repo.

--- a/src/hooks/useChatTyping.js
+++ b/src/hooks/useChatTyping.js
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import socketService from "../services/socketService";
+import { userService } from "../services/userService";
+import {
+  resolveTypingUserId,
+  resolveTypingDisplayName,
+  resolveConversationUser,
+} from "../utils/chatHelpers";
+import { formatDisplayName } from "../utils/nameFormatters";
+
+const useChatTyping = ({ conversationId, currentUser, activeConversation }) => {
+  const [typingUsers, setTypingUsers] = useState({});
+  const [resolvedUsers, setResolvedUsers] = useState({});
+  const typingTimeoutRef = useRef(null);
+
+  const clearTypingUsers = useCallback(() => {
+    setTypingUsers({});
+  }, []);
+
+  const handleTyping = useCallback(
+    (isTyping, type = "direct") => {
+      if (!conversationId) return;
+
+      if (typingTimeoutRef.current) {
+        clearTimeout(typingTimeoutRef.current);
+      }
+
+      if (isTyping) {
+        socketService.sendTypingStart(conversationId, type, {
+          firstName: currentUser?.firstName,
+          lastName: currentUser?.lastName,
+          username: currentUser?.username,
+        });
+        typingTimeoutRef.current = setTimeout(() => {
+          socketService.sendTypingStop(conversationId, type);
+        }, 3000);
+      } else {
+        socketService.sendTypingStop(conversationId, type);
+      }
+    },
+    [
+      conversationId,
+      currentUser?.firstName,
+      currentUser?.lastName,
+      currentUser?.username,
+    ],
+  );
+
+  const handleTypingUpdate = useCallback(
+    async (data) => {
+      if (String(data.conversationId) !== String(conversationId)) {
+        return;
+      }
+
+      const typingUserId = resolveTypingUserId(data);
+      if (!typingUserId) {
+        return;
+      }
+
+      let displayName = resolveTypingDisplayName(data) || "User";
+      const conversationUser = resolveConversationUser(
+        activeConversation,
+        typingUserId,
+      );
+
+      if (conversationUser) {
+        displayName = formatDisplayName(conversationUser);
+      } else if (resolvedUsers[typingUserId]) {
+        displayName = formatDisplayName(resolvedUsers[typingUserId]);
+      } else if (data.isTyping) {
+        try {
+          const userData = await userService.getUserById(typingUserId);
+          setResolvedUsers((prev) => ({ ...prev, [typingUserId]: userData }));
+          displayName = formatDisplayName(userData);
+        } catch (error) {
+          console.error("Error fetching user for typing:", error);
+          displayName = resolveTypingDisplayName(data) || "User";
+        }
+      }
+
+      setTypingUsers((prev) => {
+        const updated = {
+          ...prev,
+          [typingUserId]: data.isTyping ? displayName : null,
+        };
+
+        Object.keys(updated).forEach((key) => {
+          if (updated[key] === null) {
+            delete updated[key];
+          }
+        });
+
+        return updated;
+      });
+    },
+    [activeConversation, conversationId, resolvedUsers],
+  );
+
+  const activeTypingUsers = useMemo(
+    () =>
+      Object.entries(typingUsers)
+        .filter(
+          ([userId, username]) =>
+            String(userId) !== String(currentUser?.id) && username,
+        )
+        .map(([, username]) => username),
+    [currentUser?.id, typingUsers],
+  );
+
+  useEffect(
+    () => () => {
+      if (typingTimeoutRef.current) {
+        clearTimeout(typingTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  return {
+    activeTypingUsers,
+    clearTypingUsers,
+    handleTyping,
+    handleTypingUpdate,
+    typingUsers,
+  };
+};
+
+export default useChatTyping;

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -23,6 +23,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { messageService } from "../services/messageService";
 import socketService from "../services/socketService";
 import useSocketEvents from "../hooks/useSocketEvents";
+import useChatTyping from "../hooks/useChatTyping";
 import { userService } from "../services/userService";
 import { isQuietError } from "../services/api";
 import { teamService } from "../services/teamService";
@@ -37,7 +38,6 @@ import TeamAvatar from "../components/teams/TeamAvatar";
 import TeamDetailsModal from "../components/teams/TeamDetailsModal";
 import UserDetailsModal from "../components/users/UserDetailsModal";
 import { DEMO_PROFILE_TOOLTIP, DEMO_TEAM_TOOLTIP } from "../utils/userHelpers";
-import { formatDisplayName } from "../utils/nameFormatters";
 import {
   normalizeTimestampToDate,
   formatArchiveTimeRemaining,
@@ -46,9 +46,6 @@ import {
 import { getMessageConversationTarget } from "../utils/messageNotificationUtils";
 import {
   getConversationPartnerId,
-  resolveTypingUserId,
-  resolveTypingDisplayName,
-  resolveConversationUser,
   isActiveTeamMemberRow,
   isUserTeamMember,
   getPayloadTeamId,
@@ -117,8 +114,6 @@ const Chat = () => {
   const [replyingTo, setReplyingTo] = useState(null);
   const [error, setError] = useState(null);
   const [onlineUsers, setOnlineUsers] = useState([]);
-  const [typingUsers, setTypingUsers] = useState({});
-  const [users, setUsers] = useState({});
   const [highlightMessageIds, setHighlightMessageIds] = useState([]);
   const [isTeamArchived, setIsTeamArchived] = useState(false);
   const [hasMoreMessages, setHasMoreMessages] = useState(false);
@@ -143,7 +138,6 @@ const Chat = () => {
   const [searchNoResultsToastQuery, setSearchNoResultsToastQuery] = useState(null);
   const searchNoResultsQueryRef = useRef(null);
   const [searchChatVisible, setSearchChatVisible] = useState(false);
-  const typingTimeoutRef = useRef(null);
   const messagesContainerRef = useRef(null);
   const pendingScrollAdjustmentRef = useRef(null);
   const conversationsRef = useRef([]);
@@ -152,6 +146,16 @@ const Chat = () => {
   const chatSearchLoadingKeysRef = useRef(new Set());
   const pendingChatSearchTargetRef = useRef(null);
   const [loadingMessages, setLoadingMessages] = useState(false);
+  const {
+    activeTypingUsers,
+    clearTypingUsers,
+    handleTyping,
+    handleTypingUpdate,
+  } = useChatTyping({
+    conversationId,
+    currentUser: user,
+    activeConversation,
+  });
 
   // ---- Message de-duplication (focus: ownership/system duplicates) ----
   const toMinuteBucket = (isoOrDate) => {
@@ -311,7 +315,7 @@ const Chat = () => {
       ) {
         setActiveConversation(null);
         setMessages([]);
-        setTypingUsers({});
+        clearTypingUsers();
         setReplyingTo(null);
         setHighlightMessageIds([]);
         setHasMoreMessages(false);
@@ -319,7 +323,13 @@ const Chat = () => {
         navigate("/chat", { replace: true });
       }
     },
-    [conversationId, navigate, searchParams, setConversations],
+    [
+      clearTypingUsers,
+      conversationId,
+      navigate,
+      searchParams,
+      setConversations,
+    ],
   );
 
   const refreshActiveTeamMembership = useCallback(
@@ -784,7 +794,7 @@ const Chat = () => {
       setError("This conversation is no longer available.");
       setActiveConversation(null);
       setMessages([]);
-      setTypingUsers({});
+      clearTypingUsers();
       setHighlightMessageIds([]);
       setHasMoreMessages(false);
       navigate("/chat", { replace: true });
@@ -794,7 +804,13 @@ const Chat = () => {
     // re-run — and refetch the whole conversation list — on every chat switch.
     // This effect must only react to block/unblock state changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockedRelationshipIds, isAuthenticated, isBlockedId, refreshConversationList]);
+  }, [
+    blockedRelationshipIds,
+    clearTypingUsers,
+    isAuthenticated,
+    isBlockedId,
+    refreshConversationList,
+  ]);
 
   // Surface a load failure from the conversations query (matches the old
   // fetch-effect error message).
@@ -1531,51 +1547,6 @@ const Chat = () => {
       }
     };
 
-    // Handle typing indicators
-    const handleTypingUpdate = async (data) => {
-      if (String(data.conversationId) !== String(conversationId)) {
-        return;
-      }
-
-      const typingUserId = resolveTypingUserId(data);
-      if (!typingUserId) {
-        return;
-      }
-
-      let displayName = resolveTypingDisplayName(data) || "User";
-      const conversationUser = resolveConversationUser(activeConversation, typingUserId);
-
-      if (conversationUser) {
-        displayName = formatDisplayName(conversationUser);
-      } else if (users[typingUserId]) {
-        displayName = formatDisplayName(users[typingUserId]);
-      } else if (data.isTyping) {
-        try {
-          const userData = await userService.getUserById(typingUserId);
-          setUsers((prev) => ({ ...prev, [typingUserId]: userData }));
-          displayName = formatDisplayName(userData);
-        } catch (error) {
-          console.error("Error fetching user for typing:", error);
-          displayName = resolveTypingDisplayName(data) || "User";
-        }
-      }
-
-      setTypingUsers((prev) => {
-        const updated = {
-          ...prev,
-          [typingUserId]: data.isTyping ? displayName : null,
-        };
-
-        Object.keys(updated).forEach((key) => {
-          if (updated[key] === null) {
-            delete updated[key];
-          }
-        });
-
-        return updated;
-      });
-    };
-
     // Handle message status updates
     const handleMessageStatus = (data) => {
       if (String(data.conversationId) === String(conversationId)) {
@@ -1726,7 +1697,7 @@ const Chat = () => {
       setError("This conversation is no longer available.");
       setActiveConversation(null);
       setMessages([]);
-      setTypingUsers({});
+      clearTypingUsers();
       setHighlightMessageIds([]);
       setHasMoreMessages(false);
       navigate("/chat", { replace: true });
@@ -1832,10 +1803,10 @@ const Chat = () => {
     refreshConversationList,
     revokeTeamChatAccess,
     activeConversation,
+    handleTypingUpdate,
     searchParams,
     user?.id,
     user?.username,
-    users,
   ]);
 
   const handleHeaderTeamClick = (e) => {
@@ -1907,7 +1878,7 @@ const Chat = () => {
     if (String(conversationId) === String(teamId)) {
       setActiveConversation(null);
       setMessages([]);
-      setTypingUsers({});
+      clearTypingUsers();
       setReplyingTo(null);
       setShowChatView(false);
       setIsTeamModalOpen(false);
@@ -2323,30 +2294,7 @@ const Chat = () => {
     setReplyingTo(null);
 
     // Clear typing indicator
-    clearTimeout(typingTimeoutRef.current);
-    socketService.sendTypingStop(conversationId, type);
-  };
-
-  const handleTyping = (isTyping, type = "direct") => {
-    if (!conversationId) return;
-
-    // Clear existing timeout
-    if (typingTimeoutRef.current) {
-      clearTimeout(typingTimeoutRef.current);
-    }
-
-    if (isTyping) {
-      socketService.sendTypingStart(conversationId, type, {
-        firstName: user.firstName,
-        lastName: user.lastName,
-        username: user.username,
-      });
-      typingTimeoutRef.current = setTimeout(() => {
-        socketService.sendTypingStop(conversationId, type);
-      }, 3000);
-    } else {
-      socketService.sendTypingStop(conversationId, type);
-    }
+    handleTyping(false, type);
   };
 
   const selectConversation = (id) => {
@@ -2395,11 +2343,6 @@ const Chat = () => {
     // Navigate with type parameter
     navigate(`/chat/${id}?type=${type}`);
   };
-
-  // Get active typing users for current conversation
-  const activeTypingUsers = Object.entries(typingUsers)
-    .filter(([userId, username]) => userId !== user?.id && username)
-    .map(([, username]) => username);
 
   const pendingChatActionType = pendingChatAction?.type;
   const pendingChatActionConfig = {


### PR DESCRIPTION
## Summary

- Extract chat typing indicator state and timeout handling into `useChatTyping`
- Move typing user display-name resolution out of `Chat.jsx`
- Document Chat.jsx decomposition Stage 4a and add a focused chat refactor tracker

## Verification

- `npm run lint` passes with existing warnings
- `npm run build` passes with the existing Vite chunk-size warning
- Manual chat smoke:
  - DM typing indicator appears and clears
  - DM send keeps optimistic message without duplicate rendering
  - Team chat typing indicator shows the expected display name
  - Switching conversations does not leak old typing indicators

## Notes

- Frontend-only refactor; no backend/API changes
- Follow-up recommended: extract the large Socket.IO event wiring into `useChatSocketEvents`