### PR TITLE
refactor(chat): extract search state into hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Lomir-frontend/
 │   │   ├── useSocketEvents.js      # Subscribe to a set of Socket.IO events with React-safe cleanup
 │   │   ├── useChatTyping.js        # Chat typing indicator state, timeout cleanup, and user-name resolution
 │   │   ├── useChatSocketEvents.js  # Chat Socket.IO event wiring for messages, read status, membership, and conversation updates
+│   │   ├── useChatSearchState.js   # Chat search query state, message indexing, filtering, and no-result feedback
 │   │   ├── useAwardModals.js       # Badge award modal state management (user profile context)
 │   │   ├── useTeamAwardModals.js   # Badge award modal state management (team context)
 │   │   └── useTheme.js             # Theme toggle state
@@ -367,7 +368,7 @@ The chat page supports both direct (1-to-1) and team group conversations.
 - Messages are delivered in real time via Socket.IO
 - Typing indicators and read receipts are shown per conversation
 - Messages can be replied to, edited, and soft-deleted; deleted messages show a placeholder
-- Typing indicator state is isolated in `useChatTyping`; Socket.IO event wiring is isolated in `useChatSocketEvents`; `Chat.jsx` still owns conversation selection, message loading, search state, and send/edit/delete actions
+- Typing indicator state is isolated in `useChatTyping`; Socket.IO event wiring is isolated in `useChatSocketEvents`; chat search state and message indexing are isolated in `useChatSearchState`; `Chat.jsx` still owns conversation selection, message loading, and send/edit/delete actions
 
 **Archived (deleted) team chats**
 - When an owner deletes a team that still has other members, the team is archived (scheduled for deletion) and the chat stays open as a "farewell" window — remaining members can still read and post until they leave or the grace period (14 days) elapses

--- a/docs/CHAT_REFACTOR_TODO.md
+++ b/docs/CHAT_REFACTOR_TODO.md
@@ -9,11 +9,12 @@ Status as of 2026-07-02. This tracks the focused `Chat.jsx` decomposition work o
 - Stage 3: Extracted `ConversationHeader.jsx` and `ArchivedTeamBanner.jsx`.
 - Stage 4a: Extracted typing indicator state, typing timeout cleanup, typing user resolution, and active typing names to `src/hooks/useChatTyping.js`.
 - Stage 4b: Extracted Socket.IO event wiring for messages, read status, conversation updates, team membership changes, deleted conversations, message edits/deletes, and notification-triggered team refreshes to `src/hooks/useChatSocketEvents.js`.
+- Stage 4c: Extracted chat search query state, message search indexing, no-result toast handling, filtered conversation derivation, and search-panel visibility to `src/hooks/useChatSearchState.js`.
 
 ## Current Branch
 
-- `refactor/chat-jsx-decomposition-stage-4b-socket-events`
-- Latest completed commit: `refactor(chat): extract socket event wiring into hook` (`d725245`).
+- `refactor/chat-jsx-decomposition-stage-4c-search-state`
+- Latest completed work: extracted chat search state and message indexing to `useChatSearchState`.
 
 ## Verification
 
@@ -28,12 +29,12 @@ Status as of 2026-07-02. This tracks the focused `Chat.jsx` decomposition work o
   - Read status updates still render.
   - Message edit/delete socket updates still render.
   - Team chat membership/notification refresh paths still behave as expected.
+  - Chat search filters by conversation metadata and message snippets.
+  - Search-result selection still reveals and highlights the matching message.
+  - No-result feedback still appears and can be dismissed.
 
 ## Next Recommended Work
 
-- Stage 4c: Consider `useChatSearchState`.
-  - Move chat query state, message search indexing, no-result toast handling, and filtered conversation derivation.
-  - Keep `pendingChatSearchTargetRef` integration with message loading explicit.
 - Stage 4d: Consider `useActiveChatConversation`.
   - Move conversation fetch/load, socket join/leave, read marking, highlighted message loading, and earlier-message pagination.
 

