### PR TITLE
perf(myteams): stabilize onApplicationsModalClosed so the TeamCard memo bails

### DIFF
--- a/src/pages/MyTeams.jsx
+++ b/src/pages/MyTeams.jsx
@@ -356,6 +356,15 @@ const MyTeams = () => {
     invalidateUserTeams();
   }, [invalidateUserTeams]);
 
+  // Stable identity so TeamCard's React.memo can bail: the setState setter
+  // never changes, so an empty dependency array is correct. Passing an inline
+  // arrow here instead left the memo inert on this page (every card re-rendered
+  // on every MyTeams render), which is what #566 missed.
+  const handleApplicationsModalClosed = useCallback(
+    () => setAutoOpenApplicationsTeamId(null),
+    [],
+  );
+
   // Application handlers
   const handleApplicationCancel = useCallback(
     async (applicationId) => {
@@ -985,9 +994,7 @@ const MyTeams = () => {
                           : null
                       }
                       highlightInvitationId={highlightInvitationId}
-                      onApplicationsModalClosed={() =>
-                        setAutoOpenApplicationsTeamId(null)
-                      }
+                      onApplicationsModalClosed={handleApplicationsModalClosed}
                       viewMode="list"
                       activeFilters={{}}
                     />
@@ -1040,9 +1047,7 @@ const MyTeams = () => {
                           : null
                       }
                       highlightInvitationId={highlightInvitationId}
-                      onApplicationsModalClosed={() =>
-                        setAutoOpenApplicationsTeamId(null)
-                      }
+                      onApplicationsModalClosed={handleApplicationsModalClosed}
                       viewMode={resultView}
                       activeFilters={{}}
                     />


### PR DESCRIPTION
## What
Wrap the onApplicationsModalClosed handler MyTeams passes to TeamCard in
useCallback, so TeamCard's React.memo comparator can actually bail.

## Why
#566 stabilized the seven named handlers to make the TeamCard memo
effective on MyTeams, but missed onApplicationsModalClosed, which stayed
a fresh inline arrow at both member-list call sites. A single
identity-unstable handler makes the one-level-shallow comparator return
false for every card on every render, so the memo was still inert and
#566 delivered no measurable render savings.

## Measurement
Instrumented TeamCard with a render counter and MyTeams with a
debug-only pure re-render trigger, then compared #566-as-merged against
this fix (15 visible cards, StrictMode dev):

| variant | onApplicationsModalClosed | card re-renders per unrelated MyTeams render |
| --- | --- | --- |
| #566 as merged | inline arrow | ~30 (every card) |
| this PR | stable useCallback | 0 |

Cross-checked by logging the memo comparator's bailing prop key: after
this change the comparator returns true for every card, React skips the
render, and the counter does not move across repeated triggers.

## Scope
One handler plus its two call sites. Behaviour unchanged
(setAutoOpenApplicationsTeamId is a state setter). ESLint 0 errors,
build green.
