### PR TITLE
perf(chat): slow the team membership poll while the socket is connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Lomir-frontend/
 │   │   ├── useSocketEvents.js      # Subscribe to a set of Socket.IO events with React-safe cleanup
 │   │   ├── useChatTyping.js        # Chat typing indicator state, timeout cleanup, and user-name resolution
 │   │   ├── useChatSocketEvents.js  # Chat Socket.IO event wiring for messages, read status, membership, and conversation updates
+│   │   ├── useChatTeamAccess.js    # Team-chat access: details fetching, access revocation, and membership refresh (polled every 60 s while the socket is connected, every 10 s without it, plus on window focus)
+│   │   ├── useChatMessageActions.js # Chat send/edit/delete handlers, reply state wiring, and the confirmable chat actions (leave team, delete conversation/message)
 │   │   ├── useChatSearchState.js   # Chat search query state, message indexing, filtering, and no-result feedback
 │   │   ├── useActiveChatConversation.js # Active chat loading, join/read marking, highlights, and earlier-message pagination
 │   │   ├── useAwardModals.js       # Badge award modal state management (user profile context)

--- a/src/hooks/useChatTeamAccess.js
+++ b/src/hooks/useChatTeamAccess.js
@@ -8,6 +8,12 @@ import {
   isArchivedTeamData,
 } from "../utils/chatHelpers";
 
+// How often the active team chat re-checks membership. The socket is the
+// primary signal, so a live connection only needs a slow safety net; without
+// one the poll goes back to being the only way a revocation is noticed.
+const CONNECTED_MEMBERSHIP_POLL_MS = 60000;
+const DISCONNECTED_MEMBERSHIP_POLL_MS = 10000;
+
 // Team-chat access + membership helpers extracted from Chat.jsx (Stage 5a).
 // Owns team-details fetching, access revocation, live membership refresh, and
 // conversation hydration. These helpers are consumed both here (send/edit/delete
@@ -217,8 +223,11 @@ const useChatTeamAccess = ({
 
     const teamId = activeConversation.team.id;
     let cancelled = false;
+    let lastCheckedAt = 0;
 
     const checkMembership = async () => {
+      lastCheckedAt = Date.now();
+
       try {
         if (!cancelled) {
           await refreshActiveTeamMembership(teamId);
@@ -228,8 +237,29 @@ const useChatTeamAccess = ({
       }
     };
 
+    // Membership loss already arrives over the socket (team:member_kicked is
+    // emitted straight to the removed user, team:member_left to the team room),
+    // and every send/edit/delete re-checks access before acting. This poll is
+    // the fallback for events missed while the socket was down, so it only
+    // needs to run often when there is no socket to miss them on.
+    const tick = () => {
+      const connected = socketService.getSocket()?.connected ?? false;
+      const dueAfter = connected
+        ? CONNECTED_MEMBERSHIP_POLL_MS
+        : DISCONNECTED_MEMBERSHIP_POLL_MS;
+
+      if (Date.now() - lastCheckedAt >= dueAfter) {
+        checkMembership();
+      }
+    };
+
     checkMembership();
-    const intervalId = window.setInterval(checkMembership, 10000);
+    // Ticking at the shorter cadence keeps the poll responsive to the socket
+    // dropping; the tick itself is a timestamp comparison and does not fetch.
+    const intervalId = window.setInterval(
+      tick,
+      DISCONNECTED_MEMBERSHIP_POLL_MS,
+    );
 
     const handleFocus = () => {
       checkMembership();


### PR DESCRIPTION
The active team chat re-checked membership every 10 seconds by calling
getConversationById, which returns the whole team object including every
member with avatars and names. Measured on an idle open team chat: seven
requests in 34 seconds, about 2.8 KB each, with an identical ETag across
all of them.

That cadence is not what keeps access correct. Membership loss already
arrives over the socket - team:member_kicked is emitted straight to the
removed user and team:member_left to the team room - and every send, edit
and delete calls refreshActiveTeamMembership before acting, so a removed
member cannot post regardless of the poll. The poll's own contribution is
catching events missed while the socket was down.

So it now polls on the socket state: every 60 seconds while connected, and
back to every 10 seconds when there is no connection. For an open team chat
with a live socket that is 60 requests an hour instead of 360.

The interval still ticks every 10 seconds so a dropped socket is noticed
within one tick rather than up to a minute later; the tick itself only
compares timestamps and does not fetch. The immediate check on opening a
conversation and the window focus check are both unchanged.

The full payload is deliberately kept rather than replaced with a narrow
membership endpoint: refreshActiveTeamMembership also merges the member
list back into the active conversation, so a yes/no answer would not be
enough.

Verified: ESLint 0 errors, build green. Smoke tested that the request now
appears about once a minute, that focus still triggers an immediate check,
that stopping the backend puts the poll back on the 10 second cadence, and
that removing a member from a team still revokes their open chat
immediately through the socket.

Also fills two gaps in the README directory tree: useChatTeamAccess.js
and useChatMessageActions.js were added by the Chat.jsx decomposition
but never listed, and the useChatTeamAccess entry now records the poll
cadence.