--- a/src/hooks/useChatSearchState.js
+++ b/src/hooks/useChatSearchState.js
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { messageService } from "../services/messageService";
+import { getConversationUpdatedAt } from "../utils/chatHelpers";
+import {
+  CHAT_SEARCH_PAGE_SIZE,
+  CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION,
+  getConversationSearchKey,
+  normalizeChatSearchText,
+  countChatSearchMatches,
+  buildMessageSearchSnippets,
+  buildLatestMatchPreview,
+  buildMessagesSearchText,
+  buildConversationSearchText,
+} from "../utils/chatSearch";
+
+const useChatSearchState = ({
+  conversationId,
+  conversationType,
+  conversations,
+  isAuthenticated,
+  messages,
+  onSearchQueryChange,
+}) => {
+  const [chatSearchQuery, setChatSearchQuery] = useState("");
+  const [chatMessageSearchIndex, setChatMessageSearchIndex] = useState({});
+  const [chatMessageSearchSnippets, setChatMessageSearchSnippets] = useState({});
+  const [searchingChatMessages, setSearchingChatMessages] = useState(false);
+  const [searchNoResultsToastQuery, setSearchNoResultsToastQuery] =
+    useState(null);
+  const searchNoResultsQueryRef = useRef(null);
+  const [searchChatVisible, setSearchChatVisible] = useState(false);
+  const chatSearchLoadingKeysRef = useRef(new Set());
+
+  const normalizedChatSearchQuery = useMemo(
+    () => normalizeChatSearchText(chatSearchQuery.trim()),
+    [chatSearchQuery],
+  );
+  const isChatSearchActive = normalizedChatSearchQuery.length > 0;
+
+  const fetchConversationSearchText = useCallback(async (conversation) => {
+    const conversationType = conversation?.type || "direct";
+    const allMessages = [];
+    let before;
+    let hasMore = true;
+
+    while (
+      hasMore &&
+      allMessages.length < CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION
+    ) {
+      const remaining =
+        CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION - allMessages.length;
+      const response = await messageService.getMessages(
+        conversation.id,
+        conversationType,
+        {
+          before,
+          limit: Math.min(CHAT_SEARCH_PAGE_SIZE, remaining),
+        },
+      );
+      const pageMessages = Array.isArray(response?.data) ? response.data : [];
+
+      if (pageMessages.length === 0) {
+        break;
+      }
+
+      allMessages.push(...pageMessages);
+      hasMore = Boolean(response?.hasMore);
+      before = pageMessages[0]?.id;
+
+      if (!before) {
+        break;
+      }
+    }
+
+    return {
+      text: buildMessagesSearchText(allMessages),
+      snippets: buildMessageSearchSnippets(allMessages),
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!conversationId || messages.length === 0) return;
+
+    const key = `${conversationType}:${conversationId}`;
+    const activeMessagesSearchText = buildMessagesSearchText(messages);
+
+    setChatMessageSearchIndex((prev) => ({
+      ...prev,
+      [key]: normalizeChatSearchText(
+        `${prev[key] || ""} ${activeMessagesSearchText}`,
+      ),
+    }));
+    setChatMessageSearchSnippets((prev) => ({
+      ...prev,
+      [key]: buildMessageSearchSnippets(messages),
+    }));
+  }, [conversationId, conversationType, messages]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !isChatSearchActive || conversations.length === 0) {
+      setSearchingChatMessages(false);
+      return;
+    }
+
+    const missingConversations = conversations.filter((conversation) => {
+      const key = getConversationSearchKey(conversation);
+      return (
+        !chatMessageSearchIndex[key] &&
+        !chatSearchLoadingKeysRef.current.has(key)
+      );
+    });
+
+    if (missingConversations.length === 0) {
+      setSearchingChatMessages(chatSearchLoadingKeysRef.current.size > 0);
+      return;
+    }
+
+    missingConversations.forEach((conversation) => {
+      chatSearchLoadingKeysRef.current.add(getConversationSearchKey(conversation));
+    });
+    setSearchingChatMessages(true);
+
+    Promise.allSettled(
+      missingConversations.map(async (conversation) => ({
+        key: getConversationSearchKey(conversation),
+        result: await fetchConversationSearchText(conversation),
+      })),
+    ).then((results) => {
+      setChatMessageSearchIndex((prev) => {
+        const next = { ...prev };
+
+        results.forEach((result, index) => {
+          if (result.status === "fulfilled") {
+            next[result.value.key] = result.value.result.text || " ";
+            return;
+          }
+
+          next[getConversationSearchKey(missingConversations[index])] = " ";
+        });
+
+        return next;
+      });
+      setChatMessageSearchSnippets((prev) => {
+        const next = { ...prev };
+
+        results.forEach((result, index) => {
+          if (result.status === "fulfilled") {
+            next[result.value.key] = result.value.result.snippets || [];
+            return;
+          }
+
+          next[getConversationSearchKey(missingConversations[index])] = [];
+        });
+
+        return next;
+      });
+
+      results.forEach((result, index) => {
+        const key =
+          result.status === "fulfilled"
+            ? result.value.key
+            : getConversationSearchKey(missingConversations[index]);
+        chatSearchLoadingKeysRef.current.delete(key);
+      });
+      setSearchingChatMessages(chatSearchLoadingKeysRef.current.size > 0);
+    });
+  }, [
+    chatMessageSearchIndex,
+    conversations,
+    fetchConversationSearchText,
+    isAuthenticated,
+    isChatSearchActive,
+  ]);
+
+  const filteredConversations = useMemo(() => {
+    if (!isChatSearchActive) return conversations;
+
+    return conversations
+      .map((conversation) => {
+        const key = getConversationSearchKey(conversation);
+        const conversationSearchText = buildConversationSearchText(conversation);
+        const messageSearchText = chatMessageSearchIndex[key] || "";
+        const searchMatchCount =
+          countChatSearchMatches(
+            conversationSearchText,
+            normalizedChatSearchQuery,
+          ) +
+          countChatSearchMatches(messageSearchText, normalizedChatSearchQuery);
+        const matchedMessageSnippet = [
+          ...(chatMessageSearchSnippets[key] || []),
+        ]
+          .reverse()
+          .find((snippet) =>
+            normalizeChatSearchText(snippet.text).includes(
+              normalizedChatSearchQuery,
+            ),
+          );
+        const nextConversation = matchedMessageSnippet
+          ? {
+              ...conversation,
+              searchMatchPreview: buildLatestMatchPreview(
+                matchedMessageSnippet.text,
+                normalizedChatSearchQuery,
+              ),
+              searchMatchContent: matchedMessageSnippet.content,
+              searchMatchMessageId: matchedMessageSnippet.id,
+              searchMatchCreatedAt: matchedMessageSnippet.timestamp,
+            }
+          : conversation;
+
+        return {
+          conversation: nextConversation,
+          searchMatchCount,
+        };
+      })
+      .filter(({ searchMatchCount }) => searchMatchCount > 0)
+      .sort((a, b) => {
+        if (b.searchMatchCount !== a.searchMatchCount) {
+          return b.searchMatchCount - a.searchMatchCount;
+        }
+
+        const aDate = getConversationUpdatedAt(a.conversation)?.getTime() ?? 0;
+        const bDate = getConversationUpdatedAt(b.conversation)?.getTime() ?? 0;
+        return bDate - aDate;
+      })
+      .map(({ conversation, searchMatchCount }) => ({
+        ...conversation,
+        searchMatchCount,
+      }));
+  }, [
+    chatMessageSearchIndex,
+    chatMessageSearchSnippets,
+    conversations,
+    isChatSearchActive,
+    normalizedChatSearchQuery,
+  ]);
+
+  useEffect(() => {
+    if (
+      isChatSearchActive &&
+      !searchingChatMessages &&
+      filteredConversations.length === 0
+    ) {
+      const query = chatSearchQuery.trim();
+      if (searchNoResultsQueryRef.current !== query) {
+        searchNoResultsQueryRef.current = query;
+        setSearchNoResultsToastQuery(query);
+      }
+    } else {
+      searchNoResultsQueryRef.current = null;
+      setSearchNoResultsToastQuery(null);
+    }
+  }, [
+    chatSearchQuery,
+    filteredConversations.length,
+    isChatSearchActive,
+    searchingChatMessages,
+  ]);
+
+  useEffect(() => {
+    setSearchChatVisible(false);
+    onSearchQueryChange?.();
+  }, [chatSearchQuery, onSearchQueryChange]);
+
+  const revealSearchChat = useCallback(() => {
+    setSearchChatVisible(true);
+  }, []);
+
+  const isNoSearchResults =
+    isChatSearchActive &&
+    !searchingChatMessages &&
+    filteredConversations.length === 0;
+  const hideChatDuringSearch = isChatSearchActive && !searchChatVisible;
+  const totalSearchMatches = isChatSearchActive
+    ? filteredConversations.reduce(
+        (sum, conversation) => sum + (conversation.searchMatchCount || 0),
+        0,
+      )
+    : 0;
+
+  const chatSearchEmptyState =
+    isChatSearchActive && searchingChatMessages
+      ? {
+          title: "Searching chats...",
+          description: `Looking through message history for "${chatSearchQuery.trim()}".`,
+          showActions: false,
+        }
+      : null;
+
+  return {
+    chatSearchEmptyState,
+    chatSearchQuery,
+    filteredConversations,
+    hideChatDuringSearch,
+    isChatSearchActive,
+    isNoSearchResults,
+    normalizedChatSearchQuery,
+    revealSearchChat,
+    searchingChatMessages,
+    searchNoResultsToastQuery,
+    setChatSearchQuery,
+    setSearchNoResultsToastQuery,
+    totalSearchMatches,
+  };
+};
+
+export default useChatSearchState;

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -23,6 +23,7 @@ import { messageService } from "../services/messageService";
 import socketService from "../services/socketService";
 import useChatTyping from "../hooks/useChatTyping";
 import useChatSocketEvents from "../hooks/useChatSocketEvents";
