### PR TITLE
Refactor active chat conversation loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Lomir-frontend/
 │   │   ├── useChatTyping.js        # Chat typing indicator state, timeout cleanup, and user-name resolution
 │   │   ├── useChatSocketEvents.js  # Chat Socket.IO event wiring for messages, read status, membership, and conversation updates
 │   │   ├── useChatSearchState.js   # Chat search query state, message indexing, filtering, and no-result feedback
+│   │   ├── useActiveChatConversation.js # Active chat loading, join/read marking, highlights, and earlier-message pagination
 │   │   ├── useAwardModals.js       # Badge award modal state management (user profile context)
 │   │   ├── useTeamAwardModals.js   # Badge award modal state management (team context)
 │   │   └── useTheme.js             # Theme toggle state
@@ -368,7 +369,8 @@ The chat page supports both direct (1-to-1) and team group conversations.
 - Messages are delivered in real time via Socket.IO
 - Typing indicators and read receipts are shown per conversation
 - Messages can be replied to, edited, and soft-deleted; deleted messages show a placeholder
-- Typing indicator state is isolated in `useChatTyping`; Socket.IO event wiring is isolated in `useChatSocketEvents`; chat search state and message indexing are isolated in `useChatSearchState`; `Chat.jsx` still owns conversation selection, message loading, and send/edit/delete actions
+- Typing indicator state is isolated in `useChatTyping`; Socket.IO event wiring is isolated in `useChatSocketEvents`; chat search state and message indexing are isolated in `useChatSearchState`; active conversation loading and earlier-message pagination are isolated in `useActiveChatConversation`; `Chat.jsx` still owns conversation selection and send/edit/delete actions
+- The conversation list is cached per authenticated user, empty direct chats stay transient until the first message is sent, and revoked/deleted team access is removed from the list without repeated failing fetches
 
 **Archived (deleted) team chats**
 - When an owner deletes a team that still has other members, the team is archived (scheduled for deletion) and the chat stays open as a "farewell" window — remaining members can still read and post until they leave or the grace period (14 days) elapses

--- a/docs/CHAT_REFACTOR_TODO.md
+++ b/docs/CHAT_REFACTOR_TODO.md
@@ -1,6 +1,6 @@
 # Chat Refactor To-do
 
-Status as of 2026-07-02. This tracks the focused `Chat.jsx` decomposition work on the frontend.
+Status as of 2026-07-03. This tracks the focused `Chat.jsx` decomposition work on the frontend.
 
 ## Completed
 
@@ -10,11 +10,12 @@ Status as of 2026-07-02. This tracks the focused `Chat.jsx` decomposition work o
 - Stage 4a: Extracted typing indicator state, typing timeout cleanup, typing user resolution, and active typing names to `src/hooks/useChatTyping.js`.
 - Stage 4b: Extracted Socket.IO event wiring for messages, read status, conversation updates, team membership changes, deleted conversations, message edits/deletes, and notification-triggered team refreshes to `src/hooks/useChatSocketEvents.js`.
 - Stage 4c: Extracted chat search query state, message search indexing, no-result toast handling, filtered conversation derivation, and search-panel visibility to `src/hooks/useChatSearchState.js`.
+- Stage 4d: Extracted active conversation loading, team/direct conversation hydration, socket join/leave, read marking, highlight handling, and earlier-message pagination to `src/hooks/useActiveChatConversation.js`; tightened 403/404 team access cleanup, empty direct-chat filtering, and user-scoped conversation cache keys.
 
 ## Current Branch
 
-- `refactor/chat-jsx-decomposition-stage-4c-search-state`
-- Latest completed work: extracted chat search state and message indexing to `useChatSearchState`.
+- `refactor/chat-jsx-decomposition-stage-4d-active-conversation`
+- Latest completed work: extracted active conversation loading and earlier-message pagination to `useActiveChatConversation`, with Stage 4d follow-up fixes for stale team access, empty DMs, and account-switch cache isolation.
 
 ## Verification
 
@@ -32,11 +33,18 @@ Status as of 2026-07-02. This tracks the focused `Chat.jsx` decomposition work o
   - Chat search filters by conversation metadata and message snippets.
   - Search-result selection still reveals and highlights the matching message.
   - No-result feedback still appears and can be dismissed.
+- Active direct and team conversations still load messages and details.
+- Socket join/read marking still happens after conversation load.
+- Earlier-message pagination preserves scroll position.
+- Notification/search highlights still reveal the target message.
+- Revoked/deleted team conversations are removed from the list without repeated 403/404 fetch loops.
+- Empty direct chats remain transient while actively opened but are not kept in the persistent conversation list.
+- Switching accounts in the same browser uses a user-scoped conversation cache instead of reusing another user's chat list.
 
 ## Next Recommended Work
 
-- Stage 4d: Consider `useActiveChatConversation`.
-  - Move conversation fetch/load, socket join/leave, read marking, highlighted message loading, and earlier-message pagination.
+- Review remaining `Chat.jsx` responsibilities and decide whether Stage 5 should focus on send/edit/delete actions or team access helpers.
+- Consider a short pause before further extraction: Stage 4a-4d moved the highest-value state/effect clusters out of `Chat.jsx`.
 
 ## Guardrails
 

