### PR TITLE
Release: navbar notification tooltips and stale notification handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To test the live demo, just **register your own account** directly in the deploy
 - **User Profiles** — Customizable profiles with interest tags, badges, avatar uploads (ImageKit), and geocoded location; profile header shows city and country code; non-public profiles are protected — non-owners and non-teammates see only the username and avatar ("This profile is private"); owners see public/private visibility indicators on profile, card, list, mini-card, and map views; signed-in users can block another profile from the user details modal
 - **Real-Time Chat** — Direct and team group messaging with typing indicators, read receipts, file/image sharing, @mentions, reply threading, and rich system event messages (Socket.IO); blocked users are hidden from direct conversations, team rosters, mention lists, and rendered message streams
 - **Badge System** — Browse 30 badges across 5 color-coded categories; award badges to teammates with reasons and team context
-- **Notifications** — In-app notification center for invitations, applications, badge awards, and role updates
+- **Notifications** — Navbar bell and chat badges with interactive hover tooltips that summarize unread items by type; clear everything behind a badge in one click, or click a type-group to work through its notifications from oldest to newest; notifications whose target was already handled by someone else resolve with an explanation instead of opening an empty view
 - **Account Deletion** — Multi-step account deletion with impact preview, automatic team ownership transfer, and graceful "Former Lomir User" handling across chat, badges, and notifications
 - **Demo Data Indicators** — Synthetic/seed data is visually labeled with FlaskConical icons and "DEMO" avatar overlays so users can distinguish test content from real data
 - **Contact Page** — Email contact form with optional multipart file attachments (up to 3 files, 5 MB each, 10 MB total — JPG, PNG, WebP, PDF, TXT, CSV); authenticated users with a configured contact user ID are routed directly to in-app chat instead; optional Turnstile CAPTCHA; privacy disclosure with `/privacy` link at submission; abuse/content reports show a persistent reference ID after submit
@@ -402,6 +402,27 @@ The chat page supports both direct (1-to-1) and team group conversations.
 **Render resilience**
 - Chat routes are wrapped in a small `ErrorBoundary` so unexpected render errors show a visible fallback instead of a blank white screen
 - Individual message bubbles are also isolated by an error boundary; if a legacy message payload fails to render, the rest of the conversation remains usable
+
+---
+
+## Notifications
+
+The navbar carries two badges: a bell for general notifications (invitations, applications, badge awards, role lifecycle events) and a chat icon for unread messages and @mentions. Hovering either one opens an interactive tooltip that stays open while the pointer is inside it.
+
+**Mark all as read**
+- The first row of both tooltips clears everything behind that badge in one click
+- The bell clears all general notifications; the chat icon clears every conversation (direct and team) plus pending @mention alerts, which also zeroes the unread badges in the chat page conversation list
+- Both clear optimistically and re-sync from the server if the request fails
+
+**Working through notifications selectively**
+- Below the divider, the bell tooltip lists unread notifications grouped by type
+- Clicking a group navigates to that group's oldest unread notification and marks it read, so the group counter drops by one; clicking again steps to the next-oldest, letting you work through them in your own order
+- Navigation targets come from the unread-count response (`typeFirstUnread`), so they stay correct no matter how old a notification is
+
+**Stale notifications**
+- A notification can go stale while still unread — for example a team application that another admin has meanwhile approved or declined
+- Opening one shows an explanatory message instead of an empty or non-highlighting modal, and the modal closes when nothing else is left to review
+- The backend also removes invitation notifications once the invitation is accepted, declined, or withdrawn, so resolved invites disappear from the bell on their own
 
 ---
 

