### PR TITLE
perf(myteams): make the TeamCard handlers useCallback-stable

### DIFF
--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -306,102 +306,117 @@ const MyTeams = () => {
     setCurrentPage(1); // Reset to page 1 when changing limit
   };
 
-  const handleTeamUpdate = (updatedTeam) => {
-    if (!updatedTeam) {
-      console.warn("Received undefined team data in handleTeamUpdate");
-      invalidateUserTeams();
-      return;
-    }
+  // Depends on the current page/page-size, so its identity changes when the
+  // user pages. That is fine: paging re-renders every card anyway, and the
+  // stale-closure alternative would patch the wrong page's cache entry.
+  const handleTeamUpdate = useCallback(
+    (updatedTeam) => {
+      if (!updatedTeam) {
+        console.warn("Received undefined team data in handleTeamUpdate");
+        invalidateUserTeams();
+        return;
+      }
 
-    // Optimistic single-team patch on the current page's cached data — avoids a
-    // full refetch for an in-place card update.
-    queryClient.setQueryData(
-      userTeamsQueryKey(user?.id, currentPage, resultsPerPage),
-      (old) =>
-        old
-          ? {
-              ...old,
-              data: (old.data ?? []).map((team) =>
-                team.id === updatedTeam.id ? updatedTeam : team,
-              ),
-            }
-          : old,
-    );
-  };
+      // Optimistic single-team patch on the current page's cached data — avoids
+      // a full refetch for an in-place card update.
+      queryClient.setQueryData(
+        userTeamsQueryKey(user?.id, currentPage, resultsPerPage),
+        (old) =>
+          old
+            ? {
+                ...old,
+                data: (old.data ?? []).map((team) =>
+                  team.id === updatedTeam.id ? updatedTeam : team,
+                ),
+              }
+            : old,
+      );
+    },
+    [invalidateUserTeams, queryClient, user?.id, currentPage, resultsPerPage],
+  );
 
-  const handleTeamDelete = async (teamId) => {
-    try {
-      await teamService.deleteTeam(teamId);
-      // Refetch to update pagination correctly
-      invalidateUserTeams();
-      return true;
-    } catch (error) {
-      console.error("Error deleting team:", error);
-      return false;
-    }
-  };
+  const handleTeamDelete = useCallback(
+    async (teamId) => {
+      try {
+        await teamService.deleteTeam(teamId);
+        // Refetch to update pagination correctly
+        invalidateUserTeams();
+        return true;
+      } catch (error) {
+        console.error("Error deleting team:", error);
+        return false;
+      }
+    },
+    [invalidateUserTeams],
+  );
 
   // Handler for when user LEAVES a team (not deletes it)
-  const handleTeamLeave = () => {
+  const handleTeamLeave = useCallback(() => {
     // Refetch to update pagination correctly
     invalidateUserTeams();
-  };
+  }, [invalidateUserTeams]);
 
   // Application handlers
-  const handleApplicationCancel = async (applicationId) => {
-    try {
-      await teamService.cancelApplication(applicationId);
-      refetchViewerPending();
-    } catch (error) {
-      console.error("Error canceling application:", error);
-    }
-  };
+  const handleApplicationCancel = useCallback(
+    async (applicationId) => {
+      try {
+        await teamService.cancelApplication(applicationId);
+        refetchViewerPending();
+      } catch (error) {
+        console.error("Error canceling application:", error);
+      }
+    },
+    [refetchViewerPending],
+  );
 
-  const handleSendReminder = async () => {
+  const handleSendReminder = useCallback(async () => {
     showToast("Reminder feature coming soon!", "violet");
-  };
+  }, [showToast]);
 
   // Invitation handlers
-  const handleInvitationAccept = async (
-    invitationId,
-    responseMessage = "",
-    fillRole = false,
-    options = {},
-  ) => {
-    try {
-      await teamService.respondToInvitation(
-        invitationId,
-        "accept",
-        responseMessage,
-        fillRole,
-        options,
-      );
+  const handleInvitationAccept = useCallback(
+    async (
+      invitationId,
+      responseMessage = "",
+      fillRole = false,
+      options = {},
+    ) => {
+      try {
+        await teamService.respondToInvitation(
+          invitationId,
+          "accept",
+          responseMessage,
+          fillRole,
+          options,
+        );
 
-      // Refresh the data
-      refetchViewerPending();
-      invalidateUserTeams();
-    } catch (error) {
-      console.error("Error accepting invitation:", error);
-    }
-  };
+        // Refresh the data
+        refetchViewerPending();
+        invalidateUserTeams();
+      } catch (error) {
+        console.error("Error accepting invitation:", error);
+      }
+    },
+    [refetchViewerPending, invalidateUserTeams],
+  );
 
-  const handleInvitationDecline = async (
-    invitationId,
-    responseMessage = "",
-  ) => {
-    try {
-      await teamService.respondToInvitation(
-        invitationId,
-        "decline",
-        responseMessage,
-      );
+  const handleInvitationDecline = useCallback(
+    async (invitationId, responseMessage = "") => {
+      try {
+        await teamService.respondToInvitation(
+          invitationId,
+          "decline",
+          responseMessage,
+        );
 
-      // Refresh the data
-      refetchViewerPending();
-    } catch (error) {
-      console.error("Error declining invitation:", error);
-    }
-  };
+        // Refresh the data
+        refetchViewerPending();
+      } catch (error) {
+        console.error("Error declining invitation:", error);
+      }
+    },
+    [refetchViewerPending],
+  );
 
   // Handler for when a new team is created
   const handleTeamCreated = () => {


### PR DESCRIPTION
TeamCard is already wrapped in React.memo with a one-level-shallow comparator, and that comparator compares handlers by identity. All seven handlers MyTeams passes down were plain arrow functions recreated on every render, so the comparator could never bail and the memo was effectively inert on this page. SearchPage already does this for handleTeamUpdate.

Dependencies were favourable: invalidateUserTeams is already a useCallback, refetchViewerPending comes from React Query, both stable.

handleTeamUpdate deliberately depends on currentPage and resultsPerPage, so its identity changes when paging. That is correct: the alternative is a stale closure patching the cache entry of the wrong page, and paging re-renders every card regardless.

ESLint 0 errors, exhaustive-deps flags none of the new dependency arrays, build green. Correctness smoke passed: edit a team in place, edit on page 2, delete, leave, accept and decline an invitation, withdraw an application.