### PR TITLE
chore(notifications): remove the unused notification list client

### DIFF
--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -50,39 +50,6 @@ const normalizeNotification = (notification) => {
   });
 };
 
-const normalizeNotificationListPayload = (payload) => {
-  if (Array.isArray(payload)) {
-    return payload.map(normalizeNotification);
-  }
-
-  if (Array.isArray(payload?.data)) {
-    return {
-      ...payload,
-      data: payload.data.map(normalizeNotification),
-    };
-  }
-
-  const data = payload?.data ?? payload ?? {};
-  const rawNotifications =
-    data.notifications ?? data.data ?? payload?.notifications ?? [];
-  const notifications = Array.isArray(rawNotifications)
-    ? rawNotifications.map(normalizeNotification)
-    : rawNotifications;
-  const nextPayload = {
-    ...payload,
-    ...(Array.isArray(payload?.notifications) ? { notifications } : {}),
-  };
-
-  return {
-    ...nextPayload,
-    data: {
-      ...data,
-      notifications,
-      data: Array.isArray(data.data) ? notifications : data.data,
-    },
-  };
-};
-
 const normalizeUnreadCountPayload = (payload) => {
   const data = payload?.data ?? payload ?? {};
   const rawFirstUnread = data.firstUnread ?? data.first_unread ?? null;
@@ -112,16 +79,6 @@ export const notificationService = {
       skipResponseCaseTransform: true,
     });
     return normalizeUnreadCountPayload(response.data);
-  },
-
-  // Get all notifications
-  getNotifications: async (params = {}) => {
-    const { limit = 50, offset = 0, unreadOnly = false } = params;
-    const response = await api.get("/api/notifications", {
-      skipResponseCaseTransform: true,
-      params: { limit, offset, unreadOnly },
-    });
-    return normalizeNotificationListPayload(response.data);
   },
 
   // Mark a single notification as read


### PR DESCRIPTION
Removes dead code from notificationService. No behaviour change.

What is removed
getNotifications — defined, never called. A repo-wide search for the name found only the definition itself.
normalizeNotificationListPayload — its only consumer was getNotifications.
43 lines deleted, none added.

What deliberately stays
normalizeNotification, addCaseAliases and FIELD_ALIASES are still used by normalizeUnreadCountPayload, which backs the navbar bell counter. Removing them would have broken the counter — worth noting, because they look like part of the same dead cluster at a glance.

Backend
GET /api/notifications and notificationController.getNotifications stay in place. They now have no frontend consumer, but removing a route is a separate decision about public API surface and does not belong in this diff. Tracked as a follow-up; any such branch should first check tests and the Postman collection for other callers.

Verification
ESLint: 0 errors (31 pre-existing warnings, unchanged)
Vite build green
No references to the removed symbols in README.md or docs/
Nothing to smoke in the usual sense — the removed code had no callers. The only risk would be having cut something still live, which would show up in the bell tooltip (counter, type groups, mark all as read).