--- a/docs/USER_DELETION_SPEC.md
+++ b/docs/USER_DELETION_SPEC.md
@@ -1,0 +1,365 @@
+# Lomir — User Account Deletion: Complete Specification
+
+## Overview
+
+This document captures every decision made for implementing account deletion in Lomir. It serves as the single reference for backend and frontend implementation.
+
+---
+
+## Pre-Deletion Flow
+
+### Step 1: Password Confirmation
+- User clicks "Delete Account" in Settings
+- Modal requires **password entry** before proceeding
+- Backend verifies password against `password_hash` before returning the impact summary
+
+### Step 2: Impact Summary (new endpoint)
+- Backend calculates and returns a JSON summary of what will happen:
+  - Teams where ownership will be transferred (with auto-selected successors)
+  - Teams that will be deleted (sole-owner teams)
+  - Roles that will be reopened
+  - Counts: badge awards given, messages, team memberships
+- User sees the summary in the modal with the option to **override ownership transfer targets**
+
+### Step 3: Confirm & Execute
+- User confirms → backend executes full deletion in a single transaction
+- On success: logout, redirect to home
+- No grace period — deletion is instant and irreversible
+- No confirmation email sent
+
+---
+
+## Scenario-by-Scenario Specification
+
+### 1. Badges the User RECEIVED
+| Item | Action |
+|------|--------|
+| `badge_awards` where `awarded_to_user_id = userId` | **DELETE** |
+| `user_badges` where `user_id = userId` | **DELETE** |
+
+User's own badge collection is removed entirely.
+
+### 2. Badges the User AWARDED to Others
+| Item | Action |
+|------|--------|
+| `badge_awards.awarded_by_user_id` | **SET NULL** |
+| `user_badges.awarded_by` | **SET NULL** |
+
+Recipients keep their badges and credits intact. Frontend displays **"Former Lomir User"** with a **grey silhouette avatar** wherever the awarder's name/avatar would appear. No credit recalculation needed.
+
+### 3. Teams — Sole Owner (Only Member)
+| Item | Action |
+|------|--------|
+| The team itself | **HARD DELETE** |
+| `team_tags` for the team | **DELETE** (cascades) |
+| `team_members` for the team | **DELETE** (cascades) |
+| `team_vacant_roles` for the team | **DELETE** (cascades) |
+| `team_vacant_role_tags` for those roles | **DELETE** (cascades) |
+| `team_vacant_role_badges` for those roles | **DELETE** (cascades) |
+| `team_applications` for the team | **DELETE** |
+| `team_invitations` for the team | **DELETE** |
+| `messages` with `team_id` for the team | **DELETE** |
+
+**Before deleting:** Copy team name into `badge_awards.custom_team_name` (and SET NULL on `badge_awards.team_id`) for any badge awards that reference this team. This preserves the team name on badges without a clickable link.
+
+**Notifications to send before deletion:**
+- Notify **pending applicants** that the team has been dissolved
+- Notify **pending invitees** (team and role invitations) that the team has been dissolved
+
+**Pre-deletion summary** shows these teams with a clear message: *"This team will be permanently deleted."*
+
+### 4. Teams — Owner with Other Members (Ownership Transfer)
+| Item | Action |
+|------|--------|
+| `teams.owner_id` | **UPDATE** to successor |
+| `team_members` role of successor | **UPDATE** to `'owner'` |
+| `team_members` row of deleted user | **DELETE** |
+
+**Successor selection cascade:**
+1. User's explicit choice (from pre-deletion summary override)
+2. Longest-serving **admin** (by `joined_at`)
+3. Longest-serving **member** (by `joined_at`)
+
+**Notifications:**
+- Successor receives ownership transfer notification
+- Team chat receives system message (see §12)
+
+### 5. Teams — Regular Member (Not Owner)
+| Item | Action |
+|------|--------|
+| `team_members` row | **DELETE** |
+
+Team chat receives system message: `"🚪 [Name] has left Lomir."` (uses the user's real name one final time).
+
+### 6. Roles the User FILLED
+| Item | Action |
+|------|--------|
+| `team_vacant_roles.status` | **UPDATE** to `'open'` |
+| `team_vacant_roles.filled_by` | **SET NULL** |
+
+**Timing:** Execute after removing user from `team_members` but before deleting the user row (so the user's name is still available for notifications).
+
+**Notifications:**
+- Team **owner and admins** receive a dedicated notification: *"The role [Role Name] is now open again."*
+- Team chat receives a system message: `"🔓 The role [Role Name] is now open again."`
+
+### 7. Roles the User CREATED
+| Item | Action |
+|------|--------|
+| `team_vacant_roles.created_by` | **SET NULL** |
+
+Role definitions persist. Only the "created by" attribution is lost.
+
+### 8. User's Team Applications
+| Item | Action |
+|------|--------|
+| `team_applications` where `applicant_id = userId` | **DELETE** (all statuses) |
+
+### 9. Applications the User Reviewed
+| Item | Action |
+|------|--------|
+| `team_applications.reviewed_by` | **SET NULL** |
+
+The approval/rejection decision stands; reviewer attribution is cleared.
+
+### 10. All Invitations Involving the User
+| Item | Action |
+|------|--------|
+| `team_invitations` where `invitee_id = userId` | **DELETE** (all statuses) |
+| `team_invitations` where `inviter_id = userId` | **DELETE** (all statuses) |
+
+Both pending and resolved invitations are removed.
+
+### 11. Direct Messages
+| Item | Action |
+|------|--------|
+| `messages` where `sender_id = userId AND team_id IS NULL` | **DELETE** |
+| `messages` where `receiver_id = userId AND team_id IS NULL` | **DELETE** |
+
+All DMs involving the user are removed. The other party loses the conversation. File attachments in these messages are left alone — existing expiration/retention policies handle cleanup.
+
+### 12. Team Chat Messages
+| Item | Action |
+|------|--------|
+| `messages.sender_id` where `sender_id = userId AND team_id IS NOT NULL` | **SET NULL** |
+| System messages containing user's name | **REPLACE** name with `"Former Lomir User"` in `content` |
+
+**New departure message** posted to each team: `"🚪 [Real Name] has left Lomir."` — this is the last record of their name.
+
+**Backend query fix required:** `getMessages` must change `JOIN users u ON m.sender_id = u.id` → `LEFT JOIN users u ON m.sender_id = u.id`.
+
+**Frontend display:** Messages with `sender_id = NULL` show **"Former Lomir User"** with a **generic grey silhouette** avatar.
+
+### 13. Notifications FOR the User
+| Item | Action |
+|------|--------|
+| `notifications` where `user_id = userId` | **DELETE** |
+
+### 14. Notifications ABOUT the User
+| Item | Action |
+|------|--------|
+| `notifications.actor_id` where `actor_id = userId` | **SET NULL** |
+| `notifications.reference_id` where it points to a now-deleted resource | **SET NULL** |
+
+Notification text (`title`, `message`) already contains the name as a baked-in string, so notifications remain readable. Frontend shows "Former Lomir User" for the actor avatar/link.
+
+### 15. User Tags
+| Item | Action |
+|------|--------|
+| `user_tags` where `user_id = userId` | **DELETE** (CASCADE handles this) |
+
+### 16. Tags Created by the User
+| Item | Action |
+|------|--------|
+| `tags.created_by` where `created_by = userId` | **SET NULL** |
+
+Currently 0 user-created tags exist (all 780 are system tags), but this FK is `NO ACTION` and will block deletion if a user ever creates custom tags. Must be handled in code.
+
+### 17. Messages — deleted_by Column
+| Item | Action |
+|------|--------|
+| `messages.deleted_by` where `deleted_by = userId` | **SET NULL** |
+
+No FK constraint exists on this column, so it won't block deletion, but cleanup prevents orphaned references.
+
+---
+
+## Profile Placeholder
+
+When someone visits a deleted user's profile URL:
+- **Show a "This user profile does not exist on Lomir" placeholder page with subtitle "This profile is not available"** instead of a 404
+- Grey silhouette avatar, no personal information displayed
+- This placeholder appears for ANY profile 404 — the backend does not distinguish between "never existed" and "was deleted". This is by design (Option A).
+
+---
+
+## Real-Time Updates (Socket.IO)
+
+On successful deletion, emit events so connected clients update:
+- `team:member_left` → to each team the user was in (refreshes member list)
+- `notification:new` → to team owners/admins for reopened roles
+- `notification:new` → to pending applicants/invitees of dissolved teams
+- `conversation:deleted` → to DM partners (removes the conversation from their list)
+
+---
+
+## New API Endpoints
+
+### `POST /api/users/:id/deletion-preview`
+- **Auth:** Requires valid token + password verification
+- **Returns:** Impact summary JSON (teams to transfer, teams to delete, roles to reopen, counts)
+
+### `DELETE /api/users/:id` (updated)
+- **Auth:** Requires valid token + password in request body
+- **Body:** `{ password: string, ownershipOverrides?: { teamId: number, successorId: number }[] }`
+- **Executes:** Full deletion transaction as specified above
+- Service calls use `skipAuthRedirect` on the frontend to prevent a 401 (wrong password) from triggering a global logout.
+
+---
+
+## Frontend Changes Required
+
+1. **Settings.jsx** — Updated delete modal: password input → impact summary → confirm
+2. **Message display components** — Handle `sender_id = NULL` → show "Former Lomir User" + grey avatar
+3. **AwardCard.jsx / badge components** — Handle `awarded_by = NULL` → show "Former Lomir User"
+4. **Profile routes** — New `/profile/:id` public route with `PublicProfile.jsx` component for deleted user placeholder. `UserDetailsModal` also handles 404 inline with 'Former Lomir User' display.
+5. **Notification click handlers** — Handle `reference_id = NULL` gracefully (no navigation)
+6. **Chat/conversation list** — Handle `conversation:deleted` socket event
+7. **Shared utility** — `deletedUser.js` (or similar) with `DELETED_USER_DISPLAY_NAME` constant, `isDeletedUser()` helper, `getDisplayName()` fallback, and `FormerUserAvatar` grey silhouette component.
+
+---
+
+## Database FK Constraint Analysis
+
+Based on the actual constraints in the Neon database:
+
+### Already handled automatically by CASCADE / SET NULL on `DELETE FROM users`:
+| Table.Column | Rule | Notes |
+|---|---|---|
+| `badge_awards.awarded_to_user_id` | CASCADE | Deletes received awards |
+| `badge_awards.awarded_by_user_id` | SET NULL | Preserves others' badges |
+| `messages.sender_id` | SET NULL | Keeps team messages |
+| `messages.receiver_id` | SET NULL | Keeps DMs — but we delete DMs first |
+| `notifications.user_id` | CASCADE | Removes user's notifications |
+| `notifications.actor_id` | SET NULL | Preserves others' notifications |
+| `team_applications.applicant_id` | CASCADE | Removes user's applications |
+| `team_invitations.invitee_id` | CASCADE | Removes invitations to user |
+| `team_invitations.inviter_id` | CASCADE | Removes invitations from user |
+| `team_members.user_id` | CASCADE | Removes memberships — but we transfer ownership first |
+| `user_badges.user_id` | CASCADE | Removes user's badge summary |
+| `user_tags.user_id` | CASCADE | Removes user's tags |
+
+### 6 blockers — must be resolved BEFORE deleting user row:
+| Table.Column | Rule | Action in code |
+|---|---|---|
+| `teams.owner_id` | NO ACTION | Transfer ownership or delete team first |
+| `team_vacant_roles.filled_by` | NO ACTION | SET NULL + reopen role |
+| `team_vacant_roles.created_by` | NO ACTION | SET NULL |
+| `team_applications.reviewed_by` | NO ACTION | SET NULL |
+| `user_badges.awarded_by` | NO ACTION | SET NULL |
+| `tags.created_by` | NO ACTION | SET NULL (0 rows currently, future-proofing) |
+
+**Schema change applied:** `ALTER TABLE team_vacant_roles ALTER COLUMN created_by DROP NOT NULL` — the column originally had a NOT NULL constraint that prevented SET NULL. This was dropped in the Neon database.
+
+### No FK but needs cleanup:
+| Table.Column | Action |
+|---|---|
+| `messages.deleted_by` | SET NULL (18 rows, no FK constraint) |
+
+### Critical ordering note:
+Since `messages.sender_id/receiver_id` auto-SET-NULL and `team_members.user_id` auto-CASCADEs when the user row is deleted, all custom cleanup (DM deletion, system message rewriting, ownership transfers, role reopening) **must happen before** `DELETE FROM users`.
+
+---
+
+## Transaction Order
+
+The `deleteUser` controller executes all operations in a **single database transaction** in this order:
+
+**Phase A — Gather context (before any mutations):**
+1. **Verify password** against stored hash
+2. **Fetch user data**: name, avatar URL, team memberships (with roles), owned teams, filled roles
+
+**Phase B — Messages & chat cleanup (while sender_id still identifies the user):**
+3. **Delete all DMs** involving the user (`sender_id = userId OR receiver_id = userId` where `team_id IS NULL`)
+4. **Post departure messages** to all team chats: `"🚪 [Name] has left Lomir."`
+5. **Replace user's name** in existing system messages in team chats with `"Former Lomir User"`
+
+**Phase C — Team ownership (while team_members still exist):**
+6. **Handle sole-owner teams:**
+   a. Copy team name into `badge_awards.custom_team_name` where `badge_awards.team_id` references the team
+   b. Create notifications for pending applicants/invitees about dissolution
+   c. Hard delete: team_invitations, team_applications, messages, team_vacant_role_tags, team_vacant_role_badges, team_vacant_roles, team_tags, team_members, then the team itself
+7. **Transfer ownership** of multi-member teams (update `teams.owner_id` + `team_members.role`)
+
+**Phase D — Role & reference cleanup (resolve all 6 NO ACTION blockers):**
+8. **Reopen filled roles**: `UPDATE team_vacant_roles SET status='open', filled_by=NULL WHERE filled_by=userId`
+9. **Create notifications** for all team members about reopened roles
+10. **SET NULL on remaining blockers:**
+    - `team_vacant_roles.created_by`
+    - `team_applications.reviewed_by`
+    - `user_badges.awarded_by`
+    - `tags.created_by`
+11. **SET NULL** on `messages.deleted_by` (no FK, but clean up orphaned refs)
+12. **SET NULL** on `notifications.reference_id` for notifications pointing to resources that were deleted in Phase C
+
+**Phase E — Delete user row (CASCADE handles the rest):**
+13. **DELETE the user row** — triggers automatic CASCADE/SET NULL for all remaining FKs
+
+**Phase F — Post-transaction cleanup (outside transaction):**
+14. **Delete ImageKit avatar** (non-blocking, best-effort)
+15. **Emit Socket.IO events**: `team:member_left`, `notification:new`, `conversation:deleted`
+
+---
+
+## Query Fixes Applied
+
+All `JOIN users u ON m.sender_id = u.id` in `messageController.js` changed to `LEFT JOIN` — affects `getMessages` (both legacy and paginated versions) and `getMessageById`. Without this, team messages from deleted users (sender_id = NULL) are silently excluded from results.
+
+---
+
+## Data Impact Summary (Current Database)
+
+| Resource | Count | Action | FK handles it? |
+|----------|-------|--------|----------------|
+| Badge awards (received by user) | Varies | Deleted | ✅ CASCADE |
+| Badge awards (given by user) | Up to 188 users affected | SET NULL | ✅ SET NULL |
+| User badges (awarded_by) | Up to 186 users affected | SET NULL | ❌ NO ACTION — code required |
+| Team memberships | Up to 158 users | Removed | ✅ CASCADE (after ownership transfer) |
+| Teams (sole owner) | 3 currently | Hard deleted | ❌ NO ACTION — code required |
+| Teams (owner with members) | 74 currently | Ownership transferred | ❌ NO ACTION — code required |
+| Filled roles | 13 currently | Reopened | ❌ NO ACTION — code required |
+| Roles created_by | 21 users affected | SET NULL | ❌ NO ACTION — code required |
+| Tags created_by | 0 currently | SET NULL | ❌ NO ACTION — code required |
+| Applications reviewed_by | 41 users affected | SET NULL | ❌ NO ACTION — code required |
+| DMs | 1,292 total | Deleted before cascade | ⚠️ SET NULL would fire — must pre-delete |
+| Team messages | 1,681 total | Sender nullified | ✅ SET NULL (rewrite names before cascade) |
+| Notifications (user's) | Varies | Deleted | ✅ CASCADE |
+| Notifications (actor) | 191 users affected | SET NULL | ✅ SET NULL |
+| Invitations | 585 total | All involving user deleted | ✅ CASCADE |
+| Applications (user's) | Varies | Deleted | ✅ CASCADE |
+| Messages deleted_by | 18 rows | SET NULL | ⚠️ No FK — code required |
+
+---
+
+## Implementation Notes
+
+**Status:** Fully implemented and tested (April 2026).
+
+**Schema change applied:** `team_vacant_roles.created_by` changed from NOT NULL to nullable.
+
+**Key files (backend):**
+- `src/controllers/userController.js` — `deletionPreview` and `deleteUser` functions
+- `src/controllers/messageController.js` — LEFT JOIN fixes
+- `src/routes/userRoutes.js` — POST /:id/deletion-preview route
+- `test/userController.deleteUser.test.js` — deletion test coverage (41 tests)
+
+**Key files (frontend):**
+- `src/pages/Settings.jsx` — multi-step deletion modal
+- `src/pages/PublicProfile.jsx` — deleted user profile placeholder
+- `src/App.jsx` — /profile/:id route
+- `src/services/userService.js` — deletionPreview and updated deleteUser methods
+- `src/components/badges/AwardCard.jsx` — Former Lomir User fallback
+- Shared deleted user utility and FormerUserAvatar component
+- Chat message components — null sender handling
+- Notification components — null actor/reference handling
+- `UserDetailsModal.jsx` — inline deleted user handling on 404

--- a/src/components/common/ModalTest.jsx
+++ b/src/components/common/ModalTest.jsx
@@ -1,0 +1,180 @@
+import React, { useState } from "react";
+import Modal from "./Modal";
+import Button from "./Button";
+
+const ModalTest = () => {
+  const [centerModalOpen, setCenterModalOpen] = useState(false);
+  const [rightModalOpen, setRightModalOpen] = useState(false);
+  const [largeModalOpen, setLargeModalOpen] = useState(false);
+
+  // Test footer with buttons
+  const testFooter = (
+    <div className="flex justify-end space-x-3">
+      <Button variant="ghost" onClick={() => setCenterModalOpen(false)}>
+        Cancel
+      </Button>
+      <Button variant="primary">
+        Save
+      </Button>
+    </div>
+  );
+
+  // Test custom header
+  const customHeader = (
+    <div>
+      <h2 className="text-lg font-medium text-primary mb-1">
+        Apply to join the Team
+      </h2>
+      <h3 className="text-xl font-bold text-primary">"Sample Team Name"</h3>
+    </div>
+  );
+
+  return (
+    <div className="p-8 space-y-4">
+      <h2 className="text-2xl font-bold mb-4">Modal Component Tests</h2>
+      
+      {/* Test Buttons */}
+      <div className="flex flex-wrap gap-4">
+        <Button 
+          variant="primary" 
+          onClick={() => setCenterModalOpen(true)}
+        >
+          Test Center Modal
+        </Button>
+        
+        <Button 
+          variant="secondary" 
+          onClick={() => setRightModalOpen(true)}
+        >
+          Test Right Modal (TeamApplication style)
+        </Button>
+        
+        <Button 
+          variant="accent" 
+          onClick={() => setLargeModalOpen(true)}
+        >
+          Test Large Modal
+        </Button>
+      </div>
+
+      {/* Center Modal Test */}
+      <Modal
+        isOpen={centerModalOpen}
+        onClose={() => setCenterModalOpen(false)}
+        title="Test Center Modal"
+        footer={testFooter}
+        position="center"
+        size="default"
+      >
+        <div className="space-y-4">
+          <p>This is a center-positioned modal (like TeamApplicationDetailsModal).</p>
+          <p>It should:</p>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>Be centered on screen</li>
+            <li>Have a backdrop you can click to close</li>
+            <li>Have proper scrolling if content is long</li>
+            <li>Close with Escape key</li>
+          </ul>
+          
+          {/* Add lots of content to test scrolling */}
+          <div className="space-y-4">
+            {Array.from({length: 10}, (_, i) => (
+              <div key={i} className="bg-base-200 p-4 rounded">
+                <h4 className="font-medium">Test Content Block {i + 1}</h4>
+                <p>This is test content to make the modal scroll. The header and footer should stay fixed while this content area scrolls smoothly.</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Modal>
+
+      {/* Right Modal Test (TeamApplication style) */}
+      <Modal
+        isOpen={rightModalOpen}
+        onClose={() => setRightModalOpen(false)}
+        title={customHeader}
+        footer={
+          <div className="flex justify-end space-x-3">
+            <Button variant="ghost" onClick={() => setRightModalOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="primary">Send Application</Button>
+          </div>
+        }
+        position="right"
+        zIndex="z-[60]"
+        size="sm"
+        modalClassName="border border-base-300"
+        hideBackdrop={true}
+        closeOnBackdrop={false}
+      >
+        <div className="space-y-4">
+          <p>This is a right-positioned modal (like TeamApplicationModal).</p>
+          <p>It should:</p>
+          <ul className="list-disc pl-6 space-y-2">
+            <li>Appear on the RIGHT side of screen</li>
+            <li>Have NO backdrop</li>
+            <li>Have higher z-index (z-[60])</li>
+            <li>Have custom two-line header</li>
+            <li>Have border styling</li>
+          </ul>
+          
+          <div className="form-control">
+            <label className="label">
+              <span className="label-text">Test textarea:</span>
+            </label>
+            <textarea 
+              className="textarea textarea-bordered h-24" 
+              placeholder="This should scroll if the modal content is too long..."
+            />
+          </div>
+          
+          {/* Add content to test scrolling */}
+          {Array.from({length: 8}, (_, i) => (
+            <div key={i} className="bg-base-200/50 p-3 rounded">
+              <p>Test content {i + 1} - This content should scroll properly while header and footer stay fixed.</p>
+            </div>
+          ))}
+        </div>
+      </Modal>
+
+      {/* Large Modal Test */}
+      <Modal
+        isOpen={largeModalOpen}
+        onClose={() => setLargeModalOpen(false)}
+        title={
+          <div>
+            <h2 className="text-xl font-medium text-primary">Large Modal Test</h2>
+            <p className="text-sm text-base-content/70 mt-1">Testing large size (like TeamApplicationsModal)</p>
+          </div>
+        }
+        position="center"
+        size="lg"
+        maxHeight="max-h-[90vh]"
+        minHeight="min-h-[400px]"
+      >
+        <div className="space-y-4">
+          <p>This is a large modal (like TeamApplicationsModal).</p>
+          <p>It should be wider than the others and handle lots of content.</p>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {Array.from({length: 12}, (_, i) => (
+              <div key={i} className="bg-base-200/30 rounded-lg border border-base-300 p-4">
+                <h4 className="font-medium mb-2">Application {i + 1}</h4>
+                <p className="text-sm text-base-content/80">
+                  This represents an application item. The modal should scroll smoothly when there are many items like this.
+                </p>
+                <div className="mt-2 flex gap-2">
+                  <Button size="sm" variant="success">Accept</Button>
+                  <Button size="sm" variant="error">Decline</Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default ModalTest;

--- a/src/components/common/NotificationBadge.jsx
+++ b/src/components/common/NotificationBadge.jsx
@@ -71,6 +71,7 @@ const NotificationBadge = ({
   title,
   showZero = false,
   compact = false,
+  interactive = false,
 }) => {
   const config = VARIANTS[variant];
   const shouldShowBadge = count > 0 || showZero;
@@ -80,7 +81,7 @@ const NotificationBadge = ({
     const tooltipText =
       title || (shouldShowBadge ? config?.getTitle(count) : undefined);
     return (
-      <Tooltip content={tooltipText}>
+      <Tooltip content={tooltipText} interactive={interactive}>
         <div
           className={`relative inline-flex ${className}`}
           onClick={onClick}

--- a/src/components/common/Tooltip.jsx
+++ b/src/components/common/Tooltip.jsx
@@ -1,6 +1,10 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 
+// Grace period (ms) before an interactive tooltip closes, so the pointer can
+// travel from the trigger into the bubble without it disappearing.
+const INTERACTIVE_CLOSE_DELAY = 140;
+
 const TOOLTIP_ARROW_WIDTH = 22.5;
 const TOOLTIP_ARROW_HEIGHT = 12.8;
 const TOOLTIP_ARROW_MASK = `url("data:image/svg+xml,%3Csvg width='22.5' height='12.8' viewBox='0 0 22.5 12.8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 0H22.5C17.55 0 15.3 1.408 13.95 4.672L11.7 12.288C11.475 12.672 11.025 12.672 10.8 12.288L8.55 4.672C7.2 1.408 4.95 0 0 0Z' fill='white'/%3E%3C/svg%3E")`;
@@ -23,6 +27,7 @@ const Tooltip = ({
   position = "bottom",
   className = "",
   wrapperClassName = "inline-flex items-center",
+  interactive = false,
 }) => {
   const [isVisible, setIsVisible] = useState(false);
   const [coords, setCoords] = useState({ top: 0, left: 0 });
@@ -30,6 +35,35 @@ const Tooltip = ({
   const [actualPosition, setActualPosition] = useState(position);
   const triggerRef = useRef(null);
   const tooltipRef = useRef(null);
+  const closeTimerRef = useRef(null);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const open = useCallback(() => {
+    cancelClose();
+    setIsVisible(true);
+  }, [cancelClose]);
+
+  // Non-interactive tooltips close instantly; interactive ones wait a beat so
+  // the pointer can reach the bubble (and its buttons) before it hides.
+  const close = useCallback(() => {
+    if (!interactive) {
+      setIsVisible(false);
+      return;
+    }
+    cancelClose();
+    closeTimerRef.current = setTimeout(() => {
+      setIsVisible(false);
+      closeTimerRef.current = null;
+    }, INTERACTIVE_CLOSE_DELAY);
+  }, [interactive, cancelClose]);
+
+  useEffect(() => () => cancelClose(), [cancelClose]);
 
   const calculatePosition = useCallback(() => {
     if (!triggerRef.current || !tooltipRef.current) return;
@@ -175,10 +209,10 @@ const Tooltip = ({
         ref={triggerRef}
         data-tooltip-trigger="true"
         className={`${wrapperClassName} ${className}`}
-        onMouseEnter={() => setIsVisible(true)}
-        onMouseLeave={() => setIsVisible(false)}
-        onFocus={() => setIsVisible(true)}
-        onBlur={() => setIsVisible(false)}
+        onMouseEnter={open}
+        onMouseLeave={close}
+        onFocus={open}
+        onBlur={close}
       >
         {children}
       </span>
@@ -190,6 +224,8 @@ const Tooltip = ({
             <div
               ref={tooltipRef}
               role="tooltip"
+              onMouseEnter={interactive ? open : undefined}
+              onMouseLeave={interactive ? close : undefined}
               className={`
                 lomir-tooltip-bubble
                 fixed z-[9999]
@@ -198,7 +234,7 @@ const Tooltip = ({
                 rounded-lg
                 whitespace-pre-line text-left
                 max-w-[280px]
-                pointer-events-none
+                ${interactive ? "pointer-events-auto" : "pointer-events-none"}
                 transition-opacity duration-150
               `}
               style={{

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -81,7 +81,7 @@ const NOTIFICATION_TYPE_META = [
   { keys: ["roleStatusChangedInvitee",   "role_status_changed_invitee"],   Icon: Pencil,        text: (p, n)     => `${p(n, "role")} you were invited to changed` },
 ];
 
-const buildNotificationTooltip = (count, types, teamCounts) => {
+const buildNotificationTooltip = (count, types, teamCounts, onGroupClick) => {
   if (!count || !types) return undefined;
   const p = (n, s) => `${n} ${s}${n !== 1 ? "s" : ""}`;
   const typeCount = (...keys) =>
@@ -92,22 +92,32 @@ const buildNotificationTooltip = (count, types, teamCounts) => {
   const lines = NOTIFICATION_TYPE_META.map(({ keys, Icon, text }) => {
     const n = typeCount(...keys);
     const tc = typeTeamCount(...keys);
-    return n ? { Icon, label: text(p, n, tc) } : null;
+    return n ? { keys, Icon, label: text(p, n, tc) } : null;
   }).filter(Boolean);
 
   if (!lines.length) return `${p(count, "notification")}`;
 
+  // Each type-group is a button: clicking it jumps to that group's oldest unread
+  // notification. Hover shifts to the lighter primary green.
   return (
-    <div className="flex flex-col gap-1">
-      {lines.map(({ Icon: NotificationIcon, label }, i) => (
-        <div key={i} className="flex items-center gap-1.5">
+    <div className="flex flex-col gap-0.5">
+      {lines.map(({ keys, Icon: NotificationIcon, label }, i) => (
+        <button
+          key={i}
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onGroupClick?.(keys);
+          }}
+          className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left text-[var(--color-primary-focus)] transition-colors hover:text-[var(--color-primary)]"
+        >
           {React.createElement(NotificationIcon, {
             size: 11,
             strokeWidth: 2.5,
             className: "flex-shrink-0 opacity-70",
           })}
           <span>{label}</span>
-        </div>
+        </button>
       ))}
     </div>
   );
@@ -152,6 +162,11 @@ const Navbar = () => {
   const [firstUnreadNotification, setFirstUnreadNotification] = useState(null);
   const [notificationTypeCounts, setNotificationTypeCounts] = useState({});
   const [notificationTypeTeamCounts, setNotificationTypeTeamCounts] = useState({});
+  // Oldest unread notification per type ({ [type]: { id, createdAt, navigateTo } }),
+  // so a tooltip type-group can jump straight to its oldest entry.
+  const [notificationTypeFirstUnread, setNotificationTypeFirstUnread] = useState(
+    {},
+  );
   const location = useLocation();
   const navigate = useNavigate();
   const lastMessageFetchRef = useRef(0);
@@ -191,7 +206,9 @@ const Navbar = () => {
     }
   }, [isAuthenticated]);
 
-  // Fetch unread notification count
+  // Fetch unread notification count. The response also carries the oldest
+  // unread notification per type, which feeds the per-group navigation targets
+  // in the bell tooltip.
   const fetchUnreadNotificationCount = useCallback(async () => {
     if (!isAuthenticated) return;
 
@@ -201,6 +218,7 @@ const Navbar = () => {
       setFirstUnreadNotification(response.data?.firstUnread || null);
       setNotificationTypeCounts(response.data?.typeCounts || {});
       setNotificationTypeTeamCounts(response.data?.typeTeamCounts || {});
+      setNotificationTypeFirstUnread(response.data?.typeFirstUnread || {});
     } catch (error) {
       console.error("Error fetching unread notification count:", error);
     }
@@ -275,6 +293,7 @@ const Navbar = () => {
       setFirstUnreadNotification(null);
       setNotificationTypeCounts({});
       setNotificationTypeTeamCounts({});
+      setNotificationTypeFirstUnread({});
       return;
     }
 
@@ -389,6 +408,7 @@ const Navbar = () => {
     setFirstUnreadNotification(null);
     setNotificationTypeCounts({});
     setNotificationTypeTeamCounts({});
+    setNotificationTypeFirstUnread({});
     try {
       await notificationService.markAllAsRead();
     } catch (error) {
@@ -396,6 +416,64 @@ const Navbar = () => {
       fetchUnreadNotificationCount();
     }
   }, [fetchUnreadNotificationCount]);
+
+  // Click a tooltip type-group: jump to its OLDEST unread notification, mark it
+  // read (so the group counter drops by one), and step to the next-oldest on the
+  // next click. Optimistic; reconciles with the server after navigation.
+  const handleNotificationGroupClick = useCallback(
+    async (keys) => {
+      // A group can span several types (e.g. role_reopened + role_reopened_admin);
+      // pick the oldest entry across the ones present.
+      const target = keys
+        .map((key) =>
+          notificationTypeFirstUnread[key]
+            ? { type: key, ...notificationTypeFirstUnread[key] }
+            : null,
+        )
+        .filter(Boolean)
+        .sort(
+          (a, b) =>
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+        )[0];
+
+      if (!target) {
+        // Map is stale (nothing left for this group locally) — refresh and let
+        // the user click again.
+        fetchUnreadNotificationCount();
+        return;
+      }
+
+      // Optimistically drop this one so the counter falls and a quick repeat
+      // click does not re-target the same (now read) notification.
+      setUnreadNotificationCount((prev) => Math.max(0, prev - 1));
+      setNotificationTypeCounts((prev) => {
+        const current = Number(prev[target.type]) || 0;
+        if (current <= 0) return prev;
+        return { ...prev, [target.type]: current - 1 };
+      });
+      setNotificationTypeFirstUnread((prev) => {
+        if (!prev[target.type]) return prev;
+        const next = { ...prev };
+        delete next[target.type];
+        return next;
+      });
+
+      try {
+        await notificationService.markAsRead(target.id);
+      } catch (error) {
+        console.error("Error marking notification as read:", error);
+      }
+
+      navigate(target.navigateTo || "/teams/my-teams");
+
+      // Reconcile counts + per-type targets with the server (repopulates the
+      // next-oldest for this type) once navigation settles.
+      setTimeout(() => {
+        fetchUnreadNotificationCount();
+      }, 1000);
+    },
+    [notificationTypeFirstUnread, navigate, fetchUnreadNotificationCount],
+  );
 
   // Mark every conversation (direct + team) as read, plus @mention alerts. The
   // backend also emits messages:read-all so the chat page's conversation list
@@ -411,6 +489,12 @@ const Navbar = () => {
       if (!prev.messageMention && !prev.message_mention) return prev;
       const next = { ...prev };
       delete next.messageMention;
+      delete next.message_mention;
+      return next;
+    });
+    setNotificationTypeFirstUnread((prev) => {
+      if (!prev.message_mention) return prev;
+      const next = { ...prev };
       delete next.message_mention;
       return next;
     });
@@ -453,6 +537,7 @@ const Navbar = () => {
                             bellNotificationCount,
                             notificationTypeCounts,
                             notificationTypeTeamCounts,
+                            handleNotificationGroupClick,
                           ),
                           handleMarkAllNotificationsRead,
                         )

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   Award,
   Bell,
+  CheckCheck,
   CircleX,
   Crown,
   LogOut,
@@ -112,6 +113,31 @@ const buildNotificationTooltip = (count, types, teamCounts) => {
   );
 };
 
+// Wraps a badge's tooltip summary with a clickable "Mark all as read" action at
+// the top. The tooltip must be interactive (pointer-events enabled) for this.
+const withMarkAllRead = (summary, onMarkAll) => (
+  <div className="flex min-w-[150px] flex-col">
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onMarkAll();
+      }}
+      className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left font-semibold text-[var(--color-primary-focus)] transition-colors hover:text-[var(--color-primary)]"
+    >
+      <CheckCheck size={12} strokeWidth={2.5} className="flex-shrink-0" />
+      <span>Mark all as read</span>
+    </button>
+    <div className="mt-2 border-t border-base-300 pt-2">
+      {typeof summary === "string" ? (
+        <span className="whitespace-pre-line">{summary}</span>
+      ) : (
+        summary
+      )}
+    </div>
+  </div>
+);
+
 const Navbar = () => {
   const { isAuthenticated, user, logout } = useAuth();
   const [imageError, setImageError] = useState(false);
@@ -142,6 +168,13 @@ const Navbar = () => {
     notificationTypeCounts.messageMention ||
     notificationTypeCounts.message_mention ||
     0;
+  // The bell badge excludes @mentions (those surface on the chat icon).
+  const bellNotificationCount =
+    unreadNotificationCount - messageMentionNotificationCount;
+  // The chat icon has something to clear when there are unread messages or
+  // pending @mention alerts.
+  const hasChatActivity =
+    unreadMessageCount > 0 || messageMentionNotificationCount > 0;
 
   // Fetch unread message count
   const fetchUnreadMessageCount = useCallback(async () => {
@@ -349,6 +382,47 @@ const Navbar = () => {
     }
   };
 
+  // Mark all general (bell) notifications as read. Clears the badge + tooltip
+  // optimistically, then persists; re-syncs from the server on failure.
+  const handleMarkAllNotificationsRead = useCallback(async () => {
+    setUnreadNotificationCount(0);
+    setFirstUnreadNotification(null);
+    setNotificationTypeCounts({});
+    setNotificationTypeTeamCounts({});
+    try {
+      await notificationService.markAllAsRead();
+    } catch (error) {
+      console.error("Error marking all notifications as read:", error);
+      fetchUnreadNotificationCount();
+    }
+  }, [fetchUnreadNotificationCount]);
+
+  // Mark every conversation (direct + team) as read, plus @mention alerts. The
+  // backend also emits messages:read-all so the chat page's conversation list
+  // clears. We drop the local badge/tooltip immediately for instant feedback.
+  const handleMarkAllMessagesRead = useCallback(async () => {
+    setUnreadMessageCount(0);
+    setFirstUnreadMessage(null);
+    setMessageTeamCount(0);
+    setMessageSenderCount(0);
+    // The mention line on the chat tooltip is fed by notification counts; drop
+    // it locally too (the backend marks those notifications read).
+    setNotificationTypeCounts((prev) => {
+      if (!prev.messageMention && !prev.message_mention) return prev;
+      const next = { ...prev };
+      delete next.messageMention;
+      delete next.message_mention;
+      return next;
+    });
+    try {
+      await messageService.markAllAsRead();
+    } catch (error) {
+      console.error("Error marking all messages as read:", error);
+      fetchUnreadMessageCount();
+      fetchUnreadNotificationCount();
+    }
+  }, [fetchUnreadMessageCount, fetchUnreadNotificationCount]);
+
   return (
     <div className="navbar glass-navbar sticky top-0 z-10">
       <div className="content-container flex justify-between items-center w-full">
@@ -370,8 +444,20 @@ const Navbar = () => {
               >
                 <NotificationBadge
                   variant="alert"
-                  count={unreadNotificationCount - messageMentionNotificationCount}
-                  title={buildNotificationTooltip(unreadNotificationCount - messageMentionNotificationCount, notificationTypeCounts, notificationTypeTeamCounts)}
+                  count={bellNotificationCount}
+                  interactive={bellNotificationCount > 0}
+                  title={
+                    bellNotificationCount > 0
+                      ? withMarkAllRead(
+                          buildNotificationTooltip(
+                            bellNotificationCount,
+                            notificationTypeCounts,
+                            notificationTypeTeamCounts,
+                          ),
+                          handleMarkAllNotificationsRead,
+                        )
+                      : undefined
+                  }
                 >
                   <Bell size={22} strokeWidth={2.2} />
                 </NotificationBadge>
@@ -387,7 +473,20 @@ const Navbar = () => {
                 <NotificationBadge
                   variant="message"
                   count={unreadMessageCount}
-                  title={buildMessageTooltip(unreadMessageCount, messageTeamCount, messageSenderCount, messageMentionNotificationCount)}
+                  interactive={hasChatActivity}
+                  title={
+                    hasChatActivity
+                      ? withMarkAllRead(
+                          buildMessageTooltip(
+                            unreadMessageCount,
+                            messageTeamCount,
+                            messageSenderCount,
+                            messageMentionNotificationCount,
+                          ),
+                          handleMarkAllMessagesRead,
+                        )
+                      : undefined
+                  }
                 >
                   <MessageCircle size={22} strokeWidth={2.2} />
                 </NotificationBadge>

--- a/src/components/teams/TeamApplicationsModal.jsx
+++ b/src/components/teams/TeamApplicationsModal.jsx
@@ -50,6 +50,7 @@ const TeamApplicationsModal = ({
   teamName,
   highlightApplicationId = null,
   highlightUserId = null,
+  applicationsLoaded = false,
 }) => {
   // ============ Auth ============
   const { user: currentUser } = useAuth();
@@ -82,6 +83,8 @@ const TeamApplicationsModal = ({
 
   // ============ Refs ============
   const highlightedRef = useRef(null);
+  // Guards the stale-notification toast so it fires at most once per open.
+  const staleNotifiedRef = useRef(false);
 
   // ============ Handlers ============
   const handleResponseChange = (applicationId, response) => {
@@ -307,8 +310,44 @@ const TeamApplicationsModal = ({
     if (!isOpen) {
       setStatusUpdatingRoleId(null);
       setRoleStatusOverrides({});
+      staleNotifiedRef.current = false;
     }
   }, [isOpen]);
+
+  // A notification opened this modal for a specific application, but it is no
+  // longer pending (another admin already handled it in the meantime). Tell the
+  // user instead of leaving them on an empty / non-highlighting modal, and close
+  // the modal when there is nothing else to review.
+  useEffect(() => {
+    if (!isOpen || !applicationsLoaded || staleNotifiedRef.current) return;
+    if (highlightApplicationId == null && highlightUserId == null) return;
+
+    const targetStillPending = applications.some(
+      (application) =>
+        (highlightApplicationId != null &&
+          String(application.id) === String(highlightApplicationId)) ||
+        (highlightUserId != null &&
+          String(getRequestUserId(application, "applicant")) ===
+            String(highlightUserId)),
+    );
+
+    if (!targetStillPending) {
+      staleNotifiedRef.current = true;
+      showToast(
+        "The application you were notified about has already been handled.",
+        "info",
+      );
+      if (applications.length === 0) onClose();
+    }
+  }, [
+    isOpen,
+    applicationsLoaded,
+    highlightApplicationId,
+    highlightUserId,
+    applications,
+    showToast,
+    onClose,
+  ]);
 
   // ============ Render ============
   const anyNarrow = Object.values(narrowMap).some(Boolean);

--- a/src/components/teams/TeamCard.jsx
+++ b/src/components/teams/TeamCard.jsx
@@ -2303,6 +2303,7 @@ const TeamCard = ({
             teamName={teamData.name}
             highlightApplicationId={highlightApplicationId}
             highlightUserId={highlightApplicantId}
+            applicationsLoaded={pendingApplicationsLoaded}
           />
         )}
 
@@ -2628,6 +2629,7 @@ const TeamCard = ({
           teamName={teamData.name}
           highlightApplicationId={highlightApplicationId}
           highlightUserId={highlightApplicantId}
+          applicationsLoaded={pendingApplicationsLoaded}
         />
       )}
 

--- a/src/hooks/useChatSocketEvents.js
+++ b/src/hooks/useChatSocketEvents.js
@@ -471,7 +471,20 @@ const useChatSocketEvents = ({
       }
     };
 
+    // Fired when the user hits "Mark all as read" in the navbar: every
+    // conversation's unread badge drops to zero across the list.
+    const handleAllMessagesRead = () => {
+      setConversations((prev) =>
+        prev.map((conversation) =>
+          (conversation.unreadCount ?? conversation.unread_count ?? 0) > 0
+            ? { ...conversation, unreadCount: 0, unread_count: 0 }
+            : conversation,
+        ),
+      );
+    };
+
     socket.on("users:online", handleOnlineUsers);
+    socket.on("messages:read-all", handleAllMessagesRead);
     socket.on("message:received", handleNewMessage);
     socket.on("typing:update", handleTypingUpdate);
     socket.on("message:status", handleMessageStatus);
@@ -485,6 +498,7 @@ const useChatSocketEvents = ({
 
     return () => {
       socket.off("users:online", handleOnlineUsers);
+      socket.off("messages:read-all", handleAllMessagesRead);
       socket.off("message:received", handleNewMessage);
       socket.off("typing:update", handleTypingUpdate);
       socket.off("message:status", handleMessageStatus);

--- a/src/pages/DesignSystem.jsx
+++ b/src/pages/DesignSystem.jsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import PageContainer from '../components/layout/PageContainer';
+import Button from '../components/common/Button';
+import Alert from '../components/common/Alert';
+import Card from '../components/common/Card';
+import Input from '../components/common/Input';
+import ModalTest from '../components/common/ModalTest';
+
+const DesignSystem = () => {
+  return (
+    <PageContainer title="Design System">
+      <div className="space-y-10">
+        {/* Typography */}
+        <section>
+          <h2 className="text-2xl font-bold mb-4 text-secondary">Typography</h2>
+          <div className="grid gap-2">
+            <h1 className="text-4xl font-bold">Heading 1</h1>
+            <h2 className="text-3xl font-bold">Heading 2</h2>
+            <h3 className="text-2xl font-bold">Heading 3</h3>
+            <h4 className="text-xl font-bold">Heading 4</h4>
+            <p className="text-base">Regular paragraph text</p>
+            <p className="text-sm">Small text</p>
+            <a href="#" className="link link-primary">
+              Primary Link
+            </a>
+          </div>
+        </section>
+
+        {/* Colors */}
+        <section>
+          <h2 className="text-2xl font-bold mb-4 text-secondary">Colors</h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="p-4 bg-primary text-primary-content rounded-box">
+              Primary
+            </div>
+            <div className="p-4 bg-secondary text-secondary-content rounded-box">
+              Secondary
+            </div>
+            <div className="p-4 bg-accent text-accent-content rounded-box">
+              Accent
+            </div>
+            <div className="p-4 bg-neutral text-neutral-content rounded-box">
+              Neutral
+            </div>
+            <div className="p-4 bg-base-100 border rounded-box">Base 100</div>
+            <div className="p-4 bg-base-200 rounded-box">Base 200</div>
+            <div className="p-4 bg-base-300 rounded-box">Base 300</div>
+            <div className="p-4 bg-info text-info-content rounded-box">
+              Info
+            </div>
+            <div className="p-4 bg-success text-success-content rounded-box">
+              Success
+            </div>
+            <div className="p-4 bg-warning text-warning-content rounded-box">
+              Warning
+            </div>
+            <div className="p-4 bg-error text-error-content rounded-box">
+              Error
+            </div>
+          </div>
+        </section>
+
+        {/* Buttons */}
+        <section>
+          <h2 className="text-2xl font-bold mb-4 text-secondary">Buttons</h2>
+          <div className="flex flex-wrap gap-2">
+            <Button>Default</Button>
+            <Button variant="primary">Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="accent">Accent</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="link">Link</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="primary" size="sm">
+              Small
+            </Button>
+            <Button variant="primary" size="lg">
+              Large
+            </Button>
+            <Button variant="primary" disabled>
+              Disabled
+            </Button>
+          </div>
+        </section>
+
+        {/* Alerts */}
+        <section>
+          <h2 className="text-2xl font-bold mb-4 text-secondary">Alerts</h2>
+          <div className="space-y-2">
+            <Alert type="info" message="This is an info message" />
+            <Alert type="success" message="This is a success message" />
+            <Alert type="warning" message="This is a warning message" />
+            <Alert type="error" message="This is an error message" />
+          </div>
+        </section>
+
+        {/* Cards */}
+        <section>
+          <h2 className="text-2xl font-bold mb-4 text-secondary">Cards</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Card title="Basic Card">
+              <p>
+                This is the content of a basic card using your Card component.
+              </p>
+            </Card>
+
+            <Card
+              title="Card with Footer"
+              footer={<Button variant="primary">Action</Button>}
+            >
+              <p>This card has a footer with an action button.</p>
+            </Card>
+          </div>
+        </section>
+
+        {/* Form Elements */}
+        <section>
+          <h2 className="text-2xl font-bold mb-4 text-secondary">
+            Form Elements
+          </h2>
+          <div className="grid gap-4 max-w-md">
+            <Input
+              label="Text Input"
+              name="example"
+              placeholder="Enter some text"
+            />
+            <Input
+              type="password"
+              label="Password"
+              name="password"
+              placeholder="Enter password"
+            />
+            <Input
+              label="With Error"
+              name="error-example"
+              error="This field has an error"
+            />
+            <div className="form-control">
+              <label className="label cursor-pointer">
+                <span className="label-text">Checkbox</span>
+                <input type="checkbox" className="checkbox" />
+              </label>
+            </div>
+            <div className="form-control">
+              <label className="label cursor-pointer">
+                <span className="label-text">Toggle</span>
+                <input type="checkbox" className="toggle" />
+              </label>
+            </div>
+          </div>
+        </section>
+        {/* Modal Tests */}
+        <section>
+          <h2 className="text-2xl font-bold mb-4 text-secondary">
+            Modal Component Test
+          </h2>
+          <ModalTest />
+        </section>
+      </div>
+    </PageContainer>
+  );
+};
+
+export default DesignSystem;

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -309,6 +309,16 @@ export const messageService = {
     return _pendingUnreadCount;
   },
 
+  // Mark every conversation (direct + team) as read for the current user.
+  // The backend also emits a "messages:read-all" socket event so the Navbar
+  // badges and the chat page's conversation list update in real time.
+  markAllAsRead: () =>
+    call("marking all messages as read", () =>
+      api.put("/api/messages/read-all", undefined, {
+        skipResponseCaseTransform: true,
+      }),
+    ),
+
   getConversationById: (conversationId, type = "direct") =>
     call(`fetching conversation ${conversationId}`, () =>
       api.get(`/api/messages/conversations/${conversationId}?type=${type}`, {


### PR DESCRIPTION
Ships to production (requires the matching backend release first):

- Add Mark all as read as the first row of the bell and chat tooltips - Make bell tooltip type groups clickable, stepping through the unread  notifications of that type
- Show a friendly toast instead of an empty modal for stale notifications
- Add an opt-in interactive prop to Tooltip

Verified: ESLint 0 errors, build green, UI smoke tested.