### PR TITLE
TeamCard: React Query cache/dedup pass (remove hand-rolled Map caches)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Lomir-frontend/
 │   │   ├── useUserQueries.js       # React Query hooks for user profile/tags/badges (useUserProfile, useUserTags, useUserBadges) + unwrap helpers
 │   │   ├── useTagQueries.js        # React Query hooks for structured tags
 │   │   ├── useBadgeQueries.js      # React Query hooks for badge catalog and shared-teams lookups
-│   │   ├── useTeamQueries.js       # React Query hooks for the paginated user-teams list and bulk member badges (MyTeams)
+│   │   ├── useTeamQueries.js       # React Query hooks/keys for teams: paginated user-teams list, bulk + per-team member badges, team detail (fetchTeamById), open-roles, and viewer team-role (MyTeams, SearchPage, TeamCard)
 │   │   ├── useSearchQueries.js     # React Query hook for the global search (SearchPage): whole criteria object as query key, keepPreviousData
 │   │   ├── useChatQueries.js       # React Query hooks for Chat: team-details cache + conversation list (staleTime: Infinity, socket-maintained)
 │   │   ├── useViewerMatchProfile.js # Viewer's tags/badges/location for client-side scoring

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -33,6 +33,7 @@ import useSocketEvents from "../../hooks/useSocketEvents";
 import useTeamRequestLists from "../../hooks/useTeamRequestLists";
 import {
   teamMemberBadgesByTeamQueryKey,
+  teamOpenRolesQueryKey,
   fetchTeamById,
 } from "../../hooks/useTeamQueries";
 import {
@@ -77,7 +78,6 @@ import {
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
-const teamOpenRolesCache = new Map();
 const EMPTY_ARRAY = [];
 
 const extractArrayPayload = (payload) => {
@@ -723,17 +723,16 @@ const TeamCard = ({
     }
 
     let isActive = true;
-    const cacheKey = String(teamData.id);
-    let openRolesRequest = teamOpenRolesCache.get(cacheKey);
 
-    if (!openRolesRequest) {
-      openRolesRequest = vacantRoleService
-        .getVacantRoles(teamData.id, "open")
-        .then((response) => extractArrayPayload(response).filter(isOpenRole));
-      teamOpenRolesCache.set(cacheKey, openRolesRequest);
-    }
-
-    openRolesRequest
+    queryClient
+      .fetchQuery({
+        queryKey: teamOpenRolesQueryKey(teamData.id),
+        queryFn: () =>
+          vacantRoleService
+            .getVacantRoles(teamData.id, "open")
+            .then((response) => extractArrayPayload(response).filter(isOpenRole)),
+        staleTime: Infinity,
+      })
       .then((roles) => {
         if (!isActive) return;
 
@@ -745,7 +744,11 @@ const TeamCard = ({
         });
       })
       .catch((error) => {
-        teamOpenRolesCache.delete(cacheKey);
+        // Drop the cached rejection so a later mount can retry cleanly (mirrors
+        // the old Map delete-on-error).
+        queryClient.removeQueries({
+          queryKey: teamOpenRolesQueryKey(teamData.id),
+        });
         if (!isActive) return;
         console.warn("Could not fetch current open roles for team card:", error);
         setFreshOpenRoleSnapshot(null);
@@ -763,6 +766,7 @@ const TeamCard = ({
     teamData?.open_roles_count,
     teamData?.openRoleNames,
     teamData?.open_role_names,
+    queryClient,
   ]);
 
   //   // Fetch user's role in this team (only for member variant)
@@ -1757,7 +1761,9 @@ const TeamCard = ({
 
   const handleVacantRoleStatusChange = async () => {
     if (teamData?.id != null) {
-      teamOpenRolesCache.delete(String(teamData.id));
+      queryClient.removeQueries({
+        queryKey: teamOpenRolesQueryKey(teamData.id),
+      });
       setFreshOpenRoleSnapshot(null);
     }
 

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -29,13 +29,20 @@ import TeamInvitationDetailsModal from "./TeamInvitationDetailsModal";
 import { useQueryClient } from "@tanstack/react-query";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
-import { userService } from "../../services/userService";
 import useSocketEvents from "../../hooks/useSocketEvents";
 import useTeamRequestLists from "../../hooks/useTeamRequestLists";
 import {
   teamMemberBadgesByTeamQueryKey,
   fetchTeamById,
 } from "../../hooks/useTeamQueries";
+import {
+  userProfileQueryKey,
+  userTagsQueryKey,
+  userBadgesQueryKey,
+  fetchUserProfile,
+  fetchUserTags,
+  fetchUserBadges,
+} from "../../hooks/useUserQueries";
 import { useAuth } from "../../contexts/AuthContext";
 import Alert from "../common/Alert";
 import ConfirmModal from "../common/ConfirmModal";
@@ -55,10 +62,7 @@ import {
   formatListLocation,
   normalizeLocationData,
 } from "../../utils/locationUtils";
-import {
-  extractListPayload,
-  extractProfilePayload,
-} from "../../utils/payloadExtractors";
+import { extractProfilePayload } from "../../utils/payloadExtractors";
 import {
   buildBadgeLookup,
   buildTagLookup,
@@ -73,7 +77,6 @@ import {
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
-const viewerRoleProfileCache = new Map();
 const teamOpenRolesCache = new Map();
 const EMPTY_ARRAY = [];
 
@@ -165,52 +168,41 @@ const extractBadgeRows = (payload) => {
   return [];
 };
 
-const getViewerRoleProfile = async (userId, fallbackUser = null) => {
-  const cacheKey = String(userId);
-  if (viewerRoleProfileCache.has(cacheKey)) {
-    return viewerRoleProfileCache.get(cacheKey);
-  }
+const getViewerRoleProfile = async (userId, fallbackUser = null, queryClient) => {
+  // Profile, tags, and badges are cached + deduped through React Query under the
+  // shared useUserQueries keys (staleTime Infinity mirrors the old per-session
+  // Map). The fetchUser* helpers already return the unwrapped user / tag rows /
+  // badge rows, so no further payload extraction is needed here.
+  const [profileRes, tagsRes, badgesRes] = await Promise.allSettled([
+    queryClient.fetchQuery({
+      queryKey: userProfileQueryKey(userId),
+      queryFn: () => fetchUserProfile(userId),
+      staleTime: Infinity,
+    }),
+    queryClient.fetchQuery({
+      queryKey: userTagsQueryKey(userId),
+      queryFn: () => fetchUserTags(userId),
+      staleTime: Infinity,
+    }),
+    queryClient.fetchQuery({
+      queryKey: userBadgesQueryKey(userId),
+      queryFn: () => fetchUserBadges(userId),
+      staleTime: Infinity,
+    }),
+  ]);
 
-  const request = (async () => {
-    const [profileRes, tagsRes, badgesRes] = await Promise.allSettled([
-      userService.getUserById(userId),
-      userService.getUserTags(userId),
-      userService.getUserBadges(userId),
-    ]);
+  const profileData = profileRes.status === "fulfilled" ? profileRes.value : null;
+  const tagData = tagsRes.status === "fulfilled" ? tagsRes.value : [];
+  const badgeData = badgesRes.status === "fulfilled" ? badgesRes.value : [];
 
-    const profileData =
-      profileRes.status === "fulfilled"
-        ? extractProfilePayload(profileRes.value)
-        : null;
-    const tagData =
-      tagsRes.status === "fulfilled"
-        ? extractListPayload(tagsRes.value)
-        : [];
-    const badgeData =
-      badgesRes.status === "fulfilled"
-        ? extractListPayload(badgesRes.value)
-        : [];
-
-    return {
-      user: {
-        ...(fallbackUser || {}),
-        ...(profileData || {}),
-      },
-      userTagMap: buildTagLookup(tagData),
-      userBadgeMap: buildBadgeLookup(badgeData),
-    };
-  })();
-
-  viewerRoleProfileCache.set(cacheKey, request);
-
-  try {
-    const result = await request;
-    viewerRoleProfileCache.set(cacheKey, Promise.resolve(result));
-    return result;
-  } catch (error) {
-    viewerRoleProfileCache.delete(cacheKey);
-    throw error;
-  }
+  return {
+    user: {
+      ...(fallbackUser || {}),
+      ...(profileData || {}),
+    },
+    userTagMap: buildTagLookup(tagData),
+    userBadgeMap: buildBadgeLookup(badgeData),
+  };
 };
 
 const getExplicitMatchScore = (item) => {
@@ -1312,7 +1304,11 @@ const TeamCard = ({
           return;
         }
 
-        const viewerProfile = await getViewerRoleProfile(user.id, user);
+        const viewerProfile = await getViewerRoleProfile(
+          user.id,
+          user,
+          queryClient,
+        );
         let effectiveRole = roleData ?? null;
 
         if (!roleHasPreloadedRequirements) {
@@ -1355,6 +1351,7 @@ const TeamCard = ({
     roleHasPreloadedRequirements,
     roleTeamId,
     user?.id,
+    queryClient,
   ]);
 
   // ================= GUARD CLAUSE – AFTER ALL HOOKS =================

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -32,7 +32,10 @@ import { vacantRoleService } from "../../services/vacantRoleService";
 import { userService } from "../../services/userService";
 import useSocketEvents from "../../hooks/useSocketEvents";
 import useTeamRequestLists from "../../hooks/useTeamRequestLists";
-import { teamMemberBadgesByTeamQueryKey } from "../../hooks/useTeamQueries";
+import {
+  teamMemberBadgesByTeamQueryKey,
+  fetchTeamById,
+} from "../../hooks/useTeamQueries";
 import { useAuth } from "../../contexts/AuthContext";
 import Alert from "../common/Alert";
 import ConfirmModal from "../common/ConfirmModal";
@@ -1017,7 +1020,7 @@ const TeamCard = ({
 
       try {
         const teamByIdPromise = shouldFetchTeamById
-          ? teamService.getTeamById(teamData.id)
+          ? fetchTeamById(queryClient, teamData.id)
           : Promise.resolve(null);
 
         const memberBadgesPromise = shouldFetchMemberBadges
@@ -1046,7 +1049,9 @@ const TeamCard = ({
           memberBadgesPromise,
         ]);
 
-        const fullTeam = response?.data?.data ?? response?.data ?? null;
+        // fetchTeamById resolves to the unwrapped team payload (or null when
+        // the fetch was skipped), so no envelope unwrapping is needed here.
+        const fullTeam = response ?? null;
 
         setTeamData((prev) => {
           const baseTeam = fullTeam ?? prev;
@@ -1109,10 +1114,9 @@ const TeamCard = ({
     if (teamData.latitude != null) return;
 
     let active = true;
-    teamService.getTeamById(teamData.id)
-      .then((response) => {
+    fetchTeamById(queryClient, teamData.id)
+      .then((fullTeam) => {
         if (!active) return;
-        const fullTeam = response?.data?.data ?? response?.data ?? null;
         if (!fullTeam) return;
         const lat = fullTeam.latitude ?? fullTeam.lat ?? null;
         const lng = fullTeam.longitude ?? fullTeam.lng ?? fullTeam.lon ?? null;
@@ -1121,7 +1125,7 @@ const TeamCard = ({
       })
       .catch(() => {});
     return () => { active = false; };
-  }, [isRoleVariant, teamData?.id]);
+  }, [isRoleVariant, teamData?.id, queryClient]);
 
   // Sync parent-managed member badges into teamData. When the parent provides
   // an array (bulk fetch resolved), we use it directly. While the parent is
@@ -1677,9 +1681,10 @@ const TeamCard = ({
   const handleModalClose = async () => {
     if (effectiveVariant === "member") {
       try {
-        const response = await teamService.getTeamById(teamData.id);
-        if (response && response.data) {
-          const fullTeam = response?.data?.data ?? response?.data;
+        const fullTeam = await fetchTeamById(queryClient, teamData.id, {
+          force: true,
+        });
+        if (fullTeam) {
           // Normalize is_public to ensure it's a boolean
           const normalizedTeam = {
             ...fullTeam,
@@ -1745,8 +1750,10 @@ const TeamCard = ({
     const result = await teamService.handleTeamApplication(applicationId, action, response, fillRole);
     await fetchPendingApplications();
     if (onUpdate) {
-      const updatedTeam = await teamService.getTeamById(teamData.id);
-      onUpdate(updatedTeam.data);
+      const updatedTeam = await fetchTeamById(queryClient, teamData.id, {
+        force: true,
+      });
+      onUpdate(updatedTeam);
     }
     return result;
   };
@@ -1760,8 +1767,9 @@ const TeamCard = ({
     await fetchPendingApplications();
 
     try {
-      const response = await teamService.getTeamById(teamData.id);
-      const fullTeam = response?.data?.data ?? response?.data;
+      const fullTeam = await fetchTeamById(queryClient, teamData.id, {
+        force: true,
+      });
 
       if (!fullTeam) return;
 

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -26,11 +26,13 @@ import TeamApplicationDetailsModal from "./TeamApplicationDetailsModal";
 import VacantRoleDetailsModal from "./VacantRoleDetailsModalLazy";
 import TeamInvitesModal from "./TeamInvitesModal";
 import TeamInvitationDetailsModal from "./TeamInvitationDetailsModal";
+import { useQueryClient } from "@tanstack/react-query";
 import { teamService } from "../../services/teamService";
 import { vacantRoleService } from "../../services/vacantRoleService";
 import { userService } from "../../services/userService";
 import useSocketEvents from "../../hooks/useSocketEvents";
 import useTeamRequestLists from "../../hooks/useTeamRequestLists";
+import { teamMemberBadgesByTeamQueryKey } from "../../hooks/useTeamQueries";
 import { useAuth } from "../../contexts/AuthContext";
 import Alert from "../common/Alert";
 import ConfirmModal from "../common/ConfirmModal";
@@ -68,7 +70,6 @@ import {
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 
-const teamMemberBadgesCache = new Map();
 const viewerRoleProfileCache = new Map();
 const teamOpenRolesCache = new Map();
 const EMPTY_ARRAY = [];
@@ -623,6 +624,7 @@ const TeamCard = ({
   const [teamData, setTeamData] = useState(normalizedData.team);
   const [freshOpenRoleSnapshot, setFreshOpenRoleSnapshot] = useState(null);
   const { user, isAuthenticated } = useAuth();
+  const queryClient = useQueryClient();
   const [isApplicationsModalOpen, setIsApplicationsModalOpen] = useState(false);
   const [isInvitesModalOpen, setIsInvitesModalOpen] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState(null);
@@ -1019,25 +1021,22 @@ const TeamCard = ({
           : Promise.resolve(null);
 
         const memberBadgesPromise = shouldFetchMemberBadges
-          ? (() => {
-              const cached = teamMemberBadgesCache.get(teamData.id);
-              if (cached) return Promise.resolve(cached);
-
-              return teamService
-                .getTeamMemberBadges(teamData.id)
-                .then((badgesResponse) => {
-                  const badges = extractBadgeRows(badgesResponse);
-                  teamMemberBadgesCache.set(teamData.id, badges);
-                  return badges;
-                })
-                .catch((badgeError) => {
-                  console.warn(
-                    "Could not fetch team member badges for card display:",
-                    badgeError,
-                  );
-                  return [];
-                });
-            })()
+          ? queryClient
+              .fetchQuery({
+                queryKey: teamMemberBadgesByTeamQueryKey(teamData.id),
+                queryFn: async () =>
+                  extractBadgeRows(
+                    await teamService.getTeamMemberBadges(teamData.id),
+                  ),
+                staleTime: Infinity,
+              })
+              .catch((badgeError) => {
+                console.warn(
+                  "Could not fetch team member badges for card display:",
+                  badgeError,
+                );
+                return [];
+              })
           : Promise.resolve(
               hasDisplayableBadges(teamData.badges) ? teamData.badges : [],
             );

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -34,6 +34,7 @@ import useTeamRequestLists from "../../hooks/useTeamRequestLists";
 import {
   teamMemberBadgesByTeamQueryKey,
   teamOpenRolesQueryKey,
+  teamUserRoleQueryKey,
   fetchTeamById,
 } from "../../hooks/useTeamQueries";
 import {
@@ -822,16 +823,22 @@ const TeamCard = ({
       }
 
       try {
-        const response = await teamService.getUserRoleInTeam(
-          teamData.id,
-          user.id,
-        );
-
-        const payload = response?.data;
-        const data = payload?.data ?? payload; // supports both shapes
-
-        const isMember = data?.isMember ?? payload?.isMember;
-        const role = data?.role ?? payload?.role ?? null;
+        const { isMember, role } = await queryClient.fetchQuery({
+          queryKey: teamUserRoleQueryKey(teamData.id, user.id),
+          queryFn: async () => {
+            const response = await teamService.getUserRoleInTeam(
+              teamData.id,
+              user.id,
+            );
+            const payload = response?.data;
+            const data = payload?.data ?? payload; // supports both shapes
+            return {
+              isMember: data?.isMember ?? payload?.isMember,
+              role: data?.role ?? payload?.role ?? null,
+            };
+          },
+          staleTime: Infinity,
+        });
 
         if (isMember === false) {
           setUserRole(null);
@@ -853,6 +860,7 @@ const TeamCard = ({
     teamData?.userRole,
     teamData?.user_role,
     effectiveVariant,
+    queryClient,
   ]);
 
   // Counts may be preloaded by the parent's list response (getUserTeams).

--- a/src/hooks/useTeamQueries.js
+++ b/src/hooks/useTeamQueries.js
@@ -60,6 +60,16 @@ export const teamMemberBadgesQueryKey = (teamIds) => [
   (teamIds ?? []).join(","),
 ];
 
+// Per-team member-badge cache key (single-team endpoint), used by TeamCard's
+// fallback fetch when the parent isn't bulk-managing badges. Replaces the old
+// module-level Map so the result is deduped/invalidatable via React Query.
+export const teamMemberBadgesByTeamQueryKey = (teamId) => [
+  "teams",
+  "byId",
+  String(teamId),
+  "memberBadges",
+];
+
 /**
  * Bulk member-badge map for the given team ids, keyed by team id. One request
  * for the whole list instead of a per-card fetch. Resolves to `{}` when there

--- a/src/hooks/useTeamQueries.js
+++ b/src/hooks/useTeamQueries.js
@@ -70,6 +70,15 @@ export const teamMemberBadgesByTeamQueryKey = (teamId) => [
   "memberBadges",
 ];
 
+// Per-team open-role snapshot cache key. Used by TeamCard's fallback fetch when a
+// team has open roles (count > 0) whose names aren't embedded in the list payload.
+export const teamOpenRolesQueryKey = (teamId) => [
+  "teams",
+  "byId",
+  String(teamId),
+  "openRoles",
+];
+
 /**
  * Bulk member-badge map for the given team ids, keyed by team id. One request
  * for the whole list instead of a per-card fetch. Resolves to `{}` when there

--- a/src/hooks/useTeamQueries.js
+++ b/src/hooks/useTeamQueries.js
@@ -79,6 +79,16 @@ export const teamOpenRolesQueryKey = (teamId) => [
   "openRoles",
 ];
 
+// Viewer's role in a team cache key. Used by TeamCard's fallback when the role
+// isn't preloaded from the list payload and the viewer isn't the owner.
+export const teamUserRoleQueryKey = (teamId, userId) => [
+  "teams",
+  "byId",
+  String(teamId),
+  "userRole",
+  String(userId),
+];
+
 /**
  * Bulk member-badge map for the given team ids, keyed by team id. One request
  * for the whole list instead of a per-card fetch. Resolves to `{}` when there

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -41,6 +41,7 @@ import {
   Target,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useTeamMemberBadges } from "../hooks/useTeamQueries";
 import { getApiErrorMessage } from "../services/searchService";
 import {
   globalSearchQueryKey,
@@ -849,6 +850,24 @@ const SearchPage = () => {
         ? displaySearchResults.roles
         : [],
   };
+  // Bulk member badges for all team results in one request (keyed by team id),
+  // via React Query, mirroring MyTeams. Team cards read `null` as "still
+  // loading" so they wait instead of each firing their own per-card
+  // member-badges fetch (the old N+1); `{}` means loaded/errored -> cards stop
+  // waiting and show no badges. Keyed by the full result set so paging does not
+  // refetch.
+  const teamResultIds = useMemo(
+    () => filteredResults.teams.map((t) => t?.id).filter((id) => id != null),
+    [filteredResults.teams],
+  );
+  const { data: teamMemberBadgesData, isError: teamMemberBadgesIsError } =
+    useTeamMemberBadges(teamResultIds);
+  const teamMemberBadgesById = useMemo(() => {
+    if (teamResultIds.length === 0) return {};
+    if (teamMemberBadgesIsError) return {};
+    return teamMemberBadgesData ?? null;
+  }, [teamResultIds.length, teamMemberBadgesIsError, teamMemberBadgesData]);
+
   const usesClientMergedPagination = shouldUseMergedResultPagination({
     searchType,
     sortBy,
@@ -2524,6 +2543,11 @@ const SearchPage = () => {
                         <TeamCard
                           key={`team-${item.id}`}
                           team={withViewerTeamRole(item)}
+                          teamMemberBadges={
+                            teamMemberBadgesById === null
+                              ? null
+                              : teamMemberBadgesById[item.id] || []
+                          }
                           onUpdate={handleTeamUpdate}
                           isSearchResult={true}
                           viewerDistanceSource={viewerDistanceSource}
@@ -2598,6 +2622,11 @@ const SearchPage = () => {
                         <TeamCard
                           key={`team-${item.id}`}
                           team={withViewerTeamRole(item)}
+                          teamMemberBadges={
+                            teamMemberBadgesById === null
+                              ? null
+                              : teamMemberBadgesById[item.id] || []
+                          }
                           onUpdate={handleTeamUpdate}
                           isSearchResult={true}
                           viewerDistanceSource={viewerDistanceSource}


### PR DESCRIPTION
Routes all of TeamCard's manual data fetching through the shared React Query cache and removes the three hand-rolled module-level Map caches. Also fixes an N+1 on SearchPage uncovered during the work. Frontend-only; behavior is unchanged for users.

Motivation
TeamCard was the last hot component still doing manual, per-card fetching with its own module-level Map caches (teamMemberBadgesCache, viewerRoleProfileCache, teamOpenRolesCache). These caches did not dedupe with the rest of the app, were not invalidatable, and drifted from the shared query hooks. This pass makes TeamCard consistent with MyTeams / SearchPage / Chat, which already use React Query.

Changes (5 phases, one commit each)
A — member badges: replace teamMemberBadgesCache with queryClient.fetchQuery under a new teamMemberBadgesByTeamQueryKey. Fixes a SearchPage N+1: each team card fired its own /api/teams/:id/member-badges; SearchPage now bulk-fetches once via useTeamMemberBadges(teamResultIds) and passes the teamMemberBadges prop to each card (mirrors MyTeams) — one /api/teams/member-badges?teamIds=... request instead of N.
B — team detail: route all five teamService.getTeamById calls through fetchTeamById(queryClient, id) (teamByIdQueryKey). Reads use the cached path; post-mutation refreshes use force: true (refetch + cache update).
C — viewer role profile: remove viewerRoleProfileCache; getViewerRoleProfile now fetches profile/tags/badges through the shared useUserQueries keys and fetchers.
D — open roles: remove teamOpenRolesCache; the open-role fallback uses queryClient.fetchQuery under a new teamOpenRolesQueryKey, with removeQueries on error and for the vacant-role status-change invalidation.
E — viewer team role: route the getUserRoleInTeam fallback through queryClient.fetchQuery under a new teamUserRoleQueryKey.
Net result: no module-level Map caches left in TeamCard; every manual read fetch deduplicates through shared React Query keys in useTeamQueries / useUserQueries. Viewer pending applications/invitations were already on useTeamRequestLists.

Verification
ESLint: 0 errors (31 pre-existing warnings unchanged)
Vite build: green
git diff --check: clean
Manually smoke-tested per phase (HAR-checked): SearchPage now issues a single bulk member-badges request; team-detail flows (modal close refresh, application accept/reject, vacant-role status change, role-variant distance) work; viewer profile/tags/badges dedupe; role cards on team/role invites and applications render and change status correctly.
Notes
The doubled vacant-roles?status=all seen on team-detail expand is the known React StrictMode dev double-invoke (dev only), not from this change.
Remaining TeamCard work is render-time component decomposition (React.memo on rows), tracked separately.