### PR TITLE
refactor(teamcard): component decomposition + React.memo for list render-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,11 @@ Lomir-frontend/
 │   │   │                           #   TeamApplicationButton, TeamApplicationModal,
 │   │   │                           #   TeamApplicationsModal, TeamApplicationDetailsModal,
 │   │   │                           #   TeamInviteModal, TeamInvitesModal,
-│   │   │                           #   TeamInvitationDetailsModal, RequestRoleCard
+│   │   │                           #   TeamInvitationDetailsModal, RequestRoleCard.
+│   │   │                           #   TeamCard is wrapped in React.memo (custom comparator) and
+│   │   │                           #   its subtitle-indicator rows are extracted to memoized
+│   │   │                           #   TeamCardSubtitle / TeamCardListSubtitle + shared
+│   │   │                           #   TeamCardIndicators (open-roles / visibility / demo)
 │   │   ├── users/                  # UserCard, UserDetailsModal, UserAvatar,
 │   │   │                           #   UserProfileHeaderSection (avatar + name + location header),
 │   │   │                           #   UserBioSection, InlineUserLink, BlocklistSection,

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -13,8 +13,6 @@ import {
   ShieldCheck,
   SendHorizontal,
   Mail,
-  Globe,
-  MapPin,
   Ruler,
   Calendar,
   FlaskConical,
@@ -62,7 +60,6 @@ import { extractNames, summarizeList } from "../../utils/listSummaryUtils";
 import {
   calculateDistanceKm,
   formatListLocation,
-  normalizeLocationData,
 } from "../../utils/locationUtils";
 import { extractProfilePayload } from "../../utils/payloadExtractors";
 import {
@@ -78,6 +75,7 @@ import {
   isSyntheticTeam,
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
+import TeamCardSubtitle from "./TeamCardSubtitle";
 
 const EMPTY_ARRAY = [];
 
@@ -2494,303 +2492,54 @@ const TeamCard = ({
 
   // ============ Main Render ============
 
+  // Resolve the pure subtitle getters once so <TeamCardSubtitle> receives
+  // primitive props and its React.memo can bail out on unrelated re-renders.
+  const subtitleFormattedDate = getFormattedDate();
+  const subtitleRoleStatusTooltip = getRoleStatusTooltip();
+  const subtitleInternalRoleInvitationTooltip = getInternalRoleInvitationTooltip();
+  const subtitleMemberCount = getMemberCount();
+  const subtitleMaxMembers = getMaxMembers();
+  const subtitleShowVisibilityIcon = shouldShowVisibilityIcon();
+
   return (
     <>
       <Card
         title={cardTitle}
         subtitle={
-          <span
-            className={`mt-0.5 flex max-h-[2.75em] overflow-hidden items-center flex-wrap leading-[110%] text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-px w-full" : "text-sm gap-x-1.5 gap-y-px"}`}
-          >
-            {scoreSubtitleItem}
-            {isRoleVariant && getFormattedDate() && (
-              <Tooltip content={getRoleStatusTooltip()}>
-                <span className="flex items-center gap-0.5 whitespace-nowrap">
-                  {isRoleInvitationVariant ? (
-                    <Mail
-                      size={viewMode === "mini" ? 10 : 13}
-                      className={`flex-shrink-0 ${hasInternalRoleInvitation ? "text-orange-500" : "text-pink-500"}`}
-                    />
-                  ) : (
-                    <SendHorizontal size={viewMode === "mini" ? 10 : 13} className="flex-shrink-0 text-orange-500" />
-                  )}
-                  <span>{getFormattedDate()}</span>
-                </span>
-              </Tooltip>
-            )}
-
-            {/* Members count for member search results */}
-            {!isRoleVariant && shouldShowMemberCountInSubtitle && (
-              <span className="flex items-center">
-                <Users
-                  size={viewMode === "mini" ? 10 : 13}
-                  className="text-primary mr-0.5"
-                />
-                <span>
-                  {getMemberCount()}/{getMaxMembers()}
-                </span>
-              </span>
-            )}
-
-            {/* Pending invitation indicator with date */}
-            {(effectiveVariant === "invitation" ||
-              pendingInvitationForTeam) && (
-              <Tooltip
-                content={
-                  hasInternalRoleInvitation
-                    ? getInternalRoleInvitationTooltip()
-                    : `You were invited to this team${
-                        getFormattedDate()
-                          ? `\non ${format(
-                              new Date(normalizedData.date),
-                              "MMM d, yyyy",
-                            )}`
-                          : ""
-                      }`
-                }
-              >
-                <span className="flex items-center gap-0.5 whitespace-nowrap">
-                  <Mail
-                    size={viewMode === "mini" ? 10 : 13}
-                    className={
-                      hasInternalRoleInvitation
-                        ? "text-orange-500"
-                        : "text-pink-500"
-                    }
-                  />
-                  {getFormattedDate() && (
-                    <span>{getFormattedDate()}</span>
-                  )}
-                </span>
-              </Tooltip>
-            )}
-            {teamInvitationRoleName && (
-              <Tooltip content={teamInvitationRoleName}>
-                {viewMode === "card" ? (
-                  <span className="flex items-center">
-                    <UserSearch
-                      size={13}
-                      className="text-orange-500"
-                    />
-                  </span>
-                ) : (
-                  <span className="flex items-start gap-1">
-                    <UserSearch
-                      size={viewMode === "mini" ? 10 : 13}
-                      className="text-orange-500 flex-shrink-0 mt-0.5"
-                    />
-                    <span className="leading-[1.05]">{teamInvitationRoleName}</span>
-                  </span>
-                )}
-              </Tooltip>
-            )}
-
-            {/* Pending team application indicator (team-only = blue, combined = violet) */}
-            {(effectiveVariant === "application" ||
-              (pendingApplicationForTeam && !isPendingRoleApplicationForTeam)) && (
-              <Tooltip
-                content={
-                  isCombinedApplication
-                    ? `You applied to join this team and fill a role${getFormattedDate() ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}` : ""}`
-                    : `You applied to join this team${getFormattedDate() ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}` : ""}`
-                }
-              >
-                <span className="flex items-center gap-0.5 whitespace-nowrap">
-                  <SendHorizontal
-                    size={viewMode === "mini" ? 10 : 13}
-                    className={isCombinedApplication ? "text-violet-500" : "text-info"}
-                  />
-                  {getFormattedDate() && (
-                    <span>{getFormattedDate()}</span>
-                  )}
-                </span>
-              </Tooltip>
-            )}
-            {teamApplicationRoleName && (
-              <Tooltip content={teamApplicationRoleName}>
-                {viewMode === "card" ? (
-                  <span className="flex items-center">
-                    <UserSearch
-                      size={13}
-                      className="text-orange-500"
-                    />
-                  </span>
-                ) : (
-                  <span className="flex items-start gap-1">
-                    <UserSearch
-                      size={viewMode === "mini" ? 10 : 13}
-                      className="text-orange-500 flex-shrink-0 mt-0.5"
-                    />
-                    <span className="leading-[1.05]">{teamApplicationRoleName}</span>
-                  </span>
-                )}
-              </Tooltip>
-            )}
-
-            {/* Team name for role variants */}
-            {isRoleVariant && teamData._teamName && (
-              <Tooltip content={teamData._teamName}>
-                {viewMode === "card" ? (
-                  <span
-                    className="flex items-center cursor-pointer"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setIsModalOpen(true);
-                    }}
-                  >
-                    <Users
-                      size={13}
-                      className="text-primary"
-                    />
-                  </span>
-                ) : (
-                  <span
-                    className="flex items-start gap-1 cursor-pointer"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setIsModalOpen(true);
-                    }}
-                  >
-                    <Users
-                      size={viewMode === "mini" ? 10 : 13}
-                      className="text-primary flex-shrink-0 mt-0.5"
-                    />
-                    <span className="leading-[1.05]">{teamData._teamName}</span>
-                  </span>
-                )}
-              </Tooltip>
-            )}
-
-            {shouldMoveSearchResultRoleApplicationIndicator &&
-              isPendingRoleApplicationForTeam && (
-                <Tooltip content={isPendingCombinedApplicationForTeam ? "You applied to join this team and fill a role" : "You applied for a role within this team"}>
-                  <span className="flex items-center">
-                    <SendHorizontal
-                      size={viewMode === "mini" ? 10 : 13}
-                      className={isPendingCombinedApplicationForTeam ? "text-violet-500" : "text-orange-500"}
-                    />
-                  </span>
-                </Tooltip>
-              )}
-
-            {/* Open roles count */}
-            {shouldShowOpenRoleCount && openRoleCount > 0 && (
-              <Tooltip content={`${openRoleCount} open ${openRoleCount === 1 ? 'role' : 'roles'} posted in this team`}>
-                <span className="flex items-center">
-                  <UserSearch
-                    size={viewMode === "mini" ? 10 : 13}
-                    className="text-orange-500 mr-0.5"
-                  />
-                  <span>{openRoleCount}</span>
-                </span>
-              </Tooltip>
-            )}
-
-            {/* Privacy status */}
-            {shouldShowVisibilityIcon() && (
-              <Tooltip
-                content={
-                  teamData.is_public === true || teamData.isPublic === true
-                    ? "Public Team - visible for everyone"
-                    : "Private Team - only visible for Members"
-                }
-              >
-                {teamData.is_public === true || teamData.isPublic === true ? (
-                  <EyeIcon
-                    size={viewMode === "mini" ? 10 : 13}
-                    className="text-green-600"
-                  />
-                ) : (
-                  <EyeClosed
-                    size={viewMode === "mini" ? 10 : 13}
-                    className="text-gray-500"
-                  />
-                )}
-              </Tooltip>
-            )}
-
-            {/* Pending role application indicator */}
-            {!shouldMoveSearchResultRoleApplicationIndicator &&
-              isPendingRoleApplicationForTeam && (
-              <Tooltip content="You applied for a role within this team">
-                <span className="flex items-center">
-                  <SendHorizontal
-                    size={viewMode === "mini" ? 10 : 13}
-                    className="text-orange-500"
-                  />
-                </span>
-              </Tooltip>
-              )}
-
-            {/* User role - show for member variant when user has a role */}
-            {userRole && effectiveVariant === "member" &&
-              (userRole === "owner" || userRole === "admin" || (userRole === "member" && !hideMemberRoleIcon)) && (
-              <span className="flex items-center text-base-content/70">
-                {userRole === "owner" && (
-                  <Tooltip content="You are the owner of this team">
-                    <Crown
-                      size={viewMode === "mini" ? 10 : 13}
-                      className="text-[var(--color-role-owner-bg)]"
-                    />
-                  </Tooltip>
-                )}
-                {userRole === "admin" && (
-                  <Tooltip content="You are an admin of this team">
-                    <ShieldCheck
-                      size={viewMode === "mini" ? 10 : 13}
-                      className="text-[var(--color-role-admin-bg)]"
-                    />
-                  </Tooltip>
-                )}
-                {userRole === "member" && !hideMemberRoleIcon && (
-                  <Tooltip content="You are a member of this team">
-                    <User
-                      size={viewMode === "mini" ? 10 : 13}
-                      className="text-[var(--color-role-member-bg)]"
-                    />
-                  </Tooltip>
-                )}
-              </span>
-            )}
-
-            {/* Compact location in subtitle for mini cards — search results only (My Teams always shows location in body) */}
-            {viewMode === "mini" &&
-              !activeFilters.showLocation &&
-              isSearchResult &&
-              (teamData.city ||
-                teamData.country ||
-                teamData.is_remote ||
-                teamData.isRemote) && (
-                <span className="flex items-center gap-1">
-                  {teamData.is_remote || teamData.isRemote ? (
-                    <>
-                      <Globe size={10} className="flex-shrink-0" />
-                      <span>Remote</span>
-                    </>
-                  ) : (
-                    <>
-                      <MapPin size={10} className="flex-shrink-0" />
-                      <span>
-                        {[teamData.city, normalizeLocationData(teamData).countryName]
-                          .filter(Boolean)
-                          .join(", ")}
-                      </span>
-                    </>
-                  )}
-                </span>
-              )}
-            {showDemoIndicator && (
-              <Tooltip
-                content={demoTooltip}
-                wrapperClassName="flex items-center gap-1 text-base-content/50"
-              >
-                <FlaskConical
-                  size={viewMode === "mini" ? 10 : 13}
-                  className="flex-shrink-0"
-                />
-              </Tooltip>
-            )}
-          </span>
+          <TeamCardSubtitle
+            viewMode={viewMode}
+            scoreSubtitleItem={scoreSubtitleItem}
+            isRoleVariant={isRoleVariant}
+            isRoleInvitationVariant={isRoleInvitationVariant}
+            hasInternalRoleInvitation={hasInternalRoleInvitation}
+            formattedDate={subtitleFormattedDate}
+            roleStatusTooltip={subtitleRoleStatusTooltip}
+            internalRoleInvitationTooltip={subtitleInternalRoleInvitationTooltip}
+            shouldShowMemberCountInSubtitle={shouldShowMemberCountInSubtitle}
+            memberCount={subtitleMemberCount}
+            maxMembers={subtitleMaxMembers}
+            effectiveVariant={effectiveVariant}
+            pendingInvitationForTeam={pendingInvitationForTeam}
+            pendingApplicationForTeam={pendingApplicationForTeam}
+            isPendingRoleApplicationForTeam={isPendingRoleApplicationForTeam}
+            normalizedData={normalizedData}
+            teamInvitationRoleName={teamInvitationRoleName}
+            teamApplicationRoleName={teamApplicationRoleName}
+            isCombinedApplication={isCombinedApplication}
+            teamData={teamData}
+            setIsModalOpen={setIsModalOpen}
+            shouldMoveSearchResultRoleApplicationIndicator={shouldMoveSearchResultRoleApplicationIndicator}
+            isPendingCombinedApplicationForTeam={isPendingCombinedApplicationForTeam}
+            shouldShowOpenRoleCount={shouldShowOpenRoleCount}
+            openRoleCount={openRoleCount}
+            showVisibilityIcon={subtitleShowVisibilityIcon}
+            userRole={userRole}
+            hideMemberRoleIcon={hideMemberRoleIcon}
+            activeFilters={activeFilters}
+            isSearchResult={isSearchResult}
+            showDemoIndicator={showDemoIndicator}
+            demoTooltip={demoTooltip}
+          />
         }
         hoverable
         image={getTeamImage()}

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -2711,4 +2711,49 @@ const TeamCard = ({
   );
 };
 
-export default TeamCard;
+TeamCard.displayName = "TeamCard";
+
+// One-level shallow equality for plain objects / arrays.
+const shallowEqualOneLevel = (a, b) => {
+  if (a === b) return true;
+  if (!a || !b || typeof a !== "object" || typeof b !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+};
+
+/**
+ * Custom React.memo comparator for TeamCard.
+ *
+ * SearchPage/MyTeams re-spread their result items (`{...t}`) and re-run
+ * `withViewerTeamRole` on every render, so object props (team/application/
+ * invitation/activeFilters/teamMemberBadges/roleMatchBadgeNames) get fresh
+ * wrappers each render even when nothing changed — but the copied inner values
+ * keep their references (they come from the stable query cache). A one-level
+ * shallow compare therefore bails safely: it returns equal only when every
+ * top-level value is identical, and errs toward re-rendering on any real
+ * change. Handlers/scalars are compared by identity, so callbacks must be
+ * referentially stable (useCallback) at the call sites for the bail to apply.
+ */
+const areTeamCardPropsEqual = (prev, next) => {
+  const prevKeys = Object.keys(prev);
+  if (prevKeys.length !== Object.keys(next).length) return false;
+  for (const key of prevKeys) {
+    const a = prev[key];
+    const b = next[key];
+    if (a === b) continue;
+    if (a && b && typeof a === "object" && typeof b === "object") {
+      if (shallowEqualOneLevel(a, b)) continue;
+      return false;
+    }
+    return false;
+  }
+  return true;
+};
+
+export default React.memo(TeamCard, areTeamCardPropsEqual);

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -5,17 +5,11 @@ import Tooltip from "../common/Tooltip";
 import {
   Users,
   UserSearch,
-  EyeClosed,
-  EyeIcon,
   Award,
-  User,
-  Crown,
-  ShieldCheck,
   SendHorizontal,
   Mail,
   Ruler,
   Calendar,
-  FlaskConical,
   Trash2,
 } from "lucide-react";
 import TeamDetailsModal from "./TeamDetailsModal";
@@ -76,6 +70,7 @@ import {
 } from "../../utils/userHelpers";
 import DemoAvatarOverlay from "../users/DemoAvatarOverlay";
 import TeamCardSubtitle from "./TeamCardSubtitle";
+import TeamCardListSubtitle from "./TeamCardListSubtitle";
 
 const EMPTY_ARRAY = [];
 
@@ -2127,145 +2122,43 @@ const TeamCard = ({
       </span>
     ) : null;
 
+    // Resolve the pure subtitle getters once so <TeamCardListSubtitle> receives
+    // primitive props and its React.memo can bail out on unrelated re-renders.
+    const listFormattedDate = getFormattedDate();
+    const listInternalRoleInvitationTooltip = getInternalRoleInvitationTooltip();
+    const listShowVisibilityIcon = shouldShowVisibilityIcon();
+
     const subtitleContent = (
-      <span className="block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-base-content/60 space-x-1">
-        {scoreSubtitleItem}
-        {memberCountListItem}
-        {(effectiveVariant === "invitation" || isRoleInvitationVariant || pendingInvitationForTeam) && (
-          <Tooltip
-            content={
-              hasInternalRoleInvitation
-                ? getInternalRoleInvitationTooltip()
-                : `You were invited to this team${
-                    getFormattedDate()
-                      ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}`
-                      : ""
-                  }`
-            }
-          >
-            <span
-              className={`flex items-center gap-0.5 ${isRoleInvitationVariant ? "cursor-pointer" : ""}`}
-              onClick={
-                isRoleInvitationVariant
-                  ? (e) => {
-                      e.stopPropagation();
-                      setIsInvitationDetailsModalOpen(true);
-                    }
-                  : undefined
-              }
-            >
-              <Mail
-                size={9}
-                className={hasInternalRoleInvitation ? "text-orange-500" : "text-pink-500"}
-              />
-              {getFormattedDate() && <span>{getFormattedDate()}</span>}
-            </span>
-          </Tooltip>
-        )}
-        {teamInvitationRoleName && (
-          <Tooltip
-            content={teamInvitationRoleName}
-            wrapperClassName="inline-flex items-center gap-0.5"
-          >
-            <UserSearch size={9} className="flex-shrink-0 text-orange-500" />
-            <span>{teamInvitationRoleName}</span>
-          </Tooltip>
-        )}
-        {(effectiveVariant === "application" || isRoleApplicationVariant || pendingApplicationForTeam) && (
-          <Tooltip
-            content={
-              isCombinedApplication || isPendingCombinedApplicationForTeam
-                ? `You applied to join this team and fill a role${getFormattedDate() ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}` : ""}`
-                : isPendingInternalRoleApplicationForTeam
-                  ? "You applied for a role within this team"
-                  : `You applied${isRoleApplicationVariant ? " for this role" : " to join this team"}${
-                      getFormattedDate()
-                        ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}`
-                        : ""
-                    }`
-            }
-          >
-            <span
-              className="flex items-center gap-0.5 cursor-pointer"
-              onClick={(e) => {
-                e.stopPropagation();
-                setIsApplicationModalOpen(true);
-              }}
-            >
-              <SendHorizontal size={9} className={
-                (isCombinedApplication || isPendingCombinedApplicationForTeam) ? "text-violet-500" :
-                (isRoleApplicationVariant || isPendingInternalRoleApplicationForTeam) ? "text-orange-500" :
-                "text-info"
-              } />
-              {getFormattedDate() && <span>{getFormattedDate()}</span>}
-            </span>
-          </Tooltip>
-        )}
-        {teamApplicationRoleName && (
-          <Tooltip
-            content={teamApplicationRoleName}
-            wrapperClassName="inline-flex items-center gap-0.5"
-          >
-            <UserSearch size={9} className="flex-shrink-0 text-orange-500" />
-            <span>{teamApplicationRoleName}</span>
-          </Tooltip>
-        )}
-        {shouldShowOpenRoleCount && openRoleCount > 0 && (
-          <Tooltip content={`${openRoleCount} open ${openRoleCount === 1 ? 'role' : 'roles'} posted in this team`}>
-            <span className="flex items-center">
-              <UserSearch size={9} className="text-orange-500 mr-0.5" />
-              <span>{openRoleCount}</span>
-            </span>
-          </Tooltip>
-        )}
-        {isRoleVariant && teamData._teamName && (
-          <Tooltip content="Click to view team details" wrapperClassName="inline-flex items-center gap-0.5">
-            <span
-              className="inline-flex items-center gap-0.5 cursor-pointer"
-              onClick={(e) => { e.stopPropagation(); setIsModalOpen(true); }}
-            >
-              <Users size={9} className="flex-shrink-0 text-primary" />
-              <span>{teamData._teamName}</span>
-            </span>
-          </Tooltip>
-        )}
-        {userRole && effectiveVariant === "member" && (
-          <>
-            {userRole === "owner" && (
-              <Tooltip content="You are the owner of this team">
-                <Crown size={9} className="text-[var(--color-role-owner-bg)]" />
-              </Tooltip>
-            )}
-            {userRole === "admin" && (
-              <Tooltip content="You are an admin of this team">
-                <ShieldCheck size={9} className="text-[var(--color-role-admin-bg)]" />
-              </Tooltip>
-            )}
-            {userRole === "member" && !hideMemberRoleIcon && (
-              <Tooltip content="You are a member of this team">
-                <User size={9} className="text-[var(--color-role-member-bg)]" />
-              </Tooltip>
-            )}
-          </>
-        )}
-        {shouldShowVisibilityIcon() && (
-          <Tooltip content={teamData.is_public === true || teamData.isPublic === true ? "Public Team - visible for everyone" : "Private Team - only visible for Members"}>
-            {teamData.is_public === true || teamData.isPublic === true ? (
-              <EyeIcon size={9} className="text-green-600" />
-            ) : (
-              <EyeClosed size={9} className="text-gray-500" />
-            )}
-          </Tooltip>
-        )}
-        {showDemoIndicator && (
-          <Tooltip
-            content={demoTooltip}
-            wrapperClassName="inline-flex items-center whitespace-nowrap text-base-content/50"
-          >
-            <FlaskConical size={9} className="flex-shrink-0" />
-          </Tooltip>
-        )}
-      </span>
+      <TeamCardListSubtitle
+        scoreSubtitleItem={scoreSubtitleItem}
+        memberCountListItem={memberCountListItem}
+        effectiveVariant={effectiveVariant}
+        isRoleInvitationVariant={isRoleInvitationVariant}
+        isRoleApplicationVariant={isRoleApplicationVariant}
+        isRoleVariant={isRoleVariant}
+        pendingInvitationForTeam={pendingInvitationForTeam}
+        pendingApplicationForTeam={pendingApplicationForTeam}
+        hasInternalRoleInvitation={hasInternalRoleInvitation}
+        internalRoleInvitationTooltip={listInternalRoleInvitationTooltip}
+        formattedDate={listFormattedDate}
+        normalizedData={normalizedData}
+        setIsInvitationDetailsModalOpen={setIsInvitationDetailsModalOpen}
+        setIsApplicationModalOpen={setIsApplicationModalOpen}
+        setIsModalOpen={setIsModalOpen}
+        teamInvitationRoleName={teamInvitationRoleName}
+        teamApplicationRoleName={teamApplicationRoleName}
+        isCombinedApplication={isCombinedApplication}
+        isPendingCombinedApplicationForTeam={isPendingCombinedApplicationForTeam}
+        isPendingInternalRoleApplicationForTeam={isPendingInternalRoleApplicationForTeam}
+        shouldShowOpenRoleCount={shouldShowOpenRoleCount}
+        openRoleCount={openRoleCount}
+        teamData={teamData}
+        userRole={userRole}
+        hideMemberRoleIcon={hideMemberRoleIcon}
+        showVisibilityIcon={listShowVisibilityIcon}
+        showDemoIndicator={showDemoIndicator}
+        demoTooltip={demoTooltip}
+      />
     );
 
     return (

--- a/src/components/teams/TeamCardIndicators.jsx
+++ b/src/components/teams/TeamCardIndicators.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { UserSearch, EyeClosed, EyeIcon, FlaskConical } from "lucide-react";
+import Tooltip from "../common/Tooltip";
+
+/**
+ * Shared leaf indicators for the TeamCard subtitle rows.
+ *
+ * These three blocks are byte-identical between the card/mini and list
+ * subtitles apart from icon size (and the demo wrapper class), so they live
+ * here as size-parameterized, self-gating primitives used by both
+ * TeamCardSubtitle and TeamCardListSubtitle. Each returns null when it should
+ * not render, keeping the call sites to a single tag.
+ */
+
+export const OpenRolesIndicator = React.memo(function OpenRolesIndicator({
+  size,
+  shouldShow,
+  openRoleCount,
+}) {
+  if (!(shouldShow && openRoleCount > 0)) return null;
+  return (
+    <Tooltip content={`${openRoleCount} open ${openRoleCount === 1 ? 'role' : 'roles'} posted in this team`}>
+      <span className="flex items-center">
+        <UserSearch size={size} className="text-orange-500 mr-0.5" />
+        <span>{openRoleCount}</span>
+      </span>
+    </Tooltip>
+  );
+});
+
+export const VisibilityIndicator = React.memo(function VisibilityIndicator({
+  size,
+  show,
+  isPublic,
+}) {
+  if (!show) return null;
+  return (
+    <Tooltip
+      content={
+        isPublic
+          ? "Public Team - visible for everyone"
+          : "Private Team - only visible for Members"
+      }
+    >
+      {isPublic ? (
+        <EyeIcon size={size} className="text-green-600" />
+      ) : (
+        <EyeClosed size={size} className="text-gray-500" />
+      )}
+    </Tooltip>
+  );
+});
+
+export const DemoIndicator = React.memo(function DemoIndicator({
+  size,
+  show,
+  tooltip,
+  wrapperClassName,
+}) {
+  if (!show) return null;
+  return (
+    <Tooltip content={tooltip} wrapperClassName={wrapperClassName}>
+      <FlaskConical size={size} className="flex-shrink-0" />
+    </Tooltip>
+  );
+});

--- a/src/components/teams/TeamCardListSubtitle.jsx
+++ b/src/components/teams/TeamCardListSubtitle.jsx
@@ -1,0 +1,198 @@
+import React from "react";
+import { format } from "date-fns";
+import {
+  Users,
+  UserSearch,
+  EyeClosed,
+  EyeIcon,
+  User,
+  Crown,
+  ShieldCheck,
+  SendHorizontal,
+  Mail,
+  FlaskConical,
+} from "lucide-react";
+import Tooltip from "../common/Tooltip";
+
+/**
+ * Presentational subtitle indicator row for the list TeamCard view.
+ *
+ * Mirrors TeamCardSubtitle but for the compact list layout (all icons size 9,
+ * inline-flex spacing, plus the invitation/application click affordances).
+ * Pure getters are resolved once by the parent and passed as primitive props
+ * so the surrounding React.memo can bail out. Extracted verbatim from
+ * TeamCard.jsx (list branch). Unified with TeamCardSubtitle in a later phase.
+ */
+const TeamCardListSubtitle = ({
+  scoreSubtitleItem,
+  memberCountListItem,
+  effectiveVariant,
+  isRoleInvitationVariant,
+  isRoleApplicationVariant,
+  isRoleVariant,
+  pendingInvitationForTeam,
+  pendingApplicationForTeam,
+  hasInternalRoleInvitation,
+  internalRoleInvitationTooltip,
+  formattedDate,
+  normalizedData,
+  setIsInvitationDetailsModalOpen,
+  setIsApplicationModalOpen,
+  setIsModalOpen,
+  teamInvitationRoleName,
+  teamApplicationRoleName,
+  isCombinedApplication,
+  isPendingCombinedApplicationForTeam,
+  isPendingInternalRoleApplicationForTeam,
+  shouldShowOpenRoleCount,
+  openRoleCount,
+  teamData,
+  userRole,
+  hideMemberRoleIcon,
+  showVisibilityIcon,
+  showDemoIndicator,
+  demoTooltip,
+}) => {
+  return (
+    <span className="block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-base-content/60 space-x-1">
+      {scoreSubtitleItem}
+      {memberCountListItem}
+      {(effectiveVariant === "invitation" || isRoleInvitationVariant || pendingInvitationForTeam) && (
+        <Tooltip
+          content={
+            hasInternalRoleInvitation
+              ? internalRoleInvitationTooltip
+              : `You were invited to this team${
+                  formattedDate
+                    ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}`
+                    : ""
+                }`
+          }
+        >
+          <span
+            className={`flex items-center gap-0.5 ${isRoleInvitationVariant ? "cursor-pointer" : ""}`}
+            onClick={
+              isRoleInvitationVariant
+                ? (e) => {
+                    e.stopPropagation();
+                    setIsInvitationDetailsModalOpen(true);
+                  }
+                : undefined
+            }
+          >
+            <Mail
+              size={9}
+              className={hasInternalRoleInvitation ? "text-orange-500" : "text-pink-500"}
+            />
+            {formattedDate && <span>{formattedDate}</span>}
+          </span>
+        </Tooltip>
+      )}
+      {teamInvitationRoleName && (
+        <Tooltip
+          content={teamInvitationRoleName}
+          wrapperClassName="inline-flex items-center gap-0.5"
+        >
+          <UserSearch size={9} className="flex-shrink-0 text-orange-500" />
+          <span>{teamInvitationRoleName}</span>
+        </Tooltip>
+      )}
+      {(effectiveVariant === "application" || isRoleApplicationVariant || pendingApplicationForTeam) && (
+        <Tooltip
+          content={
+            isCombinedApplication || isPendingCombinedApplicationForTeam
+              ? `You applied to join this team and fill a role${formattedDate ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}` : ""}`
+              : isPendingInternalRoleApplicationForTeam
+                ? "You applied for a role within this team"
+                : `You applied${isRoleApplicationVariant ? " for this role" : " to join this team"}${
+                    formattedDate
+                      ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}`
+                      : ""
+                  }`
+          }
+        >
+          <span
+            className="flex items-center gap-0.5 cursor-pointer"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsApplicationModalOpen(true);
+            }}
+          >
+            <SendHorizontal size={9} className={
+              (isCombinedApplication || isPendingCombinedApplicationForTeam) ? "text-violet-500" :
+              (isRoleApplicationVariant || isPendingInternalRoleApplicationForTeam) ? "text-orange-500" :
+              "text-info"
+            } />
+            {formattedDate && <span>{formattedDate}</span>}
+          </span>
+        </Tooltip>
+      )}
+      {teamApplicationRoleName && (
+        <Tooltip
+          content={teamApplicationRoleName}
+          wrapperClassName="inline-flex items-center gap-0.5"
+        >
+          <UserSearch size={9} className="flex-shrink-0 text-orange-500" />
+          <span>{teamApplicationRoleName}</span>
+        </Tooltip>
+      )}
+      {shouldShowOpenRoleCount && openRoleCount > 0 && (
+        <Tooltip content={`${openRoleCount} open ${openRoleCount === 1 ? 'role' : 'roles'} posted in this team`}>
+          <span className="flex items-center">
+            <UserSearch size={9} className="text-orange-500 mr-0.5" />
+            <span>{openRoleCount}</span>
+          </span>
+        </Tooltip>
+      )}
+      {isRoleVariant && teamData._teamName && (
+        <Tooltip content="Click to view team details" wrapperClassName="inline-flex items-center gap-0.5">
+          <span
+            className="inline-flex items-center gap-0.5 cursor-pointer"
+            onClick={(e) => { e.stopPropagation(); setIsModalOpen(true); }}
+          >
+            <Users size={9} className="flex-shrink-0 text-primary" />
+            <span>{teamData._teamName}</span>
+          </span>
+        </Tooltip>
+      )}
+      {userRole && effectiveVariant === "member" && (
+        <>
+          {userRole === "owner" && (
+            <Tooltip content="You are the owner of this team">
+              <Crown size={9} className="text-[var(--color-role-owner-bg)]" />
+            </Tooltip>
+          )}
+          {userRole === "admin" && (
+            <Tooltip content="You are an admin of this team">
+              <ShieldCheck size={9} className="text-[var(--color-role-admin-bg)]" />
+            </Tooltip>
+          )}
+          {userRole === "member" && !hideMemberRoleIcon && (
+            <Tooltip content="You are a member of this team">
+              <User size={9} className="text-[var(--color-role-member-bg)]" />
+            </Tooltip>
+          )}
+        </>
+      )}
+      {showVisibilityIcon && (
+        <Tooltip content={teamData.is_public === true || teamData.isPublic === true ? "Public Team - visible for everyone" : "Private Team - only visible for Members"}>
+          {teamData.is_public === true || teamData.isPublic === true ? (
+            <EyeIcon size={9} className="text-green-600" />
+          ) : (
+            <EyeClosed size={9} className="text-gray-500" />
+          )}
+        </Tooltip>
+      )}
+      {showDemoIndicator && (
+        <Tooltip
+          content={demoTooltip}
+          wrapperClassName="inline-flex items-center whitespace-nowrap text-base-content/50"
+        >
+          <FlaskConical size={9} className="flex-shrink-0" />
+        </Tooltip>
+      )}
+    </span>
+  );
+};
+
+export default React.memo(TeamCardListSubtitle);

