### PR TITLE
Release: chat membership poll becomes socket-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Lomir-frontend/
 │   │   ├── useSocketEvents.js      # Subscribe to a set of Socket.IO events with React-safe cleanup
 │   │   ├── useChatTyping.js        # Chat typing indicator state, timeout cleanup, and user-name resolution
 │   │   ├── useChatSocketEvents.js  # Chat Socket.IO event wiring for messages, read status, membership, and conversation updates
+│   │   ├── useChatTeamAccess.js    # Team-chat access: details fetching, access revocation, and membership refresh (polled every 60 s while the socket is connected, every 10 s without it, plus on window focus)
+│   │   ├── useChatMessageActions.js # Chat send/edit/delete handlers, reply state wiring, and the confirmable chat actions (leave team, delete conversation/message)
 │   │   ├── useChatSearchState.js   # Chat search query state, message indexing, filtering, and no-result feedback
 │   │   ├── useActiveChatConversation.js # Active chat loading, join/read marking, highlights, and earlier-message pagination
 │   │   ├── useAwardModals.js       # Badge award modal state management (user profile context)

--- a/src/hooks/useChatTeamAccess.js
+++ b/src/hooks/useChatTeamAccess.js
@@ -8,6 +8,12 @@ import {
   isArchivedTeamData,
 } from "../utils/chatHelpers";
 
+// How often the active team chat re-checks membership. The socket is the
+// primary signal, so a live connection only needs a slow safety net; without
+// one the poll goes back to being the only way a revocation is noticed.
+const CONNECTED_MEMBERSHIP_POLL_MS = 60000;
+const DISCONNECTED_MEMBERSHIP_POLL_MS = 10000;
+
 // Team-chat access + membership helpers extracted from Chat.jsx (Stage 5a).
 // Owns team-details fetching, access revocation, live membership refresh, and
 // conversation hydration. These helpers are consumed both here (send/edit/delete
@@ -217,8 +223,11 @@ const useChatTeamAccess = ({
 
     const teamId = activeConversation.team.id;
     let cancelled = false;
+    let lastCheckedAt = 0;
 
     const checkMembership = async () => {
+      lastCheckedAt = Date.now();
+
       try {
         if (!cancelled) {
           await refreshActiveTeamMembership(teamId);
@@ -228,8 +237,29 @@ const useChatTeamAccess = ({
       }
     };
 
+    // Membership loss already arrives over the socket (team:member_kicked is
+    // emitted straight to the removed user, team:member_left to the team room),
+    // and every send/edit/delete re-checks access before acting. This poll is
+    // the fallback for events missed while the socket was down, so it only
+    // needs to run often when there is no socket to miss them on.
+    const tick = () => {
+      const connected = socketService.getSocket()?.connected ?? false;
+      const dueAfter = connected
+        ? CONNECTED_MEMBERSHIP_POLL_MS
+        : DISCONNECTED_MEMBERSHIP_POLL_MS;
+
+      if (Date.now() - lastCheckedAt >= dueAfter) {
+        checkMembership();
+      }
+    };
+
     checkMembership();
-    const intervalId = window.setInterval(checkMembership, 10000);
+    // Ticking at the shorter cadence keeps the poll responsive to the socket
+    // dropping; the tick itself is a timestamp comparison and does not fetch.
+    const intervalId = window.setInterval(
+      tick,
+      DISCONNECTED_MEMBERSHIP_POLL_MS,
+    );
 
     const handleFocus = () => {
       checkMembership();


### PR DESCRIPTION
Frontend-only release. Ships the single change already merged to dev as PR #561, plus two README additions.

What changes
The active team chat re-checked membership every 10 s by fetching the full conversation (GET /api/messages/conversations/:id?type=team, ~2.8 KB, identical ETag across polls). It now keys off the socket connection state:

socket connected — every 60 s
socket disconnected — every 10 s, as before
window focus still triggers an immediate check
That is 360 to 60 requests per hour for one open team chat.

The interval itself still fires every 10 s, but a tick is only a timestamp comparison and does not fetch. This keeps the poll responsive: if the socket drops, the faster cadence resumes within one tick.

Why this is safe
Membership loss already reaches the client three other ways:

team:member_kicked is emitted straight to the removed user
team:member_left goes to the team room
refreshActiveTeamMembership runs before every send, edit and delete (5 call sites in useChatMessageActions)
The poll's real job is the gap those leave — events missed while the socket was down — which is exactly the case where it stays at 10 s.

A narrow membership endpoint was considered and rejected: the same call also merges the member list back into the active conversation, so a yes/no answer is not enough. Conditional requests via ETag were rejected too — they would save bytes, but the member-join query would still run on every poll.

Also included
README.md now lists useChatTeamAccess.js and useChatMessageActions.js in the hooks tree — both were missing — and notes the poll cadence.

Backend
None required. No event, endpoint or payload changed.

Verification
ESLint clean (pre-existing warnings only), Vite build green
UI-smoked on all four paths: socket connected, socket disconnected, backend down, and member removal while the chat was open
Files
src/hooks/useChatTeamAccess.js
README.md
