### PR TITLE
refactor(chat): reduce SendMessageButton to the team case

### DIFF
--- a/src/components/common/SendMessageButton.jsx
+++ b/src/components/common/SendMessageButton.jsx
@@ -1,45 +1,26 @@
 import React from "react";
 import { MessageCircle } from "lucide-react";
 import Button from "./Button";
-import { messageService } from "../../services/messageService";
 
+// Opens a team chat in a new tab. There used to be a "direct" mode here that
+// called messageService.startConversation first, but its last caller was
+// removed in 17adcde; direct chats are opened straight from UserDetailsModal,
+// and Chat.jsx handles blocked partners on its own.
 const SendMessageButton = ({
-  recipientId,
+  teamId,
   variant = "primary",
   size = "sm",
   className = "",
   children,
-  type = "direct", // "direct" or "team"
-  teamId = null,
 }) => {
-  const handleSendMessage = async () => {
-    if (type === "team" && teamId) {
-      // Handle team message
-      const chatUrl = `${window.location.origin}/chat/${teamId}?type=team`;
-      window.open(chatUrl, "_blank", "noopener,noreferrer");
+  const handleSendMessage = () => {
+    if (!teamId) {
+      console.error("SendMessageButton: teamId is required");
       return;
     }
 
-    if (type === "direct" && recipientId) {
-      // Existing direct message logic
-      try {
-        await messageService.startConversation(recipientId, "");
-        const chatUrl = `${window.location.origin}/chat/${recipientId}?type=direct`;
-        window.open(chatUrl, "_blank", "noopener,noreferrer");
-      } catch (error) {
-        console.error("Error starting conversation:", error);
-        const chatUrl = `${window.location.origin}/chat/${recipientId}?type=direct`;
-        window.open(chatUrl, "_blank", "noopener,noreferrer");
-      }
-      return;
-    }
-
-    console.error("Missing required props for message type:", type);
-  };
-
-  const getDefaultText = () => {
-    if (type === "team") return "Send Team Message";
-    return "Send Message";
+    const chatUrl = `${window.location.origin}/chat/${teamId}?type=team`;
+    window.open(chatUrl, "_blank", "noopener,noreferrer");
   };
 
   return (
@@ -50,7 +31,7 @@ const SendMessageButton = ({
       className={className}
       icon={<MessageCircle size={16} />}
     >
-      {children || getDefaultText()}
+      {children || "Send Team Message"}
     </Button>
   );
 };

--- a/src/components/teams/TeamDetailsModal.jsx
+++ b/src/components/teams/TeamDetailsModal.jsx
@@ -1344,9 +1344,7 @@ const TeamDetailsModal = ({
           <div className="flex items-center gap-2">
             {/* Send Message to Team Button */}
             <SendMessageButton
-              type="team"
               teamId={team?.id}
-              teamName={team?.name}
               variant="primary"
               className="flex-1"
             >

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -368,30 +368,6 @@ export const messageService = {
     ).then(normalizeMessagePayload);
   },
 
-  // Keeps explicit try/catch — logs the response body in addition to the
-  // standard error log because conversation start failures are hard to debug
-  // without the server's reason.
-  startConversation: async (recipientId, initialMessage = "") => {
-    try {
-      const response = await api.post(
-        "/api/messages/conversations",
-        {
-          recipient_id: parseInt(recipientId, 10),
-          initial_message: initialMessage.trim(),
-        },
-        {
-          skipRequestCaseTransform: true,
-          skipResponseCaseTransform: true,
-        },
-      );
-      return normalizeConversationPayload(response.data).data;
-    } catch (error) {
-      console.error("Error starting conversation:", error);
-      console.error("Error response:", error.response?.data);
-      throw error;
-    }
-  },
-
   deleteMessage: (messageId) =>
     call(`deleting message ${messageId}`, () =>
       api.delete(`/api/messages/${messageId}`, {


### PR DESCRIPTION
Started as a fix for the open finding that SendMessageButton swallows failures. Turned into a removal instead: the affected code path has no caller.

What was found
SendMessageButton had a direct and a team mode. The repo contains exactly one usage — TeamDetailsModal, in team mode. The direct usage was removed in 17adcde, when renderJoinButton took over that case. Direct chats are opened straight from UserDetailsModal today, which never calls startConversation.

So messageService.startConversation had no caller either.

This also puts the original finding in perspective: the identical try/catch paths hid a real backend bug (a 400 on every call, fixed in backend PR #307), but on a path the UI can no longer reach.

What is removed
the direct branch of SendMessageButton, along with the type and recipientId props — the handler is no longer async
messageService.startConversation
teamName at the call site, which the component never declared
normalizeConversationPayload stays; getConversationById still uses it.

Why removing the check is safe
startConversation wrote nothing when the initial message was empty, and empty is all this button ever sent. It only verified that the recipient exists and has not blocked the sender. Chat.jsx already handles blocked partners on its own: blocked DMs are dropped from the list, an open DM closes when its partner is blocked, and messages are filtered in both directions.

Generalization from the finding
Scanned for other catch blocks whose body duplicates the success path. One near-match in Navbar.jsx is deliberate and not the same class — the navigate sits outside the try/catch, so navigation is meant to happen whether or not markAsRead succeeded, and counts are reconciled with the server afterwards.

Verification
ESLint 0 errors (31 pre-existing warnings), Vite build green
No remaining references to the removed symbols
Smoke-tested: Send Message to Team opens the correct team chat in a new tab; direct chat from UserDetailsModal still works, confirming nothing depended on the removed service method
Follow-up
POST /api/messages/conversations and messageController.startConversation now have no frontend consumer — the same open question as GET /api/notifications from the previous cleanup. Best handled together in one backend branch, after checking tests and the Postman collection for other callers.