--- a/src/components/teams/TeamCardListSubtitle.jsx
+++ b/src/components/teams/TeamCardListSubtitle.jsx
@@ -3,16 +3,18 @@ import { format } from "date-fns";
 import {
   Users,
   UserSearch,
-  EyeClosed,
-  EyeIcon,
   User,
   Crown,
   ShieldCheck,
   SendHorizontal,
   Mail,
-  FlaskConical,
 } from "lucide-react";
 import Tooltip from "../common/Tooltip";
+import {
+  OpenRolesIndicator,
+  VisibilityIndicator,
+  DemoIndicator,
+} from "./TeamCardIndicators";
 
 /**
  * Presentational subtitle indicator row for the list TeamCard view.
@@ -136,14 +138,11 @@ const TeamCardListSubtitle = ({
           <span>{teamApplicationRoleName}</span>
         </Tooltip>
       )}
-      {shouldShowOpenRoleCount && openRoleCount > 0 && (
-        <Tooltip content={`${openRoleCount} open ${openRoleCount === 1 ? 'role' : 'roles'} posted in this team`}>
-          <span className="flex items-center">
-            <UserSearch size={9} className="text-orange-500 mr-0.5" />
-            <span>{openRoleCount}</span>
-          </span>
-        </Tooltip>
-      )}
+      <OpenRolesIndicator
+        size={9}
+        shouldShow={shouldShowOpenRoleCount}
+        openRoleCount={openRoleCount}
+      />
       {isRoleVariant && teamData._teamName && (
         <Tooltip content="Click to view team details" wrapperClassName="inline-flex items-center gap-0.5">
           <span
@@ -174,23 +173,17 @@ const TeamCardListSubtitle = ({
           )}
         </>
       )}
-      {showVisibilityIcon && (
-        <Tooltip content={teamData.is_public === true || teamData.isPublic === true ? "Public Team - visible for everyone" : "Private Team - only visible for Members"}>
-          {teamData.is_public === true || teamData.isPublic === true ? (
-            <EyeIcon size={9} className="text-green-600" />
-          ) : (
-            <EyeClosed size={9} className="text-gray-500" />
-          )}
-        </Tooltip>
-      )}
-      {showDemoIndicator && (
-        <Tooltip
-          content={demoTooltip}
-          wrapperClassName="inline-flex items-center whitespace-nowrap text-base-content/50"
-        >
-          <FlaskConical size={9} className="flex-shrink-0" />
-        </Tooltip>
-      )}
+      <VisibilityIndicator
+        size={9}
+        show={showVisibilityIcon}
+        isPublic={teamData.is_public === true || teamData.isPublic === true}
+      />
+      <DemoIndicator
+        size={9}
+        show={showDemoIndicator}
+        tooltip={demoTooltip}
+        wrapperClassName="inline-flex items-center whitespace-nowrap text-base-content/50"
+      />
     </span>
   );
 };

--- a/src/components/teams/TeamCardSubtitle.jsx
+++ b/src/components/teams/TeamCardSubtitle.jsx
@@ -3,8 +3,6 @@ import { format } from "date-fns";
 import {
   Users,
   UserSearch,
-  EyeClosed,
-  EyeIcon,
   User,
   Crown,
   ShieldCheck,
@@ -12,10 +10,14 @@ import {
   Mail,
   Globe,
   MapPin,
-  FlaskConical,
 } from "lucide-react";
 import Tooltip from "../common/Tooltip";
 import { normalizeLocationData } from "../../utils/locationUtils";
+import {
+  OpenRolesIndicator,
+  VisibilityIndicator,
+  DemoIndicator,
+} from "./TeamCardIndicators";
 
 /**
  * Presentational subtitle indicator row for the card/mini TeamCard views.
@@ -236,40 +238,18 @@ const TeamCardSubtitle = ({
         )}
 
       {/* Open roles count */}