--- a/src/hooks/useActiveChatConversation.js
+++ b/src/hooks/useActiveChatConversation.js
@@ -1,0 +1,510 @@
+import { useCallback, useEffect, useRef } from "react";
+import { messageService } from "../services/messageService";
+import socketService from "../services/socketService";
+import { userService } from "../services/userService";
+import { isQuietError } from "../services/api";
+import {
+  buildConversationLastMessagePreview,
+  buildMessageSearchText,
+  getNotificationEventHighlightIds,
+  CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION,
+} from "../utils/chatSearch";
+import { isArchivedTeamData } from "../utils/chatHelpers";
+
+const useActiveChatConversation = ({
+  conversationId,
+  conversationsRef,
+  dedupeMessages,
+  hasMoreMessages,
+  hydrateTeamConversationDetails,
+  isAuthenticated,
+  loadingMore,
+  messages,
+  messagesContainerRef,
+  navigate,
+  pendingChatSearchTargetRef,
+  pendingScrollAdjustmentRef,
+  revokeTeamChatAccess,
+  searchParams,
+  setActiveConversation,
+  setConversations,
+  setError,
+  setHasMoreMessages,
+  setHighlightMessageIds,
+  setIsTeamArchived,
+  setLoadingMessages,
+  setLoadingMore,
+  setMessages,
+  setSearchParams,
+  user,
+}) => {
+  const dedupeMessagesRef = useRef(dedupeMessages);
+
+  useEffect(() => {
+    dedupeMessagesRef.current = dedupeMessages;
+  }, [dedupeMessages]);
+
+  useEffect(() => {
+    const fetchMessages = async () => {
+      if (!conversationId) return;
+
+      try {
+        setLoadingMessages(true);
+        setLoadingMore(false);
+        setHasMoreMessages(false);
+        setIsTeamArchived(false);
+
+        const urlParams = new URLSearchParams(window.location.search);
+        const type = urlParams.get("type") || "direct";
+        const highlightedMessageId =
+          urlParams.get("highlightMessage") || urlParams.get("messageId");
+        const highlightedEventTarget = {
+          type:
+            urlParams.get("highlightEvent") ||
+            urlParams.get("highlightEventType") ||
+            "",
+          referenceId:
+            urlParams.get("highlightRef") ||
+            urlParams.get("highlightReferenceId") ||
+            "",
+          actorId: urlParams.get("highlightActor") || "",
+        };
+
+        let conversationDetails;
+        try {
+          conversationDetails = await messageService.getConversationById(
+            conversationId,
+            type,
+          );
+
+          if (type === "team" && conversationDetails?.data) {
+            setIsTeamArchived(isArchivedTeamData(conversationDetails.data.team));
+
+            const accessRevoked = await hydrateTeamConversationDetails(
+              conversationDetails,
+              conversationId,
+            );
+            if (accessRevoked) return;
+          }
+
+          setActiveConversation(conversationDetails.data);
+
+          if (type === "team" && conversationDetails.data) {
+            setConversations((prev) => {
+              const existingConversation = prev.find(
+                (conv) =>
+                  String(conv.id) === String(conversationId) &&
+                  conv.type === "team",
+              );
+
+              if (!existingConversation) {
+                const newTeamConversation = {
+                  id: parseInt(conversationId),
+                  type: "team",
+                  team: {
+                    id: conversationDetails.data.team.id,
+                    name: conversationDetails.data.team.name,
+                    avatarUrl: conversationDetails.data.team.avatarUrl,
+                    isSynthetic:
+                      conversationDetails.data.team.isSynthetic ??
+                      conversationDetails.data.team.is_synthetic ??
+                      undefined,
+                    is_synthetic:
+                      conversationDetails.data.team.is_synthetic ??
+                      conversationDetails.data.team.isSynthetic ??
+                      undefined,
+                    archived_at: conversationDetails.data.team.archived_at,
+                    archivedAt:
+                      conversationDetails.data.team.archivedAt ??
+                      conversationDetails.data.team.archived_at,
+                    status: conversationDetails.data.team.status,
+                  },
+                  lastMessage: "Start your team conversation...",
+                  updatedAt: new Date().toISOString(),
+                  isVirtual: true,
+                  unreadCount: 0,
+                };
+
+                return [newTeamConversation, ...prev];
+              }
+
+              return prev;
+            });
+          }
+        } catch (error) {
+          if (
+            type === "team" &&
+            (error.response?.status === 404 || error.response?.status === 403)
+          ) {
+            revokeTeamChatAccess(
+              conversationId,
+              "You no longer have access to this team chat.",
+            );
+            setLoadingMessages(false);
+            return;
+          }
+
+          if (error.response?.status === 403) {
+            setError("You no longer have access to this conversation.");
+            setLoadingMessages(false);
+            navigate("/chat");
+            return;
+          }
+
+          if (type === "team" && conversationDetails?.data) {
+            const accessRevoked = await hydrateTeamConversationDetails(
+              conversationDetails,
+              conversationId,
+            );
+            if (accessRevoked) return;
+          }
+
+          if (type === "direct") {
+            const knownConv = conversationsRef.current.find(
+              (c) =>
+                String(c.id) === String(conversationId) &&
+                c.type === "direct",
+            );
+            if (knownConv?.partner) {
+              setActiveConversation({
+                id: parseInt(conversationId),
+                type: "direct",
+                partner: knownConv.partner,
+                isVirtual: true,
+              });
+            } else {
+              try {
+                const userResponse = await userService.getUserById(
+                  conversationId,
+                  { quietErrorStatuses: [404] },
+                );
+                const userData = userResponse.data;
+                setActiveConversation({
+                  id: parseInt(conversationId),
+                  type: "direct",
+                  partner: {
+                    id: userData.id,
+                    username: userData.username,
+                    firstName: userData.firstName || userData.first_name,
+                    lastName: userData.lastName || userData.last_name,
+                    avatarUrl: userData.avatarUrl || userData.avatar_url,
+                    isSynthetic:
+                      userData.isSynthetic ?? userData.is_synthetic ?? undefined,
+                    is_synthetic:
+                      userData.is_synthetic ?? userData.isSynthetic ?? undefined,
+                  },
+                  isVirtual: true,
+                });
+              } catch (userError) {
+                if (!isQuietError(userError)) {
+                  console.error(
+                    "Failed to load partner for new conversation:",
+                    userError,
+                  );
+                }
+              }
+            }
+          }
+        }
+
+        try {
+          const messagesResponse = await messageService.getMessages(
+            conversationId,
+            type,
+          );
+          const searchTarget = highlightedMessageId
+            ? {
+                conversationId,
+                type,
+                messageId: highlightedMessageId,
+                query: null,
+              }
+            : pendingChatSearchTargetRef.current;
+          const shouldRevealSearchTarget =
+            searchTarget?.messageId &&
+            String(searchTarget.conversationId) === String(conversationId) &&
+            searchTarget.type === type;
+          let fetchedMessages = messagesResponse.data || [];
+          let nextHasMoreMessages = messagesResponse.hasMore || false;
+
+          if (shouldRevealSearchTarget) {
+            let oldestMessage = fetchedMessages[0];
+            let loadedCount = fetchedMessages.length;
+
+            while (
+              nextHasMoreMessages &&
+              oldestMessage?.id &&
+              loadedCount < CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION
+            ) {
+              const remaining =
+                CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION - loadedCount;
+              const earlierResponse = await messageService.getMessages(
+                conversationId,
+                type,
+                {
+                  before: oldestMessage.id,
+                  limit: Math.min(50, remaining),
+                },
+              );
+              const earlierMessages = earlierResponse.data || [];
+
+              if (earlierMessages.length === 0) {
+                nextHasMoreMessages = false;
+                break;
+              }
+
+              fetchedMessages = [...earlierMessages, ...fetchedMessages];
+              loadedCount += earlierMessages.length;
+              nextHasMoreMessages = earlierResponse.hasMore || false;
+              oldestMessage = earlierMessages[0];
+            }
+          }
+
+          setHasMoreMessages(nextHasMoreMessages);
+          setMessages(dedupeMessagesRef.current(fetchedMessages));
+
+          const latestFetchedMessage =
+            fetchedMessages[fetchedMessages.length - 1] || null;
+          const latestPreview =
+            buildConversationLastMessagePreview(latestFetchedMessage);
+
+          if (latestFetchedMessage && latestPreview) {
+            setConversations((prev) =>
+              prev.map((conversation) =>
+                String(conversation.id) === String(conversationId)
+                  ? {
+                      ...conversation,
+                      lastMessage: latestPreview,
+                      updatedAt:
+                        latestFetchedMessage.createdAt ||
+                        latestFetchedMessage.created_at ||
+                        conversation.updatedAt,
+                    }
+                  : conversation,
+              ),
+            );
+          }
+
+          const highlightUser = searchParams.get("highlightUser");
+          const eventHighlightIds = getNotificationEventHighlightIds(
+            fetchedMessages,
+            highlightedEventTarget,
+          );
+
+          if (
+            shouldRevealSearchTarget &&
+            fetchedMessages.some(
+              (msg) => String(msg.id) === String(searchTarget.messageId),
+            )
+          ) {
+            const query = searchTarget.query;
+            const allMatchingIds = query
+              ? fetchedMessages
+                  .filter((msg) => buildMessageSearchText(msg).includes(query))
+                  .map((msg) => msg.id)
+                  .filter(Boolean)
+              : [];
+            const highlightIds = [
+              searchTarget.messageId,
+              ...allMatchingIds.filter(
+                (id) => String(id) !== String(searchTarget.messageId),
+              ),
+            ];
+            setHighlightMessageIds(highlightIds);
+            pendingChatSearchTargetRef.current = null;
+          } else if (eventHighlightIds.length > 0) {
+            if (shouldRevealSearchTarget) {
+              pendingChatSearchTargetRef.current = null;
+            }
+
+            setHighlightMessageIds(eventHighlightIds);
+            setTimeout(() => {
+              setHighlightMessageIds([]);
+            }, 3500);
+          } else if (highlightUser) {
+            if (shouldRevealSearchTarget) {
+              pendingChatSearchTargetRef.current = null;
+            }
+
+            const userMessages = fetchedMessages
+              .filter((msg) => String(msg.senderId) === String(highlightUser))
+              .slice(-3)
+              .map((msg) => msg.id);
+
+            if (userMessages.length > 0) {
+              setHighlightMessageIds(userMessages);
+              setTimeout(() => {
+                setHighlightMessageIds([]);
+                setSearchParams((prev) => {
+                  prev.delete("highlightUser");
+                  return prev;
+                });
+              }, 4000);
+            }
+          } else {
+            if (shouldRevealSearchTarget) {
+              pendingChatSearchTargetRef.current = null;
+            }
+
+            const unreadIds = fetchedMessages
+              .filter((msg) => msg.senderId !== user?.id && !msg.readAt)
+              .map((msg) => msg.id);
+
+            if (unreadIds.length > 0) {
+              setHighlightMessageIds(unreadIds);
+              setTimeout(() => {
+                setHighlightMessageIds([]);
+              }, 3000);
+            }
+          }
+        } catch (messagesError) {
+          if (
+            type === "team" &&
+            (messagesError.response?.status === 404 ||
+              messagesError.response?.status === 403)
+          ) {
+            revokeTeamChatAccess(
+              conversationId,
+              "You no longer have access to this team chat.",
+            );
+            setLoadingMessages(false);
+            return;
+          }
+
+          setHasMoreMessages(false);
+          setMessages([]);
+        }
+
+        setLoadingMessages(false);
+
+        const socket = socketService.getSocket();
+        if (socket && socket.connected) {
+          socketService.joinConversation(conversationId, type);
+          socketService.markMessagesAsRead(conversationId, type);
+        } else {
+          const checkConnection = setInterval(() => {
+            const socket = socketService.getSocket();
+            if (socket && socket.connected) {
+              const urlParams = new URLSearchParams(window.location.search);
+              const type = urlParams.get("type") || "direct";
+              socketService.joinConversation(conversationId, type);
+              socketService.markMessagesAsRead(conversationId, type);
+              clearInterval(checkConnection);
+            }
+          }, 100);
+
+          setTimeout(() => clearInterval(checkConnection), 5000);
+        }
+      } catch (err) {
+        console.error("Error fetching messages:", err);
+        setError("Failed to load messages. Please try again.");
+        setLoadingMessages(false);
+      }
+    };
+
+    if (isAuthenticated && conversationId) {
+      fetchMessages();
+
+      return () => {
+        if (conversationId) {
+          const urlParams = new URLSearchParams(window.location.search);
+          const type = urlParams.get("type") || "direct";
+          socketService.leaveConversation(conversationId, type);
+        }
+      };
+    }
+  }, [
+    conversationId,
+    conversationsRef,
+    hydrateTeamConversationDetails,
+    isAuthenticated,
+    navigate,
+    pendingChatSearchTargetRef,
+    revokeTeamChatAccess,
+    searchParams,
+    setActiveConversation,
+    setConversations,
+    setError,
+    setHasMoreMessages,
+    setHighlightMessageIds,
+    setIsTeamArchived,
+    setLoadingMessages,
+    setLoadingMore,
+    setMessages,
+    setSearchParams,
+    user?.id,
+  ]);
+
+  useEffect(() => {
+    if (!pendingScrollAdjustmentRef.current) return;
+
+    const container = messagesContainerRef.current;
+
+    if (!container) {
+      pendingScrollAdjustmentRef.current = null;
+      return;
+    }
+
+    const { previousScrollHeight, previousScrollTop } =
+      pendingScrollAdjustmentRef.current;
+
+    container.scrollTop =
+      container.scrollHeight - previousScrollHeight + previousScrollTop;
+    pendingScrollAdjustmentRef.current = null;
+  }, [hasMoreMessages, messages, messagesContainerRef, pendingScrollAdjustmentRef]);
+
+  const loadEarlierMessages = useCallback(async () => {
+    if (loadingMore || !hasMoreMessages || messages.length === 0) return;
+
+    const container = messagesContainerRef.current;
+
+    if (container) {
+      pendingScrollAdjustmentRef.current = {
+        previousScrollHeight: container.scrollHeight,
+        previousScrollTop: container.scrollTop,
+      };
+    }
+
+    setLoadingMore(true);
+
+    try {
+      const oldestMessage = messages[0];
+      const type = searchParams.get("type") || "direct";
+      const response = await messageService.getMessages(conversationId, type, {
+        before: oldestMessage.id,
+        limit: 50,
+      });
+      const olderMessages = response.data || [];
+
+      setHasMoreMessages(response.hasMore || false);
+
+      if (olderMessages.length > 0) {
+        setMessages((prev) =>
+          dedupeMessagesRef.current([...olderMessages, ...prev]),
+        );
+      } else {
+        pendingScrollAdjustmentRef.current = null;
+      }
+    } catch (err) {
+      pendingScrollAdjustmentRef.current = null;
+      console.error("Error loading earlier messages:", err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [
+    conversationId,
+    hasMoreMessages,
+    loadingMore,
+    messages,
+    messagesContainerRef,
+    pendingScrollAdjustmentRef,
+    searchParams,
+    setHasMoreMessages,
+    setLoadingMore,
+    setMessages,
+  ]);
+
+  return { loadEarlierMessages };
+};
+
+export default useActiveChatConversation;

--- a/src/hooks/useChatQueries.js
+++ b/src/hooks/useChatQueries.js
@@ -5,6 +5,10 @@ import { useQuery } from "@tanstack/react-query";
 // place via queryClient.setQueryData as socket events arrive. Invalidate this
 // key to re-fetch the whole list.
 export const conversationsQueryKey = ["chat", "conversations"];
+export const getConversationsQueryKey = (userId) => [
+  ...conversationsQueryKey,
+  userId ?? "anonymous",
+];
 
 /**
  * The current user's conversation list. The query function is supplied by the
@@ -12,9 +16,9 @@ export const conversationsQueryKey = ["chat", "conversations"];
  * Chat.jsx (slated to move into chatHelpers.js with the Tier 2 split). Stays
  * disabled until the user is authenticated.
  */
-export const useConversations = (queryFn, enabled) =>
+export const useConversations = (queryFn, enabled, userId) =>
   useQuery({
-    queryKey: conversationsQueryKey,
+    queryKey: getConversationsQueryKey(userId),
     queryFn,
     enabled,
     // The list is kept current by socket handlers (setQueryData) and explicit

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -11,7 +11,11 @@ import {
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { fetchTeamById } from "../hooks/useTeamQueries";
-import { useConversations, conversationsQueryKey } from "../hooks/useChatQueries";
+import {
+  useConversations,
+  conversationsQueryKey,
+  getConversationsQueryKey,
+} from "../hooks/useChatQueries";
 import PageContainer from "../components/layout/PageContainer";
 import ConversationList from "../components/chat/ConversationList";
 import ConversationHeader from "../components/chat/ConversationHeader";
@@ -24,6 +28,7 @@ import socketService from "../services/socketService";
 import useChatTyping from "../hooks/useChatTyping";
 import useChatSocketEvents from "../hooks/useChatSocketEvents";
 import useChatSearchState from "../hooks/useChatSearchState";
+import useActiveChatConversation from "../hooks/useActiveChatConversation";
 import { userService } from "../services/userService";
 import { isQuietError } from "../services/api";
 import { teamService } from "../services/teamService";
@@ -52,17 +57,20 @@ import {
   getConversationUpdatedAt,
 } from "../utils/chatHelpers";
 import {
-  CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION,
   dedupeConversations,
-  buildMessageSearchText,
-  getNotificationEventHighlightIds,
-  buildConversationLastMessagePreview,
   hydrateConversationPreviews,
 } from "../utils/chatSearch";
 
 // Stable empty fallback so the conversations query's default never changes
 // identity between renders (avoids needless re-renders / effect re-runs).
 const EMPTY_CONVERSATIONS = [];
+const EMPTY_DIRECT_CONVERSATION_PREVIEW = "Start your conversation...";
+
+const isTransientEmptyDirectConversation = (conversation) =>
+  conversation?.type === "direct" &&
+  conversation?.isVirtual &&
+  (conversation.lastMessage ?? conversation.last_message) ===
+    EMPTY_DIRECT_CONVERSATION_PREVIEW;
 
 const Chat = () => {
   const { conversationId } = useParams();
@@ -75,10 +83,14 @@ const Chat = () => {
       id != null && blockedRelationshipIds?.has?.(String(id)),
     [blockedRelationshipIds],
   );
+  const activeConversationsQueryKey = useMemo(
+    () => getConversationsQueryKey(user?.id),
+    [user?.id],
+  );
   // Conversation list is backed by the React Query cache. The query fetches +
-  // dedupes + hydrates previews once (keyed on a constant, so switching chats
-  // no longer refetches the list); socket/local updates mutate that cache via
-  // the setConversations wrapper below, keeping their (prev) => next shape.
+  // dedupes + hydrates previews once per user (switching chats no longer
+  // refetches the list); socket/local updates mutate that user's cache via the
+  // setConversations wrapper below, keeping their (prev) => next shape.
   const fetchConversations = useCallback(async () => {
     const response = await messageService.getConversations();
     return hydrateConversationPreviews(dedupeConversations(response.data || []));
@@ -87,15 +99,15 @@ const Chat = () => {
     data: conversations = EMPTY_CONVERSATIONS,
     isLoading: loading,
     isError: conversationsLoadError,
-  } = useConversations(fetchConversations, isAuthenticated);
+  } = useConversations(fetchConversations, isAuthenticated, user?.id);
   const setConversations = useCallback(
     (next) =>
       queryClient.setQueryData(
-        conversationsQueryKey,
+        activeConversationsQueryKey,
         (prev = EMPTY_CONVERSATIONS) =>
           typeof next === "function" ? next(prev) : next,
       ),
-    [queryClient],
+    [activeConversationsQueryKey, queryClient],
   );
   const [activeConversation, setActiveConversation] = useState(null);
   const [messages, setMessages] = useState([]);
@@ -442,6 +454,34 @@ const Chat = () => {
     [fetchTeamDetails, revokeTeamChatAccess, user?.id],
   );
 
+  const { loadEarlierMessages } = useActiveChatConversation({
+    conversationId,
+    conversationsRef,
+    dedupeMessages,
+    hasMoreMessages,
+    hydrateTeamConversationDetails,
+    isAuthenticated,
+    loadingMore,
+    messages,
+    messagesContainerRef,
+    navigate,
+    pendingChatSearchTargetRef,
+    pendingScrollAdjustmentRef,
+    revokeTeamChatAccess,
+    searchParams,
+    setActiveConversation,
+    setConversations,
+    setError,
+    setHasMoreMessages,
+    setHighlightMessageIds,
+    setIsTeamArchived,
+    setLoadingMessages,
+    setLoadingMore,
+    setMessages,
+    setSearchParams,
+    user,
+  });
+
   const mentionParticipants = useMemo(() => {
     if (conversationType === "direct") {
       return conversationPartner ? [conversationPartner] : [];
@@ -478,6 +518,18 @@ const Chat = () => {
   useEffect(() => {
     conversationsRef.current = conversations;
   }, [conversations]);
+
+  useEffect(() => {
+    setConversations((prev) => {
+      const next = prev.filter(
+        (conversation) =>
+          !isTransientEmptyDirectConversation(conversation) ||
+          String(conversation.id) === String(conversationId),
+      );
+
+      return next.length === prev.length ? prev : next;
+    });
+  }, [conversationId, setConversations]);
 
   useEffect(() => {
     messagesRef.current = messages;
@@ -617,9 +669,14 @@ const Chat = () => {
     if (!isAuthenticated || loading) return;
 
     if (!conversationId) {
-      if (conversations.length > 0) {
-        const firstConversationType = conversations[0].type || "direct";
-        navigate(`/chat/${conversations[0].id}?type=${firstConversationType}`);
+      const persistentConversations = conversations.filter(
+        (conversation) => !isTransientEmptyDirectConversation(conversation),
+      );
+
+      if (persistentConversations.length > 0) {
+        const firstConversation = persistentConversations[0];
+        const firstConversationType = firstConversation.type || "direct";
+        navigate(`/chat/${firstConversation.id}?type=${firstConversationType}`);
       }
       return;
     }
@@ -659,7 +716,7 @@ const Chat = () => {
             is_synthetic:
               userData.is_synthetic ?? userData.isSynthetic ?? undefined,
           },
-          lastMessage: "Start your conversation...",
+          lastMessage: EMPTY_DIRECT_CONVERSATION_PREVIEW,
           updatedAt: new Date().toISOString(),
           isVirtual: true,
           unreadCount: 0,
@@ -682,399 +739,6 @@ const Chat = () => {
     navigate,
     setConversations,
   ]);
-
-  // Fetch messages when conversation changes
-  useEffect(() => {
-    const fetchMessages = async () => {
-      if (!conversationId) return;
-
-      try {
-        setLoadingMessages(true);
-        setLoadingMore(false);
-        setHasMoreMessages(false);
-
-        // ✅ Reset archived state when switching conversations
-        setIsTeamArchived(false);
-
-        const urlParams = new URLSearchParams(window.location.search);
-        const type = urlParams.get("type") || "direct";
-        const highlightedMessageId =
-          urlParams.get("highlightMessage") || urlParams.get("messageId");
-        const highlightedEventTarget = {
-          type:
-            urlParams.get("highlightEvent") ||
-            urlParams.get("highlightEventType") ||
-            "",
-          referenceId:
-            urlParams.get("highlightRef") ||
-            urlParams.get("highlightReferenceId") ||
-            "",
-          actorId: urlParams.get("highlightActor") || "",
-        };
-
-        let conversationDetails;
-        try {
-          conversationDetails = await messageService.getConversationById(
-            conversationId,
-            type,
-          );
-
-          if (type === "team" && conversationDetails?.data) {
-            setIsTeamArchived(isArchivedTeamData(conversationDetails.data.team));
-
-            const accessRevoked = await hydrateTeamConversationDetails(
-              conversationDetails,
-              conversationId,
-            );
-            if (accessRevoked) return;
-          }
-
-          setActiveConversation(conversationDetails.data);
-
-          // Ensure team conversation appears in conversation list
-          if (type === "team" && conversationDetails.data) {
-            setConversations((prev) => {
-              const existingConversation = prev.find(
-                (conv) =>
-                  String(conv.id) === String(conversationId) &&
-                  conv.type === "team",
-              );
-
-              if (!existingConversation) {
-                const newTeamConversation = {
-                  id: parseInt(conversationId),
-                  type: "team",
-                  team: {
-                    id: conversationDetails.data.team.id,
-                    name: conversationDetails.data.team.name,
-                    avatarUrl: conversationDetails.data.team.avatarUrl,
-                    isSynthetic:
-                      conversationDetails.data.team.isSynthetic ??
-                      conversationDetails.data.team.is_synthetic ??
-                      undefined,
-                    is_synthetic:
-                      conversationDetails.data.team.is_synthetic ??
-                      conversationDetails.data.team.isSynthetic ??
-                      undefined,
-                    archived_at: conversationDetails.data.team.archived_at,
-                    archivedAt:
-                      conversationDetails.data.team.archivedAt ??
-                      conversationDetails.data.team.archived_at,
-                    status: conversationDetails.data.team.status,
-                  },
-                  lastMessage: "Start your team conversation...",
-                  updatedAt: new Date().toISOString(),
-                  isVirtual: true,
-                  unreadCount: 0,
-                };
-
-                return [newTeamConversation, ...prev];
-              }
-
-              return prev;
-            });
-          }
-        } catch (error) {
-          // Check if it's an access denied error (user was removed from team)
-          if (error.response?.status === 403) {
-            setError("You no longer have access to this conversation.");
-            setLoadingMessages(false);
-            // Navigate back to chat list or my teams
-            navigate("/chat");
-            return;
-          }
-
-          if (type === "team" && conversationDetails?.data) {
-            const accessRevoked = await hydrateTeamConversationDetails(
-              conversationDetails,
-              conversationId,
-            );
-            if (accessRevoked) return;
-          }
-
-          if (type === "direct") {
-            // No messages exist yet — this is a new/virtual conversation.
-            // Build activeConversation from what we already know so the chat
-            // panel opens and the user can type the first message. The
-            // conversation row is created in the backend when they send it.
-            const knownConv = conversationsRef.current.find(
-              (c) =>
-                String(c.id) === String(conversationId) &&
-                c.type === "direct",
-            );
-            if (knownConv?.partner) {
-              setActiveConversation({
-                id: parseInt(conversationId),
-                type: "direct",
-                partner: knownConv.partner,
-                isVirtual: true,
-              });
-            } else {
-              try {
-                // A 404 (no such user — stale link or deleted account) is an
-                // expected, gracefully-handled case, not console noise.
-                const userResponse = await userService.getUserById(
-                  conversationId,
-                  { quietErrorStatuses: [404] },
-                );
-                const userData = userResponse.data;
-                setActiveConversation({
-                  id: parseInt(conversationId),
-                  type: "direct",
-                  partner: {
-                    id: userData.id,
-                    username: userData.username,
-                    firstName: userData.firstName || userData.first_name,
-                    lastName: userData.lastName || userData.last_name,
-                    avatarUrl: userData.avatarUrl || userData.avatar_url,
-                    isSynthetic: userData.isSynthetic ?? userData.is_synthetic ?? undefined,
-                    is_synthetic: userData.is_synthetic ?? userData.isSynthetic ?? undefined,
-                  },
-                  isVirtual: true,
-                });
-              } catch (userError) {
-                if (!isQuietError(userError)) {
-                  console.error(
-                    "Failed to load partner for new conversation:",
-                    userError,
-                  );
-                }
-              }
-            }
-          }
-        }
-
-        // Get messages for the conversation
-        try {
-          const messagesResponse = await messageService.getMessages(
-            conversationId,
-            type,
-          );
-          const searchTarget = highlightedMessageId
-            ? {
-                conversationId,
-                type,
-                messageId: highlightedMessageId,
-                query: null,
-              }
-            : pendingChatSearchTargetRef.current;
-          const shouldRevealSearchTarget =
-            searchTarget?.messageId &&
-            String(searchTarget.conversationId) === String(conversationId) &&
-            searchTarget.type === type;
-          let fetchedMessages = messagesResponse.data || [];
-          let nextHasMoreMessages = messagesResponse.hasMore || false;
-
-          if (shouldRevealSearchTarget) {
-            let oldestMessage = fetchedMessages[0];
-            let loadedCount = fetchedMessages.length;
-
-            while (
-              nextHasMoreMessages &&
-              oldestMessage?.id &&
-              loadedCount < CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION
-            ) {
-              const remaining =
-                CHAT_SEARCH_MAX_MESSAGES_PER_CONVERSATION - loadedCount;
-              const earlierResponse = await messageService.getMessages(
-                conversationId,
-                type,
-                {
-                  before: oldestMessage.id,
-                  limit: Math.min(50, remaining),
-                },
-              );
-              const earlierMessages = earlierResponse.data || [];
-
-              if (earlierMessages.length === 0) {
-                nextHasMoreMessages = false;
-                break;
-              }
-
-              fetchedMessages = [...earlierMessages, ...fetchedMessages];
-              loadedCount += earlierMessages.length;
-              nextHasMoreMessages = earlierResponse.hasMore || false;
-              oldestMessage = earlierMessages[0];
-            }
-          }
-
-          setHasMoreMessages(nextHasMoreMessages);
-          setMessages(dedupeMessages(fetchedMessages));
-
-          const latestFetchedMessage =
-            fetchedMessages[fetchedMessages.length - 1] || null;
-          const latestPreview =
-            buildConversationLastMessagePreview(latestFetchedMessage);
-
-          if (latestFetchedMessage && latestPreview) {
-            setConversations((prev) =>
-              prev.map((conversation) =>
-                String(conversation.id) === String(conversationId)
-                  ? {
-                      ...conversation,
-                      lastMessage: latestPreview,
-                      updatedAt:
-                        latestFetchedMessage.createdAt ||
-                        latestFetchedMessage.created_at ||
-                        conversation.updatedAt,
-                    }
-                  : conversation,
-              ),
-            );
-          }
-
-          // Check if we need to highlight messages from a specific user (from notification)
-          const highlightUser = searchParams.get("highlightUser");
-          const eventHighlightIds = getNotificationEventHighlightIds(
-            fetchedMessages,
-            highlightedEventTarget,
-          );
-
-          if (
-            shouldRevealSearchTarget &&
-            fetchedMessages.some(
-              (msg) => String(msg.id) === String(searchTarget.messageId),
-            )
-          ) {
-            const query = searchTarget.query;
-            const allMatchingIds = query
-              ? fetchedMessages
-                  .filter((msg) => buildMessageSearchText(msg).includes(query))
-                  .map((msg) => msg.id)
-                  .filter(Boolean)
-              : [];
-            // Put the target (most recent match) first so the view scrolls to it
-            const highlightIds = [
-              searchTarget.messageId,
-              ...allMatchingIds.filter(
-                (id) => String(id) !== String(searchTarget.messageId),
-              ),
-            ];
-            setHighlightMessageIds(highlightIds);
-            pendingChatSearchTargetRef.current = null;
-            // No auto-clear — highlights persist until search query changes
-          } else if (eventHighlightIds.length > 0) {
-            if (shouldRevealSearchTarget) {
-              pendingChatSearchTargetRef.current = null;
-            }
-
-            setHighlightMessageIds(eventHighlightIds);
-            setTimeout(() => {
-              setHighlightMessageIds([]);
-            }, 3500);
-          } else if (highlightUser) {
-            if (shouldRevealSearchTarget) {
-              pendingChatSearchTargetRef.current = null;
-            }
-
-            // Highlight the most recent messages from this user (join message + response)
-            const userMessages = fetchedMessages
-              .filter((msg) => String(msg.senderId) === String(highlightUser))
-              .slice(-3) // Get last 3 messages from this user
-              .map((msg) => msg.id);
-
-            if (userMessages.length > 0) {
-              setHighlightMessageIds(userMessages);
-              // Clear highlights after 4 seconds
-              setTimeout(() => {
-                setHighlightMessageIds([]);
-                // Clear the URL parameter
-                setSearchParams((prev) => {
-                  prev.delete("highlightUser");
-                  return prev;
-                });
-              }, 4000);
-            }
-          } else {
-            if (shouldRevealSearchTarget) {
-              pendingChatSearchTargetRef.current = null;
-            }
-
-            // Default behavior: highlight unread messages
-            const unreadIds = fetchedMessages
-              .filter((msg) => msg.senderId !== user?.id && !msg.readAt)
-              .map((msg) => msg.id);
-
-            if (unreadIds.length > 0) {
-              setHighlightMessageIds(unreadIds);
-              // Clear highlights after 3 seconds
-              setTimeout(() => {
-                setHighlightMessageIds([]);
-              }, 3000);
-            }
-          }
-        } catch {
-          setHasMoreMessages(false);
-          setMessages([]);
-        }
-
-        setLoadingMessages(false);
-
-        // Wait for socket to be connected before joining
-        const socket = socketService.getSocket();
-        if (socket && socket.connected) {
-          socketService.joinConversation(conversationId, type);
-          socketService.markMessagesAsRead(conversationId, type);
-        } else {
-          const checkConnection = setInterval(() => {
-            const socket = socketService.getSocket();
-            if (socket && socket.connected) {
-              const urlParams = new URLSearchParams(window.location.search);
-              const type = urlParams.get("type") || "direct";
-              socketService.joinConversation(conversationId, type);
-              socketService.markMessagesAsRead(conversationId, type);
-              clearInterval(checkConnection);
-            }
-          }, 100);
-
-          setTimeout(() => clearInterval(checkConnection), 5000);
-        }
-      } catch (err) {
-        console.error("Error fetching messages:", err);
-        setError("Failed to load messages. Please try again.");
-        setLoadingMessages(false);
-      }
-    };
-
-    if (isAuthenticated && conversationId) {
-      fetchMessages();
-
-      return () => {
-        if (conversationId) {
-          const urlParams = new URLSearchParams(window.location.search);
-          const type = urlParams.get("type") || "direct";
-          socketService.leaveConversation(conversationId, type);
-        }
-      };
-    }
-  }, [
-    isAuthenticated,
-    conversationId,
-    hydrateTeamConversationDetails,
-    searchParams,
-    setSearchParams,
-    navigate,
-    user?.id,
-    setConversations,
-  ]);
-
-  useEffect(() => {
-    if (!pendingScrollAdjustmentRef.current) return;
-
-    const container = messagesContainerRef.current;
-
-    if (!container) {
-      pendingScrollAdjustmentRef.current = null;
-      return;
-    }
-
-    const { previousScrollHeight, previousScrollTop } =
-      pendingScrollAdjustmentRef.current;
-
-    container.scrollTop =
-      container.scrollHeight - previousScrollHeight + previousScrollTop;
-    pendingScrollAdjustmentRef.current = null;
-  }, [messages, hasMoreMessages]);
 
   useChatSocketEvents({
     activeConversationRef,
@@ -1234,44 +898,6 @@ const Chat = () => {
   const handleClearReply = useCallback(() => {
     setReplyingTo(null);
   }, []);
-
-  const loadEarlierMessages = async () => {
-    if (loadingMore || !hasMoreMessages || messages.length === 0) return;
-
-    const container = messagesContainerRef.current;
-
-    if (container) {
-      pendingScrollAdjustmentRef.current = {
-        previousScrollHeight: container.scrollHeight,
-        previousScrollTop: container.scrollTop,
-      };
-    }
-
-    setLoadingMore(true);
-
-    try {
-      const oldestMessage = messages[0];
-      const type = searchParams.get("type") || "direct";
-      const response = await messageService.getMessages(conversationId, type, {
-        before: oldestMessage.id,
-        limit: 50,
-      });
-      const olderMessages = response.data || [];
-
-      setHasMoreMessages(response.hasMore || false);
-
-      if (olderMessages.length > 0) {
-        setMessages((prev) => dedupeMessages([...olderMessages, ...prev]));
-      } else {
-        pendingScrollAdjustmentRef.current = null;
-      }
-    } catch (err) {
-      pendingScrollAdjustmentRef.current = null;
-      console.error("Error loading earlier messages:", err);
-    } finally {
-      setLoadingMore(false);
-    }
-  };
 
   const handleSendFile = async (file) => {
     if (!canSendInActiveConversation || !file) {

--- a/src/utils/chatSearch.js
+++ b/src/utils/chatSearch.js
@@ -330,10 +330,21 @@ const hasConversationPreview = (conversation) => {
   );
 };
 
+const getConversationType = (conversation) => conversation?.type || "direct";
+
+const shouldKeepHydratedConversation = (conversation, previewByKey) => {
+  const type = getConversationType(conversation);
+
+  if (conversation?.isVirtual || type !== "direct") return true;
+  if (hasConversationPreview(conversation)) return true;
+
+  return previewByKey.has(`${type}:${String(conversation.id)}`);
+};
+
 // Fill in last-message previews for conversations the list endpoint returned
 // without one, by fetching the latest message per conversation. Pure: returns a
-// new list with previews merged in (or the input unchanged when nothing needs
-// hydrating), so it can run inside the conversations queryFn.
+// new list with previews merged in, and drops persistent empty direct chats so
+// only DMs with at least one message stay in the conversation list.
 export const hydrateConversationPreviews = async (conversationList) => {
   const conversationsToHydrate = (conversationList || []).filter(
     (conversation) =>
@@ -375,24 +386,26 @@ export const hydrateConversationPreviews = async (conversationList) => {
     );
   });
 
-  if (previewByKey.size === 0) return conversationList || [];
+  return (conversationList || [])
+    .filter((conversation) =>
+      shouldKeepHydratedConversation(conversation, previewByKey),
+    )
+    .map((conversation) => {
+      const type = getConversationType(conversation);
+      const hydratedPreview = previewByKey.get(
+        `${type}:${String(conversation.id)}`,
+      );
 
-  return (conversationList || []).map((conversation) => {
-    const type = conversation.type || "direct";
-    const hydratedPreview = previewByKey.get(
-      `${type}:${String(conversation.id)}`,
-    );
+      if (!hydratedPreview || hasConversationPreview(conversation)) {
+        return conversation;
+      }
 
-    if (!hydratedPreview || hasConversationPreview(conversation)) {
-      return conversation;
-    }
-
-    return {
-      ...conversation,
-      lastMessage: hydratedPreview.preview,
-      updatedAt: hydratedPreview.updatedAt || conversation.updatedAt,
-    };
-  });
+      return {
+        ...conversation,
+        lastMessage: hydratedPreview.preview,
+        updatedAt: hydratedPreview.updatedAt || conversation.updatedAt,
+      };
+    });
 };
 
 const getMessageSearchTimestamp = (message) => {


### PR DESCRIPTION
## Summary

- Extract active conversation loading from `Chat.jsx` into `useActiveChatConversation`
- Move message fetching, team/direct hydration, highlight handling, socket join/read marking, and earlier-message pagination into the new hook
- Keep empty direct chats transient and filter persistent empty DM rows from the conversation list
- Scope the conversation React Query cache per authenticated user to prevent account-switch leakage
- Update the chat refactor tracker and frontend README

## Verification

- `npm run lint`
  - Passes with existing warnings
- `npm run build`
  - Passes with existing Vite chunk-size warning
- `git diff --check`
  - Passes

## Manual Smoke Tests

- Active direct and team conversations load messages and details
- Earlier-message pagination preserves scroll position
- Notification/search highlights reveal the target message
- Revoked/deleted team access is removed from the list without repeated 403/404 fetch loops
- Empty direct chats disappear after reload/navigation unless actively opened as a new DM
- Switching accounts in the same browser shows the correct user-specific conversation list