+import useChatSearchState from "../hooks/useChatSearchState";
 import { userService } from "../services/userService";
 import { isQuietError } from "../services/api";
 import { teamService } from "../services/teamService";
@@ -51,20 +52,12 @@ import {
   getConversationUpdatedAt,
 } from "../utils/chatHelpers";
 import {
-  CHAT_SEARCH_PAGE_SIZE,
   CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION,
   dedupeConversations,
-  getConversationSearchKey,
-  normalizeChatSearchText,
-  countChatSearchMatches,
   buildMessageSearchText,
   getNotificationEventHighlightIds,
   buildConversationLastMessagePreview,
   hydrateConversationPreviews,
-  buildMessageSearchSnippets,
-  buildLatestMatchPreview,
-  buildMessagesSearchText,
-  buildConversationSearchText,
 } from "../utils/chatSearch";
 
 // Stable empty fallback so the conversations query's default never changes
@@ -126,21 +119,22 @@ const Chat = () => {
     useState(false);
   const [isActiveConversationVisible, setIsActiveConversationVisible] =
     useState(true);
-  const [chatSearchQuery, setChatSearchQuery] = useState("");
-  const [chatMessageSearchIndex, setChatMessageSearchIndex] = useState({});
-  const [chatMessageSearchSnippets, setChatMessageSearchSnippets] = useState({});
-  const [searchingChatMessages, setSearchingChatMessages] = useState(false);
-  const [searchNoResultsToastQuery, setSearchNoResultsToastQuery] = useState(null);
-  const searchNoResultsQueryRef = useRef(null);
-  const [searchChatVisible, setSearchChatVisible] = useState(false);
   const messagesContainerRef = useRef(null);
   const pendingScrollAdjustmentRef = useRef(null);
   const conversationsRef = useRef([]);
   const activeConversationRef = useRef(null);
   const messagesRef = useRef([]);
-  const chatSearchLoadingKeysRef = useRef(new Set());
   const pendingChatSearchTargetRef = useRef(null);
   const [loadingMessages, setLoadingMessages] = useState(false);
+
+  // Conversation type (used for read-only rendering)
+  const conversationType =
+    activeConversation?.type ||
+    new URLSearchParams(window.location.search).get("type") ||
+    "direct";
+  const handleChatSearchQueryChange = useCallback(() => {
+    setHighlightMessageIds([]);
+  }, []);
   const {
     activeTypingUsers,
     clearTypingUsers,
@@ -150,6 +144,28 @@ const Chat = () => {
     conversationId,
     currentUser: user,
     activeConversation,
+  });
+  const {
+    chatSearchEmptyState,
+    chatSearchQuery,
+    filteredConversations,
+    hideChatDuringSearch,
+    isChatSearchActive,
+    isNoSearchResults,
+    normalizedChatSearchQuery,
+    revealSearchChat,
+    searchingChatMessages,
+    searchNoResultsToastQuery,
+    setChatSearchQuery,
+    setSearchNoResultsToastQuery,
+    totalSearchMatches,
+  } = useChatSearchState({
+    conversationId,
+    conversationType,
+    conversations,
+    isAuthenticated,
+    messages,
+    onSearchQueryChange: handleChatSearchQueryChange,
   });
 
   // ---- Message de-duplication (focus: ownership/system duplicates) ----
@@ -207,12 +223,6 @@ const Chat = () => {
     }
     return out;
   };
