### PR TITLE
Fix/reply preview media fields

### DIFF
--- a/src/components/chat/MessageBubble.jsx
+++ b/src/components/chat/MessageBubble.jsx
@@ -287,7 +287,9 @@ const ReplyPreview = ({ replyPreview }) => {
           <p className="text-xs text-base-content/60 truncate">
             {replyPreview.content
               ? renderReplyContent(replyPreview.content)
-              : "Original message was deleted"}
+              : replyPreview.deletedAt || replyPreview.deleted_at
+                ? "Original message was deleted"
+                : "Message unavailable"}
           </p>
         )}
       </Tooltip>

--- a/src/components/chat/MessageBubble.jsx
+++ b/src/components/chat/MessageBubble.jsx
@@ -29,6 +29,34 @@ const buildReplyPreview = (message, messagesById) => {
 
   if (!message.replyTo) return null;
 
+  // The embedded replyTo is a snapshot from send time. If the original message
+  // was deleted afterwards, honor the live/deleted state (resolved source, or a
+  // freshly fetched snapshot) and drop the stale quoted text/media so the
+  // preview reads as deleted instead of showing the old content.
+  const replyDeletedAt =
+    message.replyTo.deletedAt ??
+    message.replyTo.deleted_at ??
+    replySourceMessage?.deletedAt ??
+    replySourceMessage?.deleted_at ??
+    null;
+
+  if (replyDeletedAt) {
+    return {
+      ...message.replyTo,
+      deletedAt: replyDeletedAt,
+      content: null,
+      imageUrl: null,
+      image_url: null,
+      fileUrl: null,
+      file_url: null,
+      fileName: null,
+      file_name: null,
+      fileSize: null,
+      fileExpiresAt: null,
+      fileDeletedAt: null,
+    };
+  }
+
   return {
     ...replySourceMessage,
     ...message.replyTo,
@@ -285,11 +313,13 @@ const ReplyPreview = ({ replyPreview }) => {
           </p>
         ) : (
           <p className="text-xs text-base-content/60 truncate">
-            {replyPreview.content
-              ? renderReplyContent(replyPreview.content)
-              : replyPreview.deletedAt || replyPreview.deleted_at
-                ? "Original message was deleted"
-                : "Message unavailable"}
+            {replyPreview.content ? (
+              renderReplyContent(replyPreview.content)
+            ) : replyPreview.deletedAt || replyPreview.deleted_at ? (
+              <span className="italic">Original message was deleted</span>
+            ) : (
+              "Message unavailable"
+            )}
           </p>
         )}
       </Tooltip>


### PR DESCRIPTION
Fix reply-preview rendering for media, deleted and unresolved originals
Frontend companion to the backend PR of the same branch name (which embeds the media fields in the reply snapshot). Together they make the quoted-message preview render correctly for all viewers.

Problem
Two issues in the quoted-message preview (MessageBubble):

Replying to an image or file message showed no thumbnail or expiry for other viewers (the backend snapshot lacked the media fields; fixed in the backend PR).
Reacting to a message and then deleting the original left the quoted preview showing the old text, because the embedded replyTo is a snapshot from send time.
Changes
buildReplyPreview now honors the original's deleted state, taken from either the live resolved source message or the fetched snapshot (deletedAt / deleted_at). When the original is deleted it drops the stale quoted text and media, so deleting a message updates its quoted previews live instead of showing the old snapshot text.
The fallback shows the deleted-original placeholder only when the original is actually deleted (deletedAt); otherwise it shows a neutral unavailable text instead of always claiming deletion.
The deleted-original placeholder is rendered in italics.
With the backend now embedding image/file/expiry in the snapshot, image and file replies render their preview via the existing branches; this PR handles the deleted and unresolved cases and the styling.

Testing
ESLint clean (0 errors; existing project warnings unchanged)
Vite build green
Manually smoke-verified: reply to an image message shows the thumbnail and expiry for the other participant; deleting an original updates its quoted preview to the italic deleted placeholder live; normal text replies unchanged.