-      {shouldShowOpenRoleCount && openRoleCount > 0 && (
-        <Tooltip content={`${openRoleCount} open ${openRoleCount === 1 ? 'role' : 'roles'} posted in this team`}>
-          <span className="flex items-center">
-            <UserSearch
-              size={viewMode === "mini" ? 10 : 13}
-              className="text-orange-500 mr-0.5"
-            />
-            <span>{openRoleCount}</span>
-          </span>
-        </Tooltip>
-      )}
+      <OpenRolesIndicator
+        size={viewMode === "mini" ? 10 : 13}
+        shouldShow={shouldShowOpenRoleCount}
+        openRoleCount={openRoleCount}
+      />
 
       {/* Privacy status */}
-      {showVisibilityIcon && (
-        <Tooltip
-          content={
-            teamData.is_public === true || teamData.isPublic === true
-              ? "Public Team - visible for everyone"
-              : "Private Team - only visible for Members"
-          }
-        >
-          {teamData.is_public === true || teamData.isPublic === true ? (
-            <EyeIcon
-              size={viewMode === "mini" ? 10 : 13}
-              className="text-green-600"
-            />
-          ) : (
-            <EyeClosed
-              size={viewMode === "mini" ? 10 : 13}
-              className="text-gray-500"
-            />
-          )}
-        </Tooltip>
-      )}
+      <VisibilityIndicator
+        size={viewMode === "mini" ? 10 : 13}
+        show={showVisibilityIcon}
+        isPublic={teamData.is_public === true || teamData.isPublic === true}
+      />
 
       {/* Pending role application indicator */}
       {!shouldMoveSearchResultRoleApplicationIndicator &&
@@ -341,17 +321,12 @@ const TeamCardSubtitle = ({
             )}
           </span>
         )}