-
-  // Conversation type (used for read-only rendering)
-  const conversationType =
-    activeConversation?.type ||
-    new URLSearchParams(window.location.search).get("type") ||
-    "direct";
 
   const conversationPartner =
     conversationType === "direct"
@@ -460,11 +470,6 @@ const Chat = () => {
     !isActiveConversationVisible;
   const showEmptyConversationState =
     !loading && conversations.length === 0 && !conversationId;
-  const normalizedChatSearchQuery = useMemo(
-    () => normalizeChatSearchText(chatSearchQuery.trim()),
-    [chatSearchQuery],
-  );
-  const isChatSearchActive = normalizedChatSearchQuery.length > 0;
 
   useEffect(() => {
     setReplyingTo(null);
@@ -524,219 +529,6 @@ const Chat = () => {
     refreshActiveTeamMembership,
     user?.id,
   ]);
-
-  const fetchConversationSearchText = useCallback(async (conversation) => {
-    const conversationType = conversation?.type || "direct";
-    const allMessages = [];
-    let before;
-    let hasMore = true;
-
-    while (
-      hasMore &&
-      allMessages.length < CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION
-    ) {
-      const remaining =
-        CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION - allMessages.length;
-      const response = await messageService.getMessages(
-        conversation.id,
-        conversationType,
-        {
-          before,
-          limit: Math.min(CHAT_SEARCH_PAGE_SIZE, remaining),
-        },
-      );
-      const pageMessages = Array.isArray(response?.data) ? response.data : [];
-
-      if (pageMessages.length === 0) {
-        break;
-      }
-
-      allMessages.push(...pageMessages);
-      hasMore = Boolean(response?.hasMore);
-      before = pageMessages[0]?.id;
-
-      if (!before) {
-        break;
-      }
-    }
-
-    return {
-      text: buildMessagesSearchText(allMessages),
-      snippets: buildMessageSearchSnippets(allMessages),
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!conversationId || messages.length === 0) return;
-
-    const key = `${conversationType}:${conversationId}`;
-    const activeMessagesSearchText = buildMessagesSearchText(messages);
-
-    setChatMessageSearchIndex((prev) => ({
-      ...prev,
-      [key]: normalizeChatSearchText(
-        `${prev[key] || ""} ${activeMessagesSearchText}`,
-      ),
-    }));
-    setChatMessageSearchSnippets((prev) => ({
-      ...prev,
-      [key]: buildMessageSearchSnippets(messages),
-    }));
-  }, [conversationId, conversationType, messages]);
-
-  useEffect(() => {
-    if (!isAuthenticated || !isChatSearchActive || conversations.length === 0) {
-      setSearchingChatMessages(false);
-      return;
-    }
-
-    const missingConversations = conversations.filter((conversation) => {
-      const key = getConversationSearchKey(conversation);
-      return (
-        !chatMessageSearchIndex[key] &&
-        !chatSearchLoadingKeysRef.current.has(key)
-      );
-    });
-
-    if (missingConversations.length === 0) {
-      setSearchingChatMessages(chatSearchLoadingKeysRef.current.size > 0);
-      return;
-    }
-
-    missingConversations.forEach((conversation) => {
-      chatSearchLoadingKeysRef.current.add(getConversationSearchKey(conversation));
-    });
-    setSearchingChatMessages(true);
-
-    Promise.allSettled(
-      missingConversations.map(async (conversation) => ({
-        key: getConversationSearchKey(conversation),
-        result: await fetchConversationSearchText(conversation),
-      })),
-    ).then((results) => {
-      setChatMessageSearchIndex((prev) => {
-        const next = { ...prev };
-
-        results.forEach((result, index) => {
-          if (result.status === "fulfilled") {
-            next[result.value.key] = result.value.result.text || " ";
-            return;
-          }
-
-          next[getConversationSearchKey(missingConversations[index])] = " ";
-        });
-
-        return next;
-      });
-      setChatMessageSearchSnippets((prev) => {
-        const next = { ...prev };
-
-        results.forEach((result, index) => {
-          if (result.status === "fulfilled") {
-            next[result.value.key] = result.value.result.snippets || [];
-            return;
-          }
-
-          next[getConversationSearchKey(missingConversations[index])] = [];
-        });
-
-        return next;
-      });
-
-      results.forEach((result, index) => {
-        const key =
-          result.status === "fulfilled"
-            ? result.value.key
-            : getConversationSearchKey(missingConversations[index]);
-        chatSearchLoadingKeysRef.current.delete(key);
-      });
-      setSearchingChatMessages(chatSearchLoadingKeysRef.current.size > 0);
-    });
-  }, [
-    chatMessageSearchIndex,
-    conversations,
-    fetchConversationSearchText,
-    isAuthenticated,
-    isChatSearchActive,
-  ]);
-
-  const filteredConversations = useMemo(() => {
-    if (!isChatSearchActive) return conversations;
-
-    return conversations
-      .map((conversation) => {
-        const key = getConversationSearchKey(conversation);
-        const conversationSearchText = buildConversationSearchText(conversation);
-        const messageSearchText = chatMessageSearchIndex[key] || "";
-        const searchMatchCount =
-          countChatSearchMatches(
-            conversationSearchText,
-            normalizedChatSearchQuery,
-          ) +
-          countChatSearchMatches(messageSearchText, normalizedChatSearchQuery);
-        const matchedMessageSnippet = [
-          ...(chatMessageSearchSnippets[key] || []),
-        ]
-          .reverse()
-          .find((snippet) =>
-            normalizeChatSearchText(snippet.text).includes(
-              normalizedChatSearchQuery,
-            ),
-          );
-        const nextConversation = matchedMessageSnippet
-          ? {
-              ...conversation,
-              searchMatchPreview: buildLatestMatchPreview(
-                matchedMessageSnippet.text,
-                normalizedChatSearchQuery,
-              ),
-              searchMatchContent: matchedMessageSnippet.content,
-              searchMatchMessageId: matchedMessageSnippet.id,
-              searchMatchCreatedAt: matchedMessageSnippet.timestamp,
-            }
-          : conversation;
-
-        return {
-          conversation: nextConversation,
-          searchMatchCount,
-        };
-      })
-      .filter(({ searchMatchCount }) => searchMatchCount > 0)
-      .sort((a, b) => {
-        if (b.searchMatchCount !== a.searchMatchCount) {
-          return b.searchMatchCount - a.searchMatchCount;
-        }
-
-        const aDate = getConversationUpdatedAt(a.conversation)?.getTime() ?? 0;
-        const bDate = getConversationUpdatedAt(b.conversation)?.getTime() ?? 0;
-        return bDate - aDate;
-      })
-      .map(({ conversation, searchMatchCount }) => ({ ...conversation, searchMatchCount }));
-  }, [
-    chatMessageSearchIndex,
-    chatMessageSearchSnippets,
-    conversations,
-    isChatSearchActive,
-    normalizedChatSearchQuery,
-  ]);
-
-  useEffect(() => {
-    if (isChatSearchActive && !searchingChatMessages && filteredConversations.length === 0) {
-      const query = chatSearchQuery.trim();
-      if (searchNoResultsQueryRef.current !== query) {
-        searchNoResultsQueryRef.current = query;
-        setSearchNoResultsToastQuery(query);
-      }
-    } else {
-      searchNoResultsQueryRef.current = null;
-      setSearchNoResultsToastQuery(null);
-    }
-  }, [isChatSearchActive, searchingChatMessages, filteredConversations.length, chatSearchQuery]);
-
-  useEffect(() => {
-    setSearchChatVisible(false);
-    setHighlightMessageIds([]);
-  }, [chatSearchQuery]);
 
   useEffect(() => {
     setIsActiveConversationVisible(true);
@@ -1836,7 +1628,7 @@ const Chat = () => {
 
     // When search is active, reveal the chat panel
     if (isChatSearchActive) {
-      setSearchChatVisible(true);
+      revealSearchChat();
     }
 
     // Navigate with type parameter
@@ -1872,18 +1664,12 @@ const Chat = () => {
       icon: <LogOut size={16} />,
     },
   }[pendingChatActionType];
-  const isNoSearchResults =
-    isChatSearchActive && !searchingChatMessages && filteredConversations.length === 0;
-  const hideChatDuringSearch = isChatSearchActive && !searchChatVisible;
   const shouldShowConversationPanel =
     !showEmptyConversationState &&
     !hideChatDuringSearch &&
     Boolean(conversationId) &&
     showChatView &&
     (Boolean(activeConversation) || loadingMessages);
-  const totalSearchMatches = isChatSearchActive
-    ? filteredConversations.reduce((sum, conv) => sum + (conv.searchMatchCount || 0), 0)
-    : 0;
   const chatSearchPlaceholder = "Search chats...";
   const chatSearchInputWidth = `${Math.max(
     chatSearchQuery.length,
@@ -1928,15 +1714,6 @@ const Chat = () => {
       )}
     </div>
   );
-  const chatSearchEmptyState =
-    isChatSearchActive && searchingChatMessages
-      ? {
-          title: "Searching chats...",
-          description: `Looking through message history for "${chatSearchQuery.trim()}".`,
-          showActions: false,
-        }
-      : null;
-
   return (
     <PageContainer
       title="Chats"


### PR DESCRIPTION
## Summary

- Extract chat search state and message indexing into `useChatSearchState`
- Move filtered conversation derivation, no-result toast handling, search loading state, and search panel visibility out of `Chat.jsx`
- Keep `pendingChatSearchTargetRef` in `Chat.jsx` as the explicit bridge to message loading/highlighting
- Update README and chat refactor tracker for Stage 4c

## Verification

- `npm run lint` passes with existing warnings
- `npm run build` passes with the existing Vite chunk-size warning
- `git diff --check` passes
- Manual chat search smoke:
  - Search by user/team name
  - Search by message text
  - Select result and verify matching message highlight
  - Verify no-results toast
  - Clear search and verify normal chat list / active chat behavior

## Notes

- Frontend-only refactor; no backend/API changes
- Follow-up candidate: extract active conversation/message loading into `useActiveChatConversation`