-      {showDemoIndicator && (
-        <Tooltip
-          content={demoTooltip}
-          wrapperClassName="flex items-center gap-1 text-base-content/50"
-        >
-          <FlaskConical
-            size={viewMode === "mini" ? 10 : 13}
-            className="flex-shrink-0"
-          />
-        </Tooltip>
-      )}
+      <DemoIndicator
+        size={viewMode === "mini" ? 10 : 13}
+        show={showDemoIndicator}
+        tooltip={demoTooltip}
+        wrapperClassName="flex items-center gap-1 text-base-content/50"
+      />
     </span>
   );
 };

--- a/src/components/teams/TeamCardSubtitle.jsx
+++ b/src/components/teams/TeamCardSubtitle.jsx
@@ -1,0 +1,359 @@
+import React from "react";
+import { format } from "date-fns";
+import {
+  Users,
+  UserSearch,
+  EyeClosed,
+  EyeIcon,
+  User,
+  Crown,
+  ShieldCheck,
+  SendHorizontal,
+  Mail,
+  Globe,
+  MapPin,
+  FlaskConical,
+} from "lucide-react";
+import Tooltip from "../common/Tooltip";
+import { normalizeLocationData } from "../../utils/locationUtils";
+
+/**
+ * Presentational subtitle indicator row for the card/mini TeamCard views.
+ *
+ * Renders the horizontal strip of match-score / invitation / application /
+ * open-role / visibility / user-role / location / demo indicators. All values
+ * are precomputed by the parent and passed as primitive props (pure getters
+ * resolved once) so the surrounding React.memo can bail out when nothing
+ * relevant changed. Extracted verbatim from TeamCard.jsx (card/mini branch).
+ */
+const TeamCardSubtitle = ({
+  viewMode,
+  scoreSubtitleItem,
+  isRoleVariant,
+  isRoleInvitationVariant,
+  hasInternalRoleInvitation,
+  formattedDate,
+  roleStatusTooltip,
+  internalRoleInvitationTooltip,
+  shouldShowMemberCountInSubtitle,
+  memberCount,
+  maxMembers,
+  effectiveVariant,
+  pendingInvitationForTeam,
+  pendingApplicationForTeam,
+  isPendingRoleApplicationForTeam,
+  normalizedData,
+  teamInvitationRoleName,
+  teamApplicationRoleName,
+  isCombinedApplication,
+  teamData,
+  setIsModalOpen,
+  shouldMoveSearchResultRoleApplicationIndicator,
+  isPendingCombinedApplicationForTeam,
+  shouldShowOpenRoleCount,
+  openRoleCount,
+  showVisibilityIcon,
+  userRole,
+  hideMemberRoleIcon,
+  activeFilters,
+  isSearchResult,
+  showDemoIndicator,
+  demoTooltip,
+}) => {
+  return (
+    <span
+      className={`mt-0.5 flex max-h-[2.75em] overflow-hidden items-center flex-wrap leading-[110%] text-base-content/70 ${viewMode === "mini" ? "text-xs gap-x-1 gap-y-px w-full" : "text-sm gap-x-1.5 gap-y-px"}`}
+    >
+      {scoreSubtitleItem}
+      {isRoleVariant && formattedDate && (
+        <Tooltip content={roleStatusTooltip}>
+          <span className="flex items-center gap-0.5 whitespace-nowrap">
+            {isRoleInvitationVariant ? (
+              <Mail
+                size={viewMode === "mini" ? 10 : 13}
+                className={`flex-shrink-0 ${hasInternalRoleInvitation ? "text-orange-500" : "text-pink-500"}`}
+              />
+            ) : (
+              <SendHorizontal size={viewMode === "mini" ? 10 : 13} className="flex-shrink-0 text-orange-500" />
+            )}
+            <span>{formattedDate}</span>
+          </span>
+        </Tooltip>
+      )}
+
+      {/* Members count for member search results */}
+      {!isRoleVariant && shouldShowMemberCountInSubtitle && (
+        <span className="flex items-center">
+          <Users
+            size={viewMode === "mini" ? 10 : 13}
+            className="text-primary mr-0.5"
+          />
+          <span>
+            {memberCount}/{maxMembers}
+          </span>
+        </span>
+      )}
+
+      {/* Pending invitation indicator with date */}
+      {(effectiveVariant === "invitation" ||
+        pendingInvitationForTeam) && (
+        <Tooltip
+          content={
+            hasInternalRoleInvitation
+              ? internalRoleInvitationTooltip
+              : `You were invited to this team${
+                  formattedDate
+                    ? `\non ${format(
+                        new Date(normalizedData.date),
+                        "MMM d, yyyy",
+                      )}`
+                    : ""
+                }`
+          }
+        >
+          <span className="flex items-center gap-0.5 whitespace-nowrap">
+            <Mail
+              size={viewMode === "mini" ? 10 : 13}
+              className={
+                hasInternalRoleInvitation
+                  ? "text-orange-500"
+                  : "text-pink-500"
+              }
+            />
+            {formattedDate && (
+              <span>{formattedDate}</span>
+            )}
+          </span>
+        </Tooltip>
+      )}
+      {teamInvitationRoleName && (
+        <Tooltip content={teamInvitationRoleName}>
+          {viewMode === "card" ? (
+            <span className="flex items-center">
+              <UserSearch
+                size={13}
+                className="text-orange-500"
+              />
+            </span>
+          ) : (
+            <span className="flex items-start gap-1">
+              <UserSearch
+                size={viewMode === "mini" ? 10 : 13}
+                className="text-orange-500 flex-shrink-0 mt-0.5"
+              />
+              <span className="leading-[1.05]">{teamInvitationRoleName}</span>
+            </span>
+          )}
+        </Tooltip>
+      )}
+
+      {/* Pending team application indicator (team-only = blue, combined = violet) */}
+      {(effectiveVariant === "application" ||
+        (pendingApplicationForTeam && !isPendingRoleApplicationForTeam)) && (
+        <Tooltip
+          content={
+            isCombinedApplication
+              ? `You applied to join this team and fill a role${formattedDate ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}` : ""}`
+              : `You applied to join this team${formattedDate ? `\non ${format(new Date(normalizedData.date), "MMM d, yyyy")}` : ""}`
+          }
+        >
+          <span className="flex items-center gap-0.5 whitespace-nowrap">
+            <SendHorizontal
+              size={viewMode === "mini" ? 10 : 13}
+              className={isCombinedApplication ? "text-violet-500" : "text-info"}
+            />
+            {formattedDate && (
+              <span>{formattedDate}</span>
+            )}
+          </span>
+        </Tooltip>
+      )}
+      {teamApplicationRoleName && (
+        <Tooltip content={teamApplicationRoleName}>
+          {viewMode === "card" ? (
+            <span className="flex items-center">
+              <UserSearch
+                size={13}
+                className="text-orange-500"
+              />
+            </span>
+          ) : (
+            <span className="flex items-start gap-1">
+              <UserSearch
+                size={viewMode === "mini" ? 10 : 13}
+                className="text-orange-500 flex-shrink-0 mt-0.5"
+              />
+              <span className="leading-[1.05]">{teamApplicationRoleName}</span>
+            </span>
+          )}
+        </Tooltip>
+      )}
+
+      {/* Team name for role variants */}
+      {isRoleVariant && teamData._teamName && (
+        <Tooltip content={teamData._teamName}>
+          {viewMode === "card" ? (
+            <span
+              className="flex items-center cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsModalOpen(true);
+              }}
+            >
+              <Users
+                size={13}
+                className="text-primary"
+              />
+            </span>
+          ) : (
+            <span
+              className="flex items-start gap-1 cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsModalOpen(true);
+              }}
+            >
+              <Users
+                size={viewMode === "mini" ? 10 : 13}
+                className="text-primary flex-shrink-0 mt-0.5"
+              />
+              <span className="leading-[1.05]">{teamData._teamName}</span>
+            </span>
+          )}
+        </Tooltip>
+      )}
+
+      {shouldMoveSearchResultRoleApplicationIndicator &&
+        isPendingRoleApplicationForTeam && (
+          <Tooltip content={isPendingCombinedApplicationForTeam ? "You applied to join this team and fill a role" : "You applied for a role within this team"}>
+            <span className="flex items-center">
+              <SendHorizontal
+                size={viewMode === "mini" ? 10 : 13}
+                className={isPendingCombinedApplicationForTeam ? "text-violet-500" : "text-orange-500"}
+              />
+            </span>
+          </Tooltip>
+        )}
+
+      {/* Open roles count */}
+      {shouldShowOpenRoleCount && openRoleCount > 0 && (
+        <Tooltip content={`${openRoleCount} open ${openRoleCount === 1 ? 'role' : 'roles'} posted in this team`}>
+          <span className="flex items-center">
+            <UserSearch
+              size={viewMode === "mini" ? 10 : 13}
+              className="text-orange-500 mr-0.5"
+            />
+            <span>{openRoleCount}</span>
+          </span>
+        </Tooltip>
+      )}
+
+      {/* Privacy status */}
+      {showVisibilityIcon && (
+        <Tooltip
+          content={
+            teamData.is_public === true || teamData.isPublic === true
+              ? "Public Team - visible for everyone"
+              : "Private Team - only visible for Members"
+          }
+        >
+          {teamData.is_public === true || teamData.isPublic === true ? (
+            <EyeIcon
+              size={viewMode === "mini" ? 10 : 13}
+              className="text-green-600"
+            />
+          ) : (
+            <EyeClosed
+              size={viewMode === "mini" ? 10 : 13}
+              className="text-gray-500"
+            />
+          )}
+        </Tooltip>
+      )}
+
+      {/* Pending role application indicator */}
+      {!shouldMoveSearchResultRoleApplicationIndicator &&
+        isPendingRoleApplicationForTeam && (
+        <Tooltip content="You applied for a role within this team">
+          <span className="flex items-center">
+            <SendHorizontal
+              size={viewMode === "mini" ? 10 : 13}
+              className="text-orange-500"
+            />
+          </span>
+        </Tooltip>
+        )}
+
+      {/* User role - show for member variant when user has a role */}
+      {userRole && effectiveVariant === "member" &&
+        (userRole === "owner" || userRole === "admin" || (userRole === "member" && !hideMemberRoleIcon)) && (
+        <span className="flex items-center text-base-content/70">
+          {userRole === "owner" && (
+            <Tooltip content="You are the owner of this team">
+              <Crown
+                size={viewMode === "mini" ? 10 : 13}
+                className="text-[var(--color-role-owner-bg)]"
+              />
+            </Tooltip>
+          )}
+          {userRole === "admin" && (
+            <Tooltip content="You are an admin of this team">
+              <ShieldCheck
+                size={viewMode === "mini" ? 10 : 13}
+                className="text-[var(--color-role-admin-bg)]"
+              />
+            </Tooltip>
+          )}
+          {userRole === "member" && !hideMemberRoleIcon && (
+            <Tooltip content="You are a member of this team">
+              <User
+                size={viewMode === "mini" ? 10 : 13}
+                className="text-[var(--color-role-member-bg)]"
+              />
+            </Tooltip>
+          )}
+        </span>
+      )}
+
+      {/* Compact location in subtitle for mini cards — search results only (My Teams always shows location in body) */}
+      {viewMode === "mini" &&
+        !activeFilters.showLocation &&
+        isSearchResult &&
+        (teamData.city ||
+          teamData.country ||
+          teamData.is_remote ||
+          teamData.isRemote) && (
+          <span className="flex items-center gap-1">
+            {teamData.is_remote || teamData.isRemote ? (
+              <>
+                <Globe size={10} className="flex-shrink-0" />
+                <span>Remote</span>
+              </>
+            ) : (
+              <>
+                <MapPin size={10} className="flex-shrink-0" />
+                <span>
+                  {[teamData.city, normalizeLocationData(teamData).countryName]
+                    .filter(Boolean)
+                    .join(", ")}
+                </span>
+              </>
+            )}
+          </span>
+        )}
+      {showDemoIndicator && (
+        <Tooltip
+          content={demoTooltip}
+          wrapperClassName="flex items-center gap-1 text-base-content/50"
+        >
+          <FlaskConical
+            size={viewMode === "mini" ? 10 : 13}
+            className="flex-shrink-0"
+          />
+        </Tooltip>
+      )}
+    </span>
+  );
+};
+
+export default React.memo(TeamCardSubtitle);

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1842,28 +1842,31 @@ const SearchPage = () => {
     );
   };
 
-  const handleTeamUpdate = (updatedTeam) => {
-    queryClient.setQueryData(
-      globalSearchQueryKey(requestCriteria, isAuthenticated),
-      (prev) =>
-        prev?.data
-          ? {
-              ...prev,
-              data: {
-                ...prev.data,
-                teams: (prev.data.teams ?? []).map((t) =>
-                  t.id === updatedTeam.id
-                    ? {
-                        ...updatedTeam,
-                        is_public: updatedTeam.is_public === true,
-                      }
-                    : t,
-                ),
-              },
-            }
-          : prev,
-    );
-  };
+  const handleTeamUpdate = useCallback(
+    (updatedTeam) => {
+      queryClient.setQueryData(
+        globalSearchQueryKey(requestCriteria, isAuthenticated),
+        (prev) =>
+          prev?.data
+            ? {
+                ...prev,
+                data: {
+                  ...prev.data,
+                  teams: (prev.data.teams ?? []).map((t) =>
+                    t.id === updatedTeam.id
+                      ? {
+                          ...updatedTeam,
+                          is_public: updatedTeam.is_public === true,
+                        }
+                      : t,
+                  ),
+                },
+              }
+            : prev,
+      );
+    },
+    [queryClient, requestCriteria, isAuthenticated],
+  );
 
   const getTotalItemsForFilter = () => {
     switch (searchType) {


### PR DESCRIPTION
## Summary

Closes the TeamCard render-time track: decomposes the ~3,072-line `TeamCard.jsx`
into memoized subtitle sub-components and wraps the card in `React.memo` so that
unrelated SearchPage re-renders (typing, hover, sibling state) no longer re-render
every card. Frontend-only; no API or behavior changes. `TeamCard.jsx` 3,072 → 2,759.

The data layer was already clean after the earlier React Query cache/dedup pass
(#556), so this branch is purely presentational structure + render-time.

## What & why

`TeamCard` renders a `<Card>` with a heavy subtitle-indicator strip plus a modal
stack, and it has **two full render branches** (list vs card/mini) that duplicated
the subtitle blocks. Extracting those into memoized components — and then getting
`React.memo` to actually bail — is where the list render-time win is.

### Phases (one commit each)
1. **`TeamCardSubtitle.jsx`** (memoized) — the card/mini subtitle-indicator strip,
   extracted verbatim. The pure getters (`getFormattedDate`, `getMemberCount`,
   `getMaxMembers`, `getRoleStatusTooltip`, `getInternalRoleInvitationTooltip`,
   `shouldShowVisibilityIcon`) are resolved once in the parent and passed as
   **primitive props** so the memo can bail.
2. **`TeamCardListSubtitle.jsx`** (memoized) — the list-branch subtitle, same
   treatment (compact size-9 layout + its invitation/application click affordances).
3. **`TeamCardIndicators.jsx`** — the 3 byte-identical leaf indicators
   (`OpenRolesIndicator` / `VisibilityIndicator` / `DemoIndicator`, size-parameterized,
   self-gating, memoized) shared by both subtitles. The genuinely divergent blocks
   (invitation/application gating + click, role-name layouts, user-role wrapper) were
   **deliberately not merged** — a forced mode-aware merge would have hurt readability.
4. **`React.memo(TeamCard, areTeamCardPropsEqual)`** — profiling-driven. A default
   `React.memo` cannot bail here because SearchPage re-spreads its result items
   (`{...team}`), passes an inline `activeFilters` object, and passed a non-memoized
   `onUpdate`, so those props get fresh identities every render. The custom comparator
   does a **one-level shallow compare** on object props (safe: the re-spread wrappers
   copy stable inner references from the query cache, so it bails only when every
   top-level value is identical and otherwise errs toward re-rendering) and an identity
   compare on scalars/handlers. `SearchPage.handleTeamUpdate` is wrapped in `useCallback`
   so the bail applies.

## Verification

- **Profiler-verified** with a temporary render probe (removed before commit): on
  churn-only re-renders (typing in the search box) all cards now **bail**; real changes
  (view-mode toggle, sort/filter, optimistic team update) still re-render correctly.
- ESLint: **0 errors / 31 warnings** (baseline) throughout.
- `npm run build`: green throughout.
- Manual smoke (Julia) after each phase: SearchPage grid/list/mini + MyTeams list —
  subtitle indicators, invitation/application flows, role variants, modals, sort/filter,
  team edit, apply/cancel.

## Scope notes

- **MyTeams (`4b-2`) intentionally skipped**: fewer cards (lower payoff) and ~7 handlers
  to stabilize (more plumbing). No regression there — its handlers still churn, so the
  comparator never bails and it renders exactly as before. Left as an optional follow-up.
- No backend changes; no cross-repo coordination needed.

## Risk

Low. The comparator errs toward re-rendering (it can never skip a needed update unless a
prop is mutated in place, which this codebase does not do with React Query). Correctness
of the extracted subtitles was confirmed by verbatim extraction + per-